### PR TITLE
cleanup: drop dead code, stale comments, and redundant files

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ Use these labels consistently:
 ├── metadata/
 │   └── erdos97.yaml                  # canonical status metadata snapshot
 ├── pyproject.toml
-├── requirements.txt
 ├── src/erdos97/search.py              # main search/verification engine
 ├── src/erdos97/incidence_filters.py   # exact incidence obstruction filters
 ├── src/erdos97/n7_fano.py             # exact n=7 Fano enumeration

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,6 @@ put detailed reconciliation in the canonical synthesis.
   row-wise convexity-distance filter for cyclic orders.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
-- [`n7-fano-obstruction.md`](n7-fano-obstruction.md): proof note for the
-  Fano obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible
   `n=8` incidence-completeness enumeration.
 - [`n8-exact-survivors.md`](n8-exact-survivors.md): exact obstruction pass for

--- a/docs/n7-fano-obstruction.md
+++ b/docs/n7-fano-obstruction.md
@@ -1,3 +1,0 @@
-# n=7 Fano-incidence obstruction
-
-See `docs/n7-fano-enumeration.md` for the full enumerator note, canonical representatives, and perpendicularity-cycle obstruction.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-numpy>=1.24
-scipy>=1.10
-pytest>=7
-sympy>=1.12
-z3-solver>=4.12

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -392,7 +392,6 @@ def polygon_from_polar_x(x: Array, n: int) -> Array:
     theta[1:] = np.cumsum(gaps[:-1])
     r = np.exp(np.clip(logr, -20, 20))
     P = np.column_stack([r * np.cos(theta), r * np.sin(theta)])
-    # If orientation flipped after centering/gauge, keep order but reverse to CCW for diagnostics only.
     return normalize_points(P)
 
 
@@ -480,9 +479,6 @@ def residual_vector(x: Array, n: int, S: Pattern, mode: str, weights: LossWeight
                     convex_margin: float = 1e-3, min_edge: float = 1e-3,
                     min_pair: float = 1e-3) -> Array:
     P = polygon_from_x(x, n, mode)
-    if polygon_area2(P) < 0:
-        # preserve cyclic labels if orientation is wrong? For penalties we use signed orientations as is.
-        pass
     D2 = pairwise_sqdist(P)
     res: List[Array] = []
 


### PR DESCRIPTION
## Summary

Small cleanup pass following a codebase review. No behavior changes; no tests added or removed.

- Remove a no-op `if polygon_area2(P) < 0: pass` block in `residual_vector`. The orientation flip that actually matters happens lower down on `orient_margins`.
- Drop a stale comment in `polygon_from_polar_x` that referred to a CCW reversal the function does not perform.
- Delete `requirements.txt`. `pyproject.toml`'s `[project]` deps and `[project.optional-dependencies] dev` are the source of truth, and CI installs via `pip install -e .[dev]`. The duplicate file was a drift risk.
- Delete `docs/n7-fano-obstruction.md`, a 3-line redirect stub, and remove its entry from `docs/index.md`. `docs/n7-fano-enumeration.md` already covers the obstruction.

Net change: 5 files, 15 deletions, 0 additions.

## Test plan

- [x] `python scripts/check_text_clean.py` — passes
- [x] `python scripts/check_status_consistency.py` — passes
- [x] `git diff --check` — clean
- [x] `python -m pytest -q` — 29 passed

https://claude.ai/code/session_01CX8ATm6oBnxbGoB7M32uBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01CX8ATm6oBnxbGoB7M32uBU)_