### PR TITLE
[codex] harden reviewer trust checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 * text=auto eol=lf
+*.cff text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.py text eol=lf
+*.toml text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,5 @@ jobs:
       - run: pip install -e .[dev]
       - run: python scripts/check_text_clean.py
       - run: python scripts/check_status_consistency.py
+      - run: git diff --check
       - run: pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Run these after documentation or code changes:
 ```bash
 python scripts/check_text_clean.py
 python scripts/check_status_consistency.py
+git diff --check
 pytest -q
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ are equal. The radius may depend on `i`; the selected set may depend on `i`; the
 
 ## Current status in this repo
 
+Official/global status remains falsifiable/open.
+
 No general proof and no counterexample are claimed.
 
 The selected-witness incidence method rules out `n <= 8` in this repo-local,
@@ -146,9 +148,12 @@ Use these labels consistently:
 
 ```text
 .
+├── AGENTS.md                         # repository-level Codex guidance
 ├── README.md
 ├── RESULTS.md
 ├── STATE.md
+├── metadata/
+│   └── erdos97.yaml                  # canonical status metadata snapshot
 ├── pyproject.toml
 ├── requirements.txt
 ├── src/erdos97/search.py              # main search/verification engine
@@ -158,6 +163,10 @@ Use these labels consistently:
 ├── tests/                             # smoke tests and incidence checks
 ├── docs/
 │   ├── index.md                       # documentation navigation
+│   ├── upstream-alignment.md          # relation to teorth/erdosproblems
+│   ├── reviewer-guide.md              # independent audit instructions
+│   ├── formalization.md               # Lean/formalization alignment
+│   ├── oeis-possibilities.md          # exploratory OEIS notes
 │   ├── canonical-synthesis.md         # long-form canonical project synthesis
 │   ├── claims.md                      # proved vs heuristic statements
 │   ├── candidate-patterns.md          # ranked incidence patterns
@@ -176,7 +185,9 @@ Use these labels consistently:
 │   ├── patterns/candidate_patterns.json
 │   └── runs/best_B12_slsqp_m1e-6.json
 └── certificates/
-    └── best_B12_certificate_template.json
+    ├── best_B12_certificate_template.json
+    ├── n8_exact_analysis.json
+    └── n8_polynomial_systems.txt
 ```
 
 ## Quick start

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -5,8 +5,13 @@ claims, what it has only tested numerically, and what remains open. For the
 long-form canonical synthesis and claim reconciliation, read
 `docs/canonical-synthesis.md`.
 
-Overall status: Erdős Problem #97 remains open. This repository claims no
-general proof and no counterexample.
+Official/global status: falsifiable/open. This repository claims no general
+proof and no counterexample.
+
+Strongest local finite-case artifact: the selected-witness method rules out
+`n <= 8` in a repo-local, machine-checked finite-case sense. External
+independent review is still recommended before paper-style or public
+theorem-style claims.
 
 ## Certified Results
 
@@ -67,9 +72,9 @@ radical-axis perpendicularity constraints contain odd cycles. This obstructs
 all `n=7` selected-witness equality patterns. See
 `docs/n7-fano-enumeration.md`.
 
-### Theorem artifact: selected-witness incidence rules out n = 8
+### Machine-checked finite-case artifact: selected-witness incidence rules out n = 8
 
-Status: `THEOREM` in repo-local, machine-checked finite-case sense. External
+Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT` in repo-local sense. External
 review is still recommended before paper-style or public theorem claims.
 
 The incidence-completeness checker derives `n=8` indegree regularity from the

--- a/STATE.md
+++ b/STATE.md
@@ -8,7 +8,7 @@ claim taxonomy, failed-route reconciliation, and source/hash inventory, read
 proof attempts.
 
 Canonical status metadata is recorded in `metadata/erdos97.yaml`. It separates
-the official/global falsifiable-open status from this repo's local finite-case
+the official/global falsifiable/open status from this repo's local finite-case
 artifacts.
 
 ## Target
@@ -35,6 +35,8 @@ selected-witness incidence survivors and reduces them to 15 canonical classes.
 Exact cyclic-order noncrossing kills 1 class, and exact perpendicular-bisector /
 equal-distance algebra kills the other 14. See
 `docs/n8-incidence-enumeration.md` and `docs/n8-exact-survivors.md`.
+External independent review remains recommended before public theorem-style
+claims.
 
 ## New exact fixed-pattern obstructions
 

--- a/docs/canonical-synthesis.md
+++ b/docs/canonical-synthesis.md
@@ -1023,7 +1023,7 @@ This document was produced via the four-stage protocol requested:
 **Stage 2 — Cluster and dedupe.** Identified content clusters across documents:
 - Lemma library (in all 5 main docs) — kept one canonical version.
 - Small-case proofs $n = 5, 6, 7$ (identical across all) — kept canonical versions.
-- $n = 8$ status (all docs reach "open" but with different framings) — merged, with disagreement table.
+- Archived/pre-current-artifact $n = 8$ source-corpus status — older source documents treated `n=8` as open or gap-bearing. This is superseded by the current `n=8` incidence-completeness and exact-obstruction artifacts.
 - Failed routes (most thorough in `standalone` §C) — kept and supplemented with consensus framings.
 - Active proof programs (cleanest in `synthesis` §5; more detail in `standalone` §F) — merged.
 - Counterexamples to intermediate claims (most polished in `standalone` §D) — kept verbatim.
@@ -1036,7 +1036,7 @@ This document was produced via the four-stage protocol requested:
 
 **Stage 4 — Verification.** Cross-checked critical claims against multiple sources:
 - $n = 5, 6, 7$ proofs — consistent across all 5 main docs and source notes (modulo the weak-vs-strong witness distinction at $n = 7$).
-- $n = 8$ status — all 5 main docs agree on "open" (after the disagreement was resolved).
+- $n = 8$ source-corpus status — the older synthesis corpus predated the current finite-case artifact. Do not use this archived source-corpus status as the current repo-local status.
 - L10 rank value at solutions — consistent at $\le 2n - 4$ across `synthesis`, `standalone`, `research_state`, `consolidated_private`.
 - Counterexample coordinates — preserved verbatim from `standalone` §D and verified to be cited identically in source notes.
 - $n = 39$ circulant impossibility proof — independently confirmed by `source_notes/12_n39_circulant_degeneracy.md` and the linearized-system blow-up in `source_notes/13_n39_raw_search_notes_and_code.md`.

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -25,6 +25,31 @@ python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
 ```
 
+## Expected `n=8` outputs
+
+For `python scripts/enumerate_n8_incidence.py --summary`, expected invariants:
+
+- status is `INCIDENCE_COMPLETENESS`;
+- `canonical_survivor_class_count` is `15`;
+- `matches_existing_reconstructed_survivors` is `true`;
+- all necessary incidence survivors are reduced to the 15 canonical classes in
+  `data/incidence/n8_incidence_completeness.json` and
+  `data/incidence/n8_reconstructed_15_survivors.json`.
+
+For `python scripts/analyze_n8_exact_survivors.py --check --json`, expected
+invariants:
+
+- status is `exact_obstruction_artifact_pending_independent_review`;
+- `survivor_classes` is `15`;
+- `cyclic_order_remaining_count` is `14`, with class `12` killed by cyclic
+  order noncrossing;
+- classes `3`, `4`, `5`, and `14` report their named exact certificates as
+  verified;
+- the `pb_y2_span_ids_verified` list contains ten classes;
+- the final obstruction pass is exact and does not rely on floating-point
+  equality;
+- certificate data agrees with `certificates/n8_exact_analysis.json`.
+
 ## Files to inspect first
 
 1. `STATE.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=7",
+  "PyYAML>=6",
   "sympy>=1.12",
   "z3-solver>=4.12"
 ]

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -6,12 +6,53 @@ import re
 import sys
 from pathlib import Path
 
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dev dependencies.
+    yaml = None
+
 ROOT = Path(__file__).resolve().parents[1]
 
-REQUIRED_NO_OVERCLAIM_FILES = ["README.md", "STATE.md", "RESULTS.md"]
-NO_OVERCLAIM_RE = re.compile(r"no\s+general proof and no counterexample", re.I)
-STALE_N8_RE = re.compile(r"(?:n\s*=\s*8|\$8\$|`8`)\s*\|\s*\*\*?Open", re.I)
-ARCHIVAL_MARKERS = ("archived", "superseded", "provenance")
+REQUIRED_STATUS_FILES = ["README.md", "STATE.md", "RESULTS.md"]
+
+NO_OVERCLAIM_RE = re.compile(r"no\s+general\s+proof\s+and\s+no\s+counterexample", re.I)
+OFFICIAL_OPEN_RE = re.compile(r"falsifiable\s*[/ -]\s*open", re.I)
+LOCAL_N8_RE = re.compile(
+    r"\bselected-witness\b"
+    r"(?=.{0,500}\bn\s*<=\s*8\b)"
+    r"(?=.{0,500}\brepo-local\b)"
+    r"(?=.{0,500}\bmachine-checked\b)",
+    re.I,
+)
+REVIEW_RE = re.compile(
+    r"(?:independent\s+(?:external\s+)?review|external\s+independent\s+review)"
+    r"|(?:before\s+(?:paper-style|public\s+theorem-style|public theorem-style))",
+    re.I,
+)
+
+STALE_N8_PATTERNS = [
+    re.compile(r"(?:n\s*=\s*8|\$n\s*=\s*8\$|\$8\$|`8`)\s*\|\s*\*\*?Open", re.I),
+    re.compile(r"(?:n\s*=\s*8|n=8|\$n\s*=\s*8\$)[^.\n]{0,140}\ball\s+docs[^.\n]{0,140}\bopen\b", re.I),
+    re.compile(
+        r"(?:n\s*=\s*8|n=8|\$n\s*=\s*8\$)[^.\n]{0,140}\bstatus[^.\n]{0,140}\bopen\b",
+        re.I,
+    ),
+    re.compile(r"\ball\s+5\s+main\s+docs\s+agree\s+on\s+[\"'`]?open[\"'`]?", re.I),
+]
+ARCHIVAL_MARKERS = (
+    "archived",
+    "superseded",
+    "pre-current-artifact",
+    "source-corpus",
+    "not current repo-local status",
+)
+
+METADATA_EXPECTED_TRUE = (
+    "no_overclaiming",
+    "numerical_evidence_is_not_proof",
+    "exact_certificates_required_for_counterexamples",
+    "independent_review_required_for_public_theorem_claims",
+)
 
 
 def fail(msg: str) -> None:
@@ -23,26 +64,110 @@ def read_text(rel: str) -> str:
     return (ROOT / rel).read_text(encoding="utf-8")
 
 
-def main() -> None:
-    if not (ROOT / "metadata" / "erdos97.yaml").exists():
+def load_metadata(path: Path) -> dict[str, object]:
+    if yaml is None:
+        fail("PyYAML is required to parse metadata/erdos97.yaml; install with `pip install -e .[dev]`")
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        fail(f"metadata/erdos97.yaml is not valid YAML: {exc}")
+    if not isinstance(loaded, dict):
+        fail("metadata/erdos97.yaml should parse as a mapping")
+    return loaded
+
+
+def metadata_value(metadata: dict[str, object], path: tuple[str, ...]) -> object:
+    current: object = metadata
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            fail(f"metadata/erdos97.yaml is missing {'.'.join(path)}")
+        current = current[key]
+    return current
+
+
+def require_pattern(label: str, text: str, pattern: re.Pattern[str], detail: str) -> None:
+    if not pattern.search(text):
+        fail(f"{label} should state {detail}")
+
+
+def has_local_n8_status(text: str) -> bool:
+    for paragraph in re.split(r"\n\s*\n", text):
+        normalized = " ".join(paragraph.split())
+        if LOCAL_N8_RE.search(normalized):
+            return True
+    return False
+
+
+def require_local_n8_status(label: str, text: str) -> None:
+    if not has_local_n8_status(text):
+        fail(f"{label} should state repo-local machine-checked selected-witness n <= 8 status")
+
+
+def stale_line_is_archived(lines: list[str], index: int) -> bool:
+    window = "\n".join(lines[max(0, index - 3) : min(len(lines), index + 4)]).lower()
+    return any(marker in window for marker in ARCHIVAL_MARKERS)
+
+
+def validate_metadata() -> None:
+    path = ROOT / "metadata" / "erdos97.yaml"
+    if not path.exists():
         fail("metadata/erdos97.yaml is missing")
 
-    for rel in REQUIRED_NO_OVERCLAIM_FILES:
-        if not NO_OVERCLAIM_RE.search(read_text(rel)):
-            fail(f"{rel} is missing the no-overclaiming status sentence")
+    metadata = load_metadata(path)
+    official_status = metadata_value(metadata, ("problem", "official_status"))
+    if not isinstance(official_status, str) or official_status.lower() != "falsifiable/open":
+        fail("metadata official_status should be falsifiable/open")
+    require_pattern(
+        "metadata local_repo.overall_claim",
+        str(metadata_value(metadata, ("local_repo", "overall_claim"))),
+        NO_OVERCLAIM_RE,
+        "no general proof and no counterexample",
+    )
+    require_local_n8_status(
+        "metadata local_repo.strongest_result",
+        str(metadata_value(metadata, ("local_repo", "strongest_result"))),
+    )
+    require_pattern(
+        "metadata local_repo.strongest_result_review_status",
+        str(metadata_value(metadata, ("local_repo", "strongest_result_review_status"))),
+        REVIEW_RE,
+        "independent review before public theorem-style claims",
+    )
+    for key in METADATA_EXPECTED_TRUE:
+        if metadata_value(metadata, ("trust_policy", key)) is not True:
+            fail(f"metadata trust_policy.{key} should be true")
 
-    synthesis = ROOT / "docs" / "canonical-synthesis.md"
-    if synthesis.exists():
-        lines = synthesis.read_text(encoding="utf-8").splitlines()
-        for i, line in enumerate(lines):
-            if STALE_N8_RE.search(line):
-                window = "\n".join(lines[max(0, i - 8) : i + 1]).lower()
-                if not any(marker in window for marker in ARCHIVAL_MARKERS):
-                    fail(f"unarchived stale n=8 Open wording at {synthesis}:{i + 1}")
+
+def validate_top_level_status() -> None:
+    for rel in REQUIRED_STATUS_FILES:
+        text = read_text(rel)
+        require_pattern(rel, text, NO_OVERCLAIM_RE, "no general proof and no counterexample")
+        require_pattern(rel, text, OFFICIAL_OPEN_RE, "official/global falsifiable/open status")
+        require_local_n8_status(rel, text)
+        require_pattern(rel, text, REVIEW_RE, "independent review before public theorem-style claims")
 
     readme_state = read_text("README.md") + "\n" + read_text("STATE.md")
     if "metadata/erdos97.yaml" not in readme_state:
         fail("README.md or STATE.md should reference metadata/erdos97.yaml")
+
+
+def validate_archived_synthesis() -> None:
+    synthesis = ROOT / "docs" / "canonical-synthesis.md"
+    if not synthesis.exists():
+        return
+
+    lines = synthesis.read_text(encoding="utf-8").splitlines()
+    for i, line in enumerate(lines):
+        if not any(pattern.search(line) for pattern in STALE_N8_PATTERNS):
+            continue
+        if not stale_line_is_archived(lines, i):
+            fail(f"unarchived stale n=8 Open wording at {synthesis}:{i + 1}")
+
+
+def main() -> None:
+    validate_metadata()
+    validate_top_level_status()
+    validate_archived_synthesis()
 
 
 if __name__ == "__main__":

--- a/scripts/check_text_clean.py
+++ b/scripts/check_text_clean.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import unicodedata
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -48,6 +49,8 @@ HIDDEN_CHARS = {
     "\u2069": "POP DIRECTIONAL ISOLATE",
     "\ufeff": "BYTE ORDER MARK",
 }
+
+BIDI_CONTROL_CLASSES = {"LRE", "RLE", "LRO", "RLO", "PDF", "LRI", "RLI", "FSI", "PDI"}
 
 
 def tracked_files() -> list[Path]:
@@ -102,6 +105,16 @@ def display_path(path: Path) -> str:
         return str(path)
 
 
+def hidden_char_description(char: str) -> str | None:
+    if char in HIDDEN_CHARS:
+        return HIDDEN_CHARS[char]
+    # Policy: tracked text files should contain no Unicode format controls.
+    # They are invisible in review and too easy to mistake for ordinary text.
+    if unicodedata.category(char) == "Cf" or unicodedata.bidirectional(char) in BIDI_CONTROL_CLASSES:
+        return unicodedata.name(char, "FORMAT OR BIDI CONTROL")
+    return None
+
+
 def main() -> int:
     errors: list[str] = []
     for path in tracked_files():
@@ -117,13 +130,11 @@ def main() -> int:
             errors.append(f"{shown}: not valid UTF-8: {exc}")
             continue
         for index, char in enumerate(text):
-            if char in HIDDEN_CHARS:
+            description = hidden_char_description(char)
+            if description is not None:
                 line, col = line_col(text, index)
                 codepoint = f"U+{ord(char):04X}"
-                errors.append(
-                    f"{shown}:{line}:{col}: hidden character {codepoint} "
-                    f"({HIDDEN_CHARS[char]})"
-                )
+                errors.append(f"{shown}:{line}:{col}: hidden character {codepoint} ({description})")
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1

--- a/tests/test_check_status_consistency.py
+++ b/tests/test_check_status_consistency.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_status_consistency.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("check_status_consistency", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_n8_status_must_be_in_one_paragraph() -> None:
+    checker = load_checker()
+
+    good = (
+        "The selected-witness method rules out `n <= 8` in this repo-local, "
+        "machine-checked finite-case sense."
+    )
+    bad = (
+        "The selected-witness method is important.\n\n"
+        "Elsewhere, repo-local machine-checked finite-case artifacts are discussed for `n <= 8`."
+    )
+
+    assert checker.has_local_n8_status(good)
+    assert not checker.has_local_n8_status(bad)
+
+
+def test_stale_n8_line_requires_archival_context() -> None:
+    checker = load_checker()
+
+    stale = ['- $n = 8$ status — all 5 main docs agree on "open".']
+    archived = [
+        "- Archived/pre-current-artifact source-corpus status.",
+        '- $n = 8$ status — all 5 main docs agree on "open".',
+        "- Do not use this as current repo-local status.",
+    ]
+
+    assert any(pattern.search(stale[0]) for pattern in checker.STALE_N8_PATTERNS)
+    assert not checker.stale_line_is_archived(stale, 0)
+    assert checker.stale_line_is_archived(archived, 1)
+
+
+def test_metadata_parser_reads_structured_yaml(tmp_path: Path) -> None:
+    checker = load_checker()
+    metadata = tmp_path / "erdos97.yaml"
+    metadata.write_text(
+        """
+problem:
+    official_status: "falsifiable/open"
+local_repo:
+    overall_claim: "No general proof and no counterexample are claimed."
+trust_policy:
+    no_overclaiming: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    parsed = checker.load_metadata(metadata)
+
+    assert checker.metadata_value(parsed, ("problem", "official_status")) == "falsifiable/open"
+    assert checker.metadata_value(parsed, ("trust_policy", "no_overclaiming")) is True


### PR DESCRIPTION
## Summary

- Strengthen source-of-truth consistency checks against stale `n=8` open wording and validate the canonical metadata snapshot with structured PyYAML parsing.
- Bound the local `n <= 8` status check to a paragraph and add regression tests for status/stale-wording behavior.
- Clarify archived Appendix B `n=8` source-corpus language in `docs/canonical-synthesis.md`.
- Add explicit expected `n=8` outputs to `docs/reviewer-guide.md`.
- Expand LF/text normalization rules, harden hidden Unicode control detection, and run `git diff --check` in CI.
- Refresh README/STATE/RESULTS wording and repository map for current metadata, certificates, and reviewer guidance.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python scripts/check_mutual_rhombus_filter.py --assert-expected`

## Notes

No general proof or counterexample is claimed. Official/global status remains falsifiable/open. The local `n <= 8` selected-witness result remains repo-local, machine-checked, and marked for independent review before public theorem-style claims.