### PR TITLE
[codex] Enumerate and obstruct the n=7 Fano-incidence equality case

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the current mathematical state, read [`STATE.md`](STATE.md).
 - For the compact results ledger, read [`RESULTS.md`](RESULTS.md).
 - For proved local facts, read [`docs/claims.md`](docs/claims.md).
+- For the reproducible `n=7` Fano enumeration, read [`docs/n7-fano-enumeration.md`](docs/n7-fano-enumeration.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).
 - For known bad proof routes, read [`docs/failed-ideas.md`](docs/failed-ideas.md).
 - For the verification standard, read [`docs/verification-contract.md`](docs/verification-contract.md).
@@ -48,6 +49,12 @@ are equal. The radius may depend on `i`; the selected set may depend on `i`; the
 ## Current status in this repo
 
 No proof and no counterexample are claimed.
+
+The selected-witness incidence method rules out `n <= 7`. In the `n=7`
+equality case, the 720 pointed Fano patterns fall into 54 cyclic-dihedral
+classes; in every case the common-witness chord map has cycle type `7+7+7`,
+so the required perpendicularity relation has an odd cycle. See
+[`docs/n7-fano-enumeration.md`](docs/n7-fano-enumeration.md).
 
 The current best numerical object is a near-miss for the pattern `B12_3x4_danzer_lift`. It has small residual but appears to degenerate toward three tight clusters near an equilateral triangle. It is therefore recorded as useful evidence about a failed route, **not** as a solution.
 
@@ -93,6 +100,7 @@ Use these labels consistently:
 ├── pyproject.toml
 ├── requirements.txt
 ├── src/erdos97/search.py              # main search/verification engine
+├── src/erdos97/n7_fano.py             # exact n=7 Fano enumeration
 ├── scripts/                           # thin CLI helpers
 ├── tests/                             # smoke tests and incidence checks
 ├── docs/
@@ -104,6 +112,7 @@ Use these labels consistently:
 │   ├── literature-risk.md             # what has/has not been checked
 │   └── verification-contract.md       # candidate acceptance requirements
 ├── data/
+│   ├── incidence/n7_fano_dihedral_representatives.json
 │   ├── patterns/candidate_patterns.json
 │   └── runs/best_B12_slsqp_m1e-6.json
 └── certificates/

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -21,15 +21,20 @@ The directed 4-out incidence pattern and the pairwise cap imply no
 counterexample can have `n <= 6`; the convexity-of-indegree count gives
 `n >= 7`.
 
-### Conditional structure: n=7 equality case
+### Theorem: selected-witness incidence rules out n <= 7
 
-Status: proved as an incidence consequence; geometric impossibility unresolved.
+Status: proved and reproducible.
 
-For `n=7`, equality in the incidence count forces all indegrees to be 4 and
-every pair of selected 4-sets to intersect in exactly 2 points. The complements
-`T_i = V \ S_i` form a Fano-plane-like family of 3-sets. If
-`S_i cap S_j = {a,b}`, then segment `p_a p_b` is perpendicular to segment
-`p_i p_j` by the radical-axis theorem.
+The incidence count rules out `n <= 6`. For `n=7`, equality forces all
+indegrees to be 4 and every pair of selected 4-sets to intersect in exactly
+2 points. The complements `T_i = V \ S_i` form Fano lines with `i in T_i`.
+
+The exact enumerator checks all 30 labelled Fano planes and 720 pointed
+equality families, reducing them to 54 cyclic-dihedral classes. In every
+family, the common-witness chord map has cycle type `7+7+7`, so the required
+radical-axis perpendicularity constraints contain odd cycles. This obstructs
+all `n=7` selected-witness equality patterns. See
+`docs/n7-fano-enumeration.md`.
 
 ## Numerical Attempts
 
@@ -52,8 +57,7 @@ This is evidence about a failed route, not a solution.
 
 ## Open Subproblems
 
-1. Enumerate all `n=7` Fano-incidence cyclic labelings up to dihedral symmetry.
-2. Prove or refute degeneration for `B12_3x4_danzer_lift`.
-3. Run a `B20_4x5_FR_lift` anti-clustering margin sweep.
-4. Add interval-arithmetic verification for convexity and distance equations.
-5. Strengthen the incidence SAT/SMT abstraction beyond the pairwise cap.
+1. Prove or refute degeneration for `B12_3x4_danzer_lift`.
+2. Run a `B20_4x5_FR_lift` anti-clustering margin sweep.
+3. Add interval-arithmetic verification for convexity and distance equations.
+4. Strengthen the incidence SAT/SMT abstraction beyond the pairwise cap.

--- a/STATE.md
+++ b/STATE.md
@@ -13,6 +13,7 @@ The Erdős Problems page still lists #97 as open/falsifiable. Known nearby examp
 2. Consequence: no counterexample with `n <= 6`. For `n=5`, every pair of 4-sets shares 3 points. For `n=6`, write `S_i = V \ {i,f(i)}`; the pair `(i,f(i))` has intersection at least 3.
 3. Incidence counting: if `d_j` is the indegree of vertex `j`, then `sum_j binom(d_j,2) <= 2 binom(n,2)` and `sum_j d_j=4n`; convexity of `binom(d,2)` gives `n>=7`.
 4. Equality case `n=7`: all indegrees are 4 and every pair of selected 4-sets intersects in exactly 2 points. Complements `T_i=V\S_i` are Fano lines of size 3 with `i in T_i`. For any centers `i,j`, if `S_i ∩ S_j={a,b}`, then segment `p_a p_b` is perpendicular to segment `p_i p_j` by the radical-axis theorem.
+5. Finite `n=7` Fano obstruction: the reproducible enumeration in `scripts/enumerate_n7_fano.py` finds 30 labelled Fano planes, 720 pointed equality families, and 54 cyclic-dihedral classes. Every class has chord-cycle type `7+7+7`, so the required perpendicularity constraints contain odd cycles and cannot be realized by nonzero Euclidean chords. See `docs/n7-fano-enumeration.md`.
 
 ## Candidate incidence patterns
 Priority patterns in the current code:

--- a/data/incidence/n7_fano_dihedral_representatives.json
+++ b/data/incidence/n7_fano_dihedral_representatives.json
@@ -1,0 +1,23137 @@
+{
+  "conclusion": "No n=7 witness pattern satisfying the two-circle cap can be geometrically realized.",
+  "counts": {
+    "all_classes_obstructed": true,
+    "all_pattern_cycle_type_counts": {
+      "7+7+7": 720
+    },
+    "classes_with_odd_perpendicularity_cycle": 54,
+    "dihedral_class_cycle_type_counts": {
+      "7+7+7": 54
+    },
+    "dihedral_classes": 54,
+    "dihedral_orbit_size_distribution": {
+      "14": 51,
+      "2": 3
+    },
+    "labelled_fano_planes": 30,
+    "pointed_fano_patterns": 720
+  },
+  "n": 7,
+  "representatives": [
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 0,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 1,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 2,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 3,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 4,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 5,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 6,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 7,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 8,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          2,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 9,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 10,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 11,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 12,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          0,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 13,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 14,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 15,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 16,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 17,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 18,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 19,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 20,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 21,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          2,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 22,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          0,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 23,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 24,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 25,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 26,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 27,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 28,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 29,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          2,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 30,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 31,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 32,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 33,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 34,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 35,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 36,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          0,
+          3,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 37,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          3,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          2,
+          5
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 38,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            3,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          2,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          2,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 39,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            3,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          2,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          2,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 40,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          4
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 41,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            3,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          5
+        ],
+        [
+          0,
+          2,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 42,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            3,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            3,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          5
+        ],
+        [
+          0,
+          2,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 43,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          6
+        ],
+        [
+          0,
+          2,
+          4
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          3,
+          4,
+          6
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 44,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          5
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          2,
+          6
+        ],
+        [
+          0,
+          2,
+          5
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 45,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            3,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 46,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            3,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          3,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          6
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5
+        ],
+        [
+          3,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 47,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          4
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5
+        ],
+        [
+          0,
+          5,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 48,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            5
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          2,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          4
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          6
+        ],
+        [
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          4,
+          5
+        ],
+        [
+          3,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 49,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            3,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            3
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          3
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          4
+        ],
+        [
+          2,
+          3,
+          6
+        ],
+        [
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 50,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          2,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          4
+        ],
+        [
+          1,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3
+        ],
+        [
+          0,
+          3,
+          6
+        ],
+        [
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5
+        ],
+        [
+          2,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 51,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            4,
+            6
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ],
+        [
+          [
+            0,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          2,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          1,
+          5
+        ],
+        [
+          1,
+          2,
+          6
+        ],
+        [
+          0,
+          2,
+          3
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 52,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            4,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            3,
+            5
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            4
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ]
+      ]
+    },
+    {
+      "complements_T": [
+        [
+          0,
+          2,
+          3
+        ],
+        [
+          1,
+          3,
+          4
+        ],
+        [
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5
+        ],
+        [
+          1,
+          2,
+          6
+        ]
+      ],
+      "cycle_lengths": [
+        7,
+        7,
+        7
+      ],
+      "geometrically_realizable_under_required_perpendicularities": false,
+      "has_odd_perpendicularity_cycle": true,
+      "id": 53,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "intersection_sizes": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      "obstruction": "The common-witness chord map is a permutation of the 21 chords. It has an odd cycle, but each map edge would impose perpendicularity; alternating perpendicularity around an odd cycle is impossible for nonzero Euclidean chords.",
+      "perpendicularity_cycles": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            4,
+            6
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            1,
+            3
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            3,
+            6
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            2,
+            6
+          ]
+        ]
+      ],
+      "perpendicularity_map": [
+        {
+          "center_chord": [
+            0,
+            1
+          ],
+          "common_witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            2
+          ],
+          "common_witness_chord": [
+            1,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            3
+          ],
+          "common_witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            5
+          ],
+          "common_witness_chord": [
+            4,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            0,
+            6
+          ],
+          "common_witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            2
+          ],
+          "common_witness_chord": [
+            0,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            4
+          ],
+          "common_witness_chord": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            1,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            3
+          ],
+          "common_witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            5
+          ],
+          "common_witness_chord": [
+            3,
+            6
+          ]
+        },
+        {
+          "center_chord": [
+            2,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            4
+          ],
+          "common_witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            3,
+            6
+          ],
+          "common_witness_chord": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            5
+          ],
+          "common_witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "center_chord": [
+            4,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            5
+          ]
+        },
+        {
+          "center_chord": [
+            5,
+            6
+          ],
+          "common_witness_chord": [
+            3,
+            4
+          ]
+        }
+      ],
+      "witnesses_W": [
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          5
+        ]
+      ]
+    }
+  ],
+  "schema": "erdos97_n7_fano_dihedral_representatives_v1",
+  "status": "exact_finite_enumeration_for_n7_not_general_solution"
+}

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -40,6 +40,12 @@ Hence `6n <= n(n-1)`, so `n >= 7`.
 
 For `n=7`, equality must hold in the counting argument. Thus every indegree is 4 and every pair of selected 4-sets intersects in exactly 2 points. The complements `T_i = V \ S_i` form a Fano-plane-like family of 3-sets with pairwise intersection 1. If `S_i ∩ S_j = {a,b}`, then the chord `p_a p_b` is the radical axis of the two selected circles and is perpendicular to `p_i p_j`.
 
+### Lemma 4: finite n=7 Fano obstruction
+
+The generator in `scripts/enumerate_n7_fano.py` enumerates 30 labelled Fano planes and 720 pointed complement families `T_i` with `i in T_i`, then quotients them to 54 cyclic-dihedral classes. For every labelled family, the common-witness chord map has cycle type `7+7+7`.
+
+Along an odd chord cycle, the required perpendicularity relation would force nonzero Euclidean chord directions to alternate between two perpendicular directions and return with the wrong parity. Therefore no `n=7` selected-witness equality pattern is geometrically realizable. See `docs/n7-fano-enumeration.md`.
+
 ## Heuristics
 
 - Balanced selected vertices around the polygon often search better than clustered selected vertices.

--- a/docs/n7-fano-enumeration.md
+++ b/docs/n7-fano-enumeration.md
@@ -1,0 +1,106 @@
+# n=7 Fano-incidence enumeration
+
+Status: **THEOREM / EXACTIFICATION** for the selected-witness `n=7` equality case only. This does **not** prove the full Erdős #97 problem and does **not** give a counterexample.
+
+This note supports issue #2, “Enumerate all n=7 Fano-incidence cyclic labelings up to dihedral symmetry.” It gives a deterministic, dependency-free enumerator and a checked-in JSON artifact containing canonical representatives and their induced perpendicularity constraints.
+
+## Why n=7 reduces to Fano incidence
+
+Let `W_i` be a selected witness 4-set for center `i`, and assume the pairwise circle-intersection cap
+
+```text
+|W_i ∩ W_j| <= 2    for i != j.
+```
+
+For `n=7`, the standard counting argument is tight. Every vertex has selected indegree `4`, and every pair of selected rows intersects in exactly two vertices. Define the complement triples
+
+```text
+T_i = {0, ..., 6} \ W_i.
+```
+
+Then each `T_i` is a 3-set containing `i`, and every two triples `T_i,T_j` intersect in exactly one point. The seven triples therefore form a labelled Fano plane, with a row assignment `i -> T_i` that is incident point-to-line.
+
+## What was enumerated
+
+The script `scripts/enumerate_n7_fano.py` enumerates:
+
+```text
+30   labelled Fano planes on labels 0..6
+720  row-indexed equality families T_0,...,T_6 with i in T_i
+54   canonical representatives modulo the cyclic dihedral action x -> ±x + shift mod 7
+```
+
+The dihedral orbit-size distribution is:
+
+```text
+orbit size 14: 51 representatives
+orbit size  2:  3 representatives
+```
+
+The machine-readable artifact is checked in as:
+
+```text
+data/incidence/n7_fano_dihedral_representatives.json
+```
+
+Each representative records:
+
+- complement triples `T_i`;
+- witness rows `W_i`;
+- the 21 induced radical-axis perpendicularity constraints;
+- the chord-cycle decomposition.
+
+## Perpendicularity obstruction
+
+For a pair of centers `{i,j}`, the two shared selected targets
+
+```text
+W_i ∩ W_j = {a,b}
+```
+
+force the chord `p_i p_j` to be perpendicular to the chord `p_a p_b`: both centers lie on the perpendicular bisector of the target chord.
+
+Thus every n=7 equality family induces a map on the 21 unordered chords:
+
+```text
+{i,j} -> W_i ∩ W_j.
+```
+
+The enumerator verifies that, for every one of the 720 labelled equality families, this chord map is a permutation with cycle lengths
+
+```text
+7, 7, 7
+```
+
+Every family therefore has an odd perpendicularity cycle. Alternating perpendicularity around an odd cycle is impossible in the Euclidean plane: after an odd number of quarter-turn constraints, the initial nonzero chord direction would have to be perpendicular to itself. Since a strictly convex polygon has distinct vertices, all chords are nonzero.
+
+Therefore no `n=7` selected-witness equality family survives the radical-axis perpendicularity check.
+
+## Reproduce
+
+From the repository root:
+
+```bash
+python scripts/enumerate_n7_fano.py --summary
+python scripts/enumerate_n7_fano.py --check-data data/incidence/n7_fano_dihedral_representatives.json --summary
+pytest -q tests/test_n7_fano.py
+```
+
+Expected summary counts:
+
+```json
+{
+  "labelled_fano_planes": 30,
+  "pointed_fano_patterns": 720,
+  "dihedral_classes": 54,
+  "dihedral_orbit_size_distribution": {"2": 3, "14": 51},
+  "cycle_type_counts": {"7+7+7": 54},
+  "all_pattern_cycle_type_counts": {"7+7+7": 720},
+  "classes_with_odd_perpendicularity_cycle": 54,
+  "all_classes_obstructed": true
+}
+```
+
+## Scope and caveats
+
+This is a finite exact obstruction for `n=7`. It does not address larger `n`, and it relies on the selected-witness convention where each bad vertex contributes one chosen 4-set `W_i`. That convention is safe for proving impossibility: any true `E(i) >= 4` counterexample would allow such a selected witness subfamily.

--- a/docs/n7-fano-obstruction.md
+++ b/docs/n7-fano-obstruction.md
@@ -1,0 +1,3 @@
+# n=7 Fano-incidence obstruction
+
+See `docs/n7-fano-enumeration.md` for the full enumerator note, canonical representatives, and perpendicularity-cycle obstruction.

--- a/scripts/enumerate_n7_fano.py
+++ b/scripts/enumerate_n7_fano.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Emit the exact n=7 Fano-incidence enumeration artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n7_fano import enumeration_data, enumeration_summary  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="optional JSON output path for the full artifact")
+    parser.add_argument("--summary", action="store_true", help="print only the compact summary")
+    parser.add_argument(
+        "--check-data",
+        type=Path,
+        help="compare a checked-in JSON artifact against freshly generated data",
+    )
+    args = parser.parse_args()
+
+    data = enumeration_data()
+
+    if args.check_data:
+        checked_in = json.loads(args.check_data.read_text(encoding="utf-8"))
+        if checked_in != data:
+            raise SystemExit(f"checked-in artifact is stale or mismatched: {args.check_data}")
+        print(f"OK: {args.check_data} matches the generated n=7 Fano enumeration")
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"wrote {args.out}")
+        return 0
+
+    payload = enumeration_summary() if args.summary else data
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n7_fano.py
+++ b/src/erdos97/n7_fano.py
@@ -1,0 +1,510 @@
+"""n=7 incidence obstruction for Erdős Problem #97.
+
+This module is intentionally finite and dependency-free. It formalizes the
+small-case argument that a 7-vertex counterexample cannot exist.
+
+Setup
+-----
+For a putative counterexample choose a 4-element witness set W_i for each
+center i. If W_i and W_j have three common witnesses, then two distinct
+circles share three points, impossible. Hence |W_i cap W_j| <= 2.
+
+When n=7 this upper bound is tight everywhere by a counting argument. The
+complements T_i = V \\ W_i form a Fano-plane incidence structure with i in
+T_i. For each chord e={i,j}, the two common witnesses
+
+    phi(e) = W_i cap W_j
+
+form another chord. The map phi is a permutation of the 21 chords. In any
+geometric realization e is perpendicular to phi(e), because both centers i
+and j lie on the perpendicular bisector of the common-witness chord.
+
+A permutation of 21 objects has an odd cycle. Alternating perpendicularity
+around an odd cycle is impossible for nonzero Euclidean chords. Therefore no
+n=7 counterexample exists.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations, permutations
+from typing import Dict, Iterable, Mapping, Sequence, Tuple
+
+Vertex = int
+Pair = Tuple[int, int]
+Triple = Tuple[int, int, int]
+WitnessPattern = Tuple[Tuple[int, ...], ...]
+ComplementPattern = Tuple[Triple, ...]
+ChordMap = Dict[Pair, Pair]
+
+
+def ordered_pair(a: int, b: int) -> Pair:
+    """Return a sorted two-vertex tuple."""
+
+    if a == b:
+        raise ValueError("a chord must have two distinct vertices")
+    return (a, b) if a < b else (b, a)
+
+
+def normalize_row(row: Iterable[int]) -> Tuple[int, ...]:
+    """Return a sorted row and reject duplicates."""
+
+    out = tuple(sorted(int(x) for x in row))
+    if len(set(out)) != len(out):
+        raise ValueError(f"row contains a duplicate vertex: {out}")
+    return out
+
+
+def normalize_witness_pattern(pattern: Sequence[Sequence[int]]) -> WitnessPattern:
+    """Normalize a witness pattern as a tuple of sorted rows."""
+
+    return tuple(normalize_row(row) for row in pattern)
+
+
+def validate_witness_pattern(pattern: Sequence[Sequence[int]], n: int | None = None) -> WitnessPattern:
+    """Validate the basic witness-pattern shape.
+
+    The function checks row length four, no repeated targets, no loops, and
+    vertices in range. It does not assert the geometric circle-intersection
+    cap; use :func:`pairwise_intersection_cap` for that.
+    """
+
+    W = normalize_witness_pattern(pattern)
+    if n is None:
+        n = len(W)
+    if len(W) != n:
+        raise ValueError(f"expected {n} rows, found {len(W)}")
+    for i, row in enumerate(W):
+        if len(row) != 4:
+            raise ValueError(f"row {i} has length {len(row)}, expected 4")
+        if i in row:
+            raise ValueError(f"row {i} contains its own center")
+        bad = [j for j in row if j < 0 or j >= n]
+        if bad:
+            raise ValueError(f"row {i} has vertices outside 0..{n - 1}: {bad}")
+    return W
+
+
+def all_chords(n: int) -> Tuple[Pair, ...]:
+    """All unordered chords on vertices 0..n-1."""
+
+    return tuple((a, b) for a, b in combinations(range(n), 2))
+
+
+def indegrees(pattern: Sequence[Sequence[int]], n: int | None = None) -> Tuple[int, ...]:
+    """Column sums of a witness pattern."""
+
+    W = normalize_witness_pattern(pattern)
+    if n is None:
+        n = len(W)
+    out = [0] * n
+    for row in W:
+        for j in row:
+            out[j] += 1
+    return tuple(out)
+
+
+def pairwise_intersection_sizes(pattern: Sequence[Sequence[int]]) -> Dict[Pair, int]:
+    """Size of W_i cap W_j for every pair of rows."""
+
+    W = normalize_witness_pattern(pattern)
+    return {
+        (i, j): len(set(W[i]).intersection(W[j]))
+        for i, j in combinations(range(len(W)), 2)
+    }
+
+
+def pairwise_intersection_cap(pattern: Sequence[Sequence[int]]) -> int:
+    """Maximum common-witness count over two distinct centers."""
+
+    sizes = pairwise_intersection_sizes(pattern)
+    return max(sizes.values(), default=0)
+
+
+def complements_from_witnesses(pattern: Sequence[Sequence[int]]) -> ComplementPattern:
+    """Return T_i = V \\ W_i for an n=7 witness pattern.
+
+    For n=7 each complement is a triple and should contain its center if the
+    witness pattern has no loops.
+    """
+
+    W = validate_witness_pattern(pattern, n=7)
+    vertices = set(range(7))
+    return tuple(tuple(sorted(vertices.difference(row))) for row in W)  # type: ignore[return-value]
+
+
+def witnesses_from_complements(complements: Sequence[Sequence[int]]) -> WitnessPattern:
+    """Return W_i = V \\ T_i for n=7 complement triples."""
+
+    if len(complements) != 7:
+        raise ValueError(f"expected 7 complement triples, found {len(complements)}")
+    vertices = set(range(7))
+    rows: list[tuple[int, ...]] = []
+    for i, row in enumerate(complements):
+        T = normalize_row(row)
+        if len(T) != 3:
+            raise ValueError(f"complement row {i} has length {len(T)}, expected 3")
+        if i not in T:
+            raise ValueError(f"complement row {i} must contain its center {i}: {T}")
+        rows.append(tuple(sorted(vertices.difference(T))))
+    return validate_witness_pattern(rows, n=7)
+
+
+def chord_permutation_from_witnesses(pattern: Sequence[Sequence[int]]) -> ChordMap:
+    """Map each center chord {i,j} to the common-witness chord W_i cap W_j.
+
+    Raises if the pattern does not satisfy the n=7 equality case where every
+    pair of rows has exactly two common witnesses and the resulting map is a
+    permutation of the 21 unordered chords.
+    """
+
+    W = validate_witness_pattern(pattern, n=7)
+    mapping: ChordMap = {}
+    for i, j in all_chords(7):
+        common = tuple(sorted(set(W[i]).intersection(W[j])))
+        if len(common) != 2:
+            raise ValueError(
+                f"rows {i} and {j} share {len(common)} witnesses, expected 2: {common}"
+            )
+        mapping[(i, j)] = (common[0], common[1])
+
+    chord_set = set(all_chords(7))
+    image_set = set(mapping.values())
+    if set(mapping) != chord_set or image_set != chord_set or len(image_set) != 21:
+        raise ValueError("common-witness map is not a permutation of the 21 chords")
+    return mapping
+
+
+def permutation_cycles(mapping: Mapping[Pair, Pair]) -> Tuple[Tuple[Pair, ...], ...]:
+    """Cycle decomposition of a chord permutation."""
+
+    domain = set(mapping)
+    image = set(mapping.values())
+    if domain != image:
+        raise ValueError("mapping is not a permutation: domain and image differ")
+
+    unseen = set(domain)
+    cycles: list[tuple[Pair, ...]] = []
+    while unseen:
+        start = min(unseen)
+        cur = start
+        cycle: list[Pair] = []
+        while cur in unseen:
+            unseen.remove(cur)
+            cycle.append(cur)
+            cur = mapping[cur]
+        if cur != start:
+            raise ValueError(f"mapping chain from {start} did not close to its start")
+        cycles.append(tuple(cycle))
+    return tuple(sorted(cycles, key=lambda c: (len(c), c)))
+
+
+@dataclass(frozen=True)
+class N7Analysis:
+    """Finite summary of an n=7 witness-pattern analysis."""
+
+    witness_pattern: WitnessPattern
+    complement_pattern: ComplementPattern
+    indegrees: Tuple[int, ...]
+    intersection_sizes: Tuple[int, ...]
+    chord_map: Tuple[Tuple[Pair, Pair], ...]
+    cycles: Tuple[Tuple[Pair, ...], ...]
+    cycle_lengths: Tuple[int, ...]
+    has_odd_cycle: bool
+    geometrically_realizable: bool
+    obstruction: str
+
+    def to_jsonable(self) -> dict[str, object]:
+        """Return a JSON-friendly representation."""
+
+        return {
+            "n": 7,
+            "witness_pattern": [list(row) for row in self.witness_pattern],
+            "complement_pattern": [list(row) for row in self.complement_pattern],
+            "indegrees": list(self.indegrees),
+            "intersection_sizes": list(self.intersection_sizes),
+            "chord_map": [
+                {"center_chord": list(edge), "common_witness_chord": list(image)}
+                for edge, image in self.chord_map
+            ],
+            "cycles": [[list(edge) for edge in cycle] for cycle in self.cycles],
+            "cycle_lengths": list(self.cycle_lengths),
+            "has_odd_cycle": self.has_odd_cycle,
+            "geometrically_realizable": self.geometrically_realizable,
+            "obstruction": self.obstruction,
+        }
+
+
+def analyze_n7_witness_pattern(pattern: Sequence[Sequence[int]]) -> N7Analysis:
+    """Analyze an n=7 witness pattern satisfying the circle-intersection cap.
+
+    The returned ``geometrically_realizable`` field is always ``False`` for a
+    cap-satisfying n=7 pattern, because the induced chord permutation must have
+    an odd perpendicularity cycle.
+    """
+
+    W = validate_witness_pattern(pattern, n=7)
+    cap = pairwise_intersection_cap(W)
+    if cap > 2:
+        raise ValueError(f"pattern violates the two-circle cap: max intersection {cap} > 2")
+
+    row_intersections = tuple(pairwise_intersection_sizes(W).values())
+    if set(row_intersections) != {2}:
+        raise ValueError(
+            "n=7 counting equality failed unexpectedly; expected all row intersections to be 2"
+        )
+
+    deg = indegrees(W, n=7)
+    if deg != (4, 4, 4, 4, 4, 4, 4):
+        raise ValueError(
+            "n=7 counting equality failed unexpectedly; expected every indegree to be 4"
+        )
+
+    mapping = chord_permutation_from_witnesses(W)
+    cycles = permutation_cycles(mapping)
+    cycle_lengths = tuple(len(cycle) for cycle in cycles)
+    has_odd = any(length % 2 for length in cycle_lengths)
+    obstruction = (
+        "The common-witness chord map is a permutation of the 21 chords. "
+        "It has an odd cycle, but each map edge would impose perpendicularity; "
+        "alternating perpendicularity around an odd cycle is impossible for "
+        "nonzero Euclidean chords."
+    )
+    return N7Analysis(
+        witness_pattern=W,
+        complement_pattern=complements_from_witnesses(W),
+        indegrees=deg,
+        intersection_sizes=row_intersections,
+        chord_map=tuple(sorted(mapping.items())),
+        cycles=cycles,
+        cycle_lengths=cycle_lengths,
+        has_odd_cycle=has_odd,
+        geometrically_realizable=not has_odd,
+        obstruction=obstruction,
+    )
+
+
+def cyclic_fano_complements() -> ComplementPattern:
+    """A canonical pointed Fano complement pattern.
+
+    The triples are T_i = {i, i+1, i+3} modulo 7. They are the lines of the
+    cyclic Fano plane, labelled so each row T_i contains its own center i.
+    """
+
+    return tuple(
+        tuple(sorted({i, (i + 1) % 7, (i + 3) % 7})) for i in range(7)
+    )  # type: ignore[return-value]
+
+
+def cyclic_fano_witnesses() -> WitnessPattern:
+    """Witness sets W_i complementary to :func:`cyclic_fano_complements`."""
+
+    return witnesses_from_complements(cyclic_fano_complements())
+
+
+def _apply_vertex_permutation_to_lines(
+    lines: Sequence[Sequence[int]], perm: Sequence[int]
+) -> Tuple[Triple, ...]:
+    return tuple(
+        sorted(tuple(tuple(sorted(perm[x] for x in line)) for line in lines))
+    )  # type: ignore[return-value]
+
+
+def all_labeled_fano_planes() -> Tuple[Tuple[Triple, ...], ...]:
+    """All 30 labelled Fano planes on vertices 0..6.
+
+    Every labelled Fano plane is obtained by relabelling the cyclic difference
+    set construction. The automorphism group has order 168, so 7!/168 = 30
+    distinct labelled planes; this function constructs and deduplicates them.
+    """
+
+    base = cyclic_fano_complements()
+    planes = {
+        _apply_vertex_permutation_to_lines(base, perm) for perm in permutations(range(7))
+    }
+    return tuple(sorted(planes))
+
+
+def pointed_matchings_for_plane(lines: Sequence[Sequence[int]]) -> Tuple[ComplementPattern, ...]:
+    """All bijective assignments i -> T_i with i in T_i for one Fano plane."""
+
+    normalized_lines = tuple(normalize_row(line) for line in lines)
+    if len(normalized_lines) != 7:
+        raise ValueError("a Fano plane should have 7 lines")
+    choices = {
+        i: tuple(idx for idx, line in enumerate(normalized_lines) if i in line)
+        for i in range(7)
+    }
+    assignment: list[int | None] = [None] * 7
+    used: set[int] = set()
+    out: list[ComplementPattern] = []
+
+    def rec(i: int) -> None:
+        if i == 7:
+            out.append(tuple(normalized_lines[assignment[j]] for j in range(7)))  # type: ignore[index,arg-type]
+            return
+        for idx in choices[i]:
+            if idx in used:
+                continue
+            used.add(idx)
+            assignment[i] = idx
+            rec(i + 1)
+            assignment[i] = None
+            used.remove(idx)
+
+    rec(0)
+    return tuple(sorted(out))
+
+
+def all_pointed_fano_complements() -> Tuple[ComplementPattern, ...]:
+    """All 720 n=7 complement patterns forced by the counting equality."""
+
+    patterns: set[ComplementPattern] = set()
+    for plane in all_labeled_fano_planes():
+        patterns.update(pointed_matchings_for_plane(plane))
+    return tuple(sorted(patterns))
+
+
+def _dihedral_permutations(n: int = 7) -> Tuple[Tuple[int, ...], ...]:
+    """Dihedral permutations preserving cyclic order on n labelled vertices."""
+
+    return tuple(tuple((shift + sign * i) % n for i in range(n)) for sign in (1, -1) for shift in range(n))
+
+
+def apply_vertex_permutation_to_complements(
+    complements: Sequence[Sequence[int]], perm: Sequence[int]
+) -> ComplementPattern:
+    """Relabel a pointed complement pattern by a vertex permutation."""
+
+    if len(complements) != 7:
+        raise ValueError("expected 7 complement rows")
+    out: list[Triple | None] = [None] * 7
+    for old_center, line in enumerate(complements):
+        new_center = perm[old_center]
+        out[new_center] = tuple(sorted(perm[x] for x in line))  # type: ignore[assignment]
+    return tuple(out)  # type: ignore[return-value]
+
+
+def canonical_dihedral_representative(complements: Sequence[Sequence[int]]) -> ComplementPattern:
+    """Canonical representative modulo rotations and reversal of cyclic order."""
+
+    return min(apply_vertex_permutation_to_complements(complements, perm) for perm in _dihedral_permutations())
+
+
+def pointed_fano_dihedral_classes() -> Tuple[ComplementPattern, ...]:
+    """The 54 pointed n=7 Fano patterns up to dihedral cyclic relabelling."""
+
+    return tuple(sorted({canonical_dihedral_representative(T) for T in all_pointed_fano_complements()}))
+
+
+def _json_pair(pair: Pair) -> list[int]:
+    return [int(pair[0]), int(pair[1])]
+
+
+def _json_row(row: Sequence[int]) -> list[int]:
+    return [int(x) for x in row]
+
+
+def dihedral_orbit_size_distribution() -> dict[int, int]:
+    """Distribution of orbit sizes among the 54 dihedral classes."""
+
+    sizes: dict[ComplementPattern, int] = {}
+    for T in all_pointed_fano_complements():
+        rep = canonical_dihedral_representative(T)
+        sizes[rep] = sizes.get(rep, 0) + 1
+    return dict(Counter(sizes.values()))
+
+
+def dihedral_class_records() -> list[dict[str, object]]:
+    """Canonical class representatives with induced perpendicularity constraints."""
+
+    records: list[dict[str, object]] = []
+    for idx, T in enumerate(pointed_fano_dihedral_classes()):
+        witnesses = witnesses_from_complements(T)
+        analysis = analyze_n7_witness_pattern(witnesses)
+        records.append(
+            {
+                "id": idx,
+                "complements_T": [_json_row(row) for row in analysis.complement_pattern],
+                "witnesses_W": [_json_row(row) for row in analysis.witness_pattern],
+                "indegrees": list(analysis.indegrees),
+                "intersection_sizes": list(analysis.intersection_sizes),
+                "perpendicularity_map": [
+                    {
+                        "center_chord": _json_pair(edge),
+                        "common_witness_chord": _json_pair(image),
+                    }
+                    for edge, image in analysis.chord_map
+                ],
+                "perpendicularity_cycles": [
+                    [_json_pair(edge) for edge in cycle] for cycle in analysis.cycles
+                ],
+                "cycle_lengths": list(analysis.cycle_lengths),
+                "has_odd_perpendicularity_cycle": analysis.has_odd_cycle,
+                "geometrically_realizable_under_required_perpendicularities": analysis.geometrically_realizable,
+                "obstruction": analysis.obstruction,
+            }
+        )
+    return records
+
+
+def enumeration_data() -> dict[str, object]:
+    """Full deterministic JSON-serializable n=7 enumeration artifact."""
+
+    planes = all_labeled_fano_planes()
+    complements = all_pointed_fano_complements()
+    classes = pointed_fano_dihedral_classes()
+
+    all_cycle_type_counts: Counter[str] = Counter()
+    for T in complements:
+        analysis = analyze_n7_witness_pattern(witnesses_from_complements(T))
+        key = "+".join(str(x) for x in sorted(analysis.cycle_lengths))
+        all_cycle_type_counts[key] += 1
+
+    class_cycle_type_counts: Counter[str] = Counter()
+    odd_cycle_classes = 0
+    for T in classes:
+        analysis = analyze_n7_witness_pattern(witnesses_from_complements(T))
+        key = "+".join(str(x) for x in sorted(analysis.cycle_lengths))
+        class_cycle_type_counts[key] += 1
+        if analysis.has_odd_cycle:
+            odd_cycle_classes += 1
+
+    orbit_sizes = dihedral_orbit_size_distribution()
+    return {
+        "schema": "erdos97_n7_fano_dihedral_representatives_v1",
+        "status": "exact_finite_enumeration_for_n7_not_general_solution",
+        "n": 7,
+        "counts": {
+            "labelled_fano_planes": len(planes),
+            "pointed_fano_patterns": len(complements),
+            "dihedral_classes": len(classes),
+            "dihedral_orbit_size_distribution": {str(k): orbit_sizes[k] for k in sorted(orbit_sizes)},
+            "all_pattern_cycle_type_counts": dict(sorted(all_cycle_type_counts.items())),
+            "dihedral_class_cycle_type_counts": dict(sorted(class_cycle_type_counts.items())),
+            "classes_with_odd_perpendicularity_cycle": odd_cycle_classes,
+            "all_classes_obstructed": odd_cycle_classes == len(classes),
+        },
+        "conclusion": "No n=7 witness pattern satisfying the two-circle cap can be geometrically realized.",
+        "representatives": dihedral_class_records(),
+    }
+
+
+def enumeration_summary() -> dict[str, object]:
+    """Summarize the finite n=7 enumeration and obstruction."""
+
+    data = enumeration_data()
+    counts = data["counts"]
+    assert isinstance(counts, dict)
+    return {
+        "labelled_fano_planes": counts["labelled_fano_planes"],
+        "pointed_fano_patterns": counts["pointed_fano_patterns"],
+        "dihedral_classes": counts["dihedral_classes"],
+        "dihedral_orbit_size_distribution": counts["dihedral_orbit_size_distribution"],
+        "cycle_type_counts": counts["dihedral_class_cycle_type_counts"],
+        "all_pattern_cycle_type_counts": counts["all_pattern_cycle_type_counts"],
+        "classes_with_odd_perpendicularity_cycle": counts["classes_with_odd_perpendicularity_cycle"],
+        "all_classes_obstructed": counts["all_classes_obstructed"],
+        "conclusion": data["conclusion"],
+    }

--- a/tests/test_n7_fano.py
+++ b/tests/test_n7_fano.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from erdos97.n7_fano import (
+    all_pointed_fano_complements,
+    analyze_n7_witness_pattern,
+    cyclic_fano_witnesses,
+    enumeration_data,
+    enumeration_summary,
+    pairwise_intersection_cap,
+    pointed_fano_dihedral_classes,
+    witnesses_from_complements,
+)
+
+
+def test_cyclic_fano_pattern_is_obstructed_by_odd_cycles() -> None:
+    witnesses = cyclic_fano_witnesses()
+    assert pairwise_intersection_cap(witnesses) == 2
+
+    analysis = analyze_n7_witness_pattern(witnesses)
+
+    assert analysis.indegrees == (4, 4, 4, 4, 4, 4, 4)
+    assert set(analysis.intersection_sizes) == {2}
+    assert len(analysis.chord_map) == 21
+    assert sorted(analysis.cycle_lengths) == [7, 7, 7]
+    assert analysis.has_odd_cycle
+    assert not analysis.geometrically_realizable
+
+
+def test_finite_n7_fano_enumeration_counts() -> None:
+    summary = enumeration_summary()
+
+    assert summary["labelled_fano_planes"] == 30
+    assert summary["pointed_fano_patterns"] == 720
+    assert summary["dihedral_classes"] == 54
+    assert summary["dihedral_orbit_size_distribution"] == {"2": 3, "14": 51}
+    assert summary["cycle_type_counts"] == {"7+7+7": 54}
+    assert summary["all_pattern_cycle_type_counts"] == {"7+7+7": 720}
+    assert summary["classes_with_odd_perpendicularity_cycle"] == 54
+    assert summary["all_classes_obstructed"] is True
+
+
+def test_every_labelled_pattern_has_odd_perpendicularity_cycles() -> None:
+    for complements in all_pointed_fano_complements():
+        analysis = analyze_n7_witness_pattern(witnesses_from_complements(complements))
+        assert sorted(analysis.cycle_lengths) == [7, 7, 7]
+        assert analysis.has_odd_cycle
+        assert not analysis.geometrically_realizable
+
+
+def test_every_dihedral_class_representative_has_recorded_constraints() -> None:
+    data = enumeration_data()
+    representatives = data["representatives"]
+    assert isinstance(representatives, list)
+    assert len(representatives) == len(pointed_fano_dihedral_classes()) == 54
+
+    for record in representatives:
+        assert record["cycle_lengths"] == [7, 7, 7]
+        assert record["has_odd_perpendicularity_cycle"] is True
+        assert record["geometrically_realizable_under_required_perpendicularities"] is False
+        assert len(record["perpendicularity_map"]) == 21
+        assert len(record["perpendicularity_cycles"]) == 3
+
+
+def test_checked_in_n7_json_artifact_matches_generator() -> None:
+    root = Path(__file__).resolve().parents[1]
+    artifact = root / "data" / "incidence" / "n7_fano_dihedral_representatives.json"
+
+    checked_in = json.loads(artifact.read_text(encoding="utf-8"))
+    assert checked_in == enumeration_data()


### PR DESCRIPTION
## Summary

This adds a finite, exact n=7 Fano-incidence enumeration and obstruction for the selected-witness equality branch targeted by #2.

Highlights:
- enumerates 30 labelled Fano planes;
- enumerates 720 pointed equality families `T_i` with `i in T_i`;
- quotients them to 54 cyclic-dihedral representatives;
- records the induced radical-axis perpendicularity constraints for every representative;
- verifies every labelled family has chord-cycle type `7+7+7`, giving an odd-cycle perpendicularity obstruction.

This resolves the n=7 selected-witness equality branch only. It does not claim a general proof of Erdős #97 or a counterexample.

Closes #2.

## Validation

- `python scripts\enumerate_n7_fano.py --check-data data\incidence\n7_fano_dihedral_representatives.json --summary`
- `python -m pytest -q`
- `python scripts\check_text_clean.py`