### PR TITLE
[codex] align erdos97 status metadata

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,5 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -e .[dev]
       - run: python scripts/check_text_clean.py
+      - run: python scripts/check_status_consistency.py
       - run: pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Repository role
+
+This repository is a public research log and reproducibility workspace for
+Erdos Problem #97. It is not a solved-proof repository.
+
+## Non-overclaiming rules
+
+- Always preserve: no general proof and no counterexample are claimed.
+- The official/global status is falsifiable/open unless manually rechecked and
+  updated from the official page.
+- The local `n <= 8` result is repo-local and machine-checked; public
+  theorem-style claims require independent review.
+- Numerical near-misses are not counterexamples.
+- Exact coordinates, algebraic certificates, interval certificates, SMT
+  certificates, or formal proofs are required for exact claims.
+
+## Source-of-truth discipline
+
+- Keep `metadata/erdos97.yaml` aligned with `README.md`, `STATE.md`, and
+  `RESULTS.md`.
+- Do not edit generated artifacts if a generator exists.
+- Keep archived/provenance statements clearly marked when superseded.
+
+## Test commands
+
+Run these after documentation or code changes:
+
+```bash
+python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
+pytest -q
+```
+
+For finite-case artifacts, also run:
+
+```bash
+python scripts/enumerate_n8_incidence.py --summary
+python scripts/analyze_n8_exact_survivors.py --check --json
+```
+
+## Research hygiene
+
+- Separate exact proofs from heuristics and numerical evidence.
+- Label claims using the repo trust taxonomy.
+- Prefer small reproducible JSON artifacts over screenshots or prose-only
+  claims.
+- Record failed approaches clearly enough that future work avoids repeating
+  them.
+- Do not prepare OEIS submissions from AI-generated output.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the long-form canonical synthesis and claim reconciliation, read
   [`docs/canonical-synthesis.md`](docs/canonical-synthesis.md) before adding
   new claims, search branches, or proof attempts.
+- For upstream alignment with `teorth/erdosproblems`, read
+  [`docs/upstream-alignment.md`](docs/upstream-alignment.md).
+- For independent audit instructions, read
+  [`docs/reviewer-guide.md`](docs/reviewer-guide.md).
+- For canonical status metadata, see
+  [`metadata/erdos97.yaml`](metadata/erdos97.yaml).
 - For documentation navigation, read [`docs/index.md`](docs/index.md).
 - For the compact results ledger, read [`RESULTS.md`](RESULTS.md).
 - For proved local facts, read [`docs/claims.md`](docs/claims.md).
@@ -26,6 +32,10 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For archive synthesis provenance, read [`inventory.json`](inventory.json),
   [`kernels.json`](kernels.json), [`contradictions.md`](contradictions.md),
   and [`dropped_kernels.md`](dropped_kernels.md).
+- For formalization alignment, read [`docs/formalization.md`](docs/formalization.md).
+- For possible OEIS connections, read
+  [`docs/oeis-possibilities.md`](docs/oeis-possibilities.md).
+- For repository-level Codex guidance, read [`AGENTS.md`](AGENTS.md).
 - For runnable verification, start with [`scripts/verify_candidate.py`](scripts/verify_candidate.py).
 - For current work items, see [Issues #1-#7](https://github.com/davidiach/erdos97/issues).
 
@@ -161,6 +171,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e .[dev]
 python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
 pytest -q
 python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
@@ -214,6 +225,7 @@ If you use this repository, please cite it using [`CITATION.cff`](CITATION.cff).
 
 - Run `pytest -q`.
 - Run `python scripts/check_text_clean.py`.
+- Run `python scripts/check_status_consistency.py`.
 - Confirm this README still says no general proof and no counterexample are claimed.
 - Create labels matching `.github/labels.yml`.
 - Open the seed issues listed in `docs/initial-issues.md`.

--- a/STATE.md
+++ b/STATE.md
@@ -7,6 +7,10 @@ claim taxonomy, failed-route reconciliation, and source/hash inventory, read
 `docs/canonical-synthesis.md` before adding new claims, search branches, or
 proof attempts.
 
+Canonical status metadata is recorded in `metadata/erdos97.yaml`. It separates
+the official/global falsifiable-open status from this repo's local finite-case
+artifacts.
+
 ## Target
 
 Find, or rule out, a strictly convex polygon with vertices

--- a/docs/canonical-synthesis.md
+++ b/docs/canonical-synthesis.md
@@ -32,11 +32,11 @@ Relative to `erdos97_four_stage_consolidation.md`:
 
 **Status: OPEN.** Listed open on erdosproblems.com/97 (last edited 2025-10-27); \$100 prize.
 
-| $n$ | Status | Method |
+| `n` | Current repo-local status | Method |
 |---|---|---|
-| $5, 6, 7$ | **Proved.** No 4-bad polygon exists. | §3 — selected-witness incidence + L5 (n=5,6); parity of permutation on 21 chords (n=7). |
-| $8$ | **Open.** | §4 — orthocenter obstruction settles only the cube witness pattern. |
-| $\ge 9$ | Open. | — |
+| `5, 6, 7` | Proved locally; no selected-witness counterexample. | Incidence counting and `n=7` Fano/parity obstruction. |
+| `8` | Ruled out in repo-local, machine-checked finite-case sense; external review recommended. | Incidence-completeness enumeration to 15 canonical classes plus exact survivor obstruction. |
+| `>= 9` | Open. | No general proof or counterexample claimed. |
 
 **Background.** The $k=3$ analogue is **false**: Danzer (1963) constructed a convex 9-gon with $E(i) = 3$ everywhere; Fishburn–Reeds (1992) did the same with a uniform radius. So $k = 4$ is the boundary case Erdős conjectured.
 
@@ -52,7 +52,7 @@ Relative to `erdos97_four_stage_consolidation.md`:
 
 **Single highest-leverage open task:** **Bridge Lemma A′** — if every realizable counterexample admits an ear-orderable witness selection, #97 falls to the rigidity argument that's already proved (mod the gauge-fixing repair).
 
-**Single highest-leverage *concrete* next task:** rigorously close $n = 8$ by enumerating the finitely many witness patterns and applying L5/L6/orthocenter case-by-case (§9.2).
+**Single highest-leverage *concrete* next task:** independently audit the `n=8` incidence-completeness checker and exact obstruction certificates, then push the finite pipeline toward `n = 9`.
 
 ---
 
@@ -190,9 +190,13 @@ The Step 1 conclusion "every $d_a = 4$" is a Jensen-saturation phenomenon: $7 \b
 
 ---
 
-## §4. $n = 8$: open, with partial obstructions
+## §4. Archived pre-`n=8` state with partial obstructions
 
-Three legacy source files (`erdos_97_complete_notes.md`, `erdos_97_analysis.md`, `erdos_97_summary.md`) claim $n = 8$ is settled. The careful review files catch specific gaps in each. **Resolution: $n = 8$ is open.**
+This section records the pre-`n=8` snapshot retained for provenance. It is
+superseded by the current finite-case artifacts in `RESULTS.md`,
+`docs/n8-incidence-enumeration.md`, and `docs/n8-exact-survivors.md`.
+
+Three legacy source files (`erdos_97_complete_notes.md`, `erdos_97_analysis.md`, `erdos_97_summary.md`) claim $n = 8$ is settled. The careful review files catch specific gaps in each. In this archived snapshot, the resolution was to keep $n = 8$ open.
 
 ### §4.1 The orthocenter obstruction (real but partial)
 
@@ -218,7 +222,9 @@ Sources disagree on whether the obstruction is "rank $= 2n-3$" or "rank $\le 2n-
 
 ### §4.6 Resolution
 
-$n = 8$ is **open**. The cube *witness pattern* is provably unrealizable; that is a useful conditional obstruction, not a complete proof.
+At the time of this archived snapshot, $n = 8$ was treated as **open**. The
+cube *witness pattern* was provably unrealizable, but that was only a useful
+conditional obstruction, not a complete proof.
 
 ---
 
@@ -902,7 +908,7 @@ def constraints(p, triples):
 | Rank | Task | Why | Tractability |
 |---|---|---|---|
 | 1 | **Bridge Lemma A′** at $n = 8, 9, 10$ (computational) | Settles whether the ear-elimination program (§5.2) terminates. Same recipe as §8.6: enumerate 4-regular witness patterns satisfying L5 ∧ L6, check ear-orderability, run least-squares geometric realizability. Cost: a few CPU-days per $n$. If the Bridge Lemma fails at any $n$, the §5.2 program is dead. | High — finite cases. |
-| 2 | **Rigorously close $n = 8$** | Removes the largest disputed claim. Concrete program: enumerate all 4-regular witness systems on 8 vertices satisfying L5 ∧ L6; use the involution structure $\phi(\{i, j\}) = W_i \cap W_j$ on intersection-2 pairs; for each system derive the perpendicularity constraints and check whether any 4-tuple forms an orthocentric system. Combined with convexity, finite case analysis. SAT/SMT formulation should make this a few-hour computer-assisted proof. | Medium-high. |
+| 2 | **Independently audit the `n=8` finite artifacts** | The current repo-local claim rests on the incidence-completeness checker, the 15 survivor classes, and exact obstruction certificates. Independent reproduction and alternative certificate checkers would make the result safer to cite. | Medium-high. |
 | 3 | **Endpoint Control Auxiliary Claim** (§5.1) | The Lemma 12 program is otherwise complete. Open sub-questions are concrete: asymmetric vs symmetric statement, dependence of $m$ on $n$ ($m \le O(\sqrt n)$ would help), boundary-chain structure. | Medium. |
 | 4 | **Three-Cap Bridge Lemma** (§5.4) | Diameter case is done; this is the remaining geometric case. Possibly tractable using cyclic-order arguments inside the opposite cap alone. | Medium. |
 | 5 | **Canonical-chord injectivity** (§5.3) | Cleanest reduction; conjecture is sharp. For each bad $i$: take the smallest $r_i$ with $|S_i(r_i)| \ge 4$, then the closest pair in $S_i(r_i)$. Conjecturally injective; no obvious counterexample. | Lower (combinatorial geometry, hard). |
@@ -920,7 +926,7 @@ What the prior synthesis documents disagreed about, and what this document adopt
 
 | Disagreement | Source disagreement | Resolution adopted |
 |---|---|---|
-| $n = 8$ status | `erdos_97_complete_notes.md` & `erdos_97_analysis.md` claim "proved"; `erdos97_conversation_useful_notes (1).md` & `erdos97_review_notes.md` flag gaps | **Open.** The orthocenter obstruction handles only the cube witness pattern; uniqueness-of-cube is unjustified. (§4.1, §4.6) |
+| $n = 8$ status | `erdos_97_complete_notes.md` & `erdos_97_analysis.md` claim "proved"; `erdos97_conversation_useful_notes (1).md` & `erdos97_review_notes.md` flag gaps | Archived synthesis resolution: **Open.** This is superseded by the current `n=8` incidence-completeness and exact-obstruction artifacts. (§4.1, §4.6; current status in `RESULTS.md`) |
 | $n = 7$ "weak" vs "strong" definition | `vertex_equidistance_complete_analysis.md` §2 explicit; some notes use weak definition silently | **Strong (cocircular) definition only.** The parity proof and $K_4$ proof both require it. (§1.2, §3.3) |
 | "$n \le 12$ proven by counting" | `erdos_97_summary.md` "Lemma 6" arithmetic | **Wrong by a factor of 2.** Correct bound is $n \ge 7$. (§4.3) |
 | Forced double regularity | Multiple files implicitly assume this; one source's Cauchy–Schwarz argument is circular | **Available only at $n = 7$.** Not generally usable. (§3.4, §6.4) |
@@ -969,7 +975,9 @@ The full classification is preserved in `useful_research_findings/generated_summ
 
 **Problem.** Strictly convex polygon, every vertex has $\ge 4$ other vertices on some circle around it — does this exist?
 
-**Status.** Open. Proved impossible for $n \in \{5, 6, 7\}$.
+**Status.** Official/global status is open. Repo-local finite-case artifacts rule
+out selected-witness counterexamples for `n <= 8`, with independent review
+recommended before public theorem-style claims.
 
 **Three workhorse lemmas.**
 - **L5:** $|W_i \cap W_j| \le 2$ (two-circle bound).
@@ -984,8 +992,8 @@ The full classification is preserved in `useful_research_findings/generated_summ
 5. Distance-bound — both subcases open. Uniform-radius needs Erdős–Fishburn ($< 2n$, open since 1992); variable-radius is the actual problem at $n \ge 8$.
 
 **Highest-leverage next moves.**
-- (computational) Bridge Lemma at $n = 8, 9, 10$.
-- (analytic) Rigorously close $n = 8$.
+- Independently audit the `n=8` incidence and exact-obstruction artifacts.
+- Push the finite incidence/exact pipeline toward `n = 9`.
 
 **Hard rules for any new attempt.**
 - Strong (cocircular) witness definition only.

--- a/docs/canonical-synthesis.md
+++ b/docs/canonical-synthesis.md
@@ -30,7 +30,12 @@ Relative to `erdos97_four_stage_consolidation.md`:
 
 **Problem (Erdős #97).** For a strictly convex polygon with vertex set $V \subset \mathbb{R}^2$, define $E(i) = \max_{r > 0} \#\{j \ne i : \|p_i - p_j\| = r\}$. Does every strictly convex polygon have some vertex with $E(i) \le 3$?
 
-**Status: OPEN.** Listed open on erdosproblems.com/97 (last edited 2025-10-27); \$100 prize.
+**Official/global status: FALSIFIABLE/OPEN.** Listed open on
+erdosproblems.com/97 (last edited 2025-10-27); \$100 prize.
+
+**Local repo status:** no general proof and no counterexample are claimed.
+The strongest local result is the selected-witness finite-case obstruction
+through `n <= 8`, in the repo-local machine-checked sense.
 
 | `n` | Current repo-local status | Method |
 |---|---|---|

--- a/docs/formalization.md
+++ b/docs/formalization.md
@@ -1,0 +1,43 @@
+# Formalization alignment
+
+## Existing formal statement
+
+The Formal Conjectures repository contains
+`FormalConjectures/ErdosProblems/97.lean`. It defines
+`HasNEquidistantProperty 4` and states the open theorem using `ConvexIndep A`.
+
+## Local mathematical convention
+
+This repository often uses the language of a strictly convex polygon with
+cyclically ordered vertices. When comparing with Lean, clarify the relationship
+between:
+
+- strict convex polygon / cyclic order;
+- finite point set in convex independent position;
+- `ConvexIndep A`;
+- selected-witness 4-sets `S_i`.
+
+## Near-term formalization targets
+
+Do not start by formalizing the entire open problem. Start with local finite
+and geometric lemmas:
+
+1. Two-circle intersection cap: if two distinct circles share at least three
+   points, contradiction.
+2. Pair-sharing cap: for distinct centers `a,b`, `|S_a cap S_b| <= 2`.
+3. Incidence count ruling out `n <= 6`.
+4. `n=7` Fano/parity obstruction, if feasible.
+5. Certificate checker for `n=8` survivor obstruction.
+
+## Longer-term targets
+
+- A Lean-readable certificate format for finite incidence patterns.
+- A verified checker for perpendicularity/equal-distance obstruction steps.
+- A bridge from local selected-witness artifacts to the Lean
+  `HasNEquidistantProperty 4` statement.
+
+## Non-goals
+
+- Do not claim a Lean proof of #97.
+- Do not mark the problem solved because the statement is formalized.
+- Do not merge informal numerical evidence into formal theorem claims.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,12 @@ put detailed reconciliation in the canonical synthesis.
 ## Core state
 
 - [`../STATE.md`](../STATE.md): short working dashboard.
+- [`../metadata/erdos97.yaml`](../metadata/erdos97.yaml): canonical status
+  metadata separating official/global status from local repo claims.
+- [`upstream-alignment.md`](upstream-alignment.md): alignment notes for
+  `teorth/erdosproblems` and the official problem page.
+- [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case
+  artifacts and exact certificates.
 - [`canonical-synthesis.md`](canonical-synthesis.md): long-form canonical
   synthesis, claim taxonomy, failed-route reconciliation, and source/hash
   inventory.
@@ -35,6 +41,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`exactification-plan.md`](exactification-plan.md): route from numerical
   artifacts to exact or certified verification.
 - [`sat-smt-plan.md`](sat-smt-plan.md): finite abstraction and solver plan.
+- [`formalization.md`](formalization.md): Lean/formalization alignment and
+  near-term formal targets.
+- [`oeis-possibilities.md`](oeis-possibilities.md): exploratory OEIS sequence
+  ideas and submission policy.
 - [`../data/runs/README.md`](../data/runs/README.md): numerical artifact
   conventions.
 
@@ -44,3 +54,4 @@ put detailed reconciliation in the canonical synthesis.
   unit-distance caveats.
 - [`repo-roadmap.md`](repo-roadmap.md): staged repository plan.
 - [`initial-issues.md`](initial-issues.md): seed issue list.
+- [`../AGENTS.md`](../AGENTS.md): repository-level Codex guidance.

--- a/docs/oeis-possibilities.md
+++ b/docs/oeis-possibilities.md
@@ -1,0 +1,33 @@
+# Possible OEIS connections for Erdos Problem #97
+
+Tao's `erdosproblems` database is especially interested in meaningful OEIS
+links. This repo currently has sequence-like finite-search data, but no OEIS
+submission should be made from AI-generated or insufficiently verified data.
+
+## Candidate sequence families
+
+Potential finite-search sequences:
+
+```text
+a(n) = number of selected-witness incidence matrices satisfying the necessary pair-cap constraints, up to relabeling.
+b(n) = number of incidence survivors after forced-perpendicularity filters.
+c(n) = number of canonical survivor classes after cyclic-dihedral or simultaneous relabeling.
+d(n) = number of survivor classes not killed by exact algebraic obstruction.
+```
+
+Known local values should only be added when they are reproducible by checked
+scripts.
+
+## Submission policy
+
+- Do not submit AI-generated sequences to OEIS.
+- Do not submit sequences with too few verified values.
+- Do not submit sequences whose mathematical definition is unstable or
+  repo-internal only.
+- Prefer opening an issue or adding a problem-page comment before proposing an
+  upstream OEIS link.
+
+## Immediate action
+
+Record candidate definitions and known reproducible values. Treat this as
+exploratory until enough independently verified terms exist.

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -1,0 +1,81 @@
+# Reviewer guide for Erdos Problem #97 finite-case artifacts
+
+## What this repo claims
+
+- No general proof and no counterexample are claimed.
+- The selected-witness method rules out `n <= 8` in a repo-local,
+  machine-checked finite-case sense.
+
+## What this repo does not claim
+
+- It does not claim to solve Erdos Problem #97.
+- It does not claim that numerical near-misses are counterexamples.
+- It does not claim the `n=8` artifact has had independent external review.
+
+## Minimal reproduction commands
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
+pytest -q
+python scripts/enumerate_n8_incidence.py --summary
+python scripts/analyze_n8_exact_survivors.py --check --json
+```
+
+## Files to inspect first
+
+1. `STATE.md`
+2. `RESULTS.md`
+3. `docs/n7-fano-enumeration.md`
+4. `docs/n8-incidence-enumeration.md`
+5. `docs/n8-exact-survivors.md`
+6. `docs/verification-contract.md`
+
+## Review target A - `n=7`
+
+Check:
+
+- the Fano/equality reduction;
+- the enumeration of labelled/pointed families;
+- the cyclic-dihedral reduction;
+- the odd-cycle perpendicularity obstruction.
+
+## Review target B - `n=8` incidence completeness
+
+Check:
+
+- derivation of indegree regularity from the column-pair cap;
+- exhaustive enumeration assumptions;
+- canonicalization under relabeling;
+- reproducibility of the 15 survivor classes.
+
+## Review target C - `n=8` exact survivor obstruction
+
+Check:
+
+- the class killed by cyclic-order noncrossing;
+- the classes killed by perpendicular-bisector algebra;
+- the classes requiring full equal-distance algebra;
+- the strict-convexity obstruction cases;
+- the archived-ID provenance mapping.
+
+## Known weak points / independent review requests
+
+- Independent audit of `scripts/enumerate_n8_incidence.py`.
+- Independent audit of exact certificates, especially classes `3`, `4`, and
+  `14` if those remain singled out in `RESULTS.md`.
+- Independent reproduction of `certificates/n8_exact_analysis.json`.
+- A Lean, SMT, interval, or algebraic certificate checker would be high value.
+
+## Reporting review findings
+
+Open an issue or PR that states:
+
+- which artifact was reviewed;
+- exact command run;
+- environment details;
+- whether the result reproduced;
+- any mathematical or implementation gap found.

--- a/docs/upstream-alignment.md
+++ b/docs/upstream-alignment.md
@@ -1,0 +1,57 @@
+# Upstream alignment with `teorth/erdosproblems`
+
+## Purpose
+
+This repository is a deep, single-problem reproducibility workspace for Erdos
+Problem #97. It is not a replacement for the public Erdos problem database.
+
+## Official/global status
+
+- Official page: <https://www.erdosproblems.com/97>
+- Status: falsifiable/open
+- Prize: $100
+- Tags: geometry, distances, convex
+- Formalised statement: yes
+
+## Local repository status
+
+- No general proof and no counterexample are claimed.
+- Strongest local result: selected-witness finite-case obstruction rules out
+  `n <= 8` in a repo-local, machine-checked sense.
+- External review is recommended before public theorem-style claims.
+
+## What should go upstream
+
+Appropriate upstream contributions:
+
+- corrections to metadata fields in `teorth/erdosproblems/data/problems.yaml`;
+- relevant OEIS links, once independently verified;
+- formalization status notes, if accepted by upstream conventions;
+- short comments or links when they add clear value.
+
+Usually not appropriate as an upstream PR:
+
+- long proof sketches;
+- raw search logs;
+- numerical near-misses;
+- claims that require substantial mathematical review.
+
+Mathematical discussion should normally go on the official #97 page or in a
+clearly scoped issue.
+
+## Conservative problem-page comment template
+
+> I have started a reproducibility workspace for Erdos Problem #97:
+> `https://github.com/davidiach/erdos97`.
+> It claims no general proof and no counterexample.
+> The current strongest artifact is a repo-local machine-checked finite-case
+> obstruction ruling out selected-witness counterexamples for `n <= 8`, with
+> exact obstruction scripts for the surviving `n=8` incidence classes.
+> Independent review is especially welcome for the `n=8`
+> incidence-completeness checker and exact certificates.
+
+## Do not overclaim
+
+Do not describe this repo as solving #97 unless a complete proof or
+counterexample has been independently checked and the official/global status is
+updated accordingly.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -1,0 +1,44 @@
+problem:
+  number: "97"
+  official_page: "https://www.erdosproblems.com/97"
+  official_statement: "Does every convex polygon have a vertex with no other 4 vertices equidistant from it?"
+  official_status: "falsifiable/open"
+  official_prize: "$100"
+  official_tags:
+    - geometry
+    - distances
+    - convex
+  official_page_last_edited: "2025-10-27"
+  official_status_last_checked: "2026-04-27"
+
+upstream_database:
+  repository: "https://github.com/teorth/erdosproblems"
+  source_of_truth: "data/problems.yaml"
+  contribution_guidance: "Use upstream PRs for metadata/database fields; use erdosproblems.com #97 for mathematical discussion."
+
+formalization:
+  repository: "https://github.com/google-deepmind/formal-conjectures"
+  path: "FormalConjectures/ErdosProblems/97.lean"
+  statement_formalized: true
+  proof_formalized: false
+  lean_status: "research open"
+  local_alignment_note: "Compare strict-convex-polygon language with ConvexIndep A in the Lean statement."
+
+local_repo:
+  repository: "https://github.com/davidiach/erdos97"
+  overall_claim: "No general proof and no counterexample are claimed."
+  strongest_result: "No selected-witness counterexample for n <= 8, in the repo-local machine-checked finite-case sense."
+  strongest_result_review_status: "External independent review recommended before public theorem-style claims."
+  best_numerical_object: "B12_3x4_danzer_lift near-miss; rejected as proof/counterexample."
+  main_entry_points:
+    - "STATE.md"
+    - "RESULTS.md"
+    - "docs/n8-incidence-enumeration.md"
+    - "docs/n8-exact-survivors.md"
+    - "docs/verification-contract.md"
+
+trust_policy:
+  no_overclaiming: true
+  numerical_evidence_is_not_proof: true
+  exact_certificates_required_for_counterexamples: true
+  independent_review_required_for_public_theorem_claims: true

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Check top-level status text for stale or overclaiming contradictions."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_NO_OVERCLAIM_FILES = ["README.md", "STATE.md", "RESULTS.md"]
+NO_OVERCLAIM_RE = re.compile(r"no\s+general proof and no counterexample", re.I)
+STALE_N8_RE = re.compile(r"(?:n\s*=\s*8|\$8\$|`8`)\s*\|\s*\*\*?Open", re.I)
+ARCHIVAL_MARKERS = ("archived", "superseded", "provenance")
+
+
+def fail(msg: str) -> None:
+    print(f"status consistency error: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_text(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def main() -> None:
+    if not (ROOT / "metadata" / "erdos97.yaml").exists():
+        fail("metadata/erdos97.yaml is missing")
+
+    for rel in REQUIRED_NO_OVERCLAIM_FILES:
+        if not NO_OVERCLAIM_RE.search(read_text(rel)):
+            fail(f"{rel} is missing the no-overclaiming status sentence")
+
+    synthesis = ROOT / "docs" / "canonical-synthesis.md"
+    if synthesis.exists():
+        lines = synthesis.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            if STALE_N8_RE.search(line):
+                window = "\n".join(lines[max(0, i - 8) : i + 1]).lower()
+                if not any(marker in window for marker in ARCHIVAL_MARKERS):
+                    fail(f"unarchived stale n=8 Open wording at {synthesis}:{i + 1}")
+
+    readme_state = read_text("README.md") + "\n" + read_text("STATE.md")
+    if "metadata/erdos97.yaml" not in readme_state:
+        fail("README.md or STATE.md should reference metadata/erdos97.yaml")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add canonical `metadata/erdos97.yaml` recording official/global status separately from local repo claims.
- Add upstream alignment, reviewer guide, formalization, OEIS, and AGENTS guidance docs.
- Add `scripts/check_status_consistency.py` and wire it into CI.
- Update navigation and stale `n=8` wording in the canonical synthesis while preserving archived provenance.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `git diff --check`

## Notes

No general proof or counterexample is claimed. Official/global status remains falsifiable/open. The local `n <= 8` selected-witness result remains framed as repo-local, machine-checked finite-case evidence requiring independent review before public theorem claims.