### PR TITLE
[codex] Add vertex-circle order filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/n8-incidence-enumeration.md`](docs/n8-incidence-enumeration.md).
 - For the `n=8` exact survivor obstruction artifact, read
   [`docs/n8-exact-survivors.md`](docs/n8-exact-survivors.md).
-- For the crossing-bisector and mutual-rhombus fixed-pattern filters, read
-  [`docs/mutual-rhombus-filter.md`](docs/mutual-rhombus-filter.md).
+- For the crossing-bisector, mutual-rhombus, and vertex-circle fixed-pattern
+  filters, read [`docs/mutual-rhombus-filter.md`](docs/mutual-rhombus-filter.md)
+  and [`docs/vertex-circle-order-filter.md`](docs/vertex-circle-order-filter.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).
 - For known bad proof routes, read [`docs/failed-ideas.md`](docs/failed-ideas.md).
 - For the verification standard, read [`docs/verification-contract.md`](docs/verification-contract.md).
@@ -92,11 +93,13 @@ strictly convex realization for those classes. See
 theorem claims should still get independent review of the computer-assisted
 artifacts.
 
-The crossing-bisector and mutual-rhombus filters now exactly kill several
-previously live fixed selected-witness patterns, including
+The crossing-bisector, mutual-rhombus, cyclic crossing-CSP, and vertex-circle
+order filters now exactly kill several previously live fixed selected-witness
+patterns, including
 `B12_3x4_danzer_lift`, `B20_4x5_FR_lift`, `C17_skew`, `C20_pm_4_9`,
-`C16_pm_1_6`, `C13_pm_3_5`, and `C9_pm_2_4`. These are fixed-pattern
-obstructions, not a general proof of the problem.
+`C16_pm_1_6`, `C13_pm_3_5`, `C9_pm_2_4`, `P18_parity_balanced`, and
+`P24_parity_balanced`. These are fixed-pattern obstructions, not a general
+proof of the problem.
 
 The previous best numerical near-miss was `B12_3x4_danzer_lift`. It remains a
 useful degeneration diagnostic, but the fixed selected pattern is now exactly
@@ -175,6 +178,7 @@ Use these labels consistently:
 │   ├── n8-incidence-enumeration.md    # n=8 incidence-completeness proof
 │   ├── n8-exact-survivors.md          # n=8 exact survivor obstructions
 │   ├── mutual-rhombus-filter.md       # exact fixed-pattern filters
+│   ├── vertex-circle-order-filter.md  # exact cyclic-order distance filter
 │   ├── sat-smt-plan.md                # finite abstraction plan
 │   ├── literature-risk.md             # what has/has not been checked
 │   └── verification-contract.md       # candidate acceptance requirements
@@ -204,6 +208,7 @@ python scripts/analyze_n8_exact_survivors.py --check --json
 erdos97-search --list-patterns
 erdos97-search --verify data/runs/best_B12_slsqp_m1e-6.json --tol 1e-6
 python scripts/check_mutual_rhombus_filter.py --assert-expected
+python scripts/check_vertex_circle_order_filter.py --pattern P18_parity_balanced --search --assert-obstructed
 ```
 
 Run a small search:

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -90,7 +90,7 @@ used. See `docs/n8-incidence-enumeration.md`,
 `docs/n8-exact-survivors.md`, `data/incidence/n8_incidence_completeness.json`,
 and `certificates/n8_exact_analysis.json`.
 
-### Fixed-pattern mutual-rhombus obstructions
+### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.
 
@@ -101,11 +101,16 @@ forced-perpendicularity cycle.
 
 Under the natural cyclic order, `P18_parity_balanced` and
 `P24_parity_balanced` are killed by adjacent-row two-overlap via the
-crossing-bisector lemma. They remain cyclic-order search questions if treated
-as abstract incidence patterns with arbitrary cyclic order.
+crossing-bisector lemma. As abstract incidence patterns with arbitrary cyclic
+order, `P24_parity_balanced` is killed by the exact finite crossing CSP, and
+`P18_parity_balanced` is killed by crossing constraints plus the vertex-circle
+order strict-cycle filter.
 
 See `docs/mutual-rhombus-filter.md` and
-`scripts/check_mutual_rhombus_filter.py`.
+`scripts/check_mutual_rhombus_filter.py`. See also
+`docs/cyclic-crossing-csp.md`, `docs/vertex-circle-order-filter.md`,
+`data/certificates/p24_cyclic_crossing_unsat.json`, and
+`data/certificates/p18_vertex_circle_order_unsat.json`.
 
 ## Numerical Attempts
 
@@ -155,7 +160,5 @@ search-history artifacts, not as live candidates.
 2. Push the finite incidence/exact pipeline toward `n=9`, or identify the first
    survivor class that blocks scaling.
 3. Investigate `C19_skew`, which is not killed by the current mutual-rhombus
-   filter.
-4. Run cyclic-order searches for `P18_parity_balanced` and
-   `P24_parity_balanced` if they are treated as abstract incidence patterns.
-5. Add interval-arithmetic verification for convexity and distance equations.
+   or vertex-circle filters as an abstract incidence pattern.
+4. Add interval-arithmetic verification for convexity and distance equations.

--- a/STATE.md
+++ b/STATE.md
@@ -40,15 +40,20 @@ claims.
 
 ## New exact fixed-pattern obstructions
 
-The crossing-bisector and mutual-rhombus filters now exactly kill several
-previously live fixed selected-witness patterns. In particular,
+The crossing-bisector, mutual-rhombus, cyclic crossing-CSP, and vertex-circle
+order filters now exactly kill several previously live fixed selected-witness
+patterns. In particular,
 `B12_3x4_danzer_lift` is no longer live as a fixed selected pattern: its
 mutual-rhombus midpoint equations force labels `[0,4,8]`, `[1,5,9]`,
 `[2,6,10]`, and `[3,7,11]` to coincide. The old numerical near-miss remains
 useful as a degeneration diagnostic, but not as a counterexample candidate.
 
 Also killed as fixed selected patterns: `B20_4x5_FR_lift`, `C17_skew`,
-`C20_pm_4_9`, `C16_pm_1_6`, `C13_pm_3_5`, and `C9_pm_2_4`.
+`C20_pm_4_9`, `C16_pm_1_6`, `C13_pm_3_5`, `C9_pm_2_4`,
+`P18_parity_balanced`, and `P24_parity_balanced`. The `P18_parity_balanced`
+abstract-incidence obstruction uses the crossing constraints plus the
+vertex-circle order strict-cycle filter; `P24_parity_balanced` is already
+killed by the finite cyclic crossing CSP.
 
 ## Best saved near-miss
 
@@ -78,11 +83,8 @@ verification threshold and the other collapses to a non-strict configuration.[^c
 ## Top remaining live / unresolved patterns
 
 1. `C19_skew`: sparse common-neighbor overlap; not killed by the current
-   mutual-rhombus filter.[^repo]
-2. `P18_parity_balanced`: killed under natural cyclic order; still needs a
-   cyclic-order search if arbitrary cyclic order is allowed.[^repo]
-3. `P24_parity_balanced`: killed under natural cyclic order; still needs a
-   cyclic-order search if arbitrary cyclic order is allowed.[^repo]
+   mutual-rhombus filter, and not killed by the vertex-circle filter for the
+   known acyclic abstract order.[^repo]
 
 ## Top killed approaches
 

--- a/data/certificates/p18_vertex_circle_order_unsat.json
+++ b/data/certificates/p18_vertex_circle_order_unsat.json
@@ -1,0 +1,8934 @@
+{
+  "crossing_constraint_count": 27,
+  "crossing_constraints": [
+    {
+      "source": [
+        0,
+        1
+      ],
+      "target": [
+        8,
+        11
+      ]
+    },
+    {
+      "source": [
+        0,
+        9
+      ],
+      "target": [
+        11,
+        16
+      ]
+    },
+    {
+      "source": [
+        0,
+        15
+      ],
+      "target": [
+        4,
+        11
+      ]
+    },
+    {
+      "source": [
+        1,
+        4
+      ],
+      "target": [
+        8,
+        15
+      ]
+    },
+    {
+      "source": [
+        1,
+        10
+      ],
+      "target": [
+        3,
+        8
+      ]
+    },
+    {
+      "source": [
+        2,
+        3
+      ],
+      "target": [
+        10,
+        13
+      ]
+    },
+    {
+      "source": [
+        2,
+        11
+      ],
+      "target": [
+        0,
+        13
+      ]
+    },
+    {
+      "source": [
+        2,
+        17
+      ],
+      "target": [
+        6,
+        13
+      ]
+    },
+    {
+      "source": [
+        3,
+        6
+      ],
+      "target": [
+        10,
+        17
+      ]
+    },
+    {
+      "source": [
+        3,
+        12
+      ],
+      "target": [
+        5,
+        10
+      ]
+    },
+    {
+      "source": [
+        4,
+        5
+      ],
+      "target": [
+        12,
+        15
+      ]
+    },
+    {
+      "source": [
+        4,
+        13
+      ],
+      "target": [
+        2,
+        15
+      ]
+    },
+    {
+      "source": [
+        5,
+        8
+      ],
+      "target": [
+        1,
+        12
+      ]
+    },
+    {
+      "source": [
+        5,
+        14
+      ],
+      "target": [
+        7,
+        12
+      ]
+    },
+    {
+      "source": [
+        6,
+        7
+      ],
+      "target": [
+        14,
+        17
+      ]
+    },
+    {
+      "source": [
+        6,
+        15
+      ],
+      "target": [
+        4,
+        17
+      ]
+    },
+    {
+      "source": [
+        7,
+        10
+      ],
+      "target": [
+        3,
+        14
+      ]
+    },
+    {
+      "source": [
+        7,
+        16
+      ],
+      "target": [
+        9,
+        14
+      ]
+    },
+    {
+      "source": [
+        8,
+        9
+      ],
+      "target": [
+        1,
+        16
+      ]
+    },
+    {
+      "source": [
+        8,
+        17
+      ],
+      "target": [
+        1,
+        6
+      ]
+    },
+    {
+      "source": [
+        9,
+        12
+      ],
+      "target": [
+        5,
+        16
+      ]
+    },
+    {
+      "source": [
+        10,
+        11
+      ],
+      "target": [
+        0,
+        3
+      ]
+    },
+    {
+      "source": [
+        11,
+        14
+      ],
+      "target": [
+        0,
+        7
+      ]
+    },
+    {
+      "source": [
+        12,
+        13
+      ],
+      "target": [
+        2,
+        5
+      ]
+    },
+    {
+      "source": [
+        13,
+        16
+      ],
+      "target": [
+        2,
+        9
+      ]
+    },
+    {
+      "source": [
+        14,
+        15
+      ],
+      "target": [
+        4,
+        7
+      ]
+    },
+    {
+      "source": [
+        16,
+        17
+      ],
+      "target": [
+        6,
+        9
+      ]
+    }
+  ],
+  "crossing_prunes": 22652,
+  "max_depth": 16,
+  "n": 18,
+  "nodes_visited": 2466,
+  "order": null,
+  "pattern": "P18_parity_balanced",
+  "result": "UNSAT",
+  "sat": false,
+  "symmetry_normalization": [
+    [
+      0,
+      8,
+      1,
+      11
+    ],
+    [
+      0,
+      11,
+      1,
+      8
+    ]
+  ],
+  "terminal_conflicts": [
+    {
+      "blocked_label": 10,
+      "partial_order": [
+        0,
+        3,
+        8,
+        1,
+        11
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              1,
+              10
+            ],
+            "target": [
+              3,
+              8
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              10,
+              11
+            ],
+            "target": [
+              0,
+              3
+            ]
+          },
+          "gap_after": 3,
+          "insert_position": 2,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              1,
+              10
+            ],
+            "target": [
+              3,
+              8
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 3,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              1,
+              10
+            ],
+            "target": [
+              3,
+              8
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 4,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              1,
+              10
+            ],
+            "target": [
+              3,
+              8
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 5,
+          "type": "crossing"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        14,
+        8,
+        10,
+        3,
+        7,
+        1,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        14,
+        8,
+        10,
+        3,
+        1,
+        7,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  14,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        8,
+        14,
+        10,
+        3,
+        7,
+        1,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        8,
+        14,
+        10,
+        3,
+        1,
+        7,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  0,
+                  8,
+                  14
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        8,
+        10,
+        14,
+        7,
+        3,
+        1,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  3,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 7,
+      "partial_order": [
+        0,
+        8,
+        10,
+        3,
+        14,
+        1,
+        11
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 2,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 3,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              11,
+              14
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 3,
+          "insert_position": 4,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 5,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 6,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 7,
+          "type": "crossing"
+        }
+      ]
+    },
+    {
+      "blocked_label": 7,
+      "partial_order": [
+        0,
+        8,
+        10,
+        3,
+        1,
+        14,
+        11
+      ],
+      "reasons": [
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 0,
+          "insert_position": 1,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 8,
+          "insert_position": 2,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 10,
+          "insert_position": 3,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              11,
+              14
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 3,
+          "insert_position": 4,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              11,
+              14
+            ],
+            "target": [
+              0,
+              7
+            ]
+          },
+          "gap_after": 1,
+          "insert_position": 5,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 14,
+          "insert_position": 6,
+          "type": "crossing"
+        },
+        {
+          "constraint": {
+            "source": [
+              7,
+              10
+            ],
+            "target": [
+              3,
+              14
+            ]
+          },
+          "gap_after": 11,
+          "insert_position": 7,
+          "type": "crossing"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        8,
+        10,
+        3,
+        1,
+        11,
+        7,
+        14
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  15,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  8,
+                  3,
+                  15
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  11,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  11
+                ],
+                "row": 1,
+                "witness_order": [
+                  11,
+                  15,
+                  8,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  3,
+                  14,
+                  0,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        14,
+        10,
+        8,
+        1,
+        3,
+        7,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  3,
+                  0,
+                  14
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        10,
+        14,
+        7,
+        8,
+        1,
+        3,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        10,
+        14,
+        8,
+        7,
+        1,
+        3,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        10,
+        14,
+        8,
+        1,
+        7,
+        3,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  14,
+                  8,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        10,
+        8,
+        14,
+        7,
+        1,
+        3,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        10,
+        8,
+        14,
+        1,
+        7,
+        3,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    },
+    {
+      "blocked_label": 15,
+      "partial_order": [
+        0,
+        10,
+        8,
+        1,
+        14,
+        7,
+        3,
+        11
+      ],
+      "reasons": [
+        {
+          "gap_after": 0,
+          "insert_position": 1,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 10,
+          "insert_position": 2,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 8,
+          "insert_position": 3,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  8,
+                  15
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 1,
+          "insert_position": 4,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 14,
+          "insert_position": 5,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 7,
+          "insert_position": 6,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  15,
+                  3,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 3,
+          "insert_position": 7,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  15,
+                  11,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        },
+        {
+          "gap_after": 11,
+          "insert_position": 8,
+          "reason": {
+            "completed_rows": 2,
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  3,
+                  8
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  3,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  4
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  8
+                ],
+                "row": 10,
+                "witness_order": [
+                  8,
+                  14,
+                  3,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  4
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  11
+                ],
+                "outer_class": [
+                  3,
+                  8
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  8
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  11,
+                  15,
+                  8
+                ]
+              }
+            ],
+            "self_edge_conflicts": [],
+            "strict_edge_count": 18
+          },
+          "type": "vertex_circle"
+        }
+      ]
+    }
+  ],
+  "terminal_conflicts_truncated": true,
+  "type": "vertex_circle_order_search_result",
+  "vertex_circle_prunes": 3724
+}

--- a/data/patterns/candidate_patterns.json
+++ b/data/patterns/candidate_patterns.json
@@ -23,8 +23,8 @@
     "n": 18,
     "formula": "even offsets {-7,-2,4,8}; odd offsets {-8,-4,2,7}",
     "type": "period-2",
-    "status": "natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: survives current crossing filters, with a compatible cyclic order recorded",
-    "trust": "INCIDENCE_PATTERN"
+    "status": "natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: killed by exact crossing plus vertex-circle order strict-cycle search",
+    "trust": "EXACT_OBSTRUCTION"
   },
   {
     "rank": 4,
@@ -41,7 +41,7 @@
     "n": 19,
     "formula": "offsets {-8,-3,5,9}",
     "type": "skew circulant",
-    "status": "natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse with no phi edges and no mutual-rhombus or forced-perpendicularity obstruction",
+    "status": "natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse with no phi edges and no mutual-rhombus, forced-perpendicularity, or vertex-circle obstruction currently known",
     "trust": "INCIDENCE_PATTERN"
   },
   {

--- a/docs/altman-diagonal-sums.md
+++ b/docs/altman-diagonal-sums.md
@@ -79,4 +79,4 @@ Thus `C19_skew` is exactly obstructed in natural cyclic order.
 - Altman's diagonal-order obstruction is natural-cyclic-order only.
 - It does not kill abstract-incidence versions with arbitrary cyclic relabeling.
 - `C19_skew` remains an abstract-incidence sparse survivor of the current
-  `phi`, midpoint, and forced-perpendicularity filters.
+  `phi`, midpoint, forced-perpendicularity, and vertex-circle filters.

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -7,7 +7,7 @@ designs only; geometric realization is a separate problem.
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse, with no `phi` edges and no mutual-rhombus or forced-perpendicularity obstruction[^repo] |
+| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse, with no `phi` edges and no mutual-rhombus, forced-perpendicularity, or vertex-circle obstruction currently known[^repo] |
 
 The live abstract-incidence pattern above should pass the row-overlap filter
 `|S_i cap S_j| <= 2` before numerical optimization. Its natural-order
@@ -21,7 +21,7 @@ arbitrary cyclic orders are allowed.
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| U1 | `P18_parity_balanced` | 18 | even: `{-7,-2,4,8}`, odd: `{-8,-4,2,7}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: survives current crossing filters, with a compatible cyclic order recorded |
+| U1 | `P18_parity_balanced` | 18 | even: `{-7,-2,4,8}`, odd: `{-8,-4,2,7}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: killed by exact crossing plus vertex-circle order strict-cycle search |
 | U2 | `P24_parity_balanced` | 24 | even: `{-10,-3,5,11}`, odd: `{-11,-5,3,10}` | period-2 | natural-order status: killed by adjacent-row two-overlap via crossing-bisector; abstract-incidence status: killed by exact finite crossing-CSP; no cyclic order satisfies all 36 required crossings |
 
 ## Speculative extensions

--- a/docs/cyclic-crossing-csp.md
+++ b/docs/cyclic-crossing-csp.md
@@ -48,16 +48,18 @@ runs may pass `--full-conflicts` when a full deterministic trace is desired.
 ## P18_parity_balanced
 
 `P18_parity_balanced` is killed in natural order by adjacent-row two-overlap via
-the crossing-bisection lemma. It survives the current arbitrary-order crossing
-filters. One compatible cyclic order is:
+the crossing-bisection lemma. It survives the arbitrary-order crossing-only
+filter. One compatible cyclic order is:
 
 ```text
 0,8,4,15,1,5,11,9,3,7,17,13,2,6,14,10,16,12
 ```
 
-Thus the abstract-incidence status remains unresolved
-algebraically/geometrically; `P18_parity_balanced` is not globally archived as
-killed.
+Thus crossing constraints alone do not kill the abstract incidence pattern.
+The stronger crossing plus vertex-circle strict-cycle search now kills it as a
+fixed selected-witness abstract incidence pattern; see
+`docs/vertex-circle-order-filter.md` and
+`data/certificates/p18_vertex_circle_order_unsat.json`.
 
 ## P24_parity_balanced
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ put detailed reconciliation in the canonical synthesis.
   diagonal-sum obstruction for cyclic-offset patterns.
 - [`cyclic-crossing-csp.md`](cyclic-crossing-csp.md): exact cyclic-order
   crossing CSP for two-overlap patterns.
+- [`vertex-circle-order-filter.md`](vertex-circle-order-filter.md): exact
+  row-wise convexity-distance filter for cyclic orders.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n7-fano-obstruction.md`](n7-fano-obstruction.md): proof note for the

--- a/docs/mutual-rhombus-filter.md
+++ b/docs/mutual-rhombus-filter.md
@@ -194,13 +194,17 @@ that cyclic order.
 
 Their abstract-incidence status remains separate. The exact crossing CSP in
 `docs/cyclic-crossing-csp.md` records that `P18_parity_balanced` has compatible
-arbitrary cyclic orders, while `P24_parity_balanced` has no cyclic order
-satisfying all 36 crossing constraints.
+arbitrary cyclic orders under crossing constraints alone, while
+`P24_parity_balanced` has no cyclic order satisfying all 36 crossing
+constraints. The stronger vertex-circle order filter then kills
+`P18_parity_balanced` when combined with the crossing constraints; see
+`docs/vertex-circle-order-filter.md`.
 
 The sparse pattern `C19_skew` has no `phi` edges, so it is invisible to the
 mutual-rhombus and forced-perpendicularity filters. It is nevertheless killed
 in natural cyclic order by Altman's diagonal-order sums; see
-`docs/altman-diagonal-sums.md`. This does not kill the same abstract incidence
+`docs/altman-diagonal-sums.md`. It also passes the known vertex-circle
+acyclic-order sanity check. This does not kill the same abstract incidence
 pattern under arbitrary cyclic relabeling.
 
 ## Reproduction
@@ -209,6 +213,7 @@ pattern under arbitrary cyclic relabeling.
 pip install -e .[dev]
 python scripts/check_mutual_rhombus_filter.py --assert-expected
 python scripts/check_mutual_rhombus_filter.py --json
+python scripts/check_vertex_circle_order_filter.py --pattern P18_parity_balanced --search --assert-obstructed
 pytest -q
 ```
 

--- a/docs/vertex-circle-order-filter.md
+++ b/docs/vertex-circle-order-filter.md
@@ -122,6 +122,7 @@ python scripts/check_vertex_circle_order_filter.py \
   --pattern P18_parity_balanced \
   --search \
   --assert-obstructed \
+  --max-terminal-conflicts 16 \
   --write-certificate data/certificates/p18_vertex_circle_order_unsat.json
 ```
 
@@ -144,7 +145,9 @@ P18_parity_balanced, crossing + vertex-circle nesting filter:
 ```
 
 The result artifact is stored at
-`data/certificates/p18_vertex_circle_order_unsat.json`.
+`data/certificates/p18_vertex_circle_order_unsat.json`. It retains 16 terminal
+conflict traces to keep the checked-in diagnostic log compact; the UNSAT result
+and search counters are unchanged by retaining more terminal conflicts.
 
 Safe claim:
 

--- a/docs/vertex-circle-order-filter.md
+++ b/docs/vertex-circle-order-filter.md
@@ -1,0 +1,197 @@
+# Vertex-circle order filter
+
+Status: `EXACT_OBSTRUCTION` for fixed selected-witness incidence patterns.
+
+No general proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+## Summary
+
+This note records an exact cyclic-order filter for a selected-witness pattern.
+It uses only:
+
+- the cyclic order of labels;
+- the fact that each selected row lies on a circle centered at its row label;
+- distance-class equalities forced by the selected rows.
+
+It does not use coordinates, floating-point arithmetic, or numerical
+optimization.
+
+## Vertex-circle nesting lemma
+
+Let `P` be a strict convex polygon in cyclic order. Fix a vertex `i`, and let
+`a_0,...,a_m` be other vertices lying on one circle centered at `p_i`.
+
+The angular order of the vertices around `p_i` is the polygon boundary order
+with `i` removed, up to reversal. All angular separations among those vertices
+lie in `(0, pi)`, because all other polygon vertices lie in the open angle
+formed by the two boundary edges incident to the hull vertex `i`.
+
+If the angular interval from `a_r` to `a_s` properly contains the angular
+interval from `a_u` to `a_v`, then
+
+```text
+|p_{a_r} - p_{a_s}| > |p_{a_u} - p_{a_v}|.
+```
+
+Indeed, both chords lie on the same circle centered at `p_i`. A chord with
+central angle `theta` has length `2R sin(theta/2)`, and this is strictly
+increasing for `theta in (0, pi)`.
+
+## Strict-cycle obstruction
+
+Given a selected-witness pattern `S` and a proposed cyclic order:
+
+1. Create a distance-class variable for every unordered pair `{u,v}`.
+2. For every row `i`, union the classes `{i,w}` for all `w in S_i`.
+3. For every row `i`, sort the four witnesses `S_i` in angular order around
+   `i` using the cyclic order.
+4. For every proper interval containment among witness-witness chords in that
+   row, add a strict directed inequality
+
+```text
+class({outer endpoints}) > class({inner endpoints}).
+```
+
+If any strict edge is a self-edge, or if these strict directed inequalities
+contain a directed cycle, the proposed cyclic order is impossible.
+
+This is a finite exact obstruction for the fixed selected pattern and order.
+
+## P18 human certificate
+
+The crossing-only CSP records the following compatible order for
+`P18_parity_balanced`:
+
+```text
+0,8,4,15,1,5,11,9,3,7,17,13,2,6,14,10,16,12
+```
+
+The vertex-circle filter kills that order. Write `d(u,v)` for ordinary
+Euclidean distance.
+
+Row `13` has selected witnesses `{5,9,15,2}`, so
+
+```text
+d(5,13) = d(2,13).
+```
+
+Row `2` has selected witnesses `{13,0,6,10}`, so
+
+```text
+d(2,13) = d(2,10).
+```
+
+Around center `3`, the selected witnesses occur in the order
+
+```text
+17,13,10,5.
+```
+
+The interval `[13,5]` properly contains `[10,5]`, hence
+
+```text
+d(5,13) > d(5,10).
+```
+
+Around center `12`, the selected witnesses occur in the order
+
+```text
+5,2,10,16.
+```
+
+The interval `[5,10]` properly contains `[2,10]`, hence
+
+```text
+d(5,10) > d(2,10).
+```
+
+Therefore
+
+```text
+d(5,13) > d(5,10) > d(2,10) = d(5,13),
+```
+
+a contradiction.
+
+## Full P18 search
+
+The script
+
+```bash
+python scripts/check_vertex_circle_order_filter.py \
+  --pattern P18_parity_balanced \
+  --search \
+  --assert-obstructed \
+  --write-certificate data/certificates/p18_vertex_circle_order_unsat.json
+```
+
+performs a deterministic insertion search. It uses the same crossing seed
+normalization as `scripts/check_cyclic_crossing_csp.py`, rejects a crossing
+constraint only when all four endpoints are placed, and applies the
+vertex-circle strict-cycle filter only when a row center and all four selected
+witnesses are placed.
+
+The checked result is:
+
+```text
+P18_parity_balanced, crossing + vertex-circle nesting filter:
+  result: UNSAT
+  crossing constraints: 27
+  nodes visited: 2466
+  max depth: 16
+  crossing prunes: 22652
+  vertex-circle prunes: 3724
+```
+
+The result artifact is stored at
+`data/certificates/p18_vertex_circle_order_unsat.json`.
+
+Safe claim:
+
+```text
+EXACT_OBSTRUCTION: P18_parity_balanced is killed as a fixed
+selected-witness abstract incidence pattern by the crossing-bisection
+constraints plus the vertex-circle order strict-cycle filter.
+```
+
+## C19 caveat
+
+This filter does not kill abstract-incidence `C19_skew`. The order
+
+```text
+18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1
+```
+
+has no vertex-circle self-edge or strict directed cycle under this filter.
+Thus `C19_skew` remains the main sparse abstract-incidence survivor of the
+current fixed-pattern filters, even though its natural cyclic order is killed
+by Altman's diagonal-order sums.
+
+## Reproduction
+
+```bash
+python scripts/check_vertex_circle_order_filter.py \
+  --pattern P18_parity_balanced \
+  --order 0,8,4,15,1,5,11,9,3,7,17,13,2,6,14,10,16,12 \
+  --assert-obstructed
+
+python scripts/check_vertex_circle_order_filter.py \
+  --pattern P18_parity_balanced \
+  --search \
+  --assert-obstructed
+
+python scripts/check_vertex_circle_order_filter.py \
+  --pattern C19_skew \
+  --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1 \
+  --assert-sat
+```
+
+The corresponding regression tests are in
+`tests/test_vertex_circle_order_filter.py`.
+
+## Caveats
+
+- This is a fixed selected-pattern obstruction, not a global proof.
+- It does not certify a counterexample.
+- It does not kill abstract-incidence `C19_skew`.
+- Numerical near-misses remain numerical evidence only.

--- a/scripts/check_mutual_rhombus_filter.py
+++ b/scripts/check_mutual_rhombus_filter.py
@@ -68,7 +68,7 @@ def pattern_status(summary: dict[str, object]) -> str:
     if classes:
         return "exactly killed: mutual-rhombus midpoint equations"
     if summary["adjacent_two_overlap_violations"]:
-        return "killed under natural cyclic order; abstract order unresolved"
+        return "killed under natural cyclic order; abstract status tracked separately"
     if summary["crossing_bisector_violations"]:
         return "incompatible with natural cyclic order crossing-bisector filter"
     return "not killed by these filters"

--- a/scripts/check_vertex_circle_order_filter.py
+++ b/scripts/check_vertex_circle_order_filter.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Check the vertex-circle cyclic-order filter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.search import built_in_patterns  # noqa: E402
+from erdos97.vertex_circle_order_filter import (  # noqa: E402
+    find_cyclic_order_with_vertex_circle_filter,
+    order_result_to_json,
+    search_result_to_json,
+    vertex_circle_order_obstruction,
+)
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
+
+
+def assert_obstructed(row: dict[str, object]) -> None:
+    if row["type"] == "vertex_circle_order_result":
+        if not row["obstructed"]:
+            raise AssertionError(f"{row['pattern']}: expected vertex-circle obstruction")
+        return
+    if row["sat"]:
+        raise AssertionError(f"{row['pattern']}: expected UNSAT, got {row['order']}")
+
+
+def assert_sat(row: dict[str, object]) -> None:
+    if row["type"] == "vertex_circle_order_result":
+        if row["obstructed"]:
+            raise AssertionError(f"{row['pattern']}: expected unobstructed order")
+        return
+    if not row["sat"]:
+        raise AssertionError(f"{row['pattern']}: expected SAT")
+
+
+def print_summary(row: dict[str, object]) -> None:
+    if row["type"] == "vertex_circle_order_result":
+        result = "OBSTRUCTED" if row["obstructed"] else "PASS"
+        print(
+            "pattern  n  result      rows  strict edges  self edges  cycle"
+        )
+        print(
+            f"{row['pattern']}  {row['n']}  {result:<10}  "
+            f"{row['row_count_completed']}  {row['strict_edge_count']}  "
+            f"{len(row['self_edge_conflicts'])}  {row['cycle']}"
+        )
+        return
+
+    result = "SAT" if row["sat"] else "UNSAT"
+    print(
+        "pattern  n  constraints  result  nodes  max depth  crossing prunes  vertex prunes  order"
+    )
+    print(
+        f"{row['pattern']}  {row['n']}  {row['crossing_constraint_count']}  "
+        f"{result}  {row['nodes_visited']}  {row['max_depth']}  "
+        f"{row['crossing_prunes']}  {row['vertex_circle_prunes']}  "
+        f"{row['order'] if row['order'] is not None else '-'}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pattern", required=True, help="built-in pattern name")
+    parser.add_argument("--order", type=parse_order, help="comma-separated cyclic order")
+    parser.add_argument("--search", action="store_true", help="run crossing + vertex-circle search")
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a summary")
+    parser.add_argument("--assert-obstructed", action="store_true", help="assert obstruction/UNSAT")
+    parser.add_argument("--assert-sat", action="store_true", help="assert unobstructed/SAT")
+    parser.add_argument("--write-certificate", help="write JSON result to this path")
+    parser.add_argument(
+        "--max-terminal-conflicts",
+        type=int,
+        default=128,
+        help="maximum UNSAT terminal conflicts to retain; use --full-conflicts for no cap",
+    )
+    parser.add_argument(
+        "--full-conflicts",
+        action="store_true",
+        help="retain every terminal conflict in UNSAT output",
+    )
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern not in patterns:
+        raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+    pattern = patterns[args.pattern]
+
+    if args.search:
+        max_conflicts = None if args.full_conflicts else args.max_terminal_conflicts
+        result = find_cyclic_order_with_vertex_circle_filter(
+            pattern.S,
+            pattern.name,
+            max_terminal_conflicts=max_conflicts,
+        )
+        row = search_result_to_json(result)
+    else:
+        if args.order is None:
+            raise SystemExit("--order is required unless --search is passed")
+        result = vertex_circle_order_obstruction(pattern.S, args.order, pattern.name)
+        row = order_result_to_json(result)
+
+    if args.assert_obstructed:
+        assert_obstructed(row)
+    if args.assert_sat:
+        assert_sat(row)
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(row, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(row, indent=2, sort_keys=True))
+    else:
+        print_summary(row)
+        if args.assert_obstructed or args.assert_sat:
+            print("OK: vertex-circle expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/vertex_circle_order_filter.py
+++ b/src/erdos97/vertex_circle_order_filter.py
@@ -1,0 +1,543 @@
+"""Exact vertex-circle cyclic-order filter for selected-witness patterns."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Sequence
+
+from erdos97.cyclic_crossing_csp import crossing_constraints
+from erdos97.incidence_filters import Chord, chords_cross_in_order
+
+Pair = tuple[int, int]
+StrictEdge = tuple[Pair, Pair]
+Constraint = tuple[Chord, Chord]
+
+
+def pair(u: int, v: int) -> Pair:
+    """Return a normalized unordered pair. Reject loops."""
+    if u == v:
+        raise ValueError(f"loop pair is not allowed: ({u}, {v})")
+    return (u, v) if u < v else (v, u)
+
+
+class UnionFind:
+    """Small deterministic union-find over unordered vertex pairs."""
+
+    def __init__(self, items: Sequence[Pair]) -> None:
+        self.parent = {item: item for item in items}
+
+    def find(self, item: Pair) -> Pair:
+        if item not in self.parent:
+            self.parent[item] = item
+        while self.parent[item] != item:
+            self.parent[item] = self.parent[self.parent[item]]
+            item = self.parent[item]
+        return item
+
+    def union(self, a: Pair, b: Pair) -> None:
+        root_a = self.find(a)
+        root_b = self.find(b)
+        if root_a == root_b:
+            return
+        if root_b < root_a:
+            root_a, root_b = root_b, root_a
+        self.parent[root_b] = root_a
+
+
+@dataclass(frozen=True)
+class StrictInequality:
+    row: int
+    witness_order: list[int]
+    outer_interval: list[int]
+    inner_interval: list[int]
+    outer_pair: Pair
+    inner_pair: Pair
+    outer_class: Pair
+    inner_class: Pair
+
+
+@dataclass(frozen=True)
+class VertexCircleOrderResult:
+    pattern: str
+    n: int
+    order: list[int]
+    row_count_completed: int
+    strict_edge_count: int
+    self_edge_conflicts: list[StrictInequality]
+    cycle_edges: list[StrictInequality]
+    obstructed: bool
+
+
+@dataclass(frozen=True)
+class VertexCircleSearchResult:
+    pattern: str
+    n: int
+    crossing_constraints: list[Constraint]
+    symmetry_normalization: list[list[int]]
+    sat: bool
+    order: list[int] | None
+    nodes_visited: int
+    max_depth: int
+    crossing_prunes: int
+    vertex_circle_prunes: int
+    terminal_conflicts: list[dict[str, object]]
+    terminal_conflicts_truncated: bool
+
+
+def _all_pairs(n: int) -> list[Pair]:
+    return [(u, v) for u in range(n) for v in range(u + 1, n)]
+
+
+def _validate_order(order: Sequence[int], n: int, require_full: bool) -> None:
+    seen: set[int] = set()
+    for label in order:
+        if label in seen:
+            raise ValueError(f"cyclic order is not a permutation: repeated label {label}")
+        if label < 0 or label >= n:
+            raise ValueError(f"cyclic order label out of range: {label}")
+        seen.add(label)
+    if require_full and seen != set(range(n)):
+        missing = sorted(set(range(n)) - seen)
+        extra = sorted(seen - set(range(n)))
+        raise ValueError(f"cyclic order is not complete; missing={missing}, extra={extra}")
+
+
+def _distance_class_union_find(S: Sequence[Sequence[int]]) -> UnionFind:
+    n = len(S)
+    uf = UnionFind(_all_pairs(n))
+    for center, row in enumerate(S):
+        if len(row) != 4:
+            raise ValueError(f"row {center} has length {len(row)}, expected 4")
+        base = pair(center, row[0])
+        for witness in row[1:]:
+            uf.union(base, pair(center, witness))
+    return uf
+
+
+def angular_witness_order(
+    order: Sequence[int],
+    center: int,
+    witnesses: Sequence[int],
+) -> list[int]:
+    """Return witnesses in angular order around a convex-hull vertex center.
+
+    For a strict convex polygon, the angular order around a hull vertex is the
+    cyclic boundary order with the center removed, up to reversal. Reversal
+    preserves interval-containment relations.
+    """
+    n = len(order)
+    positions = {label: idx for idx, label in enumerate(order)}
+    if center not in positions:
+        raise ValueError(f"center {center} is missing from cyclic order")
+    missing = [witness for witness in witnesses if witness not in positions]
+    if missing:
+        raise ValueError(f"witness {missing[0]} is missing from cyclic order")
+    center_pos = positions[center]
+    return sorted(witnesses, key=lambda witness: (positions[witness] - center_pos) % n)
+
+
+def vertex_circle_strict_inequalities(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int],
+    placed: set[int] | None = None,
+) -> tuple[list[StrictInequality], int]:
+    """Return strict distance-class inequalities from completed rows.
+
+    If ``placed`` is supplied, only rows whose center and four witnesses are in
+    ``placed`` are considered. This is the safe pruning condition used by the
+    insertion search.
+    """
+    n = len(S)
+    _validate_order(order, n, require_full=placed is None)
+    if placed is None:
+        placed = set(order)
+
+    uf = _distance_class_union_find(S)
+    strict_edges: list[StrictInequality] = []
+    completed_rows = 0
+    for center, row in enumerate(S):
+        row_labels = set(row) | {center}
+        if not row_labels <= placed:
+            continue
+        completed_rows += 1
+        witnesses = angular_witness_order(order, center, row)
+        for outer_start in range(4):
+            for outer_end in range(outer_start + 1, 4):
+                for inner_start in range(4):
+                    for inner_end in range(inner_start + 1, 4):
+                        if (outer_start, outer_end) == (inner_start, inner_end):
+                            continue
+                        contains = (
+                            outer_start <= inner_start
+                            and inner_end <= outer_end
+                            and (outer_start < inner_start or inner_end < outer_end)
+                        )
+                        if not contains:
+                            continue
+                        outer_pair = pair(witnesses[outer_start], witnesses[outer_end])
+                        inner_pair = pair(witnesses[inner_start], witnesses[inner_end])
+                        strict_edges.append(
+                            StrictInequality(
+                                row=center,
+                                witness_order=list(witnesses),
+                                outer_interval=[outer_start, outer_end],
+                                inner_interval=[inner_start, inner_end],
+                                outer_pair=outer_pair,
+                                inner_pair=inner_pair,
+                                outer_class=uf.find(outer_pair),
+                                inner_class=uf.find(inner_pair),
+                            )
+                        )
+    return strict_edges, completed_rows
+
+
+def _find_strict_cycle(edges: Sequence[StrictInequality]) -> list[StrictInequality]:
+    graph: dict[Pair, list[StrictInequality]] = defaultdict(list)
+    for edge in edges:
+        if edge.outer_class != edge.inner_class:
+            graph[edge.outer_class].append(edge)
+    for source in graph:
+        graph[source].sort(key=lambda edge: (edge.inner_class, edge.row, edge.outer_pair, edge.inner_pair))
+
+    color: dict[Pair, int] = {}
+    parent: dict[Pair, tuple[Pair, StrictInequality] | None] = {}
+
+    def dfs(node: Pair) -> list[StrictInequality]:
+        color[node] = 1
+        for edge in graph.get(node, []):
+            nxt = edge.inner_class
+            nxt_color = color.get(nxt, 0)
+            if nxt_color == 0:
+                parent[nxt] = (node, edge)
+                found = dfs(nxt)
+                if found:
+                    return found
+            elif nxt_color == 1:
+                path_edges: list[StrictInequality] = []
+                cur = node
+                while cur != nxt:
+                    parent_item = parent[cur]
+                    if parent_item is None:  # pragma: no cover - defensive
+                        break
+                    prev, parent_edge = parent_item
+                    path_edges.append(parent_edge)
+                    cur = prev
+                return list(reversed(path_edges)) + [edge]
+        color[node] = 2
+        return []
+
+    for node in sorted(graph):
+        if color.get(node, 0) == 0:
+            parent[node] = None
+            found = dfs(node)
+            if found:
+                return found
+    return []
+
+
+def _partial_vertex_circle_result(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int],
+    placed: set[int],
+) -> tuple[bool, list[StrictInequality], list[StrictInequality], int, int]:
+    edges, completed_rows = vertex_circle_strict_inequalities(S, order, placed)
+    self_edges = [edge for edge in edges if edge.outer_class == edge.inner_class]
+    cycle_edges = [] if self_edges else _find_strict_cycle(edges)
+    return bool(self_edges or cycle_edges), self_edges, cycle_edges, len(edges), completed_rows
+
+
+def vertex_circle_order_obstruction(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int],
+    pattern: str = "",
+) -> VertexCircleOrderResult:
+    """Check whether one full cyclic order is killed by the vertex-circle filter."""
+    n = len(S)
+    _validate_order(order, n, require_full=True)
+    placed = set(order)
+    obstructed, self_edges, cycle_edges, edge_count, completed_rows = _partial_vertex_circle_result(
+        S,
+        order,
+        placed,
+    )
+    return VertexCircleOrderResult(
+        pattern=pattern,
+        n=n,
+        order=list(order),
+        row_count_completed=completed_rows,
+        strict_edge_count=edge_count,
+        self_edge_conflicts=self_edges,
+        cycle_edges=cycle_edges,
+        obstructed=obstructed,
+    )
+
+
+def _constraint_labels(constraint: Constraint) -> set[int]:
+    return set(constraint[0]) | set(constraint[1])
+
+
+def _initial_orders(constraints: Sequence[Constraint], n: int) -> list[list[int]]:
+    if not constraints:
+        return [[0] if n else []]
+    source, target = constraints[0]
+    return [
+        [source[0], target[0], source[1], target[1]],
+        [source[0], target[1], source[1], target[0]],
+    ]
+
+
+def find_cyclic_order_with_vertex_circle_filter(
+    S: Sequence[Sequence[int]],
+    pattern: str = "",
+    max_terminal_conflicts: int | None = 128,
+) -> VertexCircleSearchResult:
+    """Search for a cyclic order satisfying crossing and vertex-circle filters."""
+    n = len(S)
+    if max_terminal_conflicts is not None and max_terminal_conflicts < 0:
+        raise ValueError("max_terminal_conflicts must be nonnegative or None")
+
+    constraints = crossing_constraints(S)
+    labels = set(range(n))
+    constraint_label_sets = [_constraint_labels(constraint) for constraint in constraints]
+    label_to_constraints: dict[int, list[int]] = {label: [] for label in labels}
+    for idx, labels_for_constraint in enumerate(constraint_label_sets):
+        for label in labels_for_constraint:
+            label_to_constraints[label].append(idx)
+
+    row_label_sets = [set(row) | {center} for center, row in enumerate(S)]
+    label_to_rows: dict[int, list[int]] = {label: [] for label in labels}
+    for row_idx, labels_for_row in enumerate(row_label_sets):
+        for label in labels_for_row:
+            label_to_rows[label].append(row_idx)
+
+    nodes_visited = 0
+    max_depth = 0
+    crossing_prunes = 0
+    vertex_circle_prunes = 0
+    terminal_conflicts: list[dict[str, object]] = []
+    terminal_conflicts_truncated = False
+
+    def completed_crossing_failure(
+        order: Sequence[int],
+        placed: set[int],
+        affected_labels: set[int] | None = None,
+    ) -> int | None:
+        if affected_labels is None:
+            candidate_idxs = range(len(constraints))
+        else:
+            idxs: set[int] = set()
+            for label in affected_labels:
+                idxs.update(label_to_constraints[label])
+            candidate_idxs = sorted(idxs)
+        for idx in candidate_idxs:
+            if constraint_label_sets[idx] <= placed:
+                source, target = constraints[idx]
+                if not chords_cross_in_order(source, target, order):
+                    return idx
+        return None
+
+    def vertex_circle_failure(
+        order: Sequence[int],
+        placed: set[int],
+    ) -> dict[str, object] | None:
+        obstructed, self_edges, cycle_edges, edge_count, completed_rows = _partial_vertex_circle_result(
+            S,
+            order,
+            placed,
+        )
+        if not obstructed:
+            return None
+        reason_edges = self_edges if self_edges else cycle_edges
+        return {
+            "completed_rows": completed_rows,
+            "strict_edge_count": edge_count,
+            "self_edge_conflicts": [_json_inequality(edge) for edge in self_edges],
+            "cycle_edges": [_json_inequality(edge) for edge in reason_edges],
+        }
+
+    def choose_label(placed: set[int]) -> int:
+        def score(label: int) -> tuple[int, int, int, int, int, int]:
+            crossing_touches = [
+                len(constraint_label_sets[idx] & placed)
+                for idx in label_to_constraints[label]
+            ]
+            row_touches = [
+                len(row_label_sets[idx] & placed)
+                for idx in label_to_rows[label]
+            ]
+            return (
+                sum(count == 3 for count in crossing_touches),
+                sum(count == 4 for count in row_touches),
+                sum(count == 2 for count in crossing_touches),
+                sum(count == 3 for count in row_touches),
+                len(label_to_constraints[label]) + len(label_to_rows[label]),
+                -label,
+            )
+
+        return max(labels - placed, key=score)
+
+    def search(order: list[int], placed: set[int]) -> list[int] | None:
+        nonlocal nodes_visited
+        nonlocal max_depth
+        nonlocal crossing_prunes
+        nonlocal vertex_circle_prunes
+        nonlocal terminal_conflicts_truncated
+        nodes_visited += 1
+        max_depth = max(max_depth, len(placed))
+        if len(placed) == n:
+            if completed_crossing_failure(order, placed) is not None:
+                return None
+            return order if vertex_circle_failure(order, placed) is None else None
+
+        label = choose_label(placed)
+        gap_conflicts: list[dict[str, object]] = []
+        tried_valid_child = False
+        for position in range(1, len(order) + 1):
+            candidate_order = order[:position] + [label] + order[position:]
+            candidate_placed = placed | {label}
+            failed_idx = completed_crossing_failure(candidate_order, candidate_placed, {label})
+            if failed_idx is not None:
+                crossing_prunes += 1
+                gap_conflicts.append(
+                    {
+                        "insert_position": position,
+                        "gap_after": int(candidate_order[position - 1]),
+                        "type": "crossing",
+                        "constraint": _json_constraint(constraints[failed_idx]),
+                    }
+                )
+                continue
+
+            vertex_reason = vertex_circle_failure(candidate_order, candidate_placed)
+            if vertex_reason is not None:
+                vertex_circle_prunes += 1
+                gap_conflicts.append(
+                    {
+                        "insert_position": position,
+                        "gap_after": int(candidate_order[position - 1]),
+                        "type": "vertex_circle",
+                        "reason": vertex_reason,
+                    }
+                )
+                continue
+
+            tried_valid_child = True
+            found = search(candidate_order, candidate_placed)
+            if found is not None:
+                return found
+
+        if not tried_valid_child:
+            if (
+                max_terminal_conflicts is not None
+                and len(terminal_conflicts) >= max_terminal_conflicts
+            ):
+                terminal_conflicts_truncated = True
+                return None
+            terminal_conflicts.append(
+                {
+                    "partial_order": [int(label) for label in order],
+                    "blocked_label": int(label),
+                    "reasons": gap_conflicts,
+                }
+            )
+        return None
+
+    normalizations = _initial_orders(constraints, n)
+    for initial_order in normalizations:
+        found = search(initial_order, set(initial_order))
+        if found is not None:
+            return VertexCircleSearchResult(
+                pattern=pattern,
+                n=n,
+                crossing_constraints=constraints,
+                symmetry_normalization=normalizations,
+                sat=True,
+                order=found,
+                nodes_visited=nodes_visited,
+                max_depth=max_depth,
+                crossing_prunes=crossing_prunes,
+                vertex_circle_prunes=vertex_circle_prunes,
+                terminal_conflicts=[],
+                terminal_conflicts_truncated=False,
+            )
+
+    return VertexCircleSearchResult(
+        pattern=pattern,
+        n=n,
+        crossing_constraints=constraints,
+        symmetry_normalization=normalizations,
+        sat=False,
+        order=None,
+        nodes_visited=nodes_visited,
+        max_depth=max_depth,
+        crossing_prunes=crossing_prunes,
+        vertex_circle_prunes=vertex_circle_prunes,
+        terminal_conflicts=terminal_conflicts,
+        terminal_conflicts_truncated=terminal_conflicts_truncated,
+    )
+
+
+def _json_pair(item: Pair) -> list[int]:
+    return [int(item[0]), int(item[1])]
+
+
+def _json_constraint(constraint: Constraint) -> dict[str, list[int]]:
+    return {
+        "source": _json_pair(constraint[0]),
+        "target": _json_pair(constraint[1]),
+    }
+
+
+def _json_inequality(edge: StrictInequality) -> dict[str, object]:
+    return {
+        "row": int(edge.row),
+        "witness_order": [int(label) for label in edge.witness_order],
+        "outer_interval": [int(idx) for idx in edge.outer_interval],
+        "inner_interval": [int(idx) for idx in edge.inner_interval],
+        "outer_pair": _json_pair(edge.outer_pair),
+        "inner_pair": _json_pair(edge.inner_pair),
+        "outer_class": _json_pair(edge.outer_class),
+        "inner_class": _json_pair(edge.inner_class),
+    }
+
+
+def order_result_to_json(result: VertexCircleOrderResult) -> dict[str, object]:
+    """Return a JSON-serializable fixed-order result."""
+    return {
+        "type": "vertex_circle_order_result",
+        "pattern": result.pattern,
+        "n": result.n,
+        "order": result.order,
+        "row_count_completed": result.row_count_completed,
+        "strict_edge_count": result.strict_edge_count,
+        "self_edge_conflicts": [
+            _json_inequality(edge) for edge in result.self_edge_conflicts
+        ],
+        "cycle": bool(result.cycle_edges),
+        "cycle_edges": [_json_inequality(edge) for edge in result.cycle_edges],
+        "obstructed": result.obstructed,
+    }
+
+
+def search_result_to_json(result: VertexCircleSearchResult) -> dict[str, object]:
+    """Return a JSON-serializable search result."""
+    return {
+        "type": "vertex_circle_order_search_result",
+        "pattern": result.pattern,
+        "n": result.n,
+        "crossing_constraints": [
+            _json_constraint(constraint) for constraint in result.crossing_constraints
+        ],
+        "crossing_constraint_count": len(result.crossing_constraints),
+        "symmetry_normalization": result.symmetry_normalization,
+        "result": "SAT" if result.sat else "UNSAT",
+        "sat": result.sat,
+        "order": result.order,
+        "nodes_visited": result.nodes_visited,
+        "max_depth": result.max_depth,
+        "crossing_prunes": result.crossing_prunes,
+        "vertex_circle_prunes": result.vertex_circle_prunes,
+        "terminal_conflicts": result.terminal_conflicts,
+        "terminal_conflicts_truncated": result.terminal_conflicts_truncated,
+    }

--- a/tests/test_vertex_circle_order_filter.py
+++ b/tests/test_vertex_circle_order_filter.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from erdos97.search import built_in_patterns
+from erdos97.vertex_circle_order_filter import (
+    find_cyclic_order_with_vertex_circle_filter,
+    pair,
+    vertex_circle_order_obstruction,
+    vertex_circle_strict_inequalities,
+)
+
+
+P18_CROSSING_COMPATIBLE_ORDER = [
+    0,
+    8,
+    4,
+    15,
+    1,
+    5,
+    11,
+    9,
+    3,
+    7,
+    17,
+    13,
+    2,
+    6,
+    14,
+    10,
+    16,
+    12,
+]
+
+C19_VERTEX_CIRCLE_ACYCLIC_ORDER = [
+    18,
+    10,
+    7,
+    17,
+    6,
+    3,
+    5,
+    9,
+    14,
+    11,
+    2,
+    13,
+    4,
+    16,
+    12,
+    15,
+    0,
+    8,
+    1,
+]
+
+
+def test_p18_known_order_has_human_readable_vertex_circle_cycle() -> None:
+    pattern = built_in_patterns()["P18_parity_balanced"]
+    result = vertex_circle_order_obstruction(
+        pattern.S,
+        P18_CROSSING_COMPATIBLE_ORDER,
+        pattern.name,
+    )
+
+    assert result.obstructed
+    assert not result.self_edge_conflicts
+    assert result.cycle_edges
+    assert result.row_count_completed == 18
+    assert result.strict_edge_count == 162
+
+    inequalities, _ = vertex_circle_strict_inequalities(
+        pattern.S,
+        P18_CROSSING_COMPATIBLE_ORDER,
+    )
+    row3 = next(
+        edge
+        for edge in inequalities
+        if edge.row == 3
+        and edge.outer_pair == pair(5, 13)
+        and edge.inner_pair == pair(5, 10)
+    )
+    row12 = next(
+        edge
+        for edge in inequalities
+        if edge.row == 12
+        and edge.outer_pair == pair(5, 10)
+        and edge.inner_pair == pair(2, 10)
+    )
+
+    assert row3.witness_order == [17, 13, 10, 5]
+    assert row12.witness_order == [5, 2, 10, 16]
+    assert row3.outer_class == row12.inner_class
+    assert row3.inner_class == row12.outer_class
+
+
+def test_p18_crossing_plus_vertex_circle_search_unsat() -> None:
+    pattern = built_in_patterns()["P18_parity_balanced"]
+    result = find_cyclic_order_with_vertex_circle_filter(pattern.S, pattern.name)
+
+    assert not result.sat
+    assert result.order is None
+    assert result.nodes_visited > 0
+    assert result.crossing_prunes > 0
+    assert result.vertex_circle_prunes > 0
+
+
+def test_c19_supplied_order_passes_vertex_circle_filter() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    result = vertex_circle_order_obstruction(
+        pattern.S,
+        C19_VERTEX_CIRCLE_ACYCLIC_ORDER,
+        pattern.name,
+    )
+
+    assert not result.obstructed
+    assert not result.self_edge_conflicts
+    assert not result.cycle_edges
+    assert result.row_count_completed == 19
+    assert result.strict_edge_count == 171

--- a/tests/test_vertex_circle_order_filter.py
+++ b/tests/test_vertex_circle_order_filter.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from erdos97.search import built_in_patterns
 from erdos97.vertex_circle_order_filter import (
     find_cyclic_order_with_vertex_circle_filter,
     pair,
+    search_result_to_json,
     vertex_circle_order_obstruction,
     vertex_circle_strict_inequalities,
 )
 
+
+ROOT = Path(__file__).resolve().parents[1]
+P18_CERTIFICATE = ROOT / "data" / "certificates" / "p18_vertex_circle_order_unsat.json"
 
 P18_CROSSING_COMPATIBLE_ORDER = [
     0,
@@ -101,6 +108,18 @@ def test_p18_crossing_plus_vertex_circle_search_unsat() -> None:
     assert result.nodes_visited > 0
     assert result.crossing_prunes > 0
     assert result.vertex_circle_prunes > 0
+
+
+def test_p18_certificate_matches_generator_with_documented_conflict_cap() -> None:
+    pattern = built_in_patterns()["P18_parity_balanced"]
+    result = find_cyclic_order_with_vertex_circle_filter(
+        pattern.S,
+        pattern.name,
+        max_terminal_conflicts=16,
+    )
+
+    checked_in = json.loads(P18_CERTIFICATE.read_text(encoding="utf-8"))
+    assert search_result_to_json(result) == checked_in
 
 
 def test_c19_supplied_order_passes_vertex_circle_filter() -> None:


### PR DESCRIPTION
## Summary

- add an exact vertex-circle cyclic-order filter and CLI for fixed selected-witness patterns
- add regression tests and a reproducible P18 UNSAT certificate artifact
- pin the checked-in certificate to the documented `--max-terminal-conflicts 16` generator command
- update status docs and candidate-pattern metadata so P18 is recorded as killed by crossing + vertex-circle while C19 remains live under this filter

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check origin/main..HEAD`
- `python -m pytest -q` (`41 passed`)
- `python -m pytest -q tests/test_vertex_circle_order_filter.py` (`4 passed`)
- documented certificate command with `--max-terminal-conflicts 16` regenerates byte-identical JSON
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python scripts/check_mutual_rhombus_filter.py --assert-expected`
- `python scripts/check_cyclic_crossing_csp.py --pattern P18_parity_balanced --assert-sat`
- `python scripts/check_cyclic_crossing_csp.py --pattern P24_parity_balanced --assert-unsat`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --assert-natural-killed`
- `python scripts/check_vertex_circle_order_filter.py --pattern P18_parity_balanced --search --assert-obstructed`
- `python scripts/check_vertex_circle_order_filter.py --pattern C19_skew --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1 --assert-sat`

## Claim discipline

This PR adds a fixed selected-witness exact obstruction only. It does not claim a global proof, a counterexample, or an abstract-incidence obstruction for `C19_skew`.