### PR TITLE
[codex] Harden numerical candidate verifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,15 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       - run: pip install -e .[dev]
       - run: python scripts/check_text_clean.py

--- a/docs/verification-contract.md
+++ b/docs/verification-contract.md
@@ -28,6 +28,19 @@ Allowed numerical statuses:
 
 The status `certified` must not be used for a floating-point-only artifact.
 
+## Strict Numerical Verifier
+
+The runnable verifier is an acceptance filter, not just a diagnostic report. It
+requires:
+
+- finite real coordinates with shape `(n, 2)` and `n >= 5`;
+- exactly `n` witness rows;
+- each witness row to be a 4-element subset of `V \ {i}`;
+- normalized coordinates before applying absolute spread tolerances;
+- both absolute and relative selected-distance spreads below tolerance;
+- convexity checked by every oriented edge against every non-edge vertex;
+- minimum pair distance and convexity margin above the configured margin.
+
 ## Certified Counterexample Requirements
 
 A certified counterexample must include:

--- a/scripts/check_text_clean.py
+++ b/scripts/check_text_clean.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 TEXT_SUFFIXES = {
     ".cff",
     ".json",
@@ -15,6 +17,19 @@ TEXT_SUFFIXES = {
     ".txt",
     ".yaml",
     ".yml",
+}
+
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "venv",
 }
 
 HIDDEN_CHARS = {
@@ -36,14 +51,37 @@ HIDDEN_CHARS = {
 
 
 def tracked_files() -> list[Path]:
-    result = subprocess.run(
-        ["git", "ls-files"],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-        encoding="utf-8",
-    )
-    return [Path(line) for line in result.stdout.splitlines()]
+    def filesystem_files() -> list[Path]:
+        return [
+            path
+            for path in sorted(REPO_ROOT.rglob("*"))
+            if path.is_file() and not any(part in SKIP_DIRS for part in path.relative_to(REPO_ROOT).parts)
+        ]
+
+    try:
+        root_result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+        if Path(root_result.stdout.strip()).resolve() != REPO_ROOT.resolve():
+            return filesystem_files()
+        result = subprocess.run(
+            ["git", "ls-files"],
+            check=True,
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return filesystem_files()
+    return [REPO_ROOT / line for line in result.stdout.splitlines()]
 
 
 def is_text_target(path: Path) -> bool:
@@ -57,25 +95,33 @@ def line_col(text: str, index: int) -> tuple[int, int]:
     return line, col
 
 
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def main() -> int:
     errors: list[str] = []
     for path in tracked_files():
         if not is_text_target(path):
             continue
         data = path.read_bytes()
+        shown = display_path(path)
         if b"\r" in data:
-            errors.append(f"{path}: contains CR or CRLF line endings")
+            errors.append(f"{shown}: contains CR or CRLF line endings")
         try:
             text = data.decode("utf-8")
         except UnicodeDecodeError as exc:
-            errors.append(f"{path}: not valid UTF-8: {exc}")
+            errors.append(f"{shown}: not valid UTF-8: {exc}")
             continue
         for index, char in enumerate(text):
             if char in HIDDEN_CHARS:
                 line, col = line_col(text, index)
                 codepoint = f"U+{ord(char):04X}"
                 errors.append(
-                    f"{path}:{line}:{col}: hidden character {codepoint} "
+                    f"{shown}:{line}:{col}: hidden character {codepoint} "
                     f"({HIDDEN_CHARS[char]})"
                 )
     if errors:

--- a/scripts/list_patterns.py
+++ b/scripts/list_patterns.py
@@ -2,6 +2,11 @@
 """List built-in incidence patterns and basic obstruction statistics."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from erdos97.search import built_in_patterns, incidence_obstruction_stats
 
 

--- a/scripts/verify_candidate.py
+++ b/scripts/verify_candidate.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from erdos97.search import verify_json
 
 
@@ -11,8 +16,9 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("json_path")
     ap.add_argument("--tol", type=float, default=1e-8)
+    ap.add_argument("--min-margin", type=float, default=1e-8)
     args = ap.parse_args()
-    print(json.dumps(verify_json(args.json_path, tol=args.tol), indent=2))
+    print(json.dumps(verify_json(args.json_path, tol=args.tol, min_margin=args.min_margin), indent=2))
 
 
 if __name__ == "__main__":

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -26,14 +26,13 @@ import dataclasses
 import itertools
 import json
 import math
-import os
 import random
 import time
-from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.optimize import least_squares, differential_evolution, basinhopping, minimize
+from scipy.optimize import least_squares, differential_evolution
 
 Array = NDArray[np.float64]
 Pattern = List[List[int]]
@@ -57,8 +56,6 @@ class LossWeights:
     pair: float = 1.0
     concyclic_avoid: float = 0.0
     angle_gap: float = 0.0
-    centroid: float = 0.0
-    scale: float = 0.0
 
 
 @dataclasses.dataclass
@@ -134,28 +131,43 @@ def random_pattern(n: int, rng: random.Random, max_pair_common: int = 2, balance
 
     If balanced=True, keep indegrees near 4 using a soft greedy objective.
     """
-    S: Pattern = [[] for _ in range(n)]
-    indeg = [0] * n
-    for i in range(n):
-        candidates = [j for j in range(n) if j != i]
-        ok_sets = []
-        for comb in itertools.combinations(candidates, 4):
-            ss = set(comb)
-            if all(len(ss.intersection(S[a])) <= max_pair_common for a in range(i)):
-                score = sum((indeg[j] + 1 - 4) ** 2 - (indeg[j] - 4) ** 2 for j in comb) if balanced else 0
-                # discourage four clustered choices on one side in cyclic order
-                gaps = cyclic_gaps(sorted(comb), n)
-                cluster_penalty = max(gaps)  # if max gap huge, selected points are clustered
-                ok_sets.append((score + 0.02 * cluster_penalty + rng.random() * 1e-3, list(comb)))
-        if not ok_sets:
-            raise RuntimeError("random_pattern failed; try larger n or max_pair_common")
-        ok_sets.sort(key=lambda t: t[0])
-        # pick from a small elite set for diversity
-        chosen = rng.choice(ok_sets[: min(50, len(ok_sets))])[1]
-        S[i] = sorted(chosen)
-        for j in chosen:
-            indeg[j] += 1
-    return PatternInfo(name=name, n=n, S=S, family="random-greedy", formula="greedy random 4-out, pairwise common-neighbor cap")
+    if max_tries <= 0:
+        raise ValueError(f"max_tries must be positive, got {max_tries}")
+
+    for _ in range(max_tries):
+        S: Pattern = [[] for _ in range(n)]
+        indeg = [0] * n
+        failed = False
+        for i in range(n):
+            candidates = [j for j in range(n) if j != i]
+            ok_sets = []
+            for comb in itertools.combinations(candidates, 4):
+                ss = set(comb)
+                if all(len(ss.intersection(S[a])) <= max_pair_common for a in range(i)):
+                    score = sum((indeg[j] + 1 - 4) ** 2 - (indeg[j] - 4) ** 2 for j in comb) if balanced else 0
+                    # Discourage four clustered choices on one side in cyclic order.
+                    gaps = cyclic_gaps(sorted(comb), n)
+                    cluster_penalty = max(gaps)  # if max gap huge, selected points are clustered
+                    ok_sets.append((score + 0.02 * cluster_penalty + rng.random() * 1e-3, list(comb)))
+            if not ok_sets:
+                failed = True
+                break
+            ok_sets.sort(key=lambda t: t[0])
+            # Pick from a small elite set for diversity.
+            chosen = rng.choice(ok_sets[: min(50, len(ok_sets))])[1]
+            S[i] = sorted(chosen)
+            for j in chosen:
+                indeg[j] += 1
+        if not failed:
+            return PatternInfo(
+                name=name,
+                n=n,
+                S=S,
+                family="random-greedy",
+                formula="greedy random 4-out, pairwise common-neighbor cap",
+            )
+
+    raise RuntimeError(f"random_pattern failed after {max_tries} attempts; try larger n or max_pair_common")
 
 
 def cyclic_gaps(vals: Sequence[int], n: int) -> List[int]:
@@ -244,9 +256,29 @@ def pairwise_sqdist(P: Array) -> Array:
 
 
 def convexity_margin(P: Array) -> float:
-    if polygon_area2(P) < 0:
-        P = P[::-1]
-    return float(np.min(orient_margins(P)))
+    """Return the strict convexity margin for the supplied cyclic order.
+
+    The margin is the minimum signed area over every directed boundary edge and
+    every non-incident vertex. Positive margin means every other vertex lies
+    strictly to the same side of each oriented edge.
+    """
+    Q = np.asarray(P, dtype=float)
+    n = len(Q)
+    if n < 3:
+        return float("-inf")
+    if polygon_area2(Q) < 0:
+        Q = Q[::-1]
+    margins: List[float] = []
+    for i in range(n):
+        a = Q[i]
+        b = Q[(i + 1) % n]
+        edge = b - a
+        for j in range(n):
+            if j == i or j == (i + 1) % n:
+                continue
+            v = Q[j] - a
+            margins.append(float(edge[0] * v[1] - edge[1] * v[0]))
+    return min(margins) if margins else float("-inf")
 
 
 def min_edge_length(P: Array) -> float:
@@ -256,8 +288,43 @@ def min_edge_length(P: Array) -> float:
 def min_pair_distance(P: Array) -> float:
     D = pairwise_distances(P)
     n = len(P)
-    D[D == 0] = np.inf
-    return float(np.min(D))
+    if n < 2:
+        return float("inf")
+    iu = np.triu_indices(n, 1)
+    return float(np.min(D[iu]))
+
+
+def validate_candidate_shape(P: Array, S: Pattern) -> List[str]:
+    """Validate the structural contract for a numerical k=4 candidate."""
+    errors: List[str] = []
+
+    if P.ndim != 2 or P.shape[1] != 2:
+        errors.append(f"coordinates must have shape (n, 2), got {P.shape}")
+        return errors
+
+    if not np.all(np.isfinite(P)):
+        errors.append("coordinates contain NaN or infinite values")
+
+    n = int(P.shape[0])
+    if n < 5:
+        errors.append(f"n must be at least 5, got {n}")
+
+    if len(S) != n:
+        errors.append(f"expected {n} witness rows, got {len(S)}")
+        return errors
+
+    for i, row in enumerate(S):
+        if len(row) != 4:
+            errors.append(f"row {i} has length {len(row)}, expected 4")
+        if len(set(row)) != len(row):
+            errors.append(f"row {i} contains duplicate targets: {row}")
+        if i in row:
+            errors.append(f"row {i} contains its own center")
+        bad = [j for j in row if j < 0 or j >= n]
+        if bad:
+            errors.append(f"row {i} contains out-of-range targets: {bad}")
+
+    return errors
 
 
 def independent_diagnostics(P: Array, S: Pattern) -> Dict[str, object]:
@@ -380,11 +447,7 @@ def polygon_from_support_x(x: Array, n: int) -> Array:
         A = np.vstack([U[k], U[(k + 1) % n]])
         b = np.array([h[k], h[(k + 1) % n]])
         P[k] = np.linalg.solve(A, b)
-    # The vertex order from consecutive outward normals may be clockwise; normalize then flip if needed.
-    P = normalize_points(P)
-    if polygon_area2(P) < 0:
-        P = P[::-1]
-    return P
+    return normalize_points(P)
 
 
 def init_support_x(n: int, rng: np.random.Generator, jitter: float = 0.15) -> Array:
@@ -553,12 +616,38 @@ def load_json_result(path: str) -> Tuple[Array, Pattern]:
     return P, S
 
 
-def verify_json(path: str, tol: float = 1e-8) -> Dict[str, object]:
-    P, S = load_json_result(path)
+def verify_json(path: str, tol: float = 1e-8, min_margin: float = 1e-8) -> Dict[str, object]:
+    P_raw, S = load_json_result(path)
+    validation_errors = validate_candidate_shape(P_raw, S)
+
+    if validation_errors:
+        return {
+            "ok_at_tol": False,
+            "tol": tol,
+            "min_margin": min_margin,
+            "validation_errors": validation_errors,
+            "empirical_E_values": [],
+        }
+
+    # Distance equalities are scale invariant; normalize before applying any
+    # absolute spread tolerance so tiny malformed inputs cannot pass.
+    P = normalize_points(P_raw)
     diag = independent_diagnostics(P, S)
     E = empirical_E_values(P, tol=tol)
-    ok = bool(diag["max_spread"] <= tol and diag["convexity_margin"] > 0 and diag["min_pair_distance"] > 0)
-    return {"ok_at_tol": ok, "tol": tol, "empirical_E_values": E, **diag}
+    ok = bool(
+        diag["max_spread"] <= tol
+        and diag["max_rel_spread"] <= tol
+        and diag["convexity_margin"] > min_margin
+        and diag["min_pair_distance"] > min_margin
+    )
+    return {
+        "ok_at_tol": ok,
+        "tol": tol,
+        "min_margin": min_margin,
+        "validation_errors": validation_errors,
+        "empirical_E_values": E,
+        **diag,
+    }
 
 
 # ------------------------- finite/SAT-style abstraction ----------------------
@@ -679,6 +768,7 @@ def main() -> None:
     ap.add_argument("--verbose", action="store_true")
     ap.add_argument("--verify", default="")
     ap.add_argument("--tol", type=float, default=1e-8)
+    ap.add_argument("--min-margin", type=float, default=1e-8)
     args = ap.parse_args()
 
     pats = built_in_patterns()
@@ -690,7 +780,7 @@ def main() -> None:
         return
 
     if args.verify:
-        diag = verify_json(args.verify, tol=args.tol)
+        diag = verify_json(args.verify, tol=args.tol, min_margin=args.min_margin)
         print(json.dumps(diag, indent=2))
         return
 

--- a/tests/test_incidence.py
+++ b/tests/test_incidence.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
 
+import json
+import math
 import pathlib
 
-from erdos97.search import built_in_patterns, incidence_obstruction_stats, verify_json
+import numpy as np
+
+from erdos97.search import (
+    built_in_patterns,
+    convexity_margin,
+    incidence_obstruction_stats,
+    min_pair_distance,
+    verify_json,
+)
+
+
+def regular_ngon(n: int, scale: float = 1.0) -> list[list[float]]:
+    return [
+        [scale * math.cos(2.0 * math.pi * i / n), scale * math.sin(2.0 * math.pi * i / n)]
+        for i in range(n)
+    ]
+
+
+def write_candidate(path: pathlib.Path, coordinates: list[list[float]], S: list[list[int]]) -> None:
+    path.write_text(json.dumps({"coordinates": coordinates, "S": S}), encoding="utf-8")
 
 
 def test_built_in_patterns_have_outdegree_four_and_no_loops() -> None:
@@ -38,3 +59,39 @@ def test_archive_c12_imports_are_not_certified_at_synthesis_tolerance() -> None:
     for path in paths:
         diag = verify_json(str(path), tol=1e-6)
         assert not diag["ok_at_tol"]
+
+
+def test_verify_json_rejects_duplicate_self_witness_rows(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "bad_self_witness.json"
+    write_candidate(path, regular_ngon(5), [[i, i, i, i] for i in range(5)])
+
+    diag = verify_json(str(path), tol=1e-8)
+
+    assert not diag["ok_at_tol"]
+    assert any("duplicate targets" in err for err in diag["validation_errors"])
+    assert any("own center" in err for err in diag["validation_errors"])
+
+
+def test_verify_json_normalizes_before_acceptance(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "tiny_regular_pentagon.json"
+    witnesses = [[j for j in range(5) if j != i] for i in range(5)]
+    write_candidate(path, regular_ngon(5, scale=1e-12), witnesses)
+
+    diag = verify_json(str(path), tol=1e-8)
+
+    assert not diag["ok_at_tol"]
+    assert diag["validation_errors"] == []
+    assert diag["max_spread"] > 1.0
+
+
+def test_min_pair_distance_detects_duplicate_points() -> None:
+    P = np.array([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+
+    assert min_pair_distance(P) == 0.0
+
+
+def test_convexity_margin_checks_edges_against_all_vertices() -> None:
+    pentagon = np.array(regular_ngon(5), dtype=float)
+    star_order = pentagon[[0, 2, 4, 1, 3]]
+
+    assert convexity_margin(star_order) < 0.0


### PR DESCRIPTION
## Summary

Harden the numerical candidate verifier so malformed or scale-collapsed objects cannot be accidentally accepted as Erdős #97 candidates.

## What changed

- Validate candidate shape inside `verify_json()`: finite `(n, 2)` coordinates, `n >= 5`, exactly `n` witness rows, and each `S_i` is a 4-element subset of `V \ {i}`.
- Normalize coordinates before absolute spread checks and require both absolute and relative selected-distance spread tolerances.
- Strengthen convexity diagnostics to check every oriented edge against every non-edge vertex.
- Fix duplicate-point handling in `min_pair_distance()`.
- Add verifier regression tests for duplicate/self witness rows, scale collapse, duplicate points, and non-boundary cyclic order.
- Make text-clean checking work from source archives without `.git`, expose `--min-margin`, and run CI across Python 3.10, 3.11, and 3.12.

## Validation

- `python -m pytest -q` -> 13 passed
- `python scripts/check_text_clean.py` -> tracked text files are clean
- `python scripts/list_patterns.py` -> built-in pattern listing succeeds
- `python scripts/verify_candidate.py data/runs/best_B12_slsqp_m1e-6.json --tol 1e-6 --min-margin 1e-8` -> saved B12 near-miss remains rejected

## Review note

This PR intentionally leaves the existing untracked archive zip out of scope.