### PR TITLE
[codex] Add exact Altman and crossing CSP checks

### DIFF
--- a/data/certificates/p24_cyclic_crossing_unsat.json
+++ b/data/certificates/p24_cyclic_crossing_unsat.json
@@ -5068,5 +5068,6 @@
         }
       ]
     }
-  ]
+  ],
+  "terminal_conflicts_truncated": false
 }

--- a/data/certificates/p24_cyclic_crossing_unsat.json
+++ b/data/certificates/p24_cyclic_crossing_unsat.json
@@ -1,0 +1,5072 @@
+{
+  "constraint_count": 36,
+  "constraints": [
+    {
+      "source": [
+        0,
+        1
+      ],
+      "target": [
+        11,
+        14
+      ]
+    },
+    {
+      "source": [
+        0,
+        11
+      ],
+      "target": [
+        14,
+        21
+      ]
+    },
+    {
+      "source": [
+        0,
+        19
+      ],
+      "target": [
+        5,
+        14
+      ]
+    },
+    {
+      "source": [
+        1,
+        6
+      ],
+      "target": [
+        11,
+        20
+      ]
+    },
+    {
+      "source": [
+        1,
+        14
+      ],
+      "target": [
+        4,
+        11
+      ]
+    },
+    {
+      "source": [
+        2,
+        3
+      ],
+      "target": [
+        13,
+        16
+      ]
+    },
+    {
+      "source": [
+        2,
+        13
+      ],
+      "target": [
+        16,
+        23
+      ]
+    },
+    {
+      "source": [
+        2,
+        21
+      ],
+      "target": [
+        7,
+        16
+      ]
+    },
+    {
+      "source": [
+        3,
+        8
+      ],
+      "target": [
+        13,
+        22
+      ]
+    },
+    {
+      "source": [
+        3,
+        16
+      ],
+      "target": [
+        6,
+        13
+      ]
+    },
+    {
+      "source": [
+        4,
+        5
+      ],
+      "target": [
+        15,
+        18
+      ]
+    },
+    {
+      "source": [
+        4,
+        15
+      ],
+      "target": [
+        1,
+        18
+      ]
+    },
+    {
+      "source": [
+        4,
+        23
+      ],
+      "target": [
+        9,
+        18
+      ]
+    },
+    {
+      "source": [
+        5,
+        10
+      ],
+      "target": [
+        0,
+        15
+      ]
+    },
+    {
+      "source": [
+        5,
+        18
+      ],
+      "target": [
+        8,
+        15
+      ]
+    },
+    {
+      "source": [
+        6,
+        7
+      ],
+      "target": [
+        17,
+        20
+      ]
+    },
+    {
+      "source": [
+        6,
+        17
+      ],
+      "target": [
+        3,
+        20
+      ]
+    },
+    {
+      "source": [
+        7,
+        12
+      ],
+      "target": [
+        2,
+        17
+      ]
+    },
+    {
+      "source": [
+        7,
+        20
+      ],
+      "target": [
+        10,
+        17
+      ]
+    },
+    {
+      "source": [
+        8,
+        9
+      ],
+      "target": [
+        19,
+        22
+      ]
+    },
+    {
+      "source": [
+        8,
+        19
+      ],
+      "target": [
+        5,
+        22
+      ]
+    },
+    {
+      "source": [
+        9,
+        14
+      ],
+      "target": [
+        4,
+        19
+      ]
+    },
+    {
+      "source": [
+        9,
+        22
+      ],
+      "target": [
+        12,
+        19
+      ]
+    },
+    {
+      "source": [
+        10,
+        11
+      ],
+      "target": [
+        0,
+        21
+      ]
+    },
+    {
+      "source": [
+        10,
+        21
+      ],
+      "target": [
+        0,
+        7
+      ]
+    },
+    {
+      "source": [
+        11,
+        16
+      ],
+      "target": [
+        6,
+        21
+      ]
+    },
+    {
+      "source": [
+        12,
+        13
+      ],
+      "target": [
+        2,
+        23
+      ]
+    },
+    {
+      "source": [
+        12,
+        23
+      ],
+      "target": [
+        2,
+        9
+      ]
+    },
+    {
+      "source": [
+        13,
+        18
+      ],
+      "target": [
+        8,
+        23
+      ]
+    },
+    {
+      "source": [
+        14,
+        15
+      ],
+      "target": [
+        1,
+        4
+      ]
+    },
+    {
+      "source": [
+        15,
+        20
+      ],
+      "target": [
+        1,
+        10
+      ]
+    },
+    {
+      "source": [
+        16,
+        17
+      ],
+      "target": [
+        3,
+        6
+      ]
+    },
+    {
+      "source": [
+        17,
+        22
+      ],
+      "target": [
+        3,
+        12
+      ]
+    },
+    {
+      "source": [
+        18,
+        19
+      ],
+      "target": [
+        5,
+        8
+      ]
+    },
+    {
+      "source": [
+        20,
+        21
+      ],
+      "target": [
+        7,
+        10
+      ]
+    },
+    {
+      "source": [
+        22,
+        23
+      ],
+      "target": [
+        9,
+        12
+      ]
+    }
+  ],
+  "max_depth": 21,
+  "n": 24,
+  "nodes_visited": 56,
+  "order": null,
+  "pattern": "P24_parity_balanced",
+  "result": "UNSAT",
+  "sat": false,
+  "symmetry_normalization": [
+    [
+      0,
+      11,
+      1,
+      14
+    ],
+    [
+      0,
+      14,
+      1,
+      11
+    ]
+  ],
+  "terminal_conflicts": [
+    {
+      "blocked_label": 2,
+      "partial_order": [
+        0,
+        10,
+        20,
+        6,
+        16,
+        3,
+        17,
+        7,
+        21,
+        11,
+        1,
+        15,
+        5,
+        19,
+        9,
+        12,
+        22,
+        8,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 6,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              12
+            ],
+            "target": [
+              2,
+              17
+            ]
+          },
+          "gap_after": 16,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              12
+            ],
+            "target": [
+              2,
+              17
+            ]
+          },
+          "gap_after": 3,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              12
+            ],
+            "target": [
+              2,
+              17
+            ]
+          },
+          "gap_after": 17,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 7,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 15
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 12,
+          "insert_position": 16
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 17
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 18
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 19
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 20
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 21
+        }
+      ]
+    },
+    {
+      "blocked_label": 17,
+      "partial_order": [
+        0,
+        10,
+        20,
+        7,
+        6,
+        21,
+        11,
+        1,
+        15,
+        5,
+        19,
+        9,
+        22,
+        8,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              20
+            ],
+            "target": [
+              10,
+              17
+            ]
+          },
+          "gap_after": 7,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 6,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 15
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 16
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 17
+        }
+      ]
+    },
+    {
+      "blocked_label": 17,
+      "partial_order": [
+        0,
+        10,
+        20,
+        7,
+        21,
+        6,
+        11,
+        1,
+        15,
+        5,
+        19,
+        9,
+        22,
+        8,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              20
+            ],
+            "target": [
+              10,
+              17
+            ]
+          },
+          "gap_after": 7,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              20
+            ],
+            "target": [
+              10,
+              17
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 6,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 15
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 16
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 17
+        }
+      ]
+    },
+    {
+      "blocked_label": 7,
+      "partial_order": [
+        0,
+        10,
+        21,
+        20,
+        11,
+        1,
+        15,
+        5,
+        19,
+        9,
+        22,
+        8,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              20,
+              21
+            ],
+            "target": [
+              7,
+              10
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 15
+        }
+      ]
+    },
+    {
+      "blocked_label": 7,
+      "partial_order": [
+        0,
+        10,
+        21,
+        11,
+        20,
+        1,
+        15,
+        5,
+        19,
+        9,
+        22,
+        8,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              20,
+              21
+            ],
+            "target": [
+              7,
+              10
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 15
+        }
+      ]
+    },
+    {
+      "blocked_label": 22,
+      "partial_order": [
+        0,
+        10,
+        21,
+        11,
+        1,
+        15,
+        5,
+        19,
+        8,
+        9,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              19
+            ],
+            "target": [
+              5,
+              22
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 13
+        }
+      ]
+    },
+    {
+      "blocked_label": 22,
+      "partial_order": [
+        0,
+        10,
+        21,
+        11,
+        1,
+        15,
+        5,
+        19,
+        8,
+        18,
+        9,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              19
+            ],
+            "target": [
+              5,
+              22
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              19
+            ],
+            "target": [
+              5,
+              22
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 13
+        }
+      ]
+    },
+    {
+      "blocked_label": 8,
+      "partial_order": [
+        0,
+        10,
+        21,
+        11,
+        1,
+        15,
+        5,
+        18,
+        19,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              18,
+              19
+            ],
+            "target": [
+              5,
+              8
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 11
+        }
+      ]
+    },
+    {
+      "blocked_label": 8,
+      "partial_order": [
+        0,
+        10,
+        21,
+        11,
+        1,
+        15,
+        5,
+        18,
+        4,
+        19,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              18,
+              19
+            ],
+            "target": [
+              5,
+              8
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 11
+        }
+      ]
+    },
+    {
+      "blocked_label": 21,
+      "partial_order": [
+        0,
+        11,
+        10,
+        1,
+        15,
+        5,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              10,
+              11
+            ],
+            "target": [
+              0,
+              21
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 9
+        }
+      ]
+    },
+    {
+      "blocked_label": 21,
+      "partial_order": [
+        0,
+        11,
+        1,
+        10,
+        15,
+        5,
+        18,
+        4,
+        14
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              10,
+              11
+            ],
+            "target": [
+              0,
+              21
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 9
+        }
+      ]
+    },
+    {
+      "blocked_label": 21,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        5,
+        15,
+        10,
+        1,
+        11
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              11
+            ],
+            "target": [
+              0,
+              21
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 9
+        }
+      ]
+    },
+    {
+      "blocked_label": 21,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        5,
+        15,
+        1,
+        10,
+        11
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              0,
+              11
+            ],
+            "target": [
+              14,
+              21
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              11
+            ],
+            "target": [
+              0,
+              21
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 9
+        }
+      ]
+    },
+    {
+      "blocked_label": 8,
+      "partial_order": [
+        0,
+        14,
+        19,
+        4,
+        18,
+        5,
+        15,
+        1,
+        11,
+        21,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              18,
+              19
+            ],
+            "target": [
+              5,
+              8
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 11
+        }
+      ]
+    },
+    {
+      "blocked_label": 8,
+      "partial_order": [
+        0,
+        14,
+        4,
+        19,
+        18,
+        5,
+        15,
+        1,
+        11,
+        21,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              18,
+              19
+            ],
+            "target": [
+              5,
+              8
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              5,
+              18
+            ],
+            "target": [
+              8,
+              15
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 11
+        }
+      ]
+    },
+    {
+      "blocked_label": 22,
+      "partial_order": [
+        0,
+        14,
+        4,
+        9,
+        18,
+        8,
+        19,
+        5,
+        15,
+        1,
+        11,
+        21,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              19
+            ],
+            "target": [
+              5,
+              22
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              19
+            ],
+            "target": [
+              5,
+              22
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 13
+        }
+      ]
+    },
+    {
+      "blocked_label": 22,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        9,
+        8,
+        19,
+        5,
+        15,
+        1,
+        11,
+        21,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              19
+            ],
+            "target": [
+              5,
+              22
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              8,
+              9
+            ],
+            "target": [
+              19,
+              22
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 13
+        }
+      ]
+    },
+    {
+      "blocked_label": 7,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        8,
+        22,
+        9,
+        19,
+        5,
+        15,
+        1,
+        20,
+        11,
+        21,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              20,
+              21
+            ],
+            "target": [
+              7,
+              10
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 15
+        }
+      ]
+    },
+    {
+      "blocked_label": 7,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        8,
+        22,
+        9,
+        19,
+        5,
+        15,
+        1,
+        11,
+        20,
+        21,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              20,
+              21
+            ],
+            "target": [
+              7,
+              10
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              21
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 15
+        }
+      ]
+    },
+    {
+      "blocked_label": 17,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        8,
+        22,
+        9,
+        19,
+        5,
+        15,
+        1,
+        11,
+        6,
+        21,
+        7,
+        20,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              20
+            ],
+            "target": [
+              10,
+              17
+            ]
+          },
+          "gap_after": 6,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              20
+            ],
+            "target": [
+              10,
+              17
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 7,
+          "insert_position": 15
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 16
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 17
+        }
+      ]
+    },
+    {
+      "blocked_label": 17,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        8,
+        22,
+        9,
+        19,
+        5,
+        15,
+        1,
+        11,
+        21,
+        6,
+        7,
+        20,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              20
+            ],
+            "target": [
+              10,
+              17
+            ]
+          },
+          "gap_after": 6,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 7,
+          "insert_position": 15
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 16
+        },
+        {
+          "constraint": {
+            "source": [
+              6,
+              7
+            ],
+            "target": [
+              17,
+              20
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 17
+        }
+      ]
+    },
+    {
+      "blocked_label": 2,
+      "partial_order": [
+        0,
+        14,
+        4,
+        18,
+        8,
+        22,
+        12,
+        9,
+        19,
+        5,
+        15,
+        1,
+        11,
+        21,
+        7,
+        17,
+        3,
+        16,
+        6,
+        20,
+        10
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 2
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 4,
+          "insert_position": 3
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 18,
+          "insert_position": 4
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 5
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 22,
+          "insert_position": 6
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 12,
+          "insert_position": 7
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 9,
+          "insert_position": 8
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 19,
+          "insert_position": 9
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 5,
+          "insert_position": 10
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 15,
+          "insert_position": 11
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 12
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 13
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 21,
+          "insert_position": 14
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              12
+            ],
+            "target": [
+              2,
+              17
+            ]
+          },
+          "gap_after": 7,
+          "insert_position": 15
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              12
+            ],
+            "target": [
+              2,
+              17
+            ]
+          },
+          "gap_after": 17,
+          "insert_position": 16
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              12
+            ],
+            "target": [
+              2,
+              17
+            ]
+          },
+          "gap_after": 3,
+          "insert_position": 17
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 16,
+          "insert_position": 18
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 6,
+          "insert_position": 19
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 20,
+          "insert_position": 20
+        },
+        {
+          "constraint": {
+            "source": [
+              2,
+              21
+            ],
+            "target": [
+              7,
+              16
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 21
+        }
+      ]
+    }
+  ]
+}

--- a/data/patterns/candidate_patterns.json
+++ b/data/patterns/candidate_patterns.json
@@ -23,8 +23,8 @@
     "n": 18,
     "formula": "even offsets {-7,-2,4,8}; odd offsets {-8,-4,2,7}",
     "type": "period-2",
-    "status": "killed under natural cyclic order by adjacent-row two-overlap via crossing-bisector; unresolved as an abstract incidence pattern if arbitrary cyclic orders are allowed",
-    "trust": "EXACT_OBSTRUCTION"
+    "status": "natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: survives current crossing filters, with a compatible cyclic order recorded",
+    "trust": "INCIDENCE_PATTERN"
   },
   {
     "rank": 4,
@@ -32,7 +32,7 @@
     "n": 24,
     "formula": "even offsets {-10,-3,5,11}; odd offsets {-11,-5,3,10}",
     "type": "period-2",
-    "status": "killed under natural cyclic order by adjacent-row two-overlap via crossing-bisector; unresolved as an abstract incidence pattern if arbitrary cyclic orders are allowed",
+    "status": "natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: killed by exact finite crossing-CSP; no cyclic order satisfies all 36 required crossings",
     "trust": "EXACT_OBSTRUCTION"
   },
   {
@@ -41,7 +41,7 @@
     "n": 19,
     "formula": "offsets {-8,-3,5,9}",
     "type": "skew circulant",
-    "status": "sparse common-neighbor overlap; not killed by current mutual-rhombus filter",
+    "status": "natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse with no phi edges and no mutual-rhombus or forced-perpendicularity obstruction",
     "trust": "INCIDENCE_PATTERN"
   },
   {

--- a/docs/altman-diagonal-sums.md
+++ b/docs/altman-diagonal-sums.md
@@ -1,0 +1,82 @@
+# Altman diagonal-order sum obstruction
+
+Status: `EXACT_OBSTRUCTION` for natural-cyclic-order selected patterns.
+
+No general proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+## Theorem
+
+Let `P` be a strict convex `n`-gon in cyclic order. Define
+
+```text
+U_k = sum_{i=0}^{n-1} |p_i - p_{i+k}|,
+1 <= k <= floor(n/2),
+```
+
+with indices modulo `n`. For even `n` and `k=n/2`, this convention counts each
+maximal diagonal twice.
+
+Altman's theorem gives
+
+```text
+U_1 < U_2 < ... < U_floor(n/2).
+```
+
+## Proof Source
+
+E. Altman, "Some theorems on convex polygons", Canadian Mathematical Bulletin
+15(3), 1972, 329-340, Theorem 1. DOI: `10.4153/CMB-1972-060-0`.
+
+## Application Rule
+
+For a constant cyclic-offset selected pattern
+
+```text
+S_i = {i+o_1, i+o_2, i+o_3, i+o_4},
+```
+
+if the natural label order `0,1,...,n-1` is the polygonal cyclic order, the
+equal-distance row constraints imply equal ordinary distances from each center
+to all four selected offsets. Summing over all rows forces equality among the
+diagonal sums `U_ord(o_r)`. If at least two selected offsets have distinct
+cyclic chord orders, this contradicts Altman's strict chain.
+
+Squared-distance equalities imply ordinary-distance equalities because
+distances are nonnegative and selected witnesses are distinct from their
+centers.
+
+## C19_skew
+
+For `C19_skew`,
+
+```text
+n = 19
+S_i = {i-8, i-3, i+5, i+9}.
+```
+
+The natural-order selected equalities imply
+
+```text
+|p_i-p_{i-8}| = |p_i-p_{i-3}| = |p_i-p_{i+5}| = |p_i-p_{i+9}|.
+```
+
+The chord orders are `8`, `3`, `5`, and `9`, so summing over all `i` gives
+
+```text
+U_8 = U_3 = U_5 = U_9.
+```
+
+Altman gives
+
+```text
+U_3 < U_5 < U_8 < U_9.
+```
+
+Thus `C19_skew` is exactly obstructed in natural cyclic order.
+
+## Caveats
+
+- Altman's diagonal-order obstruction is natural-cyclic-order only.
+- It does not kill abstract-incidence versions with arbitrary cyclic relabeling.
+- `C19_skew` remains an abstract-incidence sparse survivor of the current
+  `phi`, midpoint, and forced-perpendicularity filters.

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -7,21 +7,22 @@ designs only; geometric realization is a separate problem.
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | sparse common-neighbor overlap; not killed by the current mutual-rhombus filter[^repo] |
+| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse, with no `phi` edges and no mutual-rhombus or forced-perpendicularity obstruction[^repo] |
 
-The live pattern above should pass the row-overlap filter
-`|S_i cap S_j| <= 2` before numerical optimization.[^comp]
+The live abstract-incidence pattern above should pass the row-overlap filter
+`|S_i cap S_j| <= 2` before numerical optimization. Its natural-order
+realization is already exactly obstructed.[^comp]
 
-## Natural-order killed / cyclic-order unresolved patterns
+## Natural-order killed / abstract-order status patterns
 
 These patterns are killed if the natural label order `0,1,...,n-1` is the
-cyclic order. As abstract incidence patterns, they require a cyclic-order
-search if arbitrary cyclic orders are allowed.
+cyclic order. Their abstract-incidence status is tracked separately when
+arbitrary cyclic orders are allowed.
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| U1 | `P18_parity_balanced` | 18 | even: `{-7,-2,4,8}`, odd: `{-8,-4,2,7}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: requires cyclic-order search |
-| U2 | `P24_parity_balanced` | 24 | even: `{-10,-3,5,11}`, odd: `{-11,-5,3,10}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: requires cyclic-order search |
+| U1 | `P18_parity_balanced` | 18 | even: `{-7,-2,4,8}`, odd: `{-8,-4,2,7}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: survives current crossing filters, with a compatible cyclic order recorded |
+| U2 | `P24_parity_balanced` | 24 | even: `{-10,-3,5,11}`, odd: `{-11,-5,3,10}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: killed by exact finite crossing-CSP; no cyclic order satisfies all 36 required crossings |
 
 ## Speculative extensions
 

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -39,6 +39,21 @@ perpendicular-bisector algebra, equal-distance algebra, duplicate vertices,
 collinearity, or strict-convexity failure. See
 `docs/n8-incidence-enumeration.md` and `docs/n8-exact-survivors.md`.
 
+### Altman diagonal-order sums
+
+For a strict convex `n`-gon in cyclic order, the sums `U_k` of chord lengths of
+cyclic order `k` satisfy
+
+```text
+U_1 < U_2 < ... < U_floor(n/2).
+```
+
+Therefore a natural-order cyclic-offset selected pattern that forces
+`U_a = U_b` for distinct chord orders `a,b` is impossible. This is a
+natural-order obstruction only; it does not apply to arbitrary cyclic
+relabelings of the same incidence pattern. See
+`docs/altman-diagonal-sums.md`.
+
 ## Lemmas
 
 ### Circle-intersection cap

--- a/docs/cyclic-crossing-csp.md
+++ b/docs/cyclic-crossing-csp.md
@@ -1,0 +1,64 @@
+# Cyclic crossing CSP for two-overlap patterns
+
+Status: finite exact cyclic-order obstruction.
+
+No general proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+## Input
+
+The input is a selected-witness incidence pattern: one 4-set `S_i` for each
+center label `i`.
+
+## Constraints
+
+For every row-pair `{i,j}` with
+
+```text
+|S_i cap S_j| = 2,
+```
+
+define
+
+```text
+phi({i,j}) = S_i cap S_j.
+```
+
+The crossing-bisection lemma requires the source chord `{i,j}` to cross the
+target chord `phi({i,j})` in any proposed cyclic order.
+
+## Exact Search
+
+The checker in `scripts/check_cyclic_crossing_csp.py` performs a deterministic
+insertion search. It fixes the first required crossing up to rotation and
+reversal, then recursively inserts unplaced labels into circular gaps. A branch
+is rejected only when all four endpoints of a crossing constraint have been
+placed and the source and target chords do not cross.
+
+The search uses exact finite combinatorics only. It does not use coordinates or
+floating point.
+
+## P18_parity_balanced
+
+`P18_parity_balanced` is killed in natural order by adjacent-row two-overlap via
+the crossing-bisection lemma. It survives the current arbitrary-order crossing
+filters. One compatible cyclic order is:
+
+```text
+0,8,4,15,1,5,11,9,3,7,17,13,2,6,14,10,16,12
+```
+
+Thus the abstract-incidence status remains unresolved
+algebraically/geometrically; `P18_parity_balanced` is not globally archived as
+killed.
+
+## P24_parity_balanced
+
+`P24_parity_balanced` is killed in natural order by adjacent-row two-overlap via
+the crossing-bisection lemma. As an abstract incidence pattern, it has 36
+two-overlap crossing constraints.
+
+The deterministic crossing CSP proves that no cyclic order of the 24 labels
+satisfies all 36 required crossings. The certificate is stored at
+`data/certificates/p24_cyclic_crossing_unsat.json`.
+
+This is an exact finite cyclic-order obstruction for the fixed selected pattern.

--- a/docs/cyclic-crossing-csp.md
+++ b/docs/cyclic-crossing-csp.md
@@ -34,8 +34,16 @@ reversal, then recursively inserts unplaced labels into circular gaps. A branch
 is rejected only when all four endpoints of a crossing constraint have been
 placed and the source and target chords do not cross.
 
+The first constraint is chosen by deterministic tuple ordering of the `phi`
+constraints. A crossing of two disjoint chords has exactly two circular endpoint
+embeddings up to rotation and reversal, so the two seeded orders cover all
+symmetry classes for any satisfying cyclic order.
+
 The search uses exact finite combinatorics only. It does not use coordinates or
 floating point.
+
+Routine JSON output caps retained terminal conflict traces by default. Certificate
+runs may pass `--full-conflicts` when a full deterministic trace is desired.
 
 ## P18_parity_balanced
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,10 @@ put detailed reconciliation in the canonical synthesis.
   proof-facing caveats.
 - [`mutual-rhombus-filter.md`](mutual-rhombus-filter.md): crossing-bisector and
   mutual-midpoint filters for fixed selected-witness patterns.
+- [`altman-diagonal-sums.md`](altman-diagonal-sums.md): natural-order
+  diagonal-sum obstruction for cyclic-offset patterns.
+- [`cyclic-crossing-csp.md`](cyclic-crossing-csp.md): exact cyclic-order
+  crossing CSP for two-overlap patterns.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n7-fano-obstruction.md`](n7-fano-obstruction.md): proof note for the

--- a/docs/mutual-rhombus-filter.md
+++ b/docs/mutual-rhombus-filter.md
@@ -192,9 +192,16 @@ Under the natural cyclic order `0,1,...,n-1`, the parity patterns
 two common witnesses. The crossing-bisector lemma therefore kills them under
 that cyclic order.
 
-Their abstract-incidence status remains separate: if arbitrary cyclic orders
-are allowed, they require a cyclic-order search before they can be globally
-archived as killed incidence patterns.
+Their abstract-incidence status remains separate. The exact crossing CSP in
+`docs/cyclic-crossing-csp.md` records that `P18_parity_balanced` has compatible
+arbitrary cyclic orders, while `P24_parity_balanced` has no cyclic order
+satisfying all 36 crossing constraints.
+
+The sparse pattern `C19_skew` has no `phi` edges, so it is invisible to the
+mutual-rhombus and forced-perpendicularity filters. It is nevertheless killed
+in natural cyclic order by Altman's diagonal-order sums; see
+`docs/altman-diagonal-sums.md`. This does not kill the same abstract incidence
+pattern under arbitrary cyclic relabeling.
 
 ## Reproduction
 

--- a/scripts/check_altman_diagonal_sums.py
+++ b/scripts/check_altman_diagonal_sums.py
@@ -17,6 +17,7 @@ if str(SRC) not in sys.path:
 from erdos97.altman_diagonal_sums import check_altman  # noqa: E402
 from erdos97.search import built_in_patterns  # noqa: E402
 
+PATTERN_LEDGER = ROOT / "data" / "patterns" / "candidate_patterns.json"
 
 EXPECTED: dict[str, dict[str, object]] = {
     "C19_skew": {
@@ -30,11 +31,39 @@ EXPECTED: dict[str, dict[str, object]] = {
 }
 
 
+def abstract_status_from_ledger(pattern_name: str) -> str:
+    data = json.loads(PATTERN_LEDGER.read_text(encoding="utf-8"))
+    by_name = {str(row["name"]): row for row in data}
+    if pattern_name not in by_name:
+        return "UNTOUCHED"
+    status = str(by_name[pattern_name].get("status", ""))
+    marker = "abstract-incidence status:"
+    if marker not in status:
+        return "UNTOUCHED"
+    abstract_status = status.split(marker, 1)[1].strip()
+    normalized = abstract_status.lower()
+    if normalized.startswith("live"):
+        return "LIVE"
+    if normalized.startswith("survives"):
+        return "SURVIVES_CURRENT_FILTERS"
+    if normalized.startswith("killed"):
+        return "EXACT_OBSTRUCTION"
+    return abstract_status or "UNTOUCHED"
+
+
+def decorate_row(row: dict[str, object]) -> dict[str, object]:
+    return {
+        **row,
+        "abstract_incidence_status": abstract_status_from_ledger(str(row["pattern"])),
+    }
+
+
 def assert_expected(rows: list[dict[str, object]]) -> None:
     by_pattern = {str(row["pattern"]): row for row in rows}
+    missing = sorted(set(EXPECTED) - set(by_pattern))
+    if missing:
+        raise AssertionError(f"missing expected pattern(s): {', '.join(missing)}")
     for pattern, expected in EXPECTED.items():
-        if pattern not in by_pattern:
-            continue
         row = by_pattern[pattern]
         for key, value in expected.items():
             if row[key] != value:
@@ -75,7 +104,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print JSON instead of a table")
     parser.add_argument("--pattern", help="limit checks to one built-in pattern")
-    parser.add_argument("--assert-expected", action="store_true", help="assert C19 expected output")
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert every registered expected output is selected and correct",
+    )
     parser.add_argument(
         "--assert-natural-killed",
         action="store_true",
@@ -91,7 +124,7 @@ def main() -> int:
     else:
         selected = list(patterns.values())
 
-    rows = [dataclasses.asdict(check_altman(pattern)) for pattern in selected]
+    rows = [decorate_row(dataclasses.asdict(check_altman(pattern))) for pattern in selected]
     if args.assert_expected:
         assert_expected(rows)
     if args.assert_natural_killed:

--- a/scripts/check_altman_diagonal_sums.py
+++ b/scripts/check_altman_diagonal_sums.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Check natural-order Altman diagonal-sum obstructions."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.altman_diagonal_sums import check_altman  # noqa: E402
+from erdos97.search import built_in_patterns  # noqa: E402
+
+
+EXPECTED: dict[str, dict[str, object]] = {
+    "C19_skew": {
+        "offsets": [-8, -3, 5, 9],
+        "chord_orders": [8, 3, 5, 9],
+        "forced_equal_U": [3, 5, 8, 9],
+        "altman_contradiction": True,
+        "status": "NATURAL_ORDER_EXACT_OBSTRUCTION",
+        "abstract_incidence_status": "LIVE",
+    }
+}
+
+
+def assert_expected(rows: list[dict[str, object]]) -> None:
+    by_pattern = {str(row["pattern"]): row for row in rows}
+    for pattern, expected in EXPECTED.items():
+        if pattern not in by_pattern:
+            continue
+        row = by_pattern[pattern]
+        for key, value in expected.items():
+            if row[key] != value:
+                raise AssertionError(f"{pattern}: {key} {row[key]} != {value}")
+
+
+def assert_natural_killed(rows: list[dict[str, object]]) -> None:
+    for row in rows:
+        if not row["altman_contradiction"]:
+            raise AssertionError(f"{row['pattern']}: expected an Altman contradiction")
+
+
+def print_table(rows: list[dict[str, object]]) -> None:
+    headers = ["pattern", "n", "offsets", "orders", "forced U", "status", "abstract"]
+    table = [
+        [
+            str(row["pattern"]),
+            str(row["n"]),
+            str(row["offsets"]),
+            str(row["chord_orders"]),
+            str(row["forced_equal_U"]),
+            str(row["status"]),
+            str(row["abstract_incidence_status"]),
+        ]
+        for row in rows
+    ]
+    widths = [
+        max(len(headers[col]), *(len(row[col]) for row in table))
+        for col in range(len(headers))
+    ]
+    print("  ".join(headers[col].ljust(widths[col]) for col in range(len(headers))))
+    print("  ".join("-" * widths[col] for col in range(len(headers))))
+    for row in table:
+        print("  ".join(row[col].ljust(widths[col]) for col in range(len(headers))))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a table")
+    parser.add_argument("--pattern", help="limit checks to one built-in pattern")
+    parser.add_argument("--assert-expected", action="store_true", help="assert C19 expected output")
+    parser.add_argument(
+        "--assert-natural-killed",
+        action="store_true",
+        help="assert every selected pattern has an Altman contradiction",
+    )
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern:
+        if args.pattern not in patterns:
+            raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+        selected = [patterns[args.pattern]]
+    else:
+        selected = list(patterns.values())
+
+    rows = [dataclasses.asdict(check_altman(pattern)) for pattern in selected]
+    if args.assert_expected:
+        assert_expected(rows)
+    if args.assert_natural_killed:
+        assert_natural_killed(rows)
+
+    if args.json:
+        output: object = rows[0] if args.pattern and len(rows) == 1 else rows
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print_table(rows)
+        if args.assert_expected or args.assert_natural_killed:
+            print("OK: Altman diagonal-sum expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_cyclic_crossing_csp.py
+++ b/scripts/check_cyclic_crossing_csp.py
@@ -65,6 +65,17 @@ def main() -> int:
     parser.add_argument("--assert-sat", action="store_true", help="assert selected pattern is SAT")
     parser.add_argument("--assert-unsat", action="store_true", help="assert selected pattern is UNSAT")
     parser.add_argument("--write-certificate", help="write a JSON certificate/result file")
+    parser.add_argument(
+        "--max-terminal-conflicts",
+        type=int,
+        default=128,
+        help="maximum UNSAT terminal conflicts to retain; use --full-conflicts for no cap",
+    )
+    parser.add_argument(
+        "--full-conflicts",
+        action="store_true",
+        help="retain every terminal conflict in UNSAT output",
+    )
     args = parser.parse_args()
 
     patterns = built_in_patterns()
@@ -77,7 +88,12 @@ def main() -> int:
 
     rows: list[dict[str, object]] = []
     for pattern in selected:
-        result = find_cyclic_crossing_order(pattern.S, pattern.name)
+        max_conflicts = None if args.full_conflicts else args.max_terminal_conflicts
+        result = find_cyclic_crossing_order(
+            pattern.S,
+            pattern.name,
+            max_terminal_conflicts=max_conflicts,
+        )
         row = result_to_json(result)
         if result.order is not None:
             constraints = crossing_constraints(pattern.S)

--- a/scripts/check_cyclic_crossing_csp.py
+++ b/scripts/check_cyclic_crossing_csp.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Check cyclic-order crossing CSPs for two-overlap patterns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.cyclic_crossing_csp import (  # noqa: E402
+    all_constraints_cross,
+    crossing_constraints,
+    find_cyclic_crossing_order,
+    result_to_json,
+)
+from erdos97.search import built_in_patterns  # noqa: E402
+
+
+def assert_sat(row: dict[str, object]) -> None:
+    if not row["sat"]:
+        raise AssertionError(f"{row['pattern']}: expected SAT")
+
+
+def assert_unsat(row: dict[str, object]) -> None:
+    if row["sat"]:
+        raise AssertionError(f"{row['pattern']}: expected UNSAT, got {row['order']}")
+
+
+def print_table(rows: list[dict[str, object]]) -> None:
+    headers = ["pattern", "n", "constraints", "result", "nodes", "max depth", "order"]
+    table = []
+    for row in rows:
+        order = row["order"]
+        table.append(
+            [
+                str(row["pattern"]),
+                str(row["n"]),
+                str(row["constraint_count"]),
+                str(row["result"]),
+                str(row["nodes_visited"]),
+                str(row["max_depth"]),
+                "-" if order is None else str(order),
+            ]
+        )
+    widths = [
+        max(len(headers[col]), *(len(row[col]) for row in table))
+        for col in range(len(headers))
+    ]
+    print("  ".join(headers[col].ljust(widths[col]) for col in range(len(headers))))
+    print("  ".join("-" * widths[col] for col in range(len(headers))))
+    for row in table:
+        print("  ".join(row[col].ljust(widths[col]) for col in range(len(headers))))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a table")
+    parser.add_argument("--pattern", help="limit checks to one built-in pattern")
+    parser.add_argument("--assert-sat", action="store_true", help="assert selected pattern is SAT")
+    parser.add_argument("--assert-unsat", action="store_true", help="assert selected pattern is UNSAT")
+    parser.add_argument("--write-certificate", help="write a JSON certificate/result file")
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern:
+        if args.pattern not in patterns:
+            raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+        selected = [patterns[args.pattern]]
+    else:
+        selected = [patterns["P18_parity_balanced"], patterns["P24_parity_balanced"]]
+
+    rows: list[dict[str, object]] = []
+    for pattern in selected:
+        result = find_cyclic_crossing_order(pattern.S, pattern.name)
+        row = result_to_json(result)
+        if result.order is not None:
+            constraints = crossing_constraints(pattern.S)
+            if not all_constraints_cross(result.order, constraints):
+                raise AssertionError(f"{pattern.name}: search returned an invalid order")
+        rows.append(row)
+
+    if args.assert_sat:
+        for row in rows:
+            assert_sat(row)
+    if args.assert_unsat:
+        for row in rows:
+            assert_unsat(row)
+
+    output: object = rows[0] if args.pattern and len(rows) == 1 else rows
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(output, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print_table(rows)
+        if args.assert_sat or args.assert_unsat:
+            print("OK: cyclic crossing CSP expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/altman_diagonal_sums.py
+++ b/src/erdos97/altman_diagonal_sums.py
@@ -22,7 +22,6 @@ class AltmanDiagonalSumResult:
     forced_equal_U: list[int]
     altman_contradiction: bool
     status: str
-    abstract_incidence_status: str
 
 
 def chord_order(n: int, offset: int) -> int:
@@ -34,7 +33,11 @@ def chord_order(n: int, offset: int) -> int:
 
 
 def signed_offset(n: int, residue: int) -> int:
-    """Return a canonical signed representative for a nonzero residue mod n."""
+    """Return a canonical signed representative for a nonzero residue mod n.
+
+    Callers pass target-center residues. A zero residue is rejected because it
+    would select the center itself rather than a witness.
+    """
     residue %= n
     if residue == 0:
         raise ValueError("zero offset would select the center")
@@ -74,13 +77,11 @@ def check_altman(pattern: PatternInfo) -> AltmanDiagonalSumResult:
             forced_equal_U=[],
             altman_contradiction=False,
             status="NOT_APPLIED_NONCONSTANT_OFFSETS",
-            abstract_incidence_status="UNTOUCHED",
         )
 
     chord_orders = [chord_order(pattern.n, offset) for offset in offsets]
     forced_equal_U = sorted(set(chord_orders))
     contradiction = len(forced_equal_U) >= 2
-    abstract_status = "LIVE" if pattern.name == "C19_skew" else "UNTOUCHED"
     return AltmanDiagonalSumResult(
         pattern=pattern.name,
         n=pattern.n,
@@ -94,5 +95,4 @@ def check_altman(pattern: PatternInfo) -> AltmanDiagonalSumResult:
             if contradiction
             else "NO_NATURAL_ORDER_ALTMAN_OBSTRUCTION"
         ),
-        abstract_incidence_status=abstract_status,
     )

--- a/src/erdos97/altman_diagonal_sums.py
+++ b/src/erdos97/altman_diagonal_sums.py
@@ -1,0 +1,98 @@
+"""Natural-order Altman diagonal-sum obstruction.
+
+This module is exact finite bookkeeping around cyclic offsets. It never uses
+coordinates or floating point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from erdos97.search import PatternInfo
+
+
+@dataclass(frozen=True)
+class AltmanDiagonalSumResult:
+    pattern: str
+    n: int
+    natural_order_only: bool
+    offsets: list[int]
+    chord_orders: list[int]
+    forced_equal_U: list[int]
+    altman_contradiction: bool
+    status: str
+    abstract_incidence_status: str
+
+
+def chord_order(n: int, offset: int) -> int:
+    """Return the cyclic chord order of an offset modulo n."""
+    if n <= 0:
+        raise ValueError(f"n must be positive, got {n}")
+    t = offset % n
+    return min(t, n - t)
+
+
+def signed_offset(n: int, residue: int) -> int:
+    """Return a canonical signed representative for a nonzero residue mod n."""
+    residue %= n
+    if residue == 0:
+        raise ValueError("zero offset would select the center")
+    if residue > n // 2:
+        return residue - n
+    return residue
+
+
+def constant_cyclic_offsets(S: Sequence[Sequence[int]]) -> list[int] | None:
+    """
+    Return offsets if S_i is one constant cyclic-offset pattern, else None.
+
+    The offsets are canonical signed representatives sorted increasingly. This
+    deliberately declines period-2 and other nonconstant patterns.
+    """
+    n = len(S)
+    if n == 0:
+        return []
+    offsets = sorted(signed_offset(n, target) for target in S[0])
+    residues = {offset % n for offset in offsets}
+    for i, row in enumerate(S):
+        if set(row) != {(i + offset) % n for offset in residues}:
+            return None
+    return offsets
+
+
+def check_altman(pattern: PatternInfo) -> AltmanDiagonalSumResult:
+    """Check the natural-order diagonal-sum obstruction for one pattern."""
+    offsets = constant_cyclic_offsets(pattern.S)
+    if offsets is None:
+        return AltmanDiagonalSumResult(
+            pattern=pattern.name,
+            n=pattern.n,
+            natural_order_only=True,
+            offsets=[],
+            chord_orders=[],
+            forced_equal_U=[],
+            altman_contradiction=False,
+            status="NOT_APPLIED_NONCONSTANT_OFFSETS",
+            abstract_incidence_status="UNTOUCHED",
+        )
+
+    chord_orders = [chord_order(pattern.n, offset) for offset in offsets]
+    forced_equal_U = sorted(set(chord_orders))
+    contradiction = len(forced_equal_U) >= 2
+    abstract_status = "LIVE" if pattern.name == "C19_skew" else "UNTOUCHED"
+    return AltmanDiagonalSumResult(
+        pattern=pattern.name,
+        n=pattern.n,
+        natural_order_only=True,
+        offsets=offsets,
+        chord_orders=chord_orders,
+        forced_equal_U=forced_equal_U,
+        altman_contradiction=contradiction,
+        status=(
+            "NATURAL_ORDER_EXACT_OBSTRUCTION"
+            if contradiction
+            else "NO_NATURAL_ORDER_ALTMAN_OBSTRUCTION"
+        ),
+        abstract_incidence_status=abstract_status,
+    )

--- a/src/erdos97/cyclic_crossing_csp.py
+++ b/src/erdos97/cyclic_crossing_csp.py
@@ -1,0 +1,202 @@
+"""Exact cyclic-order CSP for crossing-bisection constraints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from erdos97.incidence_filters import Chord, chords_cross_in_order, phi_map
+
+Constraint = tuple[Chord, Chord]
+
+
+@dataclass(frozen=True)
+class CyclicCrossingResult:
+    pattern: str
+    n: int
+    constraints: list[Constraint]
+    symmetry_normalization: list[list[int]]
+    sat: bool
+    order: list[int] | None
+    nodes_visited: int
+    max_depth: int
+    terminal_conflicts: list[dict[str, object]]
+
+
+def crossing_constraints(S: Sequence[Sequence[int]]) -> list[Constraint]:
+    """Return all phi crossing constraints source -> target."""
+    return sorted(phi_map(S).items())
+
+
+def all_constraints_cross(order: Sequence[int], constraints: Sequence[Constraint]) -> bool:
+    """Return True iff every source chord crosses its target in order."""
+    return all(chords_cross_in_order(source, target, order) for source, target in constraints)
+
+
+def _constraint_labels(constraint: Constraint) -> set[int]:
+    return set(constraint[0]) | set(constraint[1])
+
+
+def _json_chord(chord: Chord) -> list[int]:
+    return [int(chord[0]), int(chord[1])]
+
+
+def _json_constraint(constraint: Constraint) -> dict[str, list[int]]:
+    return {
+        "source": _json_chord(constraint[0]),
+        "target": _json_chord(constraint[1]),
+    }
+
+
+def _initial_orders(constraints: Sequence[Constraint], n: int) -> list[list[int]]:
+    if not constraints:
+        return [[0]] if n else [[]]
+    source, target = constraints[0]
+    return [
+        [source[0], target[0], source[1], target[1]],
+        [source[0], target[1], source[1], target[0]],
+    ]
+
+
+def find_cyclic_crossing_order(
+    S: Sequence[Sequence[int]],
+    pattern: str = "",
+) -> CyclicCrossingResult:
+    """
+    Search for a cyclic order satisfying all crossing-bisection constraints.
+
+    The search fixes the first crossing constraint up to rotation/reversal and
+    then inserts one unplaced label at a time into circular gaps. It is exact
+    finite combinatorics: a branch is rejected only when a completed crossing
+    constraint fails.
+    """
+    n = len(S)
+    constraints = crossing_constraints(S)
+    labels = set(range(n))
+    constraint_label_sets = [_constraint_labels(constraint) for constraint in constraints]
+    label_to_constraints: dict[int, list[int]] = {label: [] for label in labels}
+    for idx, constraint_labels in enumerate(constraint_label_sets):
+        for label in constraint_labels:
+            label_to_constraints[label].append(idx)
+
+    nodes_visited = 0
+    max_depth = 0
+    terminal_conflicts: list[dict[str, object]] = []
+
+    def completed_failure(
+        order: Sequence[int],
+        placed: set[int],
+        affected_labels: set[int] | None = None,
+    ) -> int | None:
+        if affected_labels is None:
+            candidate_idxs = range(len(constraints))
+        else:
+            idxs: set[int] = set()
+            for label in affected_labels:
+                idxs.update(label_to_constraints[label])
+            candidate_idxs = sorted(idxs)
+        for idx in candidate_idxs:
+            if constraint_label_sets[idx] <= placed:
+                source, target = constraints[idx]
+                if not chords_cross_in_order(source, target, order):
+                    return idx
+        return None
+
+    def choose_label(placed: set[int]) -> int:
+        def score(label: int) -> tuple[int, int, int, int, int]:
+            touches = [
+                len(constraint_label_sets[idx] & placed)
+                for idx in label_to_constraints[label]
+            ]
+            return (
+                sum(count == 3 for count in touches),
+                sum(count == 2 for count in touches),
+                sum(count == 1 for count in touches),
+                len(label_to_constraints[label]),
+                -label,
+            )
+
+        return max(labels - placed, key=score)
+
+    def search(order: list[int], placed: set[int]) -> list[int] | None:
+        nonlocal nodes_visited, max_depth
+        nodes_visited += 1
+        max_depth = max(max_depth, len(placed))
+        if len(placed) == n:
+            return order if completed_failure(order, placed) is None else None
+
+        label = choose_label(placed)
+        gap_conflicts: list[dict[str, object]] = []
+        tried_valid_child = False
+        for position in range(1, len(order) + 1):
+            candidate_order = order[:position] + [label] + order[position:]
+            candidate_placed = placed | {label}
+            failed_idx = completed_failure(candidate_order, candidate_placed, {label})
+            if failed_idx is not None:
+                gap_conflicts.append(
+                    {
+                        "insert_position": position,
+                        "gap_after": int(candidate_order[position - 1]),
+                        "constraint": _json_constraint(constraints[failed_idx]),
+                    }
+                )
+                continue
+            tried_valid_child = True
+            found = search(candidate_order, candidate_placed)
+            if found is not None:
+                return found
+
+        if not tried_valid_child:
+            terminal_conflicts.append(
+                {
+                    "partial_order": [int(label) for label in order],
+                    "blocked_label": int(label),
+                    "reasons": gap_conflicts,
+                }
+            )
+        return None
+
+    normalizations = _initial_orders(constraints, n)
+    for initial_order in normalizations:
+        found = search(initial_order, set(initial_order))
+        if found is not None:
+            return CyclicCrossingResult(
+                pattern=pattern,
+                n=n,
+                constraints=constraints,
+                symmetry_normalization=normalizations,
+                sat=True,
+                order=found,
+                nodes_visited=nodes_visited,
+                max_depth=max_depth,
+                terminal_conflicts=[],
+            )
+
+    return CyclicCrossingResult(
+        pattern=pattern,
+        n=n,
+        constraints=constraints,
+        symmetry_normalization=normalizations,
+        sat=False,
+        order=None,
+        nodes_visited=nodes_visited,
+        max_depth=max_depth,
+        terminal_conflicts=terminal_conflicts,
+    )
+
+
+def result_to_json(result: CyclicCrossingResult) -> dict[str, object]:
+    """Return a JSON-serializable form of a CSP result."""
+    return {
+        "pattern": result.pattern,
+        "n": result.n,
+        "constraints": [_json_constraint(constraint) for constraint in result.constraints],
+        "constraint_count": len(result.constraints),
+        "symmetry_normalization": result.symmetry_normalization,
+        "result": "SAT" if result.sat else "UNSAT",
+        "sat": result.sat,
+        "order": result.order,
+        "nodes_visited": result.nodes_visited,
+        "max_depth": result.max_depth,
+        "terminal_conflicts": result.terminal_conflicts,
+    }

--- a/src/erdos97/cyclic_crossing_csp.py
+++ b/src/erdos97/cyclic_crossing_csp.py
@@ -21,10 +21,15 @@ class CyclicCrossingResult:
     nodes_visited: int
     max_depth: int
     terminal_conflicts: list[dict[str, object]]
+    terminal_conflicts_truncated: bool
 
 
 def crossing_constraints(S: Sequence[Sequence[int]]) -> list[Constraint]:
-    """Return all phi crossing constraints source -> target."""
+    """Return all phi crossing constraints source -> target.
+
+    The tuple sort is deterministic and fixes the first constraint used for
+    symmetry normalization in the search.
+    """
     return sorted(phi_map(S).items())
 
 
@@ -50,8 +55,10 @@ def _json_constraint(constraint: Constraint) -> dict[str, list[int]]:
 
 def _initial_orders(constraints: Sequence[Constraint], n: int) -> list[list[int]]:
     if not constraints:
-        return [[0]] if n else [[]]
+        return [[0] if n else []]
     source, target = constraints[0]
+    # A crossing of two disjoint chords has exactly these two endpoint
+    # embeddings up to circular rotation and reversal.
     return [
         [source[0], target[0], source[1], target[1]],
         [source[0], target[1], source[1], target[0]],
@@ -61,6 +68,7 @@ def _initial_orders(constraints: Sequence[Constraint], n: int) -> list[list[int]
 def find_cyclic_crossing_order(
     S: Sequence[Sequence[int]],
     pattern: str = "",
+    max_terminal_conflicts: int | None = 128,
 ) -> CyclicCrossingResult:
     """
     Search for a cyclic order satisfying all crossing-bisection constraints.
@@ -71,6 +79,9 @@ def find_cyclic_crossing_order(
     constraint fails.
     """
     n = len(S)
+    if max_terminal_conflicts is not None and max_terminal_conflicts < 0:
+        raise ValueError("max_terminal_conflicts must be nonnegative or None")
+
     constraints = crossing_constraints(S)
     labels = set(range(n))
     constraint_label_sets = [_constraint_labels(constraint) for constraint in constraints]
@@ -82,6 +93,7 @@ def find_cyclic_crossing_order(
     nodes_visited = 0
     max_depth = 0
     terminal_conflicts: list[dict[str, object]] = []
+    terminal_conflicts_truncated = False
 
     def completed_failure(
         order: Sequence[int],
@@ -119,7 +131,7 @@ def find_cyclic_crossing_order(
         return max(labels - placed, key=score)
 
     def search(order: list[int], placed: set[int]) -> list[int] | None:
-        nonlocal nodes_visited, max_depth
+        nonlocal nodes_visited, max_depth, terminal_conflicts_truncated
         nodes_visited += 1
         max_depth = max(max_depth, len(placed))
         if len(placed) == n:
@@ -147,6 +159,12 @@ def find_cyclic_crossing_order(
                 return found
 
         if not tried_valid_child:
+            if (
+                max_terminal_conflicts is not None
+                and len(terminal_conflicts) >= max_terminal_conflicts
+            ):
+                terminal_conflicts_truncated = True
+                return None
             terminal_conflicts.append(
                 {
                     "partial_order": [int(label) for label in order],
@@ -170,6 +188,7 @@ def find_cyclic_crossing_order(
                 nodes_visited=nodes_visited,
                 max_depth=max_depth,
                 terminal_conflicts=[],
+                terminal_conflicts_truncated=False,
             )
 
     return CyclicCrossingResult(
@@ -182,6 +201,7 @@ def find_cyclic_crossing_order(
         nodes_visited=nodes_visited,
         max_depth=max_depth,
         terminal_conflicts=terminal_conflicts,
+        terminal_conflicts_truncated=terminal_conflicts_truncated,
     )
 
 
@@ -199,4 +219,5 @@ def result_to_json(result: CyclicCrossingResult) -> dict[str, object]:
         "nodes_visited": result.nodes_visited,
         "max_depth": result.max_depth,
         "terminal_conflicts": result.terminal_conflicts,
+        "terminal_conflicts_truncated": result.terminal_conflicts_truncated,
     }

--- a/tests/test_altman_diagonal_sums.py
+++ b/tests/test_altman_diagonal_sums.py
@@ -18,7 +18,6 @@ def test_c19_natural_order_altman_kill() -> None:
     assert result.chord_orders == [8, 3, 5, 9]
     assert set(result.forced_equal_U) == {3, 5, 8, 9}
     assert result.altman_contradiction
-    assert result.abstract_incidence_status == "LIVE"
 
 
 def test_c17_is_also_natural_order_altman_killed() -> None:

--- a/tests/test_altman_diagonal_sums.py
+++ b/tests/test_altman_diagonal_sums.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from erdos97.altman_diagonal_sums import check_altman, chord_order
+from erdos97.search import built_in_patterns
+
+
+def test_chord_order_uses_shorter_cyclic_offset() -> None:
+    assert chord_order(19, -8) == 8
+    assert chord_order(19, 9) == 9
+    assert chord_order(24, -13) == 11
+
+
+def test_c19_natural_order_altman_kill() -> None:
+    result = check_altman(built_in_patterns()["C19_skew"])
+
+    assert result.natural_order_only
+    assert result.offsets == [-8, -3, 5, 9]
+    assert result.chord_orders == [8, 3, 5, 9]
+    assert set(result.forced_equal_U) == {3, 5, 8, 9}
+    assert result.altman_contradiction
+    assert result.abstract_incidence_status == "LIVE"
+
+
+def test_c17_is_also_natural_order_altman_killed() -> None:
+    result = check_altman(built_in_patterns()["C17_skew"])
+
+    assert result.altman_contradiction
+    assert set(result.forced_equal_U) == {2, 4, 7, 8}
+
+
+def test_parity_patterns_are_not_automatically_altman_checked() -> None:
+    result = check_altman(built_in_patterns()["P18_parity_balanced"])
+
+    assert not result.altman_contradiction
+    assert result.status == "NOT_APPLIED_NONCONSTANT_OFFSETS"

--- a/tests/test_cyclic_crossing_csp.py
+++ b/tests/test_cyclic_crossing_csp.py
@@ -34,3 +34,19 @@ def test_p24_crossing_csp_unsat() -> None:
     assert result.order is None
     assert result.nodes_visited > 0
     assert result.terminal_conflicts
+    conflict = result.terminal_conflicts[0]
+    assert set(conflict) == {"partial_order", "blocked_label", "reasons"}
+    assert conflict["reasons"]
+
+
+def test_terminal_conflicts_can_be_capped() -> None:
+    pattern = built_in_patterns()["P24_parity_balanced"]
+    result = find_cyclic_crossing_order(
+        pattern.S,
+        pattern.name,
+        max_terminal_conflicts=1,
+    )
+
+    assert not result.sat
+    assert len(result.terminal_conflicts) == 1
+    assert result.terminal_conflicts_truncated

--- a/tests/test_cyclic_crossing_csp.py
+++ b/tests/test_cyclic_crossing_csp.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from erdos97.cyclic_crossing_csp import (
+    all_constraints_cross,
+    crossing_constraints,
+    find_cyclic_crossing_order,
+)
+from erdos97.search import built_in_patterns
+
+
+def test_p18_known_order_satisfies_crossing_csp() -> None:
+    pattern = built_in_patterns()["P18_parity_balanced"]
+    order = [0, 8, 4, 15, 1, 5, 11, 9, 3, 7, 17, 13, 2, 6, 14, 10, 16, 12]
+
+    assert len(crossing_constraints(pattern.S)) == 27
+    assert all_constraints_cross(order, crossing_constraints(pattern.S))
+
+
+def test_p18_crossing_csp_sat() -> None:
+    pattern = built_in_patterns()["P18_parity_balanced"]
+    result = find_cyclic_crossing_order(pattern.S, pattern.name)
+
+    assert result.sat
+    assert result.order is not None
+    assert all_constraints_cross(result.order, result.constraints)
+
+
+def test_p24_crossing_csp_unsat() -> None:
+    pattern = built_in_patterns()["P24_parity_balanced"]
+    result = find_cyclic_crossing_order(pattern.S, pattern.name)
+
+    assert len(result.constraints) == 36
+    assert not result.sat
+    assert result.order is None
+    assert result.nodes_visited > 0
+    assert result.terminal_conflicts


### PR DESCRIPTION
## Summary

Adds exact, reproducible obstruction layers from the reconciled Erdős #97 findings:

- documents Altman's natural-order diagonal-sum obstruction and applies it to `C19_skew` without killing the abstract-incidence pattern
- adds an exact cyclic crossing CSP checker for two-overlap patterns
- records `P18_parity_balanced` as natural-order killed but abstract-order SAT under current crossing filters
- records `P24_parity_balanced` as abstract-order killed by a deterministic finite crossing CSP, with an UNSAT certificate
- updates candidate status metadata and adds focused pytest coverage

## Validation

- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --assert-expected`
- `python scripts/check_altman_diagonal_sums.py --pattern C17_skew --assert-natural-killed`
- `python scripts/check_cyclic_crossing_csp.py --pattern P18_parity_balanced --assert-sat`
- `python scripts/check_cyclic_crossing_csp.py --pattern P24_parity_balanced --assert-unsat`
- `python scripts/check_text_clean.py`
- `python -m pytest -q` (`37 passed`)

## Review follow-up

Addressed review feedback by removing hard-coded abstract-incidence status from the Altman core, tightening `--assert-expected`, documenting CSP symmetry completeness, adding bounded terminal-conflict retention, and adding tests for conflict shape/truncation.

## Caveats

No general proof of Erdős #97 is claimed. No counterexample is claimed. The Altman obstruction is natural-cyclic-order only. `P18_parity_balanced` and `C19_skew` remain abstract-incidence survivors under the stated filters.