### PR TITLE
[codex] add mutual-rhombus incidence filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/n8-incidence-enumeration.md`](docs/n8-incidence-enumeration.md).
 - For the `n=8` exact survivor obstruction artifact, read
   [`docs/n8-exact-survivors.md`](docs/n8-exact-survivors.md).
+- For the crossing-bisector and mutual-rhombus fixed-pattern filters, read
+  [`docs/mutual-rhombus-filter.md`](docs/mutual-rhombus-filter.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).
 - For known bad proof routes, read [`docs/failed-ideas.md`](docs/failed-ideas.md).
 - For the verification standard, read [`docs/verification-contract.md`](docs/verification-contract.md).
@@ -78,9 +80,20 @@ strictly convex realization for those classes. See
 theorem claims should still get independent review of the computer-assisted
 artifacts.
 
-The current best numerical object is a near-miss for the pattern `B12_3x4_danzer_lift`. It has small residual but appears to degenerate toward three tight clusters near an equilateral triangle. It is therefore recorded as useful evidence about a failed route, **not** as a solution.
+The crossing-bisector and mutual-rhombus filters now exactly kill several
+previously live fixed selected-witness patterns, including
+`B12_3x4_danzer_lift`, `B20_4x5_FR_lift`, `C17_skew`, `C20_pm_4_9`,
+`C16_pm_1_6`, `C13_pm_3_5`, and `C9_pm_2_4`. These are fixed-pattern
+obstructions, not a general proof of the problem.
 
-The best saved B12 object is **not** a counterexample: its max selected-distance spread is about `0.0068`, and its convexity margin is about `1e-6`.
+The previous best numerical near-miss was `B12_3x4_danzer_lift`. It remains a
+useful degeneration diagnostic, but the fixed selected pattern is now exactly
+killed by the mutual-rhombus midpoint filter. The saved numerical artifact is
+still retained as provenance for the failed route, **not** as a solution.
+
+The best saved B12 object is **not** a counterexample: its max
+selected-distance spread is about `0.0068`, and its convexity margin is about
+`1e-6`.
 
 Any claimed counterexample needs exact coordinates, or an exact algebraic
 certificate, verifying the distance equalities and strict convexity.
@@ -94,7 +107,7 @@ max squared-distance spread: 0.006806368780585714
 RMS equality residual:       0.0019599509549614457
 convexity margin:            9.999999943508973e-07
 minimum edge length:         0.0007465865604262556
-status: numerical only, rejected as proof/counterexample
+status: numerical artifact only; fixed selected pattern exactly killed
 ```
 
 See [`STATE.md`](STATE.md) for the most compact working summary and
@@ -129,6 +142,7 @@ Use these labels consistently:
 ├── pyproject.toml
 ├── requirements.txt
 ├── src/erdos97/search.py              # main search/verification engine
+├── src/erdos97/incidence_filters.py   # exact incidence obstruction filters
 ├── src/erdos97/n7_fano.py             # exact n=7 Fano enumeration
 ├── scripts/                           # thin CLI helpers
 ├── tests/                             # smoke tests and incidence checks
@@ -141,6 +155,7 @@ Use these labels consistently:
 │   ├── exactification-plan.md         # numerical-to-exact certificate route
 │   ├── n8-incidence-enumeration.md    # n=8 incidence-completeness proof
 │   ├── n8-exact-survivors.md          # n=8 exact survivor obstructions
+│   ├── mutual-rhombus-filter.md       # exact fixed-pattern filters
 │   ├── sat-smt-plan.md                # finite abstraction plan
 │   ├── literature-risk.md             # what has/has not been checked
 │   └── verification-contract.md       # candidate acceptance requirements
@@ -166,6 +181,7 @@ python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
 erdos97-search --list-patterns
 erdos97-search --verify data/runs/best_B12_slsqp_m1e-6.json --tol 1e-6
+python scripts/check_mutual_rhombus_filter.py --assert-expected
 ```
 
 Run a small search:

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -26,6 +26,32 @@ The directed 4-out incidence pattern and the pairwise cap imply no
 counterexample can have `n <= 6`; the convexity-of-indegree count gives
 `n >= 7`.
 
+### Lemma: crossing-bisector and sharpened count
+
+Status: `EXACT_OBSTRUCTION`.
+
+If two selected witness rows share exactly two labels, the source chord is the
+perpendicular bisector of the common-witness chord and the two chords cross at
+the common-witness midpoint. Adjacent row-pairs therefore have intersection
+size at most `1`, improving the incidence count to `n >= 8`.
+
+This gives a short independent exclusion of `n <= 7`. The Fano enumeration is
+still retained because it is structurally useful and reproducible.
+
+For a hypothetical `n=8` counterexample, equality holds throughout: witness
+indegrees are all 4, adjacent row-pairs meet in exactly one selected witness,
+nonadjacent row-pairs meet in exactly two, and the common-witness map is a
+crossing permutation of the 20 octagon diagonals.
+
+### Lemma: minimal-counterexample critical tie
+
+Status: proved.
+
+In a counterexample with the minimum possible number of vertices, every vertex
+`x` is essential to some remaining vertex `y`: deleting `x` makes `y` good, so
+`x` lies in the unique distance class of size exactly 4 at `y`. This is a
+structural condition on minimal counterexamples, not a contradiction by itself.
+
 ### Theorem: selected-witness incidence rules out n <= 7
 
 Status: proved and reproducible.
@@ -59,11 +85,29 @@ used. See `docs/n8-incidence-enumeration.md`,
 `docs/n8-exact-survivors.md`, `data/incidence/n8_incidence_completeness.json`,
 and `certificates/n8_exact_analysis.json`.
 
+### Fixed-pattern mutual-rhombus obstructions
+
+Status: `EXACT_OBSTRUCTION`.
+
+The mutual-rhombus midpoint filter kills the fixed selected patterns
+`B12_3x4_danzer_lift`, `B20_4x5_FR_lift`, `C20_pm_4_9`, `C16_pm_1_6`,
+`C13_pm_3_5`, and `C9_pm_2_4`. The pattern `C17_skew` is killed by an odd
+forced-perpendicularity cycle.
+
+Under the natural cyclic order, `P18_parity_balanced` and
+`P24_parity_balanced` are killed by adjacent-row two-overlap via the
+crossing-bisector lemma. They remain cyclic-order search questions if treated
+as abstract incidence patterns with arbitrary cyclic order.
+
+See `docs/mutual-rhombus-filter.md` and
+`scripts/check_mutual_rhombus_filter.py`.
+
 ## Numerical Attempts
 
 ### B12_3x4_danzer_lift
 
-Status: near-miss degeneration, rejected as counterexample.
+Status: historical near-miss degeneration; fixed selected pattern exactly
+killed.
 
 Diagnostics:
 
@@ -76,7 +120,9 @@ Diagnostics:
 Interpretation:
 
 The residual improves as the polygon approaches a three-cluster degeneration.
-This is evidence about a failed route, not a solution.
+This is evidence about a failed route, not a solution. The fixed selected
+pattern is now exactly killed by the mutual-rhombus midpoint equations, while
+the numerical artifact remains useful as a degeneration diagnostic.
 
 ### Archived C12 artifacts
 
@@ -103,6 +149,8 @@ search-history artifacts, not as live candidates.
    and `14` exact certificates.
 2. Push the finite incidence/exact pipeline toward `n=9`, or identify the first
    survivor class that blocks scaling.
-3. Prove or refute degeneration for `B12_3x4_danzer_lift`.
-4. Run a `B20_4x5_FR_lift` anti-clustering margin sweep.
+3. Investigate `C19_skew`, which is not killed by the current mutual-rhombus
+   filter.
+4. Run cyclic-order searches for `P18_parity_balanced` and
+   `P24_parity_balanced` if they are treated as abstract incidence patterns.
 5. Add interval-arithmetic verification for convexity and distance equations.

--- a/STATE.md
+++ b/STATE.md
@@ -19,11 +19,12 @@ the directed incidence graph need not be symmetric.[^repo]
 
 The selected-witness method rules out `n <= 8` in this repo-local,
 machine-checked finite-case sense. The core filters are the
-two-circle cap `|S_a cap S_b| <= 2`, radical-axis perpendicularity when two
-rows share exactly two witnesses, the incidence count forcing `n >= 7`, and
+two-circle cap `|S_a cap S_b| <= 2`, radical-axis crossing/bisection when two
+rows share exactly two witnesses, the sharpened incidence count forcing
+`n >= 8`, and
 the `n=8` column-pair cap forcing all witness indegrees to equal 4.
-At `n=7`, the equality case forces a chord permutation on 21 chords, and odd
-cycle parity contradicts alternating perpendicularity.[^small]
+The older `n=7` Fano enumeration remains in the repo because it is a useful
+independent reproduction of the equality-case obstruction.[^small]
 
 For `n=8`, `scripts/enumerate_n8_incidence.py` enumerates all necessary
 selected-witness incidence survivors and reduces them to 15 canonical classes.
@@ -31,11 +32,24 @@ Exact cyclic-order noncrossing kills 1 class, and exact perpendicular-bisector /
 equal-distance algebra kills the other 14. See
 `docs/n8-incidence-enumeration.md` and `docs/n8-exact-survivors.md`.
 
+## New exact fixed-pattern obstructions
+
+The crossing-bisector and mutual-rhombus filters now exactly kill several
+previously live fixed selected-witness patterns. In particular,
+`B12_3x4_danzer_lift` is no longer live as a fixed selected pattern: its
+mutual-rhombus midpoint equations force labels `[0,4,8]`, `[1,5,9]`,
+`[2,6,10]`, and `[3,7,11]` to coincide. The old numerical near-miss remains
+useful as a degeneration diagnostic, but not as a counterexample candidate.
+
+Also killed as fixed selected patterns: `B20_4x5_FR_lift`, `C17_skew`,
+`C20_pm_4_9`, `C16_pm_1_6`, `C13_pm_3_5`, and `C9_pm_2_4`.
+
 ## Best saved near-miss
 
-The best saved near-miss remains `B12_3x4_danzer_lift`. It is numerical only
-and is rejected as proof or counterexample because the residual improves toward
-a clustered boundary degeneration.[^repo]
+The best saved near-miss is still the historical `B12_3x4_danzer_lift`
+artifact. It is numerical only, rejected as proof or counterexample, and now
+also attached to a fixed selected pattern that is exactly killed by the
+mutual-rhombus midpoint filter.[^repo]
 
 Numerical near-misses are not counterexamples. Any solution claim needs exact
 coordinates, or an exact algebraic/interval certificate, for both the selected
@@ -48,20 +62,21 @@ max squared-distance spread: 0.006806368780585714
 RMS equality residual:       0.0019599509549614457
 convexity margin:            9.999999943508973e-07
 minimum edge length:         0.0007465865604262556
-status: numerical only, rejected as proof/counterexample
+status: numerical artifact only; fixed selected pattern exactly killed
 ```
 
 The archive also contained two C12 numerical artifacts. They were normalized
 under `data/runs/`, but excluded from this dashboard: one fails the `1e-6`
 verification threshold and the other collapses to a non-strict configuration.[^comp]
 
-## Top live patterns
+## Top remaining live / unresolved patterns
 
-1. `B12_3x4_danzer_lift`: leading saved degeneration diagnostic, not a
-   counterexample candidate in its current form.[^repo]
-2. `B20_4x5_FR_lift`: next block/symmetric margin sweep with anti-clustering
-   diagnostics.[^repo]
-3. `P18_parity_balanced`: period-2 pattern worth broader numerical search.[^repo]
+1. `C19_skew`: sparse common-neighbor overlap; not killed by the current
+   mutual-rhombus filter.[^repo]
+2. `P18_parity_balanced`: killed under natural cyclic order; still needs a
+   cyclic-order search if arbitrary cyclic order is allowed.[^repo]
+3. `P24_parity_balanced`: killed under natural cyclic order; still needs a
+   cyclic-order search if arbitrary cyclic order is allowed.[^repo]
 
 ## Top killed approaches
 

--- a/data/patterns/candidate_patterns.json
+++ b/data/patterns/candidate_patterns.json
@@ -5,7 +5,8 @@
     "n": 12,
     "formula": "i=(a,b) mod (3,4); S_i={(a+1,b),(a+2,b),(a+1,b+1),(a+2,b-1)}",
     "type": "block/symmetric",
-    "status": "best near-miss; degenerates toward three clusters"
+    "status": "exactly killed as a fixed selected pattern by mutual-rhombus midpoint equations; numerical near-miss retained as a degeneration diagnostic",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 2,
@@ -13,7 +14,8 @@
     "n": 20,
     "formula": "i=(a,b) mod (4,5); S_i={(a+1,b),(a+3,b),(a+1,b+2),(a+3,b-2)}",
     "type": "block/symmetric",
-    "status": "promising next margin sweep"
+    "status": "exactly killed as a fixed selected pattern by mutual-rhombus midpoint equations",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 3,
@@ -21,7 +23,8 @@
     "n": 18,
     "formula": "even offsets {-7,-2,4,8}; odd offsets {-8,-4,2,7}",
     "type": "period-2",
-    "status": "worth numerical search"
+    "status": "killed under natural cyclic order by adjacent-row two-overlap via crossing-bisector; unresolved as an abstract incidence pattern if arbitrary cyclic orders are allowed",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 4,
@@ -29,7 +32,8 @@
     "n": 24,
     "formula": "even offsets {-10,-3,5,11}; odd offsets {-11,-5,3,10}",
     "type": "period-2",
-    "status": "higher-dimensional search"
+    "status": "killed under natural cyclic order by adjacent-row two-overlap via crossing-bisector; unresolved as an abstract incidence pattern if arbitrary cyclic orders are allowed",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 5,
@@ -37,7 +41,8 @@
     "n": 19,
     "formula": "offsets {-8,-3,5,9}",
     "type": "skew circulant",
-    "status": "sparse common-neighbor overlap"
+    "status": "sparse common-neighbor overlap; not killed by current mutual-rhombus filter",
+    "trust": "INCIDENCE_PATTERN"
   },
   {
     "rank": 6,
@@ -45,7 +50,8 @@
     "n": 17,
     "formula": "offsets {-7,-2,4,8}",
     "type": "skew circulant",
-    "status": "overdetermined but useful"
+    "status": "exactly killed by an odd forced-perpendicularity cycle",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 7,
@@ -53,7 +59,8 @@
     "n": 20,
     "formula": "offsets {-9,-4,4,9}",
     "type": "palindromic circulant",
-    "status": "do not impose coordinate symmetry"
+    "status": "exactly killed by mutual-rhombus midpoint equations; residue mod 4 collapse",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 8,
@@ -61,7 +68,8 @@
     "n": 16,
     "formula": "offsets {-6,-1,1,6}",
     "type": "palindromic circulant",
-    "status": "may encourage local edge collapse"
+    "status": "exactly killed by mutual-rhombus midpoint equations; parity collapse",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 9,
@@ -69,7 +77,8 @@
     "n": 13,
     "formula": "offsets {-5,-3,3,5}",
     "type": "palindromic circulant",
-    "status": "small smoke test"
+    "status": "exactly killed by mutual-rhombus midpoint equations; all labels collapse",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 10,
@@ -77,6 +86,7 @@
     "n": 9,
     "formula": "offsets {-4,-2,2,4}",
     "type": "palindromic circulant",
-    "status": "likely too constrained"
+    "status": "exactly killed by mutual-rhombus midpoint equations; all labels collapse",
+    "trust": "EXACT_OBSTRUCTION"
   }
 ]

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -7,19 +7,21 @@ designs only; geometric realization is a separate problem.
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| 1 | `B12_3x4_danzer_lift` | 12 | `(a,b) -> {(a+1,b),(a+2,b),(a+1,b+1),(a+2,b-1)}` mod `(3,4)` | block/symmetric | best saved near-miss; rejected as proof/counterexample because it degenerates toward three tight clusters[^repo] |
-| 2 | `B20_4x5_FR_lift` | 20 | `(a,b) -> {(a+1,b),(a+3,b),(a+1,b+2),(a+3,b-2)}` mod `(4,5)` | block/symmetric | next margin sweep with anti-clustering diagnostics[^repo] |
-| 3 | `P18_parity_balanced` | 18 | even: `{-7,-2,4,8}`, odd: `{-8,-4,2,7}` | period-2 | worth basin-hopping / differential-evolution testing[^repo] |
-| 4 | `P24_parity_balanced` | 24 | even: `{-10,-3,5,11}`, odd: `{-11,-5,3,10}` | period-2 | more variables, harder search[^repo] |
-| 5 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | sparse common-neighbor overlap[^repo] |
-| 6 | `C17_skew` | 17 | offsets `{-7,-2,4,8}` | skew circulant | overdetermined but useful[^repo] |
-| 7 | `C20_pm_4_9` | 20 | offsets `{-9,-4,4,9}` | palindromic circulant | do not impose coordinate symmetry[^repo] |
-| 8 | `C16_pm_1_6` | 16 | offsets `{-6,-1,1,6}` | palindromic circulant | may encourage local edge collapse[^repo] |
-| 9 | `C13_pm_3_5` | 13 | offsets `{-5,-3,3,5}` | palindromic circulant | small smoke test[^repo] |
-| 10 | `C9_pm_2_4` | 9 | offsets `{-4,-2,2,4}` | palindromic circulant | likely too constrained[^repo] |
+| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | sparse common-neighbor overlap; not killed by the current mutual-rhombus filter[^repo] |
 
-All live patterns above should pass the row-overlap filter
+The live pattern above should pass the row-overlap filter
 `|S_i cap S_j| <= 2` before numerical optimization.[^comp]
+
+## Natural-order killed / cyclic-order unresolved patterns
+
+These patterns are killed if the natural label order `0,1,...,n-1` is the
+cyclic order. As abstract incidence patterns, they require a cyclic-order
+search if arbitrary cyclic orders are allowed.
+
+| Rank | Name | n | Formula | Type | Current status |
+|---:|---|---:|---|---|---|
+| U1 | `P18_parity_balanced` | 18 | even: `{-7,-2,4,8}`, odd: `{-8,-4,2,7}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: requires cyclic-order search |
+| U2 | `P24_parity_balanced` | 24 | even: `{-10,-3,5,11}`, odd: `{-11,-5,3,10}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: requires cyclic-order search |
 
 ## Speculative extensions
 
@@ -41,6 +43,13 @@ row-overlap failure that killed the n=39 branch.[^n39]
 |---:|---|---:|---|---|---|
 | A1 | `Q8_cube_witness` | 8 | vertices `{0,1}^3`, witnesses at Hamming distance at least 2 | cube pattern | unrealizable by orthocenter obstruction; the full `n=8` case is now covered by the incidence/exact pipeline |
 | A2 | `C39_pm_18_19` | 39 | `S_i={i+18,i-18,i+19,i-19}` mod 39 | circulant | impossible: adjacent rows share three targets, violating the two-circle cap[^n39] |
+| A3 | `B12_3x4_danzer_lift` | 12 | `(a,b) -> {(a+1,b),(a+2,b),(a+1,b+1),(a+2,b-1)}` mod `(3,4)` | block/symmetric | exactly killed as a fixed selected pattern by mutual-rhombus midpoint equations; numerical near-miss remains useful as a degeneration diagnostic |
+| A4 | `B20_4x5_FR_lift` | 20 | `(a,b) -> {(a+1,b),(a+3,b),(a+1,b+2),(a+3,b-2)}` mod `(4,5)` | block/symmetric | exactly killed as a fixed selected pattern by mutual-rhombus midpoint equations |
+| A5 | `C17_skew` | 17 | offsets `{-7,-2,4,8}` | skew circulant | exactly killed by an odd forced-perpendicularity cycle |
+| A6 | `C20_pm_4_9` | 20 | offsets `{-9,-4,4,9}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; residue mod 4 collapse |
+| A7 | `C16_pm_1_6` | 16 | offsets `{-6,-1,1,6}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; parity collapse |
+| A8 | `C13_pm_3_5` | 13 | offsets `{-5,-3,3,5}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; all labels collapse |
+| A9 | `C9_pm_2_4` | 9 | offsets `{-4,-2,2,4}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; all labels collapse |
 
 [^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
 [^comp]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/04_COMPUTATIONAL_FINDINGS.md`.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -25,12 +25,18 @@ to 54 cyclic-dihedral classes. Every class has common-witness chord-cycle type
 `7+7+7`, so every class contains odd perpendicularity cycles. See
 `docs/n7-fano-enumeration.md`.
 
-For `n=8`, the column-pair cap below forces every witness indegree to equal 4.
-The checked incidence enumerator then exhausts all selected-witness systems
-under the necessary incidence and forced-perpendicularity filters, obtaining 15
-canonical survivor classes. The exact obstruction checker kills all 15 by
-cyclic-order noncrossing, perpendicular-bisector algebra, equal-distance
-algebra, duplicate vertices, collinearity, or strict-convexity failure. See
+The crossing/bisection lemma below gives a shorter independent exclusion of
+`n <= 7`. The repo still keeps the Fano enumeration because it is structurally
+useful and reproducible.
+
+For `n=8`, the sharpened count saturates: all witness indegrees equal 4,
+adjacent row-pairs meet in exactly one selected witness, and nonadjacent
+row-pairs meet in exactly two. The checked incidence enumerator then exhausts
+all selected-witness systems under the necessary incidence and
+forced-perpendicularity filters, obtaining 15 canonical survivor classes. The
+exact obstruction checker kills all 15 by cyclic-order noncrossing,
+perpendicular-bisector algebra, equal-distance algebra, duplicate vertices,
+collinearity, or strict-convexity failure. See
 `docs/n8-incidence-enumeration.md` and `docs/n8-exact-survivors.md`.
 
 ## Lemmas
@@ -45,22 +51,126 @@ In any selected-witness counterexample, for distinct centers `a,b`,
 
 Otherwise two distinct Euclidean circles would share at least three points.[^small]
 
-### Radical-axis perpendicularity
+### Radical-axis crossing / bisection
 
-If `S_i cap S_j = {a,b}`, then `p_i p_j` is perpendicular to `p_a p_b`.
-Both centers lie on the perpendicular bisector of the common chord.[^small]
-
-### Incidence counting lower bound
-
-Let `d_j = #{i : j in S_i}`. Then `sum_j d_j = 4n`, and the cap gives
+If
 
 ```text
-sum_j binom(d_j,2) <= 2 binom(n,2).
+S_x cap S_y = {a,b}
 ```
 
-Convexity of `binom(d,2)` with average indegree 4 gives
-`sum_j binom(d_j,2) >= 6n`, so any selected-witness counterexample has
-`n >= 7`.[^repo]
+for distinct centers `x,y`, then the line `p_x p_y` is the perpendicular
+bisector of segment `p_a p_b`; the segment `p_x p_y` contains the midpoint of
+segment `p_a p_b`; chords `{x,y}` and `{a,b}` cross in the cyclic order; and
+neither chord is a polygon edge.
+
+Both centers are equidistant from `p_a` and `p_b`, so they lie on the
+perpendicular bisector of `p_a p_b`. Let `m = (p_a + p_b)/2`. The point `m`
+lies on segment `ab`, hence in `conv(P)`, and also on the line `xy`.
+
+If `xy` were a polygon edge, its line would support the strictly convex polygon,
+but `a` and `b` lie on opposite sides of their perpendicular bisector. Thus
+`xy` is a diagonal. A line through two nonadjacent vertices of a strictly convex
+polygon meets the polygon in exactly the chord segment between them, so
+`m in [p_x,p_y]`. Since `m` is also in the relative interior of `[p_a,p_b]`,
+the two chords cross at `m`. A crossed chord cannot be a boundary edge, so
+`ab` is not an edge either.
+
+Consequently, adjacent centers satisfy
+
+```text
+|S_x cap S_y| <= 1,
+```
+
+and any proposed cyclic order must make every source chord with two common
+witnesses cross its common-witness chord. See
+`docs/mutual-rhombus-filter.md` for the fixed-pattern filters built from this
+lemma.
+
+### Sharpened incidence counting lower bound
+
+Let `d_j = #{i : j in S_i}`. Then `sum_j d_j = 4n`, and convexity of
+`binom(d,2)` with average indegree 4 gives
+
+```text
+sum_j binom(d_j,2) >= 6n.
+```
+
+Also
+
+```text
+sum_j binom(d_j,2) = sum_{i<j} |S_i cap S_j|.
+```
+
+The two-circle cap gives intersection size at most `2` for every row-pair. The
+crossing/bisection lemma improves the `n` adjacent row-pairs to size at most
+`1`. Hence
+
+```text
+sum_{i<j} |S_i cap S_j|
+  <= n + 2*(binom(n,2) - n)
+  = n(n-2).
+```
+
+Thus `6n <= n(n-2)`, so any selected-witness counterexample has `n >= 8`.
+This gives a shorter exact proof excluding `n <= 7`; it does not replace the
+separate `n=8` exact pipeline.[^repo]
+
+### n=8 crossing-permutation compression
+
+If a selected-witness counterexample had `n=8`, equality would hold throughout
+the sharpened incidence count. Therefore:
+
+```text
+d_v = 4 for every label v,
+|S_i cap S_j| = 1 for adjacent row-pairs {i,j},
+|S_i cap S_j| = 2 for nonadjacent row-pairs {i,j}.
+```
+
+The map
+
+```text
+phi({i,j}) = S_i cap S_j
+```
+
+is consequently defined on all 20 diagonals of the octagon and on no boundary
+edges. The crossing/bisection lemma says every source diagonal crosses its
+image. The pair-sharing cap makes `phi` injective on these diagonals: a witness
+pair `{a,b}` can occur together in at most two selected rows, hence can be the
+common-witness pair of at most one row-pair. Since there are 20 source
+diagonals and 20 target diagonals, `phi` is a crossing permutation of the
+octagon diagonals.
+
+This is a compression of the hypothetical `n=8` case, not a replacement for the
+checked `n=8` exact survivor pipeline.
+
+### Mutual-rhombus midpoint obstruction
+
+Define
+
+```text
+phi({x,y}) = S_x cap S_y
+```
+
+whenever the intersection has size exactly `2`. If `phi(e) = f` and
+`phi(f) = e` for unordered chords `e={x,y}` and `f={a,b}`, then the two chords
+are mutual perpendicular bisectors. Therefore they share a midpoint:
+
+```text
+p_x + p_y = p_a + p_b.
+```
+
+For each coordinate this is the exact integer linear equation
+
+```text
+X_x + X_y - X_a - X_b = 0.
+```
+
+If exact rational row reduction of all such midpoint equations forces
+`X_u = X_v` for distinct labels `u,v`, then every realization has
+`p_u = p_v`, impossible in a strictly convex polygon. This is a fixed
+selected-witness pattern obstruction, not a proof against other possible
+4-subset selections on the same hypothetical coordinate set.
 
 ### Pair and triple sharing
 
@@ -70,6 +180,25 @@ meets a strictly convex polygon boundary in at most two vertices.[^digest]
 
 Any noncollinear triple of vertices can appear together in at most one selected
 witness set, because three noncollinear points have a unique circumcenter.[^digest]
+
+### Minimal-counterexample critical tie
+
+In a counterexample with the minimum possible number of vertices, every deleted
+vertex is essential to some remaining vertex's badness. More precisely, for
+each vertex `x`, there is a vertex `y != x` such that `x` belongs to the unique
+distance class of size exactly 4 at `y`.
+
+Proof. Delete `x`. By minimality, the remaining polygon is not a counterexample,
+so some remaining vertex `y` has `E(y) <= 3` after deletion. In the original
+polygon, any distance class at `y` of size at least 4 must have contained `x`;
+otherwise it would still have size at least 4 after deletion. Since `x` lies at
+only one distance from `y`, there is at most one such class. Its size cannot
+exceed 4, because a class of size at least 5 containing `x` would still have
+size at least 4 after deletion. Thus `x` lies in a unique critical 4-tie at
+`y`.
+
+This is structural information about minimal counterexamples; by itself it is
+not a contradiction.
 
 ### n=8 witness indegree regularity
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ put detailed reconciliation in the canonical synthesis.
 
 - [`claims.md`](claims.md): proved local facts, conditional programs, and
   proof-facing caveats.
+- [`mutual-rhombus-filter.md`](mutual-rhombus-filter.md): crossing-bisector and
+  mutual-midpoint filters for fixed selected-witness patterns.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n7-fano-obstruction.md`](n7-fano-obstruction.md): proof note for the

--- a/docs/mutual-rhombus-filter.md
+++ b/docs/mutual-rhombus-filter.md
@@ -1,0 +1,214 @@
+# Mutual-rhombus filter
+
+Status: `EXACT_OBSTRUCTION` for fixed selected-witness incidence patterns.
+
+## Summary
+
+This note records two exact filters:
+
+1. crossing-bisector: a two-overlap row-pair forces the source chord and the
+   common-witness chord to cross at the witness chord midpoint;
+2. mutual-rhombus: a reciprocal `phi` 2-cycle gives an exact midpoint equality.
+
+These are fixed-pattern obstructions. They do not prove Erdos Problem #97.
+
+## Crossing-bisector lemma
+
+Let `P` be a strictly convex polygon with selected witness sets `S_i`. If
+
+```text
+S_x cap S_y = {a,b}
+```
+
+for distinct centers `x,y`, then:
+
+1. the line `p_x p_y` is the perpendicular bisector of segment `p_a p_b`;
+2. segment `p_x p_y` contains the midpoint of segment `p_a p_b`;
+3. chords `{x,y}` and `{a,b}` cross in the cyclic order;
+4. neither `{x,y}` nor `{a,b}` is a polygon edge.
+
+Proof. Since `a,b in S_x cap S_y`, both `p_x` and `p_y` are equidistant from
+`p_a` and `p_b`. Hence both centers lie on the perpendicular bisector of
+segment `p_a p_b`, so the line `p_x p_y` is that perpendicular bisector.
+
+Let
+
+```text
+m = (p_a + p_b)/2.
+```
+
+The point `m` lies on segment `ab`, hence in `conv(P)`, and also lies on the
+line `xy`.
+
+If `xy` were a polygon edge, its line would support the strictly convex polygon.
+But `a` and `b` lie on opposite sides of their perpendicular bisector, a
+contradiction. Hence `xy` is a diagonal.
+
+For a strictly convex polygon, the intersection of the line through two
+nonadjacent vertices `x,y` with `conv(P)` is exactly the segment `[p_x,p_y]`.
+Since `m` lies on that line and in `conv(P)`, `m in [p_x,p_y]`.
+
+Also `m` lies in the relative interior of `[p_a,p_b]`. Therefore chords `xy`
+and `ab` cross at `m`. A polygon boundary edge cannot be crossed in its
+relative interior by a chord contained in the convex polygon, so `ab` is not a
+polygon edge either.
+
+Consequently,
+
+```text
+adjacent x,y  =>  |S_x cap S_y| <= 1
+```
+
+and, for any proposed cyclic order,
+
+```text
+|S_x cap S_y| = 2  =>  chord {x,y} crosses chord S_x cap S_y.
+```
+
+## Sharpened n >= 8 lower bound
+
+Let
+
+```text
+d_v = #{ i : v in S_i }.
+```
+
+Then `sum_v d_v = 4n`, and Jensen gives
+
+```text
+sum_v binom(d_v,2) >= n * binom(4,2) = 6n.
+```
+
+Also
+
+```text
+sum_v binom(d_v,2) = sum_{i<j} |S_i cap S_j|.
+```
+
+By the two-circle cap, every row-pair has intersection size at most `2`. By the
+adjacent-row consequence above, the `n` adjacent row-pairs have intersection
+size at most `1`. Therefore
+
+```text
+sum_{i<j} |S_i cap S_j|
+  <= n + 2*(binom(n,2) - n)
+  = n(n-2).
+```
+
+Thus `6n <= n(n-2)`, so every selected-witness counterexample satisfies
+
+```text
+n >= 8.
+```
+
+This is a shorter exact proof excluding `n <= 7`. The repo still keeps the
+Fano enumeration for `n=7` because it is structurally useful and reproducible.
+The existing `n <= 8` theorem still depends on the separate exact `n=8`
+pipeline.
+
+For `n=8`, equality holds throughout the count. Thus every witness indegree is
+4, adjacent row-pairs have intersection size 1, and nonadjacent row-pairs have
+intersection size 2. The `phi` map is therefore defined on all 20 diagonals of
+the octagon. Since the pair-sharing cap makes this map injective on diagonals,
+it is a crossing permutation of the 20 octagon diagonals. This is a useful
+compression of the `n=8` search target, not a substitute for the checked exact
+survivor analysis.
+
+## The phi map
+
+For a row-pair with exactly two common witnesses, define
+
+```text
+phi({x,y}) = S_x cap S_y.
+```
+
+The source and target are unordered chords.
+
+## Mutual-rhombus lemma
+
+If
+
+```text
+phi(e) = f
+phi(f) = e
+```
+
+for unordered chords `e={x,y}` and `f={a,b}`, then `e` and `f` are mutual
+perpendicular bisectors. Therefore they share a midpoint:
+
+```text
+p_x + p_y = p_a + p_b.
+```
+
+This yields an exact integer linear equation on scalar label variables:
+
+```text
+X_x + X_y - X_a - X_b = 0.
+```
+
+The same equation holds separately for the two coordinate axes. If exact
+rational row reduction of the resulting matrix forces `X_u = X_v` for distinct
+labels `u,v`, then any geometric realization has `p_u = p_v`, so the fixed
+selected pattern cannot realize a strictly convex polygon.
+
+This kills fixed selected-witness incidence patterns. It does not prove that no
+other 4-subset selection on the same hypothetical coordinate set could work.
+
+## Exact integer matrix test
+
+The script builds one integer row for each reciprocal `phi` pair:
+
+```text
+X_e0 + X_e1 - X_f0 - X_f1 = 0.
+```
+
+It computes the rank and nullspace over exact rational arithmetic using SymPy.
+Labels `u,v` are reported as forced equal exactly when every nullspace basis
+vector has equal coordinates in positions `u` and `v`.
+
+## Verified fixed-pattern kills
+
+These outcomes are checked by
+`python scripts/check_mutual_rhombus_filter.py --assert-expected`.
+
+| Pattern | Filter | Rank | Forced class summary |
+|---|---|---:|---|
+| `B12_3x4_danzer_lift` | mutual-rhombus midpoint | 8 | `[0,4,8]`, `[1,5,9]`, `[2,6,10]`, `[3,7,11]` |
+| `B20_4x5_FR_lift` | mutual-rhombus midpoint | 15 | residues mod 5 collapse |
+| `C20_pm_4_9` | mutual-rhombus midpoint | 16 | residues mod 4 collapse |
+| `C16_pm_1_6` | mutual-rhombus midpoint | 14 | parity collapse |
+| `C13_pm_3_5` | mutual-rhombus midpoint | 12 | all labels collapse |
+| `C9_pm_2_4` | mutual-rhombus midpoint | 8 | all labels collapse |
+| `C17_skew` | odd forced-perpendicularity cycle | 0 | length-17 odd cycle |
+
+The built-in smoke pattern `C12_pm_2_5` is also killed by the same midpoint
+filter, with parity classes forced equal. It is not listed as a live ranked
+pattern in `candidate-patterns.md`.
+
+## Natural-order-only kills
+
+Under the natural cyclic order `0,1,...,n-1`, the parity patterns
+`P18_parity_balanced` and `P24_parity_balanced` have adjacent row-pairs with
+two common witnesses. The crossing-bisector lemma therefore kills them under
+that cyclic order.
+
+Their abstract-incidence status remains separate: if arbitrary cyclic orders
+are allowed, they require a cyclic-order search before they can be globally
+archived as killed incidence patterns.
+
+## Reproduction
+
+```bash
+pip install -e .[dev]
+python scripts/check_mutual_rhombus_filter.py --assert-expected
+python scripts/check_mutual_rhombus_filter.py --json
+pytest -q
+```
+
+## Caveats
+
+- These filters kill fixed selected patterns, not arbitrary selections.
+- The crossing test depends on cyclic order.
+- Natural label order is not automatically the geometric cyclic order unless
+  explicitly assumed by the pattern or search mode.
+- No general proof or counterexample is claimed.

--- a/docs/n8-exact-survivors.md
+++ b/docs/n8-exact-survivors.md
@@ -89,7 +89,8 @@ det(p_j - p_i, p_a + p_b - 2 p_i) = 0.
 ```
 
 The second equation is twice the midpoint-line condition, so no denominators are
-introduced.
+introduced. It is the algebraic form of the crossing/bisection lemma recorded
+in `claims.md` and `mutual-rhombus-filter.md`.
 
 The gauge is
 

--- a/scripts/check_mutual_rhombus_filter.py
+++ b/scripts/check_mutual_rhombus_filter.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Check exact crossing-bisector and mutual-rhombus filters on patterns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.incidence_filters import filter_summary  # noqa: E402
+from erdos97.search import PatternInfo, built_in_patterns  # noqa: E402
+
+
+EXPECTED: dict[str, dict[str, object]] = {
+    "B12_3x4_danzer_lift": {
+        "midpoint_matrix_rank": 8,
+        "forced_equality_classes": [[0, 4, 8], [1, 5, 9], [2, 6, 10], [3, 7, 11]],
+    },
+    "B20_4x5_FR_lift": {
+        "midpoint_matrix_rank": 15,
+        "forced_equality_classes": [
+            [0, 5, 10, 15],
+            [1, 6, 11, 16],
+            [2, 7, 12, 17],
+            [3, 8, 13, 18],
+            [4, 9, 14, 19],
+        ],
+    },
+    "C9_pm_2_4": {
+        "forced_equality_classes": [[0, 1, 2, 3, 4, 5, 6, 7, 8]],
+    },
+    "C13_pm_3_5": {
+        "forced_equality_classes": [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]],
+    },
+    "C16_pm_1_6": {
+        "forced_equality_classes": [[0, 2, 4, 6, 8, 10, 12, 14], [1, 3, 5, 7, 9, 11, 13, 15]],
+    },
+    "C20_pm_4_9": {
+        "forced_equality_classes": [
+            [0, 4, 8, 12, 16],
+            [1, 5, 9, 13, 17],
+            [2, 6, 10, 14, 18],
+            [3, 7, 11, 15, 19],
+        ],
+    },
+    "C17_skew": {
+        "odd_cycle": True,
+    },
+    "P18_parity_balanced": {
+        "adjacent_two_overlap_violations": True,
+    },
+    "P24_parity_balanced": {
+        "adjacent_two_overlap_violations": True,
+    },
+}
+
+
+def pattern_status(summary: dict[str, object]) -> str:
+    if summary["odd_cycle_length"]:
+        return "exactly killed: odd forced-perpendicularity cycle"
+    classes = summary["forced_equality_classes"]
+    if classes:
+        return "exactly killed: mutual-rhombus midpoint equations"
+    if summary["adjacent_two_overlap_violations"]:
+        return "killed under natural cyclic order; abstract order unresolved"
+    if summary["crossing_bisector_violations"]:
+        return "incompatible with natural cyclic order crossing-bisector filter"
+    return "not killed by these filters"
+
+
+def summarize_pattern(pattern: PatternInfo) -> dict[str, object]:
+    summary = filter_summary(pattern.S)
+    return {
+        "name": pattern.name,
+        "family": pattern.family,
+        "formula": pattern.formula,
+        **summary,
+        "status": pattern_status(summary),
+    }
+
+
+def compact_classes(classes: object) -> str:
+    if not classes:
+        return "-"
+    text = "; ".join(str(cls) for cls in classes)  # type: ignore[union-attr]
+    if len(text) <= 54:
+        return text
+    return text[:51] + "..."
+
+
+def print_table(rows: list[dict[str, object]]) -> None:
+    headers = [
+        "pattern",
+        "n",
+        "phi",
+        "odd",
+        "mutual",
+        "rank",
+        "eq classes",
+        "adj",
+        "cross",
+        "status",
+    ]
+    table: list[list[str]] = []
+    for row in rows:
+        table.append(
+            [
+                str(row["name"]),
+                str(row["n"]),
+                str(row["phi_edges"]),
+                str(row["odd_cycle_length"] or "-"),
+                str(row["mutual_phi_2_cycles"]),
+                str(row["midpoint_matrix_rank"]),
+                compact_classes(row["forced_equality_classes"]),
+                str(len(row["adjacent_two_overlap_violations"])),  # type: ignore[arg-type]
+                str(len(row["crossing_bisector_violations"])),  # type: ignore[arg-type]
+                str(row["status"]),
+            ]
+        )
+
+    widths = [
+        max(len(headers[col]), *(len(row[col]) for row in table))
+        for col in range(len(headers))
+    ]
+    print("  ".join(headers[col].ljust(widths[col]) for col in range(len(headers))))
+    print("  ".join("-" * widths[col] for col in range(len(headers))))
+    for row in table:
+        print("  ".join(row[col].ljust(widths[col]) for col in range(len(headers))))
+
+
+def assert_expected(rows: list[dict[str, object]], require_all: bool = True) -> None:
+    by_name = {str(row["name"]): row for row in rows}
+    for name, expected in EXPECTED.items():
+        if name not in by_name:
+            if require_all:
+                raise AssertionError(f"missing built-in pattern {name}")
+            continue
+        row = by_name[name]
+        if "midpoint_matrix_rank" in expected:
+            actual_rank = row["midpoint_matrix_rank"]
+            expected_rank = expected["midpoint_matrix_rank"]
+            if actual_rank != expected_rank:
+                raise AssertionError(f"{name}: rank {actual_rank} != {expected_rank}")
+        if "forced_equality_classes" in expected:
+            actual_classes = row["forced_equality_classes"]
+            expected_classes = expected["forced_equality_classes"]
+            if actual_classes != expected_classes:
+                raise AssertionError(f"{name}: classes {actual_classes} != {expected_classes}")
+        if expected.get("odd_cycle") and not row["odd_cycle_length"]:
+            raise AssertionError(f"{name}: expected an odd forced-perpendicularity cycle")
+        if expected.get("adjacent_two_overlap_violations") and not row[
+            "adjacent_two_overlap_violations"
+        ]:
+            raise AssertionError(f"{name}: expected natural-order adjacent two-overlap violations")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a table")
+    parser.add_argument("--pattern", help="limit checks to one built-in pattern")
+    parser.add_argument("--assert-expected", action="store_true", help="assert expected kills")
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern:
+        if args.pattern not in patterns:
+            raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+        selected = [patterns[args.pattern]]
+    else:
+        selected = list(patterns.values())
+
+    rows = [summarize_pattern(pattern) for pattern in selected]
+    if args.assert_expected:
+        assert_expected(rows, require_all=args.pattern is None)
+
+    if args.json:
+        print(json.dumps(rows, indent=2, sort_keys=True))
+    else:
+        print_table(rows)
+        if args.assert_expected:
+            print("OK: expected mutual-rhombus and crossing-bisector outcomes verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/incidence_filters.py
+++ b/src/erdos97/incidence_filters.py
@@ -1,0 +1,297 @@
+"""Exact incidence filters for selected-witness patterns.
+
+The utilities in this module are combinatorial or rational-linear. They do not
+use geometry coordinates, numerical optimization, NumPy, or floating-point
+equality.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from itertools import combinations
+from typing import Sequence
+
+Chord = tuple[int, int]
+Pattern = list[list[int]]
+
+
+def normalize_chord(a: int, b: int) -> Chord:
+    """Return a sorted unordered chord tuple. Reject loops."""
+    if a == b:
+        raise ValueError(f"loop chord is not allowed: ({a}, {b})")
+    return (a, b) if a < b else (b, a)
+
+
+def phi_map(S: Sequence[Sequence[int]]) -> dict[Chord, Chord]:
+    """
+    Return phi({i,j}) = S_i cap S_j whenever the intersection has size 2.
+
+    Chords are normalized sorted tuples.
+    """
+    witness_sets = [set(row) for row in S]
+    out: dict[Chord, Chord] = {}
+    for i, j in combinations(range(len(S)), 2):
+        inter = sorted(witness_sets[i] & witness_sets[j])
+        if len(inter) == 2:
+            out[normalize_chord(i, j)] = normalize_chord(inter[0], inter[1])
+    return out
+
+
+def _positions(order: Sequence[int]) -> dict[int, int]:
+    pos: dict[int, int] = {}
+    for idx, label in enumerate(order):
+        if label in pos:
+            raise ValueError(f"cyclic order is not a permutation: repeated label {label}")
+        pos[label] = idx
+    return pos
+
+
+def chords_cross_in_order(e: Chord, f: Chord, order: Sequence[int]) -> bool:
+    """
+    Return True iff disjoint chords e and f have alternating endpoints.
+
+    The supplied order is a cyclic order of labels. Chords sharing an endpoint
+    return False.
+    """
+    e = normalize_chord(*e)
+    f = normalize_chord(*f)
+    if set(e) & set(f):
+        return False
+
+    pos = _positions(order)
+    missing = [label for label in (*e, *f) if label not in pos]
+    if missing:
+        raise ValueError(f"chord endpoint is missing from cyclic order: {missing[0]}")
+
+    a, b = e
+    c, d = f
+    a_pos, b_pos = pos[a], pos[b]
+    if a_pos > b_pos:
+        a_pos, b_pos = b_pos, a_pos
+    c_inside = a_pos < pos[c] < b_pos
+    d_inside = a_pos < pos[d] < b_pos
+    return c_inside != d_inside
+
+
+def adjacent_pairs(order: Sequence[int]) -> set[Chord]:
+    """Return polygon edges for the supplied cyclic order."""
+    if len(order) < 2:
+        return set()
+    _positions(order)
+    return {
+        normalize_chord(order[i], order[(i + 1) % len(order)])
+        for i in range(len(order))
+    }
+
+
+def adjacent_two_overlap_violations(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+) -> list[tuple[Chord, Chord]]:
+    """
+    Return row-edge violations for adjacent center chords with two overlaps.
+
+    Each item is (source_chord, witness_chord). The default order is the natural
+    label order 0,1,...,n-1.
+    """
+    if order is None:
+        order = list(range(len(S)))
+    edges = adjacent_pairs(order)
+    phis = phi_map(S)
+    return [(edge, phis[edge]) for edge in sorted(edges) if edge in phis]
+
+
+def crossing_bisector_violations(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int],
+) -> list[tuple[Chord, Chord]]:
+    """Return phi edges e -> f where e and f do not cross in the supplied order."""
+    violations: list[tuple[Chord, Chord]] = []
+    for source, target in sorted(phi_map(S).items()):
+        if not chords_cross_in_order(source, target, order):
+            violations.append((source, target))
+    return violations
+
+
+def forced_perpendicular_graph(S: Sequence[Sequence[int]]) -> dict[Chord, set[Chord]]:
+    """Build the undirected graph with an edge e--phi(e) for every two-overlap."""
+    n = len(S)
+    graph: dict[Chord, set[Chord]] = {
+        normalize_chord(i, j): set() for i, j in combinations(range(n), 2)
+    }
+    for source, target in phi_map(S).items():
+        graph.setdefault(source, set()).add(target)
+        graph.setdefault(target, set()).add(source)
+    return graph
+
+
+def _odd_cycle_from_conflict(
+    u: Chord,
+    v: Chord,
+    parent: dict[Chord, Chord | None],
+) -> list[Chord]:
+    u_path: list[Chord] = []
+    cur: Chord | None = u
+    while cur is not None:
+        u_path.append(cur)
+        cur = parent[cur]
+
+    v_path: list[Chord] = []
+    cur = v
+    while cur is not None:
+        v_path.append(cur)
+        cur = parent[cur]
+
+    u_index = {node: idx for idx, node in enumerate(u_path)}
+    lca = next(node for node in v_path if node in u_index)
+    u_prefix = u_path[: u_index[lca] + 1]
+    v_prefix = v_path[: v_path.index(lca)]
+    return u_prefix + list(reversed(v_prefix))
+
+
+def odd_forced_perpendicular_cycle(
+    S: Sequence[Sequence[int]],
+) -> list[Chord] | None:
+    """
+    Return one odd cycle in the forced-perpendicularity graph if found.
+
+    The graph is checked by BFS 2-coloring. A same-color edge reconstructs an
+    odd cycle from the two parent paths plus the conflict edge.
+    """
+    graph = forced_perpendicular_graph(S)
+    color: dict[Chord, int] = {}
+    parent: dict[Chord, Chord | None] = {}
+
+    for start in sorted(graph):
+        if start in color:
+            continue
+        color[start] = 0
+        parent[start] = None
+        q: deque[Chord] = deque([start])
+        while q:
+            u = q.popleft()
+            for v in sorted(graph[u]):
+                if v not in color:
+                    color[v] = 1 - color[u]
+                    parent[v] = u
+                    q.append(v)
+                elif color[v] == color[u] and parent.get(u) != v:
+                    return _odd_cycle_from_conflict(u, v, parent)
+    return None
+
+
+def mutual_phi_pairs(S: Sequence[Sequence[int]]) -> list[tuple[Chord, Chord]]:
+    """Return unordered reciprocal pairs (e,f) with phi(e)=f and phi(f)=e."""
+    phis = phi_map(S)
+    pairs: set[tuple[Chord, Chord]] = set()
+    for source, target in phis.items():
+        if phis.get(target) == source:
+            pairs.add((source, target) if source < target else (target, source))
+    return sorted(pairs)
+
+
+def _sympy():
+    try:
+        import sympy as sp  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depends on optional dev dep
+        raise RuntimeError("SymPy is required for mutual midpoint filters") from exc
+    return sp
+
+
+def mutual_midpoint_matrix(S: Sequence[Sequence[int]]):
+    """
+    Return a SymPy integer matrix with one row per mutual phi 2-cycle.
+
+    Each row is X_e0 + X_e1 - X_f0 - X_f1 = 0.
+    """
+    sp = _sympy()
+    n = len(S)
+    rows: list[list[int]] = []
+    for e, f in mutual_phi_pairs(S):
+        row = [0] * n
+        row[e[0]] += 1
+        row[e[1]] += 1
+        row[f[0]] -= 1
+        row[f[1]] -= 1
+        rows.append(row)
+    if not rows:
+        return sp.zeros(0, n)
+    return sp.Matrix(rows)
+
+
+def forced_equal_classes_from_matrix(M, n: int) -> list[list[int]]:
+    """
+    Return non-singleton label classes forced equal by the system M X = 0.
+
+    Labels u,v are forced equal iff every basis vector of nullspace(M) has equal
+    coordinates at u and v.
+    """
+    if M.shape[1] != n:
+        raise ValueError(f"matrix has {M.shape[1]} columns, expected {n}")
+
+    basis = M.nullspace()
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for u, v in combinations(range(n), 2):
+        if all(vec[u, 0] == vec[v, 0] for vec in basis):
+            union(u, v)
+
+    classes: dict[int, list[int]] = defaultdict(list)
+    for label in range(n):
+        classes[find(label)].append(label)
+    return sorted(cls for cls in classes.values() if len(cls) >= 2)
+
+
+def _json_chord(chord: Chord) -> list[int]:
+    return [int(chord[0]), int(chord[1])]
+
+
+def _json_chord_pair(pair: tuple[Chord, Chord]) -> list[list[int]]:
+    return [_json_chord(pair[0]), _json_chord(pair[1])]
+
+
+def filter_summary(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+) -> dict[str, object]:
+    """
+    Return a JSON-serializable summary of exact incidence filters.
+    """
+    if order is None:
+        order = list(range(len(S)))
+
+    phis = phi_map(S)
+    odd_cycle = odd_forced_perpendicular_cycle(S)
+    mutual_pairs = mutual_phi_pairs(S)
+    matrix = mutual_midpoint_matrix(S)
+    forced_classes = forced_equal_classes_from_matrix(matrix, len(S))
+    adjacent_violations = adjacent_two_overlap_violations(S, order)
+    crossing_violations = crossing_bisector_violations(S, order)
+
+    return {
+        "n": len(S),
+        "phi_edges": len(phis),
+        "odd_cycle_length": len(odd_cycle) if odd_cycle else None,
+        "odd_cycle": [_json_chord(chord) for chord in odd_cycle] if odd_cycle else None,
+        "mutual_phi_2_cycles": len(mutual_pairs),
+        "mutual_phi_pairs": [_json_chord_pair(pair) for pair in mutual_pairs],
+        "midpoint_matrix_rank": int(matrix.rank()),
+        "forced_equality_classes": forced_classes,
+        "adjacent_two_overlap_violations": [
+            _json_chord_pair(pair) for pair in adjacent_violations
+        ],
+        "crossing_bisector_violations": [
+            _json_chord_pair(pair) for pair in crossing_violations
+        ],
+    }

--- a/tests/test_incidence_filters.py
+++ b/tests/test_incidence_filters.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from erdos97.incidence_filters import (
+    adjacent_two_overlap_violations,
+    chords_cross_in_order,
+    forced_equal_classes_from_matrix,
+    mutual_midpoint_matrix,
+    odd_forced_perpendicular_cycle,
+    phi_map,
+)
+from erdos97.search import built_in_patterns
+
+
+def test_chords_cross_in_order() -> None:
+    order = [0, 1, 2, 3]
+
+    assert chords_cross_in_order((0, 2), (1, 3), order)
+    assert not chords_cross_in_order((0, 1), (2, 3), order)
+    assert not chords_cross_in_order((0, 2), (2, 3), order)
+
+
+def test_phi_map_on_toy_pattern() -> None:
+    S = [
+        [2, 3, 4, 5],
+        [2, 3, 6, 7],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+    ]
+
+    assert phi_map(S)[(0, 1)] == (2, 3)
+
+
+def test_mutual_midpoint_matrix_on_toy_reciprocal_pair() -> None:
+    S = [
+        [2, 3, 4, 5],
+        [2, 3, 6, 7],
+        [0, 1, 4, 6],
+        [0, 1, 5, 7],
+        [],
+        [],
+        [],
+        [],
+    ]
+
+    matrix = mutual_midpoint_matrix(S)
+
+    assert matrix.shape == (1, 8)
+    assert list(matrix.row(0)) == [1, 1, -1, -1, 0, 0, 0, 0]
+    assert forced_equal_classes_from_matrix(matrix, 8) == []
+
+
+def test_expected_mutual_midpoint_fixed_pattern_kills() -> None:
+    patterns = built_in_patterns()
+    expected = {
+        "B12_3x4_danzer_lift": {
+            "rank": 8,
+            "classes": [[0, 4, 8], [1, 5, 9], [2, 6, 10], [3, 7, 11]],
+        },
+        "B20_4x5_FR_lift": {
+            "rank": 15,
+            "classes": [
+                [0, 5, 10, 15],
+                [1, 6, 11, 16],
+                [2, 7, 12, 17],
+                [3, 8, 13, 18],
+                [4, 9, 14, 19],
+            ],
+        },
+        "C9_pm_2_4": {
+            "rank": 8,
+            "classes": [[0, 1, 2, 3, 4, 5, 6, 7, 8]],
+        },
+        "C13_pm_3_5": {
+            "rank": 12,
+            "classes": [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]],
+        },
+        "C16_pm_1_6": {
+            "rank": 14,
+            "classes": [[0, 2, 4, 6, 8, 10, 12, 14], [1, 3, 5, 7, 9, 11, 13, 15]],
+        },
+        "C20_pm_4_9": {
+            "rank": 16,
+            "classes": [
+                [0, 4, 8, 12, 16],
+                [1, 5, 9, 13, 17],
+                [2, 6, 10, 14, 18],
+                [3, 7, 11, 15, 19],
+            ],
+        },
+    }
+
+    for name, values in expected.items():
+        matrix = mutual_midpoint_matrix(patterns[name].S)
+        assert matrix.rank() == values["rank"]
+        assert forced_equal_classes_from_matrix(matrix, patterns[name].n) == values["classes"]
+
+
+def test_c17_skew_has_odd_forced_perpendicularity_cycle() -> None:
+    cycle = odd_forced_perpendicular_cycle(built_in_patterns()["C17_skew"].S)
+
+    assert cycle is not None
+    assert len(cycle) % 2 == 1
+
+
+def test_parity_patterns_have_natural_order_adjacent_two_overlap_violations() -> None:
+    patterns = built_in_patterns()
+
+    assert adjacent_two_overlap_violations(patterns["P18_parity_balanced"].S)
+    assert adjacent_two_overlap_violations(patterns["P24_parity_balanced"].S)


### PR DESCRIPTION
## Summary

- Add exact incidence-filter utilities for crossing-bisector checks, forced-perpendicularity odd cycles, reciprocal phi pairs, and mutual-rhombus midpoint matrices.
- Add a CLI checker for built-in patterns with expected exact fixed-pattern kills and JSON/table output.
- Add deterministic tests covering chord crossing, phi maps, midpoint matrices, fixed-pattern kills, C17 odd cycle detection, and natural-order parity-pattern violations.
- Document the strengthened crossing/bisection lemma, sharpened `n >= 8` bound, `n=8` crossing-permutation compression, minimal-counterexample critical-tie lemma, and fixed-pattern candidate ledger updates.

## Validation

- `python scripts\check_text_clean.py`
- `python scripts\check_mutual_rhombus_filter.py --assert-expected`
- `python scripts\check_mutual_rhombus_filter.py --json`
- `python -m pytest -q` (26 passed)
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `git diff --cached --check` before commit

## Notes

This PR does not claim a general proof or a counterexample. The new exact kills are fixed selected-witness incidence-pattern obstructions. `P18_parity_balanced` and `P24_parity_balanced` are only marked killed under the natural cyclic order; their abstract-incidence status still requires cyclic-order search if arbitrary cyclic orders are allowed.