### PR TITLE
[codex] Resolve maintenance issue cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: python -m pip install --upgrade pip
       - run: pip install -e .[dev]
       - run: python scripts/check_text_clean.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "erdos97-research"
 version = "0.1.0"
 description = "Research tooling for Erdős Problem #97"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE-CODE.md"]
 requires-python = ">=3.10"
 dependencies = [
   "numpy>=1.24",

--- a/src/erdos97/n7_fano.py
+++ b/src/erdos97/n7_fano.py
@@ -239,9 +239,8 @@ class N7Analysis:
 def analyze_n7_witness_pattern(pattern: Sequence[Sequence[int]]) -> N7Analysis:
     """Analyze an n=7 witness pattern satisfying the circle-intersection cap.
 
-    The returned ``geometrically_realizable`` field is always ``False`` for a
-    cap-satisfying n=7 pattern, because the induced chord permutation must have
-    an odd perpendicularity cycle.
+    For a cap-satisfying n=7 equality pattern, the induced chord permutation has
+    21 chords and therefore an odd perpendicularity cycle.
     """
 
     W = validate_witness_pattern(pattern, n=7)
@@ -265,12 +264,19 @@ def analyze_n7_witness_pattern(pattern: Sequence[Sequence[int]]) -> N7Analysis:
     cycles = permutation_cycles(mapping)
     cycle_lengths = tuple(len(cycle) for cycle in cycles)
     has_odd = any(length % 2 for length in cycle_lengths)
-    obstruction = (
-        "The common-witness chord map is a permutation of the 21 chords. "
-        "It has an odd cycle, but each map edge would impose perpendicularity; "
-        "alternating perpendicularity around an odd cycle is impossible for "
-        "nonzero Euclidean chords."
-    )
+    if has_odd:
+        obstruction = (
+            "The common-witness chord map is a permutation of the 21 chords. "
+            "It has an odd cycle, but each map edge would impose perpendicularity; "
+            "alternating perpendicularity around an odd cycle is impossible for "
+            "nonzero Euclidean chords."
+        )
+    else:
+        obstruction = (
+            "The common-witness chord map has no odd cycle in this input, so "
+            "this helper does not derive the odd-cycle perpendicularity "
+            "obstruction."
+        )
     return N7Analysis(
         witness_pattern=W,
         complement_pattern=complements_from_witnesses(W),

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -23,10 +23,8 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import itertools
 import json
 import math
-import random
 import time
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -125,51 +123,6 @@ def block_pattern(m: int, q: int, offsets: Sequence[Tuple[int, int]], name: str)
     return PatternInfo(name=name, n=n, S=S, family=f"block-{m}x{q}", formula=f"i=(a,b), S_i=(a,b)+{list(offsets)} mod ({m},{q})")
 
 
-def random_pattern(n: int, rng: random.Random, max_pair_common: int = 2, balanced: bool = True,
-                   max_tries: int = 100000, name: str = "random") -> PatternInfo:
-    """Generate a random 4-out pattern with pairwise |S_a cap S_b| <= max_pair_common.
-
-    If balanced=True, keep indegrees near 4 using a soft greedy objective.
-    """
-    if max_tries <= 0:
-        raise ValueError(f"max_tries must be positive, got {max_tries}")
-
-    for _ in range(max_tries):
-        S: Pattern = [[] for _ in range(n)]
-        indeg = [0] * n
-        failed = False
-        for i in range(n):
-            candidates = [j for j in range(n) if j != i]
-            ok_sets = []
-            for comb in itertools.combinations(candidates, 4):
-                ss = set(comb)
-                if all(len(ss.intersection(S[a])) <= max_pair_common for a in range(i)):
-                    score = sum((indeg[j] + 1 - 4) ** 2 - (indeg[j] - 4) ** 2 for j in comb) if balanced else 0
-                    # Discourage four clustered choices on one side in cyclic order.
-                    gaps = cyclic_gaps(sorted(comb), n)
-                    cluster_penalty = max(gaps)  # if max gap huge, selected points are clustered
-                    ok_sets.append((score + 0.02 * cluster_penalty + rng.random() * 1e-3, list(comb)))
-            if not ok_sets:
-                failed = True
-                break
-            ok_sets.sort(key=lambda t: t[0])
-            # Pick from a small elite set for diversity.
-            chosen = rng.choice(ok_sets[: min(50, len(ok_sets))])[1]
-            S[i] = sorted(chosen)
-            for j in chosen:
-                indeg[j] += 1
-        if not failed:
-            return PatternInfo(
-                name=name,
-                n=n,
-                S=S,
-                family="random-greedy",
-                formula="greedy random 4-out, pairwise common-neighbor cap",
-            )
-
-    raise RuntimeError(f"random_pattern failed after {max_tries} attempts; try larger n or max_pair_common")
-
-
 def cyclic_gaps(vals: Sequence[int], n: int) -> List[int]:
     vals = sorted(vals)
     return [((vals[(k + 1) % len(vals)] - vals[k]) % n) for k in range(len(vals))]
@@ -207,7 +160,8 @@ def softmax(z: Array) -> Array:
 def softplus(x: Array, beta: float = 20.0) -> Array:
     # stable softplus(x) / beta approx max(x, 0)
     bx = beta * x
-    return np.where(bx > 40, x, np.log1p(np.exp(bx)) / beta)
+    safe_bx = np.minimum(bx, 40.0)
+    return np.where(bx > 40, x, np.log1p(np.exp(safe_bx)) / beta)
 
 
 def rotate_points(P: Array, theta: float) -> Array:
@@ -516,15 +470,6 @@ def residual_vector(x: Array, n: int, S: Pattern, mode: str, weights: LossWeight
     return np.concatenate(res) if res else np.zeros(0)
 
 
-def equality_only_loss(P: Array, S: Pattern) -> float:
-    D2 = pairwise_sqdist(P)
-    terms = []
-    for i, Si in enumerate(S):
-        vals = np.array([D2[i, j] for j in Si])
-        terms.extend((vals - vals.mean()).tolist())
-    return float(np.mean(np.square(terms))) if terms else 0.0
-
-
 # ------------------------------ search --------------------------------------
 
 def search_pattern(pat: PatternInfo, mode: str = "polar", restarts: int = 20,
@@ -574,8 +519,6 @@ def search_pattern(pat: PatternInfo, mode: str = "polar", restarts: int = 20,
     if best is None or best_x is None:
         raise RuntimeError("all restarts failed")
     P = polygon_from_x(best_x, n, mode)
-    # If overall orientation is clockwise, flip coordinates and relabel S accordingly? We do not relabel;
-    # the generated polar order should be CCW unless centering causes numerical area flip. Report as is.
     diag = independent_diagnostics(P, pat.S)
     elapsed = time.time() - start
     return SearchResult(
@@ -689,6 +632,9 @@ def z3_incidence_search(n: int, max_pair_common: int = 2, balance_indegree: bool
     matrix satisfying the chosen finite constraints; it says nothing directly about
     Euclidean realizability.
     """
+    if n < 5:
+        raise ValueError(f"z3_incidence_search requires n >= 5, got {n}")
+
     try:
         import z3  # type: ignore
     except Exception as e:

--- a/tests/test_search_hygiene.py
+++ b/tests/test_search_hygiene.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from erdos97.search import softplus, z3_incidence_search
+
+
+def test_softplus_large_positive_values_do_not_overflow() -> None:
+    x = np.array([-3.0, 3.0, 1_000.0], dtype=float)
+
+    with np.errstate(over="raise"):
+        out = softplus(x)
+
+    assert np.isfinite(out[0])
+    assert np.isfinite(out[1])
+    assert out[2] == x[2]
+
+
+def test_z3_incidence_search_rejects_too_small_n_before_importing_z3() -> None:
+    with pytest.raises(ValueError, match="requires n >= 5"):
+        z3_incidence_search(4)


### PR DESCRIPTION
## Summary

- Remove remaining unused search helpers/imports and a stale orientation comment.
- Make `softplus` avoid eager overflow warnings and add a small `z3_incidence_search` precondition for `n < 5`.
- Align package license metadata with the code-only MIT package surface and enable pip caching in CI.
- Add focused regression tests for the numerical warning path and SAT precondition.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check origin/main..HEAD`
- `python -m pytest -q` (`43 passed`)
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`

Closes #13.
Closes #14.
Closes #15.
Closes #16.
Closes #17.
Refs #18.
Refs #20.