### PR TITLE
[codex] Add prompt audit roadmap

### DIFF
--- a/docs/canonical-synthesis.md
+++ b/docs/canonical-synthesis.md
@@ -128,7 +128,7 @@ These are used everywhere downstream and are not in dispute.
 
 | ID | Statement | Why |
 |---|---|---|
-| **L1** | Cone containment. All other vertices of $P$ lie inside an open cone $K_i$ at $v_i$ with opening angle $\alpha_i \in (0, \pi)$; the angular span of $W_i$ around $v_i$ is $< \pi$. | Strict convexity + vertex on hull. |
+| **L1** | Cone containment. All other vertices of $P$ lie in the closed cone spanned by the two incident edges at $v_i$; only adjacent vertices lie on the boundary rays, all non-adjacent vertices lie in the open cone, and the angular span of $W_i$ around $v_i$ is $< \pi$. | Strict convexity + vertex on hull. |
 | **L2** | No three polygon vertices are collinear. | Strict convexity. |
 | **L3** | Boundary cyclic order matches angular order at any vertex. | L1 + L2. |
 | **L4** | Perpendicular-bisector vertex bound. For any unordered pair $\{a, b\}$, at most 2 polygon vertices $v$ satisfy $\|v - a\| = \|v - b\|$. | The locus is one line; intersects a strictly convex polygon in at most 2 points. |

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -233,9 +233,10 @@ in at most two rows, so `3d <= 14` and `d <= 4`. Since the total indegree is
 
 ### Vertex cone and chord order
 
-At a vertex of a strictly convex polygon, all other vertices lie in the open
-cone between the two incident edges. Boundary order therefore agrees with
-angular order around that vertex.[^digest]
+At a vertex of a strictly convex polygon, all other vertices lie in the closed
+cone spanned by the two incident edges. Only the two adjacent vertices lie on
+the boundary rays, and all non-adjacent vertices lie in the open cone. Boundary
+order therefore agrees with angular order around that vertex.[^digest]
 
 For witnesses on a circle centered at that vertex, chord length is
 `2r sin(theta/2)` and is monotone while the angular separation is below `pi`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,9 @@ put detailed reconciliation in the canonical synthesis.
 
 - [`literature-risk.md`](literature-risk.md): external-reference risks and
   unit-distance caveats.
+- [`prompt-roadmap.md`](prompt-roadmap.md): prompt-derived planning roadmap and
+  next recommended workstreams; heuristic guidance only, not mathematical
+  evidence.
 - [`repo-roadmap.md`](repo-roadmap.md): staged repository plan.
 - [`initial-issues.md`](initial-issues.md): seed issue list.
 - [`../AGENTS.md`](../AGENTS.md): repository-level Codex guidance.

--- a/docs/prompt-roadmap.md
+++ b/docs/prompt-roadmap.md
@@ -1,0 +1,167 @@
+# Prompt Roadmap
+
+Status: HEURISTIC planning note. This file is not mathematical evidence and
+does not claim a proof or counterexample for Erdos Problem #97.
+
+This note distills the local prompt-pack comparison into repo-facing guidance:
+which prompt directions are worth running next, what artifacts they should
+produce, and which routes should be treated as exhausted or auxiliary.
+
+## Operating Protocol
+
+Use prompt runs as hypothesis generators, not as sources of truth.
+
+1. Run proof-generation prompts in fresh no-web chats.
+2. Audit any plausible proof in a separate no-web chat.
+3. Keep web/literature triangulation in a separate mode from proof generation.
+4. Promote only independently checked results into repo docs.
+5. Prefer outputs that create reproducible artifacts: scripts, JSON survivor
+   lists, exact certificates, or small formally checkable lemmas.
+
+The most important audit checks are:
+
+1. Identify every load-bearing use of strict convexity.
+2. Justify cyclic-order claims from convexity, not pictures.
+3. Verify every crossing-bisector use instead of assuming it.
+4. Treat generic rank and dimension counts as diagnostics unless the special
+   solution locus is controlled.
+5. Label numerical evidence separately from exact claims.
+
+## Current Prompt Status
+
+### Completed Or Parked: A/B Matrix Route
+
+The centered-circle incidence matrix route has already produced its stable
+matrix-only yield:
+
+1. the crossing-bisector lemma;
+2. the forbidden noncrossing `2x2`, `2x3`, and `3x2` submatrices;
+3. the discharging bound
+   `sum_i binom(|S_i|, 2) <= n(n-2)`;
+4. the matrix-only consequence `n >= 8` under minimum row size `4`;
+5. explicit abstract A/B countermodels showing that A/B alone cannot prove the
+   full theorem.
+
+Do not keep rerunning this as a standalone prompt unless the goal is a
+targeted audit of a new lemma. Future work should use this route as a filter
+or subroutine, not as the main engine.
+
+For the detailed audit of recent A/B prompt runs, see
+`incoming/chatgpt-runs/audit.md`.
+
+### Priority 1: Certified Fragile-Hypergraph Computation
+
+This is the best next direction because it can produce reproducible repo
+artifacts.
+
+The first Prompt 3 fragile-cover run was reviewed in
+`incoming/prompt3-runs/audit.md`. Its cover lemma is valid and already matches
+the repo's minimal-counterexample critical-tie claim, but the run also gives
+linear-cover and convex-octagon warning examples showing that cover plus
+crossing is not enough. Treat fragile cover as a computation filter, not as a
+standalone contradiction route.
+
+Target deliverables:
+
+1. a precise finite abstraction of fragile pointed `4`-sets;
+2. proved constraints: cover, self-exclusion, row intersection, cyclic
+   crossing, and any additional exact geometric filters;
+3. enumeration code up to a small `n` range;
+4. JSON survivor artifacts;
+5. symmetry reduction under cyclic/dihedral relabeling;
+6. handoff from surviving hypergraphs to polynomial equal-distance systems;
+7. optional rank-test integration with existing exactification tools.
+
+Success does not require a general proof. A useful result is a short list of
+survivor patterns, a new exact obstruction, or a reproducible infeasibility
+certificate for a finite range.
+
+### Priority 2: Affine-Circuit / Rank Rigidity
+
+This has high upside but is more fragile than the computation route.
+
+Use the corrected target:
+
+> In the non-concyclic case, prove that the only kernel functions are the
+> unavoidable span of `1`, `x`, `y`, and `x^2+y^2`, or construct an explicit
+> exotic syzygy.
+
+Avoid the older naive rank claim. The unavoidable quadratic kernel is real and
+must be built into the statement. Generic rank at random non-solutions is only
+diagnostic.
+
+The first Prompt 2 rank run was reviewed in
+`incoming/prompt2-runs/audit.md`. Its quotient reduction is useful: after
+choosing a nonsingular lifted four-point base, exotic syzygies are exactly the
+kernel of the remaining-column affine-circuit matrix, and singleton peeling
+reduces this to a weighted two-core. The continuation refines those defects to
+minimal-support cofactor certificates: isolated quotient columns, balanced
+pair-gain components, and mixed hypercore determinant identities. This is a
+checker specification, not a proof of full rank.
+
+Useful artifacts from this path:
+
+1. a concrete exotic-syzygy example;
+2. a finite list of rank-defect incidence patterns;
+3. a verified symbolic minor for a restricted pattern class;
+4. a bridge lemma connecting rank rigidity to selected witness patterns.
+
+### Side Probe: Smooth Strictly Convex Curve
+
+The smooth-curve falsification probe is useful for intuition:
+
+> Does there exist a smooth strictly convex closed curve such that every point
+> has some centered circle meeting the curve in at least four other points?
+
+Either answer would clarify whether the obstruction is primarily discrete or
+convex-geometric. This should remain a side experiment unless it produces a
+short rigorous lemma.
+
+### Side Probe: Local Angle Filters
+
+The first Prompt 0 run was reviewed in `incoming/prompt0-runs/audit.md`. It
+does not provide a proof, but its middle-witness angle inequality appears
+usable as a local filter after correcting the cone statement at a hull vertex:
+other vertices lie in the closed incident-edge cone, with only adjacent
+vertices on the boundary rays. Treat this as an auxiliary filter for selected
+witness patterns, not as a primary proof route.
+
+### Side Probe: Fishburn-Reeds / Near-Miss Perturbation
+
+The `k=3` Fishburn-Reeds and Danzer-style examples are useful stress tests, not
+templates to promote directly to `k=4`.
+
+A useful prompt run here should try to prove that perturbing or lifting a
+known `3`-neighbor example necessarily creates an exact obstruction, or else
+produce exact algebraic data for a serious candidate. Floating-point
+near-misses remain provenance only.
+
+## Lower Priority Routes
+
+The following can be useful, but should not displace the certified computation
+and corrected rank paths:
+
+1. vertex-centered incidence bounds;
+2. VC-dimension or shatter-function estimates;
+3. perpendicular-bisector arrangement counts;
+4. sum inequality `sum_i m_i < 4n`;
+5. SOS/Lasserre certificates for fixed small patterns;
+6. local four-vertex-theorem analogies.
+
+These routes become high value only if they produce a concrete lemma or a
+checkable certificate that interacts with the selected-witness formulation.
+
+## Suggested Next Work Item
+
+Start a Prompt 4 style computation pass:
+
+1. Define the exact fragile-hypergraph abstraction used in this repo.
+2. Implement or extend enumeration for the next finite range not already
+   covered by `n=7` and `n=8`.
+3. Emit reproducible JSON artifacts.
+4. Add tests for every combinatorial filter.
+5. Route survivors to existing exact obstruction machinery.
+
+Keep all outputs labeled as finite abstraction, incidence pattern, exact
+obstruction, numerical evidence, or failed approach according to the repo trust
+taxonomy.

--- a/docs/vertex-circle-order-filter.md
+++ b/docs/vertex-circle-order-filter.md
@@ -23,8 +23,9 @@ Let `P` be a strict convex polygon in cyclic order. Fix a vertex `i`, and let
 
 The angular order of the vertices around `p_i` is the polygon boundary order
 with `i` removed, up to reversal. All angular separations among those vertices
-lie in `(0, pi)`, because all other polygon vertices lie in the open angle
-formed by the two boundary edges incident to the hull vertex `i`.
+lie in `(0, pi)`: the other polygon vertices lie in the closed angle formed by
+the two boundary edges incident to the hull vertex `i`, only adjacent vertices
+can lie on the boundary rays, and the opening angle is less than `pi`.
 
 If the angular interval from `a_r` to `a_s` properly contains the angular
 interval from `a_u` to `a_v`, then

--- a/incoming/chatgpt-runs/audit.md
+++ b/incoming/chatgpt-runs/audit.md
@@ -1,0 +1,205 @@
+# Audit of ChatGPT Runs on the A/B Matrix Argument
+
+Status: draft audit note, not a theorem file.
+
+This note reviews `run-01.md` through `run-20.md` against the original prompt.
+It treats all LLM outputs as hypotheses until checked.
+
+## Executive Summary
+
+The stable, reusable result across the runs is:
+
+> From facts (A) and (B) one gets
+> \[
+> \sum_i \binom{|S_i|}{2}\le n(n-2).
+> \]
+> Therefore minimum row size 4 implies \(n\ge 8\).
+
+The full contradiction cannot follow from (A) and (B) alone. This was
+computationally checked for the recurring circulant examples, and there are
+stronger abstract examples with row sums growing like \(\sqrt n\) where (B) is
+vacuous.
+
+The best proof of the crossing lemma is the coordinate/extreme-point proof:
+the radical-axis/reflection step shows the two shared vertices are symmetric
+across \(p_ip_k\), and strict convexity is used to force the midpoint of
+\(p_ap_b\) to lie in the open segment \(p_ip_k\). This avoids relying on a
+hand-wavy half-plane chain statement.
+
+## Safe Theorem Skeleton
+
+Let \(M\) be a cyclically indexed zero-diagonal \(0\)-\(1\) matrix with row
+sets \(R_i\), satisfying:
+
+1. \(|R_i\cap R_k|\le 2\) for \(i\ne k\).
+2. If \(R_i\cap R_k=\{a,b\}\), then \(\{i,k\}\) separates \(\{a,b\}\) in the
+   cyclic order.
+
+Then:
+
+1. Noncrossing all-one \(2\times2\) submatrices are forbidden.
+2. All-one \(2\times3\) submatrices are forbidden.
+3. All-one \(3\times2\) submatrices are forbidden.
+4. Adjacent column pairs occur together in at most one row.
+5. Nonadjacent column pairs occur together in at most two rows.
+
+Discharging row-pairs of ones to unordered column pairs gives
+\[
+\sum_i \binom{|R_i|}{2}
+\le
+n+2\left(\binom n2-n\right)
+=n(n-2).
+\]
+
+If every \(|R_i|\ge 4\), then \(6n\le n(n-2)\), so \(n\ge 8\).
+
+The total-incidence consequence is also valid:
+\[
+\sum_i |R_i|
+\le
+\frac n2\left(1+\sqrt{8n-15}\right).
+\]
+
+This is \(O(n^{3/2})\), so it cannot contradict \(\sum_i |R_i|\ge 4n\) for
+large \(n\).
+
+## Verified Matrix Survivors
+
+I checked the recurring circulant claims with a small cyclic separator checker.
+For a circulant row template \(D\subset \mathbb Z_n\), row \(i\) is \(i+D\).
+For every shift \(t\), the checker tested:
+
+1. \(|D\cap(t+D)|\le 2\).
+2. If the intersection has size 2, its two columns lie on opposite cyclic arcs
+   between \(0\) and \(t\).
+
+Verified examples:
+
+| Template | Range checked / claim | Result |
+| --- | --- | --- |
+| \(D=\{1,2,5,7\}\) | \(n=8\) | valid; equality example |
+| \(D=\{1,2,4,8\}\) | all \(n\ge 9\) | valid; lists for \(9\le n\le14\) match |
+| \(D=\{1,2,5,7\}\) | all \(n\ge 8\) | valid |
+| \(D=\{-3,-1,1,2\}\) | all \(n\ge 8\) | valid |
+| \(D=\{-1,1,2,4\}\) | all \(n\ge 9\) | valid |
+| \(D=\{-2,-1,2,4\}\) | all \(n\ge 9\) | valid |
+
+The sparse Sidon-type templates in the runs were also checked at their stated
+sufficient thresholds. They are valid and usually conservative:
+
+| Template | Stated sufficient range | Checked result |
+| --- | --- | --- |
+| \(\{1,3,7,15\}\) | \(n\ge29\) | valid, (B) vacuous |
+| \(\{1,4,10,20\}\) | \(n\ge39\) | valid, (B) vacuous |
+| \(\{2,5,9,14\}\) | \(n\ge25\) | valid, (B) vacuous |
+| \(\{2,5,11,23\}\) | \(n\ge43\) | valid, (B) vacuous |
+| \(\{1,4,10,18\}\) | \(n\ge35\) | valid, (B) vacuous |
+| \(\{3,7,15,26\}\) | \(n\ge47\) | valid, (B) vacuous |
+| \(\{1,3,7,12\}\) | \(n\ge23\) | valid, (B) vacuous |
+| \(\{1,2,5,10\}\) | \(n\ge19\) | valid, (B) vacuous |
+
+The explicit 13-row pattern in `run-16.md` was checked: every row has size 4,
+the diagonal is zero, and every pair of rows intersects in exactly one column.
+Thus (A) holds strongly and (B) is vacuous.
+
+The finite-field affine-line construction in `run-19.md` is valid over actual
+finite fields. I checked the prime cases \(q=5,7\) directly over \(\mathbb F_q\):
+diagonal zero, all rows have size \(q\), and row intersections are at most one.
+This shows A/B allow row sums of order \(\sqrt n\), so no constant upper bound
+on row sums can follow from A/B alone.
+
+## Extra Geometry Claims
+
+These claims use information beyond (A) and (B). They should not be folded into
+the matrix-only theorem.
+
+### Geometric impossibility for n = 8
+
+The `n=8` matrix equality structure is valid:
+
+1. Every row has size 4.
+2. Every column has size 4.
+3. Adjacent row pairs meet in exactly one column.
+4. Nonadjacent row pairs meet in exactly two columns.
+5. Every row contains its two cyclic neighbors.
+
+The strongest additional geometric argument appears in `run-20.md`:
+
+1. For every side \(\{j,j+1\}\), one of rows \(j-1\) or \(j+2\) contains both
+   endpoints of that side.
+2. If row \(j-1\) contains \(j,j+1\), then triangle
+   \(p_{j-1}p_jp_{j+1}\) is isosceles with base \(p_jp_{j+1}\), so the
+   polygon angle at \(p_j\) is acute.
+3. Similarly, if row \(j+2\) contains \(j,j+1\), the angle at \(p_{j+1}\) is
+   acute.
+4. Hence every side has at least one acute endpoint, so no two non-acute angles
+   are adjacent. In an 8-cycle, at most four angles are non-acute.
+5. The angle sum is then strictly less than
+   \(4\cdot90^\circ+4\cdot180^\circ=1080^\circ\), contradicting the octagon
+   angle sum.
+
+This looks valid, but it is not an A/B-only consequence.
+
+The spectral argument in `run-05.md` for excluding the symmetric `n=8`
+geometric equality case also appears internally consistent, but it is more
+fragile and less direct than the angle proof.
+
+### Acute-angle obstruction for simple circulants
+
+For templates containing \(i+1,i+2\in R_i\) for every \(i\), a geometric
+realization would force
+\[
+|p_i-p_{i+1}|=|p_i-p_{i+2}|.
+\]
+In triangle \(p_ip_{i+1}p_{i+2}\), this implies the polygon interior angle at
+\(p_{i+1}\) is acute. If this holds for every \(i\), all angles are acute,
+which is impossible for any convex \(n\)-gon with \(n\ge4\).
+
+This correctly rules out several simple circulant survivors geometrically, but
+not the sparse Sidon-type survivors.
+
+### Row-sum 5 sharpening
+
+The row-sum-at-least-5 aside in `run-13.md` checks out as a matrix-level
+claim:
+
+1. The same counting gives \(n\ge12\).
+2. The equality case \(n=12\) would force the Gram matrix
+   \(G=2J+3I-A(C_{12})\).
+3. Its determinant is \(2^8 3^4 5^3\), not a square.
+4. Since \(G=MM^T\) for an integer matrix \(M\), this is impossible.
+
+The row-sum-5 circulant \(D=\{1,2,5,10,12\}\) modulo 13 was also checked and
+satisfies A/B, so the threshold \(n\ge13\) is sharp for that matrix statement.
+
+This is interesting but secondary to the original row-sum-4 prompt.
+
+## Claims to Soften or Avoid
+
+1. Do not say the pair-count theorem is the "strongest possible" without
+   qualification. It is the strongest theorem proved in these runs, and the
+   \(n\ge8\) threshold is sharp, but "strongest possible" is too broad unless
+   formalized.
+2. Do not present any circulant survivor as geometrically realizable. The runs
+   mostly avoid this, but the distinction should stay explicit.
+3. Do not use the `q=4` finite-field example with ordinary arithmetic modulo
+   4. It requires the actual field \(\mathbb F_4\). Prime cases such as
+   \(q=5,7\) are straightforward.
+4. The half-plane proof of the crossing lemma is acceptable only if it clearly
+   justifies why the line through two vertices separates the two boundary
+   chains into opposite open half-planes. The coordinate/extreme-point proof is
+   cleaner and safer.
+
+## Suggested Repo Use
+
+If promoting any of this into main documentation, the safest additions are:
+
+1. A lemma file or note with the coordinate proof of the crossing lemma.
+2. A matrix-only theorem stating the discharging bound and \(n\ge8\).
+3. A clearly labeled section of abstract A/B countermodels, especially
+   \(C_8(\{1,2,5,7\})\), \(C_n(\{1,2,4,8\})\) for \(n\ge9\), and the
+   finite-field linear construction.
+4. A separate "extra geometry beyond A/B" note for the \(n=8\) angle
+   contradiction.
+
+None of these should be stated as solving Erdos Problem #97.

--- a/incoming/chatgpt-runs/prompt.md
+++ b/incoming/chatgpt-runs/prompt.md
@@ -1,0 +1,21 @@
+# Original Prompt
+
+```text
+This is a complex competition-style math problem. Solve the problem and give a rigorous proof or disproof. Do not search the internet, browse, or cite external sources.
+
+Let P={p_1,...,p_n} be the vertices of a strictly convex n-gon in cyclic order. For each i choose a radius r_i>0 and define S_i={j != i : |p_j-p_i|=r_i}. Let M be the 0-1 matrix with M_{ij}=1 iff j in S_i.
+
+Assume every row has size at least 4. Use the following two facts. Fact (A) is elementary; fact (B) is NOT elementary and you must prove it from the strict convexity hypothesis before using it:
+(A) For i != k, |S_i cap S_k| <= 2. (Two distinct circles meet in at most two points.)
+(B) Convex-position crossing lemma. If S_i and S_k share two indices a,b, then in the cyclic order of the polygon the pair {i,k} separates the pair {a,b}; equivalently, the chord p_i p_k crosses the chord p_a p_b. The proof must use that a,b are reflections across line p_i p_k (radical-axis property) and that convex position forces them onto opposite sides of that line; identify the exact step where strict convexity is invoked.
+
+Task. Starting from (A) and the proven form of (B), derive forbidden cyclic 0-1 submatrices for M. Try to prove that no such matrix can exist with all row sums at least 4 when the rows and columns are indexed by the same cyclically ordered set.
+
+If the full contradiction does not follow, give the strongest theorem you can prove: a bound on sum_i |S_i|, a forbidden configuration involving 3 or 4 rows, or a structural theorem about rows of size 4. Where your argument requires more than (A) and (B), state the additional geometric input explicitly.
+
+Output format:
+1. State and prove the convex-position crossing lemma in full. Mark every use of strict convexity.
+2. State the exact theorem you ultimately prove.
+3. Develop the cyclic-matrix / discharging argument.
+4. List any configurations that remain unresolved, with exact 0-1 patterns.
+```

--- a/incoming/chatgpt-runs/run-01.md
+++ b/incoming/chatgpt-runs/run-01.md
@@ -1,0 +1,408 @@
+## 1. Convex-position crossing lemma
+
+Call two unordered pairs ({x,y}) and ({u,v}) **separated** in the cyclic order if, after deleting (x,y), the two indices (u,v) lie in different open cyclic arcs. Equivalently, up to reversing the cyclic order, the four indices occur as
+
+[
+x,\ u,\ y,\ v .
+]
+
+Geometrically, for vertices of a strictly convex polygon, this is equivalent to saying that the chords (p_xp_y) and (p_up_v) cross.
+
+### Lemma B
+
+Suppose (i\ne k) and (S_i\cap S_k) contains two distinct indices (a,b). Then ({i,k}) separates ({a,b}). Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+### Proof
+
+Let
+
+[
+C_i={x: |x-p_i|=r_i},\qquad C_k={x: |x-p_k|=r_k}.
+]
+
+Because (a,b\in S_i\cap S_k), the two points (p_a,p_b) lie on both circles (C_i,C_k). Thus the line (p_ap_b) is the common chord, i.e. the radical axis, of the two circles.
+
+The radical axis of two nonconcentric circles is perpendicular to the line of centers. Hence the line (p_ip_k) is perpendicular to the common chord (p_ap_b). Moreover, since (p_i) lies on the perpendicular from the center of (C_i) to the chord (p_ap_b), the intersection point
+
+[
+h=p_ip_k\cap p_ap_b
+]
+
+is the midpoint of (p_ap_b). Therefore reflection across the line (p_ip_k) swaps (p_a) and (p_b). In particular, since (a\ne b), neither (p_a) nor (p_b) lies on the line (p_ip_k), and the two points (p_a,p_b) lie in opposite open half-planes bounded by (p_ip_k).
+
+Now use convexity. The chord (p_ip_k) splits the boundary cycle of the polygon into two open chains from (p_i) to (p_k). In a convex polygon, each of these two chains lies in one of the two closed half-planes bounded by the line (p_ip_k). The two chains lie on opposite sides unless one chain is empty, i.e. unless (i,k) are adjacent.
+
+Here is the exact use of strict convexity: strict convexity rules out any third vertex lying on the line (p_ip_k). Therefore the vertices on the two open chains lie in the two **open** half-planes bounded by (p_ip_k).
+
+Since (p_a) and (p_b) are on opposite sides of (p_ip_k), they must lie on opposite boundary chains between (i) and (k). Hence ({i,k}) separates ({a,b}) in cyclic order. Equivalently, the chords (p_ip_k) and (p_ap_b) cross. (\square)
+
+---
+
+## 2. Exact theorem proved
+
+The full contradiction “no such matrix exists with every row sum at least (4)” **does not follow from facts (A) and (B) alone**.
+
+The sharp cyclic-matrix theorem obtainable from (A) and (B) is this:
+
+### Theorem
+
+Let (M) be a cyclically indexed (0)-(1) matrix with (M_{ii}=0), satisfying:
+
+1. for distinct rows (i,k),
+
+[
+|S_i\cap S_k|\le 2;
+]
+
+2. if (|S_i\cap S_k|=2), say (S_i\cap S_k={a,b}), then ({i,k}) separates ({a,b}).
+
+Then:
+
+* all noncrossing (2\times 2) all-one submatrices are forbidden;
+* all (2\times 3) and (3\times 2) all-one submatrices are forbidden;
+* the pair-counting / discharging bound
+
+[
+\sum_i \binom{|S_i|}{2}\le n(n-2)
+]
+
+holds;
+
+* therefore no such matrix with all row sums at least (4) exists for (n\le 7);
+* but for every (n\ge 8), there exists a cyclic matrix satisfying all of these rules with every row sum exactly (4).
+
+Thus any proof of the original geometric contradiction, if true, must use additional geometry beyond (A) and (B). In particular, it must rule out linear (4)-uniform incidence patterns in which no two rows share two columns; facts (A) and (B) are silent in that case.
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Write (d_i=|S_i|).
+
+### Forbidden (2\times 2) pattern
+
+Suppose rows (i,k) and columns (a,b) form an all-one (2\times 2):
+
+[
+M_{ia}=M_{ib}=M_{ka}=M_{kb}=1.
+]
+
+Then (a,b\in S_i\cap S_k). By (A), the intersection is exactly ({a,b}). By (B), the pairs ({i,k}) and ({a,b}) must be separated in cyclic order.
+
+Therefore the following pattern is forbidden whenever the four labels are not alternating:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+with cyclic order, for example,
+
+[
+i,\ k,\ a,\ b.
+]
+
+The only allowed all-one (2\times 2) pattern is the crossing one, with cyclic order
+
+[
+i,\ a,\ k,\ b
+]
+
+or its reverse.
+
+A useful interval version is:
+
+> If (R) and (C) are disjoint cyclic intervals, then the submatrix (M[R,C]) contains no all-one (2\times 2).
+
+Indeed, two rows in the same interval and two columns in a disjoint interval cannot alternate.
+
+### Forbidden (2\times 3)
+
+Two rows cannot share three columns, because that would violate (A). Hence no submatrix of the form
+
+[
+\begin{array}{c|ccc}
+& a & b & c\ \hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+is possible.
+
+### Forbidden (3\times 2)
+
+Fix two columns (a,b). Let
+
+[
+R_{ab}={i: M_{ia}=M_{ib}=1}.
+]
+
+If (i,k\in R_{ab}), then (S_i\cap S_k) contains ({a,b}), so by (A) it equals ({a,b}), and by (B) the pair ({i,k}) separates ({a,b}).
+
+But the cyclic order cut by (a,b) has only two open arcs. At most one row of (R_{ab}) can lie in each arc, because two rows in the same arc would not separate (a,b). Therefore
+
+[
+|R_{ab}|\le 2.
+]
+
+So no (3\times 2) all-one submatrix is possible:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+is forbidden.
+
+Moreover, if (a,b) are adjacent in the cyclic order, then one of the two arcs between them is empty. Hence in that case
+
+[
+|R_{ab}|\le 1.
+]
+
+### Pair-discharge bound
+
+For each row (i), give one unit of charge to each unordered pair of (1)’s in that row. Thus row (i) emits
+
+[
+\binom{d_i}{2}
+]
+
+units of charge. Discharge each unit to the corresponding unordered column-pair ({a,b}).
+
+For a nonadjacent column-pair ({a,b}), the pair can receive charge from at most two rows. For an adjacent column-pair, it can receive charge from at most one row. There are (n) adjacent unordered column-pairs and (\binom n2-n) nonadjacent unordered column-pairs. Therefore
+
+[
+\sum_i \binom{d_i}{2}
+\le
+1\cdot n+2\left(\binom n2-n\right)
+==================================
+
+n(n-2).
+]
+
+If every row has size at least (4), then
+
+[
+\sum_i \binom{d_i}{2}
+\ge
+n\binom 42
+==========
+
+6n.
+]
+
+Thus
+
+[
+6n\le n(n-2),
+]
+
+so necessarily
+
+[
+n\ge 8.
+]
+
+This proves that the matrix rules already forbid the desired configuration for (n\le 7). But the next construction shows that the same rules allow row sum (4) for every (n\ge 8).
+
+---
+
+## 4. Explicit cyclic matrices with all row sums (4)
+
+Indices are taken modulo (n), in cyclic order
+
+[
+0,1,\dots,n-1.
+]
+
+For (n\ge 9), define
+
+[
+D={1,2,4,8}\subset \mathbb Z_n,
+]
+
+and set
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\in D.
+]
+
+Every row has exactly four (1)’s. Since the construction is circulant, every column also has exactly four (1)’s.
+
+It remains to check (A) and (B).
+
+For two rows (0) and (h), the common columns are
+
+[
+D\cap (h+D).
+]
+
+For (n\ge 15), the nonzero ordered differences of (D={1,2,4,8}) are
+
+[
+\pm1,\ \pm2,\ \pm3,\ \pm4,\ \pm6,\ \pm7,
+]
+
+which are all distinct modulo (n). Hence two different rows share at most one column. Thus (A) holds, and (B) is vacuous.
+
+For (9\le n\le 14), the only cases where two rows share two columns are listed below. In every case, the two common columns lie on opposite sides of the row-pair ({0,h}), so the crossing condition (B) holds.
+
+[
+\begin{array}{c|c}
+n & \text{pairs } h:\ D\cap(h+D) \ \hline
+9 & 2:{1,4},\ 3:{2,4},\ 6:{1,8},\ 7:{2,8}\
+10 & 3:{1,4},\ 4:{2,8},\ 6:{4,8},\ 7:{1,8}\
+11 & 4:{1,8},\ 7:{4,8}\
+12 & 6:{2,8}\
+13 & 6:{1,8},\ 7:{2,8}\
+14 & 7:{1,8}
+\end{array}
+]
+
+For example, when (n=10) and (h=4), the two common columns are (2) and (8), and in cyclic order we have
+
+[
+0,\ 2,\ 4,\ 8,
+]
+
+so ({0,4}) separates ({2,8}).
+
+For (n=8), with (D={1,2,5,7}), the double intersections are
+
+[
+\begin{array}{c|c}
+h & D\cap(h+D) \ \hline
+2 & {1,7}\
+3 & {2,5}\
+4 & {1,5}\
+5 & {2,7}\
+6 & {5,7}
+\end{array}
+]
+
+and again the two common columns lie on opposite sides of ({0,h}). Therefore (A) and (B) hold.
+
+By rotation, the same verification applies to every pair of rows. Hence for every (n\ge 8), there is a cyclic matrix satisfying all consequences of (A) and (B) with all row sums equal to (4).
+
+So the proposed contradiction cannot be proved from (A) and (B) alone.
+
+---
+
+## 5. Structural theorem for rows of size (4)
+
+Suppose (d_i=4). Then row (i) contains six unordered column-pairs. For each pair ({a,b}\subset S_i), there is at most one other row (k) also containing both (a,b). If such a row (k) exists, then (k) must lie on the opposite side of the chord (p_ap_b) from (i).
+
+Equivalently, define the double-intersection graph (H) on row indices by
+
+[
+ik\in E(H)
+\quad\Longleftrightarrow\quad
+|S_i\cap S_k|=2.
+]
+
+Then for a row of size (4),
+
+[
+\deg_H(i)\le \binom 42=6.
+]
+
+If (H) is empty, the matrix is linear: every two rows meet in at most one column. In that case fact (B) never fires. The circulant examples above are exactly of this type for (n\ge 15).
+
+Thus any geometric proof of impossibility must somehow rule out the case
+
+[
+|S_i|=4\quad\text{for all }i,
+\qquad
+|S_i\cap S_k|\le 1\quad\text{for all }i\ne k.
+]
+
+Facts (A) and (B) do not address this case.
+
+---
+
+## 6. Configurations remaining unresolved by (A) and (B)
+
+The following exact patterns are not eliminated by the crossing lemma and the circle-intersection bound.
+
+### Unresolved pattern 1: crossing (2\times 2)
+
+With cyclic order
+
+[
+r_1,\ c_1,\ r_2,\ c_2,
+]
+
+the all-one submatrix
+
+[
+\begin{array}{c|cc}
+& c_1 & c_2\ \hline
+r_1 & 1 & 1\
+r_2 & 1 & 1
+\end{array}
+]
+
+is allowed by (A) and (B). It is the only possible (2\times 2) all-one pattern.
+
+### Unresolved pattern 2: a three-row triangle of double intersections
+
+Take cyclic order
+
+[
+r_1,\ \alpha,\ \beta,\ r_2,\ \gamma,\ \delta,\ r_3,\ \varepsilon,\ \zeta.
+]
+
+Consider the submatrix
+
+[
+\begin{array}{c|cccccc}
+& \alpha & \beta & \gamma & \delta & \varepsilon & \zeta \ \hline
+r_1 & 1 & 0 & 0 & 1 & 1 & 1\
+r_2 & 1 & 1 & 1 & 0 & 0 & 1\
+r_3 & 0 & 1 & 1 & 1 & 1 & 0
+\end{array}
+]
+
+Then
+
+[
+S_{r_1}\cap S_{r_2}={\alpha,\zeta},
+]
+[
+S_{r_2}\cap S_{r_3}={\beta,\gamma},
+]
+[
+S_{r_1}\cap S_{r_3}={\delta,\varepsilon}.
+]
+
+Each common pair is separated by its corresponding row-pair, so this pattern is allowed by (A) and (B).
+
+### Unresolved pattern 3: linear (4)-uniform circulant matrices
+
+For (n\ge 15), the pattern
+
+[
+S_i={i+1,\ i+2,\ i+4,\ i+8}\pmod n
+]
+
+has every row sum equal to (4) and satisfies
+
+[
+|S_i\cap S_k|\le 1
+\qquad\text{for all }i\ne k.
+]
+
+Thus it avoids every forbidden (2\times 2), (2\times 3), and (3\times 2) pattern. Since no two rows share two columns, the crossing lemma is never invoked.
+
+This is the main obstruction to a proof using only (A) and (B). To prove the original geometric impossibility, one needs an additional geometric input that rules out such linear favorite-distance incidence patterns.

--- a/incoming/chatgpt-runs/run-02.md
+++ b/incoming/chatgpt-runs/run-02.md
@@ -1,0 +1,390 @@
+## 1. Convex-position crossing lemma
+
+Let (P=(p_1,\dots,p_n)) be a strictly convex polygon in cyclic order. I use “strictly convex” in the standard discrete sense needed here: no three vertices are collinear, and every vertex is an extreme point of the convex hull.
+
+### Lemma B
+
+Suppose (i\ne k) and
+
+[
+a,b\in S_i\cap S_k,\qquad a\ne b.
+]
+
+Then the pair ({i,k}) separates the pair ({a,b}) in the cyclic order. Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+### Proof
+
+Because (a,b\in S_i\cap S_k),
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,
+\qquad
+|p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of the segment (p_ap_b). Since (p_i\ne p_k), the line
+
+[
+L:=p_ip_k
+]
+
+is exactly that perpendicular bisector. Therefore reflection across (L) swaps (p_a) and (p_b). This is the radical-axis/common-chord property of two circles: the two common points of the circles centered at (p_i,p_k) are mirror images across the line of centers.
+
+In particular, since (p_a\ne p_b), neither (p_a) nor (p_b) lies on (L), and they lie in opposite open half-planes bounded by (L).
+
+Now use convexity. Consider the two boundary chains of the polygon from (p_i) to (p_k). The line (L) meets the convex polygon in the segment ([p_i,p_k]). Hence the two open boundary chains cannot cross (L). Therefore each open chain lies entirely in one open half-plane bounded by (L).
+
+This is the exact point where strict convexity is invoked: strict convexity rules out any third vertex lying on (L). Without that, a boundary chain could touch (L) at another vertex, and the clean “one chain = one open half-plane” conclusion could fail.
+
+Since (p_a) and (p_b) lie in opposite open half-planes, they must lie on opposite cyclic chains between (i) and (k). Hence the cyclic order is alternating:
+
+[
+i,\ a,\ k,\ b
+\quad\text{or}\quad
+i,\ b,\ k,\ a
+]
+
+up to rotation and reversal. Thus ({i,k}) separates ({a,b}), equivalently the chords (p_ip_k) and (p_ap_b) cross. (\square)
+
+---
+
+## 2. Exact theorem proved from (A) and (B)
+
+Let (R_i=S_i) be the support of row (i), and let
+
+[
+s_i=|R_i|,\qquad m=\sum_i s_i.
+]
+
+Call a cyclic (0)-(1) matrix admissible if it has zero diagonal and satisfies:
+
+[
+\tag{A} |R_i\cap R_k|\le 2\quad(i\ne k),
+]
+
+and
+
+[
+\tag{B} |R_i\cap R_k|=2,\ R_i\cap R_k={a,b}
+\implies
+{i,k}\text{ separates }{a,b}.
+]
+
+The strongest general theorem I can prove from only (A) and (B) is the following.
+
+### Theorem
+
+For every admissible cyclic matrix,
+
+[
+\sum_{i=1}^n \binom{s_i}{2}\le n(n-2).
+]
+
+Consequently,
+
+[
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+In particular, if every row has size at least (4), then
+
+[
+n\ge 8.
+]
+
+This is sharp at the matrix level: there exists an admissible cyclic (8\times 8) matrix with every row sum equal to (4). Therefore no contradiction can be proved from (A) and (B) alone.
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+### Basic forbidden submatrices
+
+The crossing lemma gives the following cyclic (0)-(1) restrictions.
+
+First, a (2\times 2) all-one submatrix
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is allowed only if the cyclic order of (i,k,a,b) is alternating:
+
+[
+i,\ a,\ k,\ b
+\quad\text{or}\quad
+i,\ b,\ k,\ a.
+]
+
+So the same (2\times 2) pattern is forbidden when (a,b) lie on the same side of the chord (ik), or equivalently when (i,k) lie on the same side of the chord (ab).
+
+Second, by (A), a (2\times 3) all-one submatrix is forbidden:
+
+[
+\begin{array}{c|ccc}
+& a & b & c\ \hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+because then (|R_i\cap R_k|\ge 3).
+
+Third, a (3\times 2) all-one submatrix is forbidden:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+Indeed, the two columns (a,b) cut the cyclic order into two arcs. Among the three row indices (i,k,\ell), two lie on the same arc. Those two rows share both (a) and (b), but their row indices do not separate (a,b), contradicting (B).
+
+There are also two important adjacent versions.
+
+If (i) and (i+1) are adjacent row indices, then
+
+[
+|R_i\cap R_{i+1}|\le 1,
+]
+
+because an edge of a convex polygon crosses no chord. Similarly, if (a) and (a+1) are adjacent column indices, then the pair ({a,a+1}) can occur together in at most one row. Two rows containing both adjacent columns would force some chord to cross the boundary edge (p_ap_{a+1}), impossible.
+
+### Discharging on column pairs
+
+For every row (i), distribute one unit of charge to each unordered pair of columns inside (R_i). Thus row (i) sends
+
+[
+\binom{s_i}{2}
+]
+
+units of charge.
+
+Now fix a column pair ({a,b}).
+
+If (a,b) are adjacent in the cyclic order, then ({a,b}) can occur together in at most one row.
+
+If (a,b) are nonadjacent, then ({a,b}) can occur together in at most two rows. Otherwise three row indices would contain both (a,b), and two of those row indices would lie on the same cyclic side of ({a,b}), contradicting the crossing condition.
+
+There are (n) adjacent column pairs and
+
+[
+\binom n2-n
+]
+
+nonadjacent column pairs. Therefore the total charge is at most
+
+[
+1\cdot n+2\left(\binom n2-n\right)
+= n+n(n-1)-2n
+= n(n-2).
+]
+
+Hence
+
+[
+\boxed{\sum_i \binom{s_i}{2}\le n(n-2).}
+]
+
+Now let (m=\sum_i s_i). By convexity of (x\mapsto \binom x2),
+
+[
+\sum_i \binom{s_i}{2}
+\ge
+n\binom{m/n}{2}
+===============
+
+\frac n2\left(\frac mn\right)\left(\frac mn-1\right).
+]
+
+Combining with the upper bound gives
+
+[
+\frac n2\left(\frac mn\right)\left(\frac mn-1\right)
+\le n(n-2).
+]
+
+Writing (x=m/n),
+
+[
+x(x-1)\le 2(n-2),
+]
+
+so
+
+[
+x\le \frac{1+\sqrt{1+8(n-2)}}2
+==============================
+
+\frac{1+\sqrt{8n-15}}2.
+]
+
+Thus
+
+[
+\boxed{
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+If every row has size at least (4), then
+
+[
+\sum_i \binom{s_i}{2}\ge 6n.
+]
+
+Therefore
+
+[
+6n\le n(n-2),
+]
+
+so
+
+[
+n\ge 8.
+]
+
+For (n=8), equality must hold throughout. Thus any admissible (8\times 8) matrix with all row sums at least (4) must have every row sum exactly (4), every adjacent column pair appearing exactly once, and every nonadjacent column pair appearing exactly twice.
+
+### Sharpness: an admissible (8\times 8) matrix
+
+Index rows and columns modulo (8). Define
+
+[
+R_i={i+1,\ i+2,\ i+5,\ i+7}\pmod 8.
+]
+
+Equivalently, with rows and columns indexed (0,1,\dots,7),
+
+[
+\begin{array}{c|cccccccc}
+&0&1&2&3&4&5&6&7\ \hline
+0&0&1&1&0&0&1&0&1\
+1&1&0&1&1&0&0&1&0\
+2&0&1&0&1&1&0&0&1\
+3&1&0&1&0&1&1&0&0\
+4&0&1&0&1&0&1&1&0\
+5&0&0&1&0&1&0&1&1\
+6&1&0&0&1&0&1&0&1\
+7&1&1&0&0&1&0&1&0
+\end{array}
+]
+
+Every row has size (4), and the diagonal is zero.
+
+Let (D={1,2,5,7}). Then (R_i=i+D). For (\delta=k-i\pmod 8), the intersections are:
+
+[
+\begin{array}{c|c}
+\delta & R_i\cap R_{i+\delta}\ \hline
+1 & {i+2}\
+2 & {i+1,i+7}\
+3 & {i+2,i+5}\
+4 & {i+1,i+5}\
+5 & {i+2,i+7}\
+6 & {i+5,i+7}\
+7 & {i+1}
+\end{array}
+]
+
+Thus every intersection has size (1) or (2), so (A) holds.
+
+When the intersection has size (2), one common column lies on the open arc from (i) to (i+\delta), and the other lies on the complementary arc. Hence the row pair ({i,i+\delta}) separates the common column pair. So (B) holds.
+
+Therefore the matrix is admissible and has all row sums (4). This proves that (A) and (B) alone cannot imply a contradiction.
+
+---
+
+## 4. Remaining unresolved configurations and exact patterns
+
+The following patterns survive all consequences of (A) and (B). They are not claimed to be geometrically realizable; they show exactly where the cyclic-matrix method stops.
+
+### Residual pattern 1: the sharp (8\times 8) pattern
+
+The matrix
+
+[
+R_i={i+1,i+2,i+5,i+7}\pmod 8
+]
+
+is admissible and has every row sum (4). Thus any proof of geometric impossibility must use information beyond (A) and (B).
+
+For example, to rule out this particular matrix geometrically one can use the additional metric fact
+
+[
+j\in S_i\ \text{and}\ i\in S_j
+\implies r_i=r_j.
+]
+
+In this (8\times 8) pattern, adjacent vertices are mutually joined, so a geometric realization would force
+
+[
+r_0=r_1=\cdots=r_7.
+]
+
+Then each triangle
+
+[
+p_i p_{i+1} p_{i+2}
+]
+
+would have all three sides equal, because (i+1,i+2\in S_i) and (i,i+2\in S_{i+1}). Hence every three consecutive vertices would form an equilateral triangle, forcing every polygon interior angle to be (60^\circ), impossible for a convex octagon. This extra argument uses metric symmetry of distance, not merely (A) and (B).
+
+### Residual pattern 2: a linear (13\times 13) pattern where (B) is never triggered
+
+Index rows and columns modulo (13), and set
+
+[
+R_i={i+2,\ i+3,\ i+5,\ i+11}\pmod{13}.
+]
+
+The difference set
+
+[
+D={2,3,5,11}
+]
+
+has the property that every nonzero residue modulo (13) occurs exactly once as a difference of two elements of (D). Therefore
+
+[
+|R_i\cap R_k|=1
+\qquad (i\ne k).
+]
+
+Thus (A) holds, and (B) is vacuous. Every row has size (4), and the diagonal is zero. This is another exact cyclic (0)-(1) configuration left completely untouched by the crossing obstruction.
+
+So the final conclusion is:
+
+[
+\boxed{
+\text{The desired contradiction does not follow from (A) and (B) alone.}
+}
+]
+
+From those two facts one gets the sharp bound
+
+[
+\boxed{
+\sum_i \binom{|S_i|}{2}\le n(n-2),
+}
+]
+
+and hence
+
+[
+\boxed{
+\sum_i |S_i|
+\le
+\frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+Any full geometric contradiction must use additional metric input beyond the pairwise circle-intersection bound and the convex-position crossing lemma.

--- a/incoming/chatgpt-runs/run-03.md
+++ b/incoming/chatgpt-runs/run-03.md
@@ -1,0 +1,419 @@
+I will use indices cyclically, modulo (n). For a row (i), write
+[
+R_i=S_i={j:M_{ij}=1},\qquad m_i=|R_i|.
+]
+
+The full contradiction **does not follow from (A) and (B) alone**. In fact, there are exact cyclic (0)-(1) matrices with zero diagonal and all row sums at least (4) satisfying every consequence of (A) and (B). What can be proved from (A) and (B) is a sharp cyclic discharging theorem: if all rows have size at least (4), then necessarily (n\ge 8), and the (n=8) case is completely tight at the cyclic-matrix level.
+
+---
+
+## 1. Convex-position crossing lemma
+
+**Lemma (B).** Suppose (S_i\cap S_k={a,b}) with (i\ne k). Then the two pairs ({i,k}) and ({a,b}) separate each other in the cyclic order. Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+**Proof.** Since (a,b\in S_i\cap S_k), we have
+[
+|p_a-p_i|=|p_b-p_i|,\qquad |p_a-p_k|=|p_b-p_k|.
+]
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of the segment (p_ap_b). Since (p_i\ne p_k), the line (p_ip_k) is exactly that perpendicular bisector. Equivalently, (p_a) and (p_b) are reflections of one another across the line (p_ip_k). This is the radical-axis/common-chord property for the two circles centered at (p_i) and (p_k).
+
+Choose coordinates so that
+[
+p_i=(0,0),\qquad p_k=(d,0),\qquad d>0,
+]
+and the line (p_ip_k) is the (x)-axis. Since (p_a,p_b) are symmetric across this line, write
+[
+p_a=(u,v),\qquad p_b=(u,-v),
+]
+with (v>0). Thus (p_a,p_b) lie on opposite sides of the line (p_ip_k).
+
+Now we prove that (0<u<d). This is where **strict convexity is used**.
+
+If (u<0), then (p_i=(0,0)) lies strictly inside the triangle with vertices (p_k,p_a,p_b). Indeed, the vertical cross-section of that triangle at (x=0) contains a nontrivial interval around (y=0). That contradicts strict convexity, because a vertex of a strictly convex polygon cannot lie inside the triangle spanned by three other vertices.
+
+If (u=0), then (p_i) lies on the segment (p_ap_b), again impossible in a strictly convex polygon.
+
+Similarly, if (u>d), then (p_k) lies strictly inside the triangle (p_i p_a p_b), and if (u=d), then (p_k) lies on (p_ap_b). Both are impossible by strict convexity.
+
+Therefore (0<u<d). Hence the segment (p_ip_k) meets the segment (p_ap_b) at the point ((u,0)), which lies in the relative interior of both segments. Thus the two chords cross.
+
+For four vertices of a strictly convex polygon, two chords cross in their interiors exactly when their endpoints alternate in the cyclic order. Therefore ({i,k}) separates ({a,b}). ∎
+
+The exact strict-convexity step is the exclusion of (u\le 0) and (u\ge d), because otherwise one of (p_i,p_k) lies on or inside the triangle formed by the other three relevant vertices.
+
+---
+
+## 2. The exact theorem proved from (A) and (B)
+
+Let (M) be any cyclic (0)-(1) matrix with zero diagonal satisfying:
+
+[
+\tag{A} |R_i\cap R_k|\le 2\quad\text{for }i\ne k,
+]
+and
+
+[
+\tag{B} |R_i\cap R_k|=2,\ R_i\cap R_k={a,b}
+\implies {i,k}\text{ separates }{a,b}.
+]
+
+Then:
+
+**Theorem.**
+
+1. For every unordered pair of columns ({a,b}), let
+   [
+   \lambda_{ab}:=#{i:a,b\in R_i}.
+   ]
+   If (a,b) are adjacent in the cyclic order, then
+   [
+   \lambda_{ab}\le 1.
+   ]
+   If (a,b) are nonadjacent, then
+   [
+   \lambda_{ab}\le 2.
+   ]
+
+2. Consequently,
+   [
+   \sum_i \binom{m_i}{2}\le n(n-2).
+   ]
+
+3. Hence if every row has size at least (4), then
+   [
+   n\ge 8.
+   ]
+
+4. If (n=8) and every row has size at least (4), then equality holds everywhere:
+   [
+   m_i=4\quad\text{for every }i,
+   ]
+   every adjacent column-pair appears together in exactly one row, and every nonadjacent column-pair appears together in exactly two rows. Moreover every column also has degree (4), adjacent row-pairs intersect in exactly one column, and nonadjacent row-pairs intersect in exactly two columns.
+
+5. This is the strongest contradiction obtainable from (A) and (B) alone: there exist exact cyclic matrices with zero diagonal and all row sums at least (4) satisfying (A) and (B). Therefore the desired full geometric contradiction requires additional metric input beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+### 3.1 Forbidden cyclic submatrices
+
+The first forbidden pattern is just (A):
+
+[
+\begin{array}{c|ccc}
+& a&b&c\ \hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+\qquad\text{is forbidden.}
+]
+
+Two distinct rows cannot share three columns.
+
+The second forbidden pattern is the cyclic one coming from (B):
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is forbidden unless the pair ({i,k}) separates the pair ({a,b}). In particular, adjacent rows cannot share two columns, because an adjacent pair of vertices separates no other pair.
+
+Now dualize this observation. Fix two columns (a,b). Suppose two rows (i,k) both contain (a,b). Then (R_i\cap R_k) contains ({a,b}). By (A), it contains exactly ({a,b}). Therefore (B) applies, so ({i,k}) separates ({a,b}).
+
+This gives two useful dual forbidden patterns.
+
+First, no three rows can contain the same two columns:
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1\
+\ell&1&1
+\end{array}
+\qquad\text{is forbidden.}
+]
+
+Indeed, if three row indices all had to pairwise separate (a,b), two of them would lie on the same side of the cut determined by (a,b), contradiction.
+
+Second, if (a,b) are adjacent columns, then even two rows cannot contain both (a) and (b):
+
+[
+\begin{array}{c|cc}
+& a&a+1\ \hline
+i&1&1\
+k&1&1
+\end{array}
+\qquad\text{is forbidden.}
+]
+
+An adjacent column-pair has an empty open arc on one side, so no two row indices can separate it.
+
+More generally, for nonadjacent (a,b), two rows (i,k) may both contain (a,b) only if (i) and (k) lie on opposite arcs between (a) and (b).
+
+---
+
+### 3.2 Discharging on column-pairs
+
+Give one unit of charge to each unordered pair of (1)’s in each row. Thus row (i) sends
+
+[
+\binom{m_i}{2}
+]
+
+units of charge to column-pairs, and the total charge is
+
+[
+\sum_i \binom{m_i}{2}.
+]
+
+Now bound how much charge a fixed column-pair can receive.
+
+There are (n) adjacent column-pairs in the cycle. Each adjacent column-pair can appear together in at most one row, so each has capacity (1).
+
+There are
+
+[
+\binom n2-n
+]
+
+nonadjacent column-pairs. Each nonadjacent column-pair can appear together in at most two rows, so each has capacity (2).
+
+Therefore
+
+[
+\sum_i \binom{m_i}{2}
+\le n\cdot 1+2\left(\binom n2-n\right)
+= n+n(n-1)-2n
+= n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_i \binom{m_i}{2}\le n(n-2).}
+]
+
+If every (m_i\ge 4), then (\binom{m_i}{2}\ge 6), hence
+
+[
+6n\le \sum_i \binom{m_i}{2}\le n(n-2).
+]
+
+Thus
+
+[
+6\le n-2,
+]
+
+so
+
+[
+\boxed{n\ge 8.}
+]
+
+This proves that no such cyclic matrix exists for (n\le 7).
+
+---
+
+### 3.3 The tight (n=8) structure
+
+If (n=8) and all rows have size at least (4), then
+
+[
+6n=48\le \sum_i\binom{m_i}{2}\le n(n-2)=48.
+]
+
+So equality holds. Hence every row has size exactly (4), every adjacent column-pair is used exactly once, and every nonadjacent column-pair is used exactly twice.
+
+Let (d_a) be the degree of column (a). Fix a column (a). It has two adjacent partners and five nonadjacent partners. Therefore
+
+[
+\sum_{b\ne a}\lambda_{ab}=2\cdot 1+5\cdot 2=12.
+]
+
+But every row containing (a) has three other (1)’s, so
+
+[
+\sum_{b\ne a}\lambda_{ab}=3d_a.
+]
+
+Thus (3d_a=12), so
+
+[
+d_a=4.
+]
+
+Therefore every column also has degree (4). Applying the row-pair version of the same capacity count, adjacent row-pairs must intersect in exactly one column, and nonadjacent row-pairs must intersect in exactly two columns.
+
+---
+
+### 3.4 A sharp (8\times 8) cyclic-matrix survivor
+
+The (n=8) lower bound is sharp at the matrix level. Index rows and columns by (\mathbb Z/8\mathbb Z), and set
+
+[
+R_i={i-3,\ i-1,\ i+1,\ i+2}\pmod 8.
+]
+
+Explicitly:
+
+[
+\begin{array}{c|cccccccc}
+&0&1&2&3&4&5&6&7\ \hline
+0&0&1&1&0&0&1&0&1\
+1&1&0&1&1&0&0&1&0\
+2&0&1&0&1&1&0&0&1\
+3&1&0&1&0&1&1&0&0\
+4&0&1&0&1&0&1&1&0\
+5&0&0&1&0&1&0&1&1\
+6&1&0&0&1&0&1&0&1\
+7&1&1&0&0&1&0&1&0
+\end{array}
+]
+
+Every row has size (4). By rotation, it is enough to compare row (0) with row (t). The intersections are:
+
+[
+\begin{array}{c|c}
+t & R_0\cap R_t\ \hline
+1&{2}\
+2&{1,7}\
+3&{2,5}\
+4&{1,5}\
+5&{2,7}\
+6&{5,7}\
+7&{1}
+\end{array}
+]
+
+Every two-element intersection has one element on each side of the row-pair ({0,t}). Thus (A) and (B) both hold.
+
+So the cyclic discharging theorem cannot be improved to a contradiction using only (A) and (B).
+
+This particular (8\times 8) survivor is **not** geometrically realizable, but ruling it out uses extra metric information. Indeed, in this pattern row (i) contains (i+1) and (i+2), while row (i+1) contains (i) and (i+2). Therefore
+
+[
+|p_i-p_{i+1}|=|p_i-p_{i+2}|,
+]
+and
+
+[
+|p_{i+1}-p_i|=|p_{i+1}-p_{i+2}|.
+]
+
+Thus every triangle
+
+[
+p_i p_{i+1} p_{i+2}
+]
+
+is equilateral. Hence every interior angle of the polygon is (60^\circ), impossible for a strictly convex (n)-gon with (n\ge 4). This argument uses the actual distance equalities inside individual rows, not merely (A) and (B).
+
+---
+
+### 3.5 A total-incidence bound
+
+There is also a row-pair version of the same discharging argument. Let
+
+[
+d_j=#{i:j\in R_i}
+]
+
+be the column degree of column (j), and let
+
+[
+T=\sum_i m_i=\sum_j d_j
+]
+
+be the total number of (1)’s.
+
+Adjacent row-pairs can share at most one column, and nonadjacent row-pairs can share at most two columns. Hence
+
+[
+\sum_j \binom{d_j}{2}\le n(n-2).
+]
+
+By convexity,
+
+[
+\sum_j \binom{d_j}{2}
+=\frac12\left(\sum_j d_j^2-T\right)
+\ge \frac12\left(\frac{T^2}{n}-T\right).
+]
+
+Therefore
+
+[
+\frac12\left(\frac{T^2}{n}-T\right)\le n(n-2),
+]
+
+so
+
+[
+T^2-nT-2n^2(n-2)\le 0.
+]
+
+Thus
+
+[
+\boxed{
+T\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+This is only (O(n^{3/2})), not linear. The next family shows that this order of magnitude cannot be beaten using only (A) and (B).
+
+---
+
+## 4. Remaining unresolved configurations
+
+The main unresolved obstruction is that (A) and (B) say essentially nothing when no two rows share two columns. Here is an exact infinite family of such cyclic matrices.
+
+Let (\mathbb F_q) be a finite field with (q\ge 4). Index both rows and columns by the same set (\mathbb F_q^2), in any fixed cyclic order. For a row indexed by ((m,b)\in\mathbb F_q^2), define
+
+[
+R_{(m,b)}
+=========
+
+{(x,y)\in\mathbb F_q^2:\ y=mx+b+1-m^2}.
+]
+
+Equivalently,
+
+[
+M_{(m,b),(x,y)}=1
+\quad\Longleftrightarrow\quad
+y=mx+b+1-m^2.
+]
+
+Then:
+
+[
+|R_{(m,b)}|=q.
+]
+
+The diagonal is zero, because substituting ((x,y)=(m,b)) gives
+
+[
+b=m^2+b+1-m^2=b+1,
+]
+
+which is impossible.
+
+Two rows with the same slope (m) are parallel distinct affine lines, so they are disjoint. Two rows with different slopes meet in exactly one point. Hence
+
+[
+|R_i\cap R_k|\le 1
+]
+
+for every (i\ne k). Thus (A) holds, and (B) is vacuous.
+
+For (q=4), this gives an exact (16\times 16) cyclic (0)-(1) matrix with every row sum exactly (4), zero diagonal, and no double row intersections. For (q=5), it gives a completely concrete (25\times 25) matrix over (\mathbb F_5) with every row sum (5).
+
+This family is not claimed to come from a convex polygon. It shows that the crossing lemma and the discharging argument cannot, by themselves, prove the desired geometric contradiction. Any full nonexistence proof must use additional Euclidean information about equal-distance sets in individual rows, beyond the pairwise circle-intersection facts (A) and (B).

--- a/incoming/chatgpt-runs/run-04.md
+++ b/incoming/chatgpt-runs/run-04.md
@@ -1,0 +1,340 @@
+I will use indices modulo (n) in the matrix part, writing (0,1,\dots,n-1). Translate back to the problem’s notation by adding (1) to every index.
+
+## 1. Convex-position crossing lemma
+
+### Lemma B
+
+Let (P={p_0,\dots,p_{n-1}}) be the vertices of a strictly convex polygon in cyclic order. Suppose (i\ne k), and suppose two distinct indices (a,b) satisfy
+[
+a,b\in S_i\cap S_k.
+]
+Then the pair ({i,k}) separates the pair ({a,b}) in the cyclic order. Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+### Proof
+
+Since (a,b\in S_i\cap S_k),
+[
+|p_a-p_i|=|p_b-p_i|,\qquad |p_a-p_k|=|p_b-p_k|.
+]
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of the segment (p_ap_b). Since (p_i\ne p_k), the line
+[
+L:=p_ip_k
+]
+is exactly that perpendicular bisector. Equivalently, using the radical-axis/common-chord property for the two circles centered at (p_i,p_k), the common chord (p_ap_b) is perpendicular to the line of centers (p_ip_k), and (p_ip_k) bisects (p_ap_b).
+
+Let
+[
+m=\frac{p_a+p_b}{2}.
+]
+Then (m\in L), (p_ap_b\perp L), and reflection across (L=p_ip_k) sends (p_a) to (p_b). Hence (p_a,p_b) lie in opposite open half-planes bounded by (L).
+
+It remains to prove that (m) lies on the segment (p_ip_k), not merely on the infinite line (p_ip_k). Suppose not. Then (m) lies outside the open segment (p_ip_k), so one of (p_i,p_k) lies on the segment joining the other one to (m). Say (p_k) lies between (p_i) and (m). Then for some (0<t<1),
+[
+p_k=(1-t)p_i+t m
+=(1-t)p_i+\frac t2p_a+\frac t2p_b.
+]
+Thus (p_k) is a strict convex combination of (p_i,p_a,p_b), so (p_k) lies inside the triangle (\operatorname{conv}{p_i,p_a,p_b}).
+
+**This is the exact step where strict convexity is used:** in a strictly convex polygon, every listed vertex is an extreme point of the convex hull; no vertex may lie in the convex hull of the other vertices, and no three vertices are collinear. Therefore the above containment is impossible. The endpoint cases (m=p_i) or (m=p_k) are also impossible, since then a polygon vertex would lie on the segment (p_ap_b), contradicting strict convexity.
+
+Hence (m) lies in the open segment (p_ip_k). Since (m) is also the midpoint of (p_ap_b), the two segments (p_ip_k) and (p_ap_b) cross at (m). For four vertices of a convex polygon, two chords cross exactly when their endpoints alternate in the cyclic order. Therefore ({i,k}) separates ({a,b}). (\square)
+
+---
+
+## 2. Exact theorem proved
+
+Call a cyclic (0)-(1) matrix (M) **admissible** if its row sets (R_i={j:M_{ij}=1}) satisfy:
+
+1. (i\notin R_i);
+2. (|R_i\cap R_k|\le 2) for (i\ne k);
+3. if (R_i\cap R_k={a,b}), then ({i,k}) separates ({a,b}) cyclically.
+
+Every matrix arising from the geometric problem is admissible by Fact (A) and the lemma above.
+
+### Theorem
+
+For admissible cyclic matrices:
+
+1. The following cyclic submatrices are forbidden:
+
+   * any (2\times 3) all-one submatrix;
+   * any noncrossing (2\times 2) all-one submatrix;
+   * in particular, two adjacent rows have at most one common (1);
+   * no (3\times 2) all-one submatrix is possible.
+
+2. If every row has size at least (4), then (n\ge 8).
+
+3. If (n=8) and every row has size at least (4), then in fact every row has size exactly (4).
+
+4. The matrix-only contradiction cannot be proved from (A) and (B) alone: for every (n\ge 8) there exists an admissible cyclic matrix with every row sum exactly (4).
+
+Thus a full geometric contradiction, if true, requires additional metric information beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+### Forbidden (2\times 2) patterns
+
+Let rows (i,k) share two columns (a,b). By admissibility, the four indices must alternate cyclically. Equivalently, if (a,b) lie in the same open arc of the cycle after removing (i,k), then the submatrix
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is forbidden.
+
+So a (2\times 2) all-one submatrix is allowed only when it is a crossing pattern.
+
+In particular, if (k=i+1), then one arc between (i) and (k) is empty. Hence two adjacent rows cannot share two columns:
+
+[
+|R_i\cap R_{i+1}|\le 1.
+]
+
+More generally, if (k=i+2), then a two-column intersection must use the unique middle vertex (i+1).
+
+### Forbidden (2\times 3) and (3\times 2) patterns
+
+Fact (A) immediately forbids any (2\times 3) all-one submatrix, because two rows cannot share three columns.
+
+A (3\times 2) all-one submatrix is also impossible. Suppose rows (x,y,z) all contain columns (a,b). By Fact (A), each pair of those rows has intersection exactly ({a,b}). By the crossing lemma, every pair among (x,y,z) must be separated by (a,b). But deleting (a,b) leaves two arcs, and three row indices cannot be pairwise placed in opposite arcs. Contradiction.
+
+So every column pair can occur together in at most two rows.
+
+### Adjacent-row discharging inequality
+
+Let
+[
+m_i=|R_i|,\qquad T=\sum_i m_i.
+]
+Because adjacent rows share at most one column,
+[
+m_i+m_{i+1}
+=|R_i\cup R_{i+1}|+|R_i\cap R_{i+1}|
+\le n+1.
+]
+Summing over all (i),
+[
+2T=\sum_i(m_i+m_{i+1})\le n(n+1),
+]
+so
+[
+T\le \frac{n(n+1)}2.
+]
+
+If every (m_i\ge 4), then (T\ge 4n). Hence
+[
+4n\le \frac{n(n+1)}2,
+]
+so (n\ge 7). This already rules out (n\le 6).
+
+### The (n=7) case
+
+For (n=7), the inequality gives
+[
+T\le 28,
+]
+while row sums at least (4) give
+[
+T\ge 28.
+]
+Thus equality holds everywhere. Therefore every row has size exactly (4), and every adjacent pair of rows has intersection exactly (1).
+
+Let
+[
+Z_i=[7]\setminus R_i.
+]
+Then (|Z_i|=3). Since (|R_i\cap R_{i+1}|=1), we have
+[
+|Z_i\cup Z_{i+1}|=6,
+]
+so
+[
+Z_i\cap Z_{i+1}=\varnothing.
+]
+
+Now fix (i). Both (Z_i) and (Z_{i+2}) are disjoint from (Z_{i+1}), so both are (3)-subsets of the (4)-element set ([7]\setminus Z_{i+1}). Therefore
+[
+|Z_i\cap Z_{i+2}|\ge 2.
+]
+But then
+[
+|R_i\cap R_{i+2}|
+=7-|Z_i\cup Z_{i+2}|
+=7-(6-|Z_i\cap Z_{i+2}|)
+=1+|Z_i\cap Z_{i+2}|
+\ge 3,
+]
+contradicting Fact (A). Hence no admissible matrix with all row sums at least (4) exists for (n=7).
+
+Therefore (n\ge 8).
+
+### The (n=8) row-size structure
+
+For (n=8), adjacent rows satisfy
+[
+m_i+m_{i+1}\le 9.
+]
+Since every (m_i\ge 4), every row has size (4) or (5), and no two adjacent rows can both have size (5).
+
+Suppose some row (R_i) has size (5). Then its neighbors (R_{i-1},R_{i+1}) have size (4). The adjacent-row bound forces
+[
+|R_i\cap R_{i-1}|=|R_i\cap R_{i+1}|=1.
+]
+Let (Z_j=[8]\setminus R_j). Then
+[
+|Z_i|=3,\qquad |Z_{i-1}|=|Z_{i+1}|=4,
+]
+and the equations above imply
+[
+Z_i\cap Z_{i-1}=Z_i\cap Z_{i+1}=\varnothing.
+]
+Thus both (Z_{i-1}) and (Z_{i+1}) are (4)-subsets of the same (5)-element set ([8]\setminus Z_i). Hence
+[
+|Z_{i-1}\cup Z_{i+1}|\le 5.
+]
+Therefore
+[
+|R_{i-1}\cap R_{i+1}|
+=8-|Z_{i-1}\cup Z_{i+1}|
+\ge 3,
+]
+again contradicting Fact (A). Thus no row has size (5), and every row has size exactly (4).
+
+### Why the matrix contradiction stops here
+
+The preceding argument is sharp as a matrix argument. For (n=8), define
+
+[
+R_i=i+{1,2,5,7}\pmod 8.
+]
+
+Explicitly:
+
+[
+\begin{array}{c|c}
+i & R_i\ \hline
+0 & {1,2,5,7}\
+1 & {0,2,3,6}\
+2 & {1,3,4,7}\
+3 & {0,2,4,5}\
+4 & {1,3,5,6}\
+5 & {2,4,6,7}\
+6 & {0,3,5,7}\
+7 & {0,1,4,6}
+\end{array}
+]
+
+This matrix has row sum (4). For row difference (d=1,\dots,7),
+
+[
+{1,2,5,7}\cap(d+{1,2,5,7})
+]
+
+is respectively
+
+[
+{2},\ {1,7},\ {2,5},\ {1,5},\ {2,7},\ {5,7},\ {1}.
+]
+
+Whenever the intersection has size (2), one common column lies in the clockwise interval from (i) to (i+d), and the other lies outside it. Hence every (2\times 2) all-one submatrix is crossing. So this is an admissible cyclic matrix with all row sums (4).
+
+For every (n\ge 9), another admissible construction is
+
+[
+R_i=i+{1,2,4,8}\pmod n.
+]
+
+For (n\ge 15), no two rows share more than one column, so Fact (B) is vacuous. For (9\le n\le 14), the only two-column intersections are:
+
+[
+\begin{array}{c|c}
+n & (d,\ {1,2,4,8}\cap(d+{1,2,4,8}))\ \hline
+9 & (2,{1,4}),\ (3,{2,4}),\ (6,{1,8}),\ (7,{2,8})\
+10 & (3,{1,4}),\ (4,{2,8}),\ (6,{4,8}),\ (7,{1,8})\
+11 & (4,{1,8}),\ (7,{4,8})\
+12 & (6,{2,8})\
+13 & (6,{1,8}),\ (7,{2,8})\
+14 & (7,{1,8})
+\end{array}
+]
+
+In each case, one shared column lies inside the interval from (i) to (i+d), and the other lies outside. Hence the crossing rule holds.
+
+So (A) and (B) alone do not imply the desired contradiction.
+
+---
+
+## 4. Configurations remaining after the matrix argument
+
+Using the notation
+
+[
+C_n(D):\qquad R_i=i+D\pmod n,
+]
+
+the following exact patterns are not eliminated by the cyclic-matrix rules (A) and (B):
+
+[
+C_8({1,2,5,7}),
+]
+
+and, for every (n\ge 9),
+
+[
+C_n({1,2,4,8}).
+]
+
+There is also a sparse family for which the crossing lemma is completely vacuous. For (n\ge 29), let
+
+[
+R_i=i+{1,3,7,15}\pmod n.
+]
+
+The positive differences among ({1,3,7,15}) are
+
+[
+2,4,6,8,12,14,
+]
+
+all distinct. Since (n\ge 29), no two nonzero differences become congruent modulo (n). Hence two rows share at most one column. This gives an admissible row-sum-(4) matrix with no (2\times 2) all-one submatrix at all.
+
+These are not claimed to be geometrically realizable. They show only that the matrix consequences of (A) and (B) are insufficient.
+
+One example of an additional geometric obstruction is this: if a geometric matrix had
+
+[
+M_{i,i+1}=M_{i,i+2}=1
+]
+
+for every (i), then
+
+[
+|p_i-p_{i+1}|=|p_i-p_{i+2}|.
+]
+
+Let (\alpha_{i+1}) be the interior angle at (p_{i+1}). By the law of cosines in triangle (p_i p_{i+1}p_{i+2}),
+
+[
+|p_i-p_{i+2}|^2
+===============
+
+|p_i-p_{i+1}|^2+|p_{i+1}-p_{i+2}|^2
+-2|p_i-p_{i+1}||p_{i+1}-p_{i+2}|\cos\alpha_{i+1}.
+]
+
+Since (|p_i-p_{i+2}|=|p_i-p_{i+1}|), this gives
+
+[
+\cos\alpha_{i+1}
+================
+
+\frac{|p_{i+1}-p_{i+2}|}{2|p_i-p_{i+1}|}>0,
+]
+
+so every interior angle would be (<\pi/2), impossible for a convex (n)-gon with (n\ge 4). This extra angle argument rules out the simple circulant patterns above geometrically, but it is not a consequence of (A) and (B). The sparse pattern (C_n({1,3,7,15})) remains a genuine unresolved matrix pattern under the methods developed here.

--- a/incoming/chatgpt-runs/run-05.md
+++ b/incoming/chatgpt-runs/run-05.md
@@ -1,0 +1,443 @@
+## 1. Convex-position crossing lemma
+
+Let the vertices be (p_1,\dots,p_n) in cyclic order. I will write (i,k,a,b) also for the corresponding vertices when no confusion is possible.
+
+### Lemma B
+
+Suppose (i\neq k) and (S_i\cap S_k) contains two distinct indices (a,b). Then the pair ({i,k}) separates the pair ({a,b}) in the cyclic order. Equivalently, the chord (p_i p_k) crosses the chord (p_a p_b).
+
+### Proof
+
+Because (a,b\in S_i\cap S_k), we have
+
+[
+|p_i-p_a|=|p_i-p_b|=r_i,\qquad |p_k-p_a|=|p_k-p_b|=r_k.
+]
+
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of the segment (p_a p_b). Since (p_i\neq p_k), the line (L=p_ip_k) is exactly that perpendicular bisector. Equivalently, (p_a) and (p_b) are mirror images across the line (L). This is the radical-axis/common-chord fact: the common chord (p_a p_b) of the two circles is perpendicular to the line of centers (p_ip_k).
+
+Hence (p_a) and (p_b) lie in opposite open half-planes bounded by (L).
+
+Now use strict convexity. In a strictly convex polygon, for the line (L) through two vertices (p_i,p_k), no other vertex lies on (L), and the two polygonal boundary chains from (p_i) to (p_k) lie in the two opposite open half-planes bounded by (L). This is the exact step where strict convexity is invoked: without strict convexity, other vertices could lie on the chord line and the cyclic separation conclusion could fail or become degenerate.
+
+Since (p_a) and (p_b) lie in opposite open half-planes, they lie on opposite boundary chains from (p_i) to (p_k). Therefore the cyclic order alternates:
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a.
+]
+
+Thus ({i,k}) separates ({a,b}), and the two chords (p_ip_k) and (p_ap_b) cross. (\square)
+
+---
+
+## 2. The exact theorem proved here
+
+Let (m_i=|S_i|), and let
+
+[
+E=\sum_{i=1}^n m_i
+]
+
+be the total number of ones in (M). From facts (A) and (B) one gets the following purely cyclic-matrix theorem.
+
+### Theorem
+
+For every cyclic (0)-(1) matrix (M) satisfying (A) and (B),
+
+[
+\sum_{i=1}^n \binom{m_i}{2}\le n(n-2).
+]
+
+Consequently,
+
+[
+E\le \frac n2\Bigl(1+\sqrt{8n-15}\Bigr).
+]
+
+In particular, if every row has size at least (4), then (n\ge 8).
+
+For the original geometric problem, the case (n=8) is also impossible. Thus any geometric counterexample to “some row has size at most (3)” must have
+
+[
+n\ge 9.
+]
+
+However, facts (A) and (B) alone do **not** prove a full contradiction for (n\ge 9): there are explicit cyclic (0)-(1) matrices with all row sums (4) satisfying all consequences of (A) and (B). I list exact unresolved patterns in Section 4.
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+Write (I(x,y)) for the open clockwise interval of indices strictly after (x) and strictly before (y).
+
+From (B), we immediately get the forbidden (2\times 2) cyclic pattern:
+
+[
+\begin{array}{c|cc}
+& a & b\
+\hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is allowed only if (a) and (b) lie on opposite sides of the chord (ik), i.e. only if one of (a,b) lies in (I(i,k)) and the other lies in (I(k,i)).
+
+Equivalently,
+
+[
+|S_i\cap S_k\cap I(i,k)|\le 1,
+]
+
+and
+
+[
+|S_i\cap S_k\cap I(k,i)|\le 1.
+]
+
+In particular, adjacent rows satisfy
+
+[
+|S_i\cap S_{i+1}|\le 1,
+]
+
+because one of the two cyclic intervals is empty.
+
+### Dual forbidden configurations
+
+Now fix two columns (a,b). Ask how many rows can contain both (a) and (b).
+
+If (a,b) are nonadjacent, then at most two rows can contain both columns. Indeed, if three rows (i,k,\ell) all contained both (a) and (b), then among (i,k,\ell), two would lie on the same side of the pair ({a,b}). Those two rows would share the two columns (a,b) without being separated by them, contradicting (B).
+
+If (a,b) are adjacent columns, then at most one row can contain both. For if two rows contained both (a,b), those two row indices would necessarily lie in the single nonempty cyclic interval between (a) and (b), so again the separation required by (B) would fail.
+
+Thus:
+
+* an adjacent column-pair has capacity (1);
+* a nonadjacent column-pair has capacity (2).
+
+There are (n) adjacent column-pairs and (\binom n2-n) nonadjacent column-pairs. Therefore the total capacity is
+
+[
+n\cdot 1+2\left(\binom n2-n\right)=n(n-2).
+]
+
+Now discharge as follows: every row (i) sends one unit of charge to each unordered pair of columns inside (S_i). Row (i) sends
+
+[
+\binom{m_i}{2}
+]
+
+units of charge. By the capacity bound above,
+
+[
+\sum_i \binom{m_i}{2}\le n(n-2).
+]
+
+This proves the main discharging inequality.
+
+Using convexity,
+
+[
+\sum_i \binom{m_i}{2}
+=====================
+
+\frac12\sum_i m_i^2-\frac12E
+\ge
+\frac{E^2}{2n}-\frac E2.
+]
+
+Hence
+
+[
+\frac{E^2}{2n}-\frac E2\le n(n-2),
+]
+
+so
+
+[
+E^2-nE-2n^2(n-2)\le 0.
+]
+
+Solving the quadratic inequality gives
+
+[
+E\le \frac n2\Bigl(1+\sqrt{8n-15}\Bigr).
+]
+
+If every row has size at least (4), then (E\ge 4n). More directly,
+
+[
+6n=\sum_i \binom 42\le \sum_i\binom{m_i}{2}\le n(n-2),
+]
+
+so
+
+[
+6\le n-2,
+]
+
+hence
+
+[
+n\ge 8.
+]
+
+So (A) and (B) already forbid (n\le 7).
+
+### The geometric (n=8) case
+
+Assume now that (n=8) and every row has size at least (4). The discharging inequality forces equality everywhere:
+
+[
+m_i=4 \qquad \text{for all }i.
+]
+
+A symmetric version of the same counting, now counting common columns of row-pairs, gives:
+
+* adjacent row-pairs intersect in exactly (1) column;
+* nonadjacent row-pairs intersect in exactly (2) columns.
+
+Indeed, if (c_j) is the column sum of column (j), then
+
+[
+\sum_j \binom{c_j}{2}
+=====================
+
+\sum_{i<k}|S_i\cap S_k|.
+]
+
+The left side is at least (8\binom42=48), while the row-pair version of the capacity bound gives at most
+
+[
+8\cdot 1+2\left(\binom82-8\right)=48.
+]
+
+So equality holds.
+
+Now look at rows (i) and (i+2). They are nonadjacent, so they share exactly two columns. By (B), one shared column must lie in the interval
+
+[
+I(i,i+2)={i+1}.
+]
+
+Therefore
+
+[
+i+1\in S_i.
+]
+
+Similarly, comparing rows (i) and (i-2) gives
+
+[
+i-1\in S_i.
+]
+
+Thus every row contains both cyclic neighbours:
+
+[
+i-1,\ i+1\in S_i.
+]
+
+Geometrically this means
+
+[
+r_i=|p_i-p_{i-1}|=|p_i-p_{i+1}|.
+]
+
+Let (e_i=|p_i-p_{i+1}|). Then
+
+[
+e_{i-1}=r_i=e_i
+]
+
+for every (i), so all side lengths are equal, and all radii (r_i) are the same common length (L).
+
+Therefore
+
+[
+M_{ij}=1
+\iff
+|p_i-p_j|=L
+\iff
+M_{ji}=1.
+]
+
+So in the (n=8) geometric equality case, (M) must be symmetric.
+
+Let (C) be the adjacency matrix of the (8)-cycle. Since (M) is symmetric, ((M^2)_{ik}=|S_i\cap S_k|). From the equality conditions,
+
+[
+M^2=G,
+]
+
+where
+
+[
+G_{ii}=4,\qquad G_{i,i\pm1}=1,\qquad G_{ik}=2 \text{ otherwise}.
+]
+
+Equivalently,
+
+[
+G=2J+2I-C,
+]
+
+where (J) is the all-ones matrix.
+
+The eigenvalues of (C) are (2\cos(2\pi k/8)). Hence the eigenvalues of (G) are:
+
+[
+16,\quad 4,\quad 2,2,\quad 2-\sqrt2,2-\sqrt2,\quad 2+\sqrt2,2+\sqrt2.
+]
+
+Because (M^2=G) and (M) is symmetric, each eigenspace of (G) is (M)-invariant. Since every row of (M) has sum (4), (M) has eigenvalue (4) on the all-ones vector. On the one-dimensional alternating eigenspace, (M) has eigenvalue (\pm 2). On the two-dimensional eigenspaces with (G)-eigenvalues (2), (2-\sqrt2), (2+\sqrt2), the traces of (M) are respectively of the form
+
+[
+a\sqrt2,\qquad b\sqrt{2-\sqrt2},\qquad c\sqrt{2+\sqrt2},
+]
+
+where (a,b,c\in{-2,0,2}).
+
+But (\operatorname{tr}M=0), because (M) has zero diagonal. Therefore
+
+[
+0=4\pm 2+a\sqrt2+b\sqrt{2-\sqrt2}+c\sqrt{2+\sqrt2}.
+]
+
+The numbers
+
+[
+1,\quad \sqrt2,\quad \sqrt{2-\sqrt2},\quad \sqrt{2+\sqrt2}
+]
+
+are linearly independent over (\mathbb Q). For example, if (\alpha=\sqrt{2-\sqrt2}), then (\alpha) has minimal polynomial
+
+[
+x^4-4x^2+2,
+]
+
+and
+
+[
+\sqrt2=2-\alpha^2,\qquad \sqrt{2+\sqrt2}=3\alpha-\alpha^3,
+]
+
+so these four numbers form a (\mathbb Q)-basis of the same degree-four field.
+
+Thus the rational part (4\pm 2) would have to vanish. But (4+2=6) and (4-2=2), impossible.
+
+So the geometric (n=8) case cannot occur.
+
+Therefore any genuine geometric example with all rows of size at least (4) would have to satisfy
+
+[
+n\ge 9.
+]
+
+---
+
+## 4. Unresolved exact cyclic patterns
+
+The discharging argument cannot prove a full contradiction for (n\ge 9). The obstruction is concrete: there are cyclic matrices satisfying all consequences of (A) and (B) with every row sum equal to (4).
+
+### A (9\times 9) unresolved pattern
+
+Work modulo (9), and define
+
+[
+S_i={i+1,\ i+2,\ i+5,\ i+7}.
+]
+
+Explicitly:
+
+[
+\begin{aligned}
+S_0&={1,2,5,7},\
+S_1&={2,3,6,8},\
+S_2&={0,3,4,7},\
+S_3&={1,4,5,8},\
+S_4&={0,2,5,6},\
+S_5&={1,3,6,7},\
+S_6&={2,4,7,8},\
+S_7&={0,3,5,8},\
+S_8&={0,1,4,6}.
+\end{aligned}
+]
+
+For row (0), the intersections with row-shifts (d=1,\dots,8) are:
+
+[
+\begin{array}{c|c}
+d & S_0\cap S_d\
+\hline
+1 & {2}\
+2 & {7}\
+3 & {1,5}\
+4 & {2,5}\
+5 & {1,7}\
+6 & {2,7}\
+7 & {5}\
+8 & {1}
+\end{array}
+]
+
+The double intersections occur only for (d=3,4,5,6), and in each case one common column lies in the interval ((0,d)) and the other lies outside it. By cyclic translation, the same holds for every row-pair. Thus this matrix satisfies (A) and (B), and every row has size (4).
+
+This pattern is not claimed to be geometrically realizable. It is unresolved by the discharging argument above.
+
+### An infinite unresolved family
+
+For every (n\ge 19), work modulo (n), and define
+
+[
+S_i={i+1,\ i+2,\ i+5,\ i+10}.
+]
+
+The positive differences among
+
+[
+D={1,2,5,10}
+]
+
+are
+
+[
+1,\ 3,\ 4,\ 5,\ 8,\ 9,
+]
+
+all distinct. Since (n\ge 19), the signed differences
+
+[
+\pm1,\ \pm3,\ \pm4,\ \pm5,\ \pm8,\ \pm9
+]
+
+are also distinct modulo (n). Therefore two different rows intersect in at most one column. Fact (A) holds, and fact (B) is vacuous because there are no double intersections.
+
+So this gives exact cyclic (0)-(1) matrices with all row sums (4) satisfying the full ((A),(B)) matrix theory.
+
+### Extra geometric obstruction not captured by (A) and (B)
+
+There is one more elementary geometric input that rules out some such patterns, but not all.
+
+Choose a vertex (i) with minimal radius (r_i). Since the polygon is strictly convex, all other vertices lie in an open cone at (p_i) of angle (<\pi). This is another explicit use of strict convexity.
+
+If (|S_i|\ge 4), list four elements of (S_i) in their angular order around (p_i). Among the three angular gaps, one is (<\pi/3). The chord between the corresponding two vertices has length
+
+[
+2r_i\sin(\theta/2)<r_i.
+]
+
+Since (r_i) was minimal, those two vertices cannot be joined by an (M)-edge in either direction. Therefore, in a genuine geometric configuration, a minimum-radius row must contain a consecutive pair of selected vertices ((a,b)) such that
+
+[
+M_{ab}=M_{ba}=0.
+]
+
+The (9\times 9) pattern above and the infinite family (S_i={i+1,i+2,i+5,i+10}) both contain such a consecutive non-edge in every row, so even this additional short-gap obstruction does not eliminate them. More geometry would be needed to decide whether any of these cyclic matrix patterns can actually arise from strictly convex point sets.

--- a/incoming/chatgpt-runs/run-06.md
+++ b/incoming/chatgpt-runs/run-06.md
@@ -1,0 +1,399 @@
+## 1. Convex-position crossing lemma
+
+Let (P={p_1,\dots,p_n}) be in strictly convex position, and suppose two distinct rows (i\neq k) share two indices (a,b). Thus
+
+[
+a,b\in S_i\cap S_k,
+]
+
+so
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+Let (L) be the line through (p_i,p_k).
+
+Because (p_i) is equidistant from (p_a,p_b), it lies on the perpendicular bisector of the segment (p_ap_b). Likewise (p_k) lies on the same perpendicular bisector. Since (p_i\neq p_k), the line (L=p_ip_k) is exactly the perpendicular bisector of (p_ap_b). Equivalently, (p_ap_b) is the radical axis / common chord of the two circles centered at (p_i,p_k), and the line of centers (p_ip_k) is perpendicular to and bisects that common chord.
+
+Therefore (p_a) and (p_b) are reflections of one another across (L). In particular, they lie in opposite open half-planes bounded by (L), and the segment (p_ap_b) meets (L) at its midpoint.
+
+Now let (K=\operatorname{conv}(P)). Since the polygon is strictly convex, every (p_v) is an extreme point of (K), and no third vertex lies on the line through two vertices.
+
+**This is the first explicit use of strict convexity:** for the line (L=p_ip_k), the only vertices of (P) on (L) are (p_i,p_k), and (K\cap L=[p_i,p_k]). If (K\cap L) extended past (p_i) or (p_k), then that endpoint vertex would not be extreme.
+
+The two boundary chains of the convex polygon from (p_i) to (p_k) lie in the two closed half-planes determined by (L). Because of strict convexity, all internal vertices of those two chains lie in the corresponding open half-planes.
+
+**This is the second explicit use of strict convexity:** it rules out a vertex of either chain lying on (L), so “same side” and “opposite side” are nondegenerate.
+
+Since (p_a,p_b) lie on opposite sides of (L), they lie on opposite boundary chains from (p_i) to (p_k). Hence the cyclic order alternates:
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a,
+]
+
+up to cyclic reversal. Equivalently, the pair ({i,k}) separates the pair ({a,b}).
+
+Moreover, the midpoint of (p_ap_b) lies on (L) and inside (K), hence inside ([p_i,p_k]). It cannot equal (p_i) or (p_k), because then an extreme vertex would lie in the interior of the segment (p_ap_b). Thus the two chords (p_ip_k) and (p_ap_b) cross in their relative interiors.
+
+That proves Fact (B). (\square)
+
+---
+
+## 2. Exact theorem proved here
+
+The full geometric contradiction does **not** follow from Facts (A) and (B) alone. The strongest clean theorem obtainable from those two facts is the following cyclic-matrix theorem.
+
+Write (d_i=|S_i|).
+
+### Theorem
+
+Let (M) be a cyclically indexed (0)-(1) matrix with zero diagonal, satisfying:
+
+1. for every two rows (i\neq k),
+
+[
+|S_i\cap S_k|\le 2;
+]
+
+2. if (|S_i\cap S_k|=2), say (S_i\cap S_k={a,b}), then the pairs ({i,k}) and ({a,b}) alternate in the cyclic order.
+
+Then
+
+[
+\sum_{i=1}^n \binom{d_i}{2}\le n(n-2).
+]
+
+Consequently,
+
+[
+\sum_{i=1}^n d_i
+\le
+\frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+In particular, if every row has size at least (4), then necessarily
+
+[
+n\ge 8.
+]
+
+This bound is sharp in the purely cyclic-matrix setting: for every (n\ge 8), there exists an abstract cyclic (0)-(1) matrix satisfying (A) and (B) with every row sum exactly (4). Therefore an impossibility proof for the original geometric problem must use additional metric information beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+### Forbidden (2\times 2) submatrices
+
+Let two rows be (i,k), and suppose they share two columns (a,b). Then the submatrix
+
+[
+\begin{array}{c|cc}
+& a & b\
+\hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is allowed only if the cyclic order alternates:
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a.
+]
+
+Thus a nonalternating all-one (2\times 2) submatrix is forbidden. Equivalently, if (a,b) lie in the same open cyclic interval between (i) and (k), then the above (2\times2) all-one pattern is impossible.
+
+Fact (A) also forbids every all-one (2\times 3) submatrix:
+
+[
+\begin{array}{c|ccc}
+& a & b & c\
+\hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+because two rows cannot share three columns.
+
+A useful dual consequence is that every all-one (3\times2) submatrix is also forbidden. Indeed, fix two columns (a,b). Any two rows containing both (a,b) must lie on opposite sides of the pair ({a,b}) in the cyclic order. There are only two sides, so at most two rows can contain both (a,b). Hence
+
+[
+\begin{array}{c|cc}
+& a & b\
+\hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+is impossible.
+
+Also, if (a,b) are adjacent cyclically, then no two rows can contain both (a,b), because the pair ({a,b}) has one empty side and cannot be separated by any row pair. Therefore every adjacent column-pair occurs in at most one row.
+
+### Discharging count
+
+For each row (i), place one token on every unordered pair of (1)’s in that row. Row (i) receives
+
+[
+\binom{d_i}{2}
+]
+
+tokens. Thus the total number of tokens is
+
+[
+T=\sum_i \binom{d_i}{2}.
+]
+
+Now move each token to its corresponding unordered pair of columns ({a,b}). Let
+
+[
+\lambda_{ab}=#{i:\ a,b\in S_i}
+]
+
+be the number of rows containing both columns (a,b). Then
+
+[
+T=\sum_{{a,b}}\lambda_{ab}.
+]
+
+From the forbidden (3\times2) pattern,
+
+[
+\lambda_{ab}\le 2
+]
+
+for every column-pair ({a,b}). If (a,b) are adjacent cyclically, then in fact
+
+[
+\lambda_{ab}\le 1.
+]
+
+There are (n) adjacent column-pairs and
+
+[
+\binom n2-n
+]
+
+nonadjacent column-pairs. Therefore
+
+[
+T
+\le
+n\cdot 1+2\left(\binom n2-n\right)
+==================================
+
+# n+n(n-1)-2n
+
+n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_i \binom{d_i}{2}\le n(n-2).}
+]
+
+If every row has size at least (4), then
+
+[
+\sum_i \binom{d_i}{2}\ge n\binom42=6n.
+]
+
+Hence
+
+[
+6n\le n(n-2),
+]
+
+so
+
+[
+n\ge 8.
+]
+
+For the total row-sum bound, let
+
+[
+E=\sum_i d_i.
+]
+
+By Cauchy,
+
+[
+\sum_i d_i^2\ge \frac{E^2}{n}.
+]
+
+Thus
+
+[
+2T
+==
+
+# \sum_i d_i(d_i-1)
+
+\sum_i d_i^2-\sum_i d_i
+\ge
+\frac{E^2}{n}-E.
+]
+
+Since (T\le n(n-2)),
+
+[
+\frac{E^2}{n}-E\le 2n(n-2).
+]
+
+Solving the resulting quadratic inequality gives
+
+[
+\boxed{
+E\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+### Sharpness of the (n\ge 8) threshold in the abstract matrix setting
+
+Use indices modulo (n).
+
+For (n=8), define
+
+[
+S_i={i+1,i+2,i+5,i+7}\pmod 8.
+]
+
+Equivalently, the first row has support
+
+[
+D_8={1,2,5,7}.
+]
+
+For row (0) and row (t), the intersections are:
+
+[
+\begin{array}{c|c}
+t & S_0\cap S_t\
+\hline
+1 & {2}\
+2 & {1,7}\
+3 & {2,5}\
+4 & {1,5}\
+5 & {2,7}\
+6 & {5,7}\
+7 & {1}
+\end{array}
+]
+
+Every intersection has size at most (2), and whenever the intersection has size (2), the two common columns lie on opposite sides of the row-pair ({0,t}). By cyclic translation, Facts (A) and (B) hold for every row-pair. Thus this is an abstract (8\times8) cyclic matrix with every row sum (4).
+
+For (n\ge 9), define
+
+[
+S_i={i+1,i+2,i+4,i+8}\pmod n.
+]
+
+For (n\ge 15), the signed differences among
+
+[
+D={1,2,4,8}
+]
+
+are
+
+[
+\pm1,\pm2,\pm3,\pm4,\pm6,\pm7,
+]
+
+all distinct modulo (n). Hence two shifted copies of (D) intersect in at most one point, so Fact (B) is vacuous.
+
+For (9\le n\le 14), the only double intersections are as follows:
+
+[
+\begin{array}{c|c|c}
+n & t & S_0\cap S_t\
+\hline
+9 & 2 & {1,4}\
+9 & 3 & {2,4}\
+9 & 6 & {1,8}\
+9 & 7 & {2,8}\
+\hline
+10 & 3 & {1,4}\
+10 & 4 & {2,8}\
+10 & 6 & {4,8}\
+10 & 7 & {1,8}\
+\hline
+11 & 4 & {1,8}\
+11 & 7 & {4,8}\
+\hline
+12 & 6 & {2,8}\
+\hline
+13 & 6 & {1,8}\
+13 & 7 & {2,8}\
+\hline
+14 & 7 & {1,8}
+\end{array}
+]
+
+In every listed case, one common column lies in the open cyclic interval ((0,t)), and the other lies in the complementary interval ((t,0)). Thus the required crossing/alternation condition holds. Therefore for every (n\ge 8), the abstract cyclic-matrix axioms permit all row sums to be (4).
+
+So the desired contradiction cannot be obtained from (A) and (B) alone.
+
+---
+
+## 4. Remaining unresolved configurations and exact patterns
+
+The cyclic argument eliminates only repeated column-pairs and noncrossing (2\times2) all-one patterns. It does not control rows that are almost disjoint from all other rows. In particular, any (4)-regular cyclic Sidon-type pattern with no all-one (2\times2) submatrix survives the entire argument.
+
+A clean unresolved abstract pattern is the following. For (n\ge 39), define
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\equiv 1,4,10,20\pmod n.
+]
+
+Equivalently,
+
+[
+S_i={i+1,i+4,i+10,i+20}\pmod n.
+]
+
+The positive differences among
+
+[
+{1,4,10,20}
+]
+
+are
+
+[
+3,6,9,10,16,19,
+]
+
+all distinct, and for (n\ge 39) no positive difference is congruent to the negative of another. Hence two rows intersect in at most one column. Thus Fact (A) holds, and Fact (B) is vacuous because no two rows share two columns.
+
+So the exact surviving pattern is:
+
+[
+\boxed{
+S_i={i+1,i+4,i+10,i+20}\pmod n,\qquad n\ge 39.
+}
+]
+
+This pattern has every row sum (4), zero diagonal, and no forbidden (2\times2) submatrix at all. It is not claimed to be geometrically realizable; it shows that the cyclic crossing/discharging method alone cannot prove the full geometric impossibility.
+
+The missing geometric input would have to use more than pairwise row intersections. For example, in the original geometry, each row support (S_i) is not just an arbitrary (4)-set: all four points ({p_j:j\in S_i}) must lie on one circle centered at (p_i). Equivalently, for every pair (a,b\in S_i), the point (p_i) lies on the perpendicular bisector of (p_ap_b). That is a strong concurrency/metric condition on the six pairs inside a row of size (4), and it is invisible to Facts (A) and (B).

--- a/incoming/chatgpt-runs/run-07.md
+++ b/incoming/chatgpt-runs/run-07.md
@@ -1,0 +1,324 @@
+## 1. Convex-position crossing lemma
+
+Let (P={p_1,\dots,p_n}) be the vertices of a strictly convex polygon in cyclic order. Suppose (i\ne k) and
+
+[
+S_i\cap S_k={a,b}.
+]
+
+Then
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+So (p_a,p_b) are the two intersection points of the two circles centered at (p_i,p_k).
+
+Let (L) be the line (p_ip_k). Reflection in (L) fixes both circles, because both centers lie on (L). Hence reflection in (L) permutes their two intersection points. Since the intersection points are distinct, reflection swaps (p_a) and (p_b). Equivalently, (p_a,p_b) are mirror images across (L). This is the radical-axis/common-chord property: the line (p_ap_b) is perpendicular to (p_ip_k), and its midpoint lies on (p_ip_k).
+
+It remains to show that the midpoint of (p_ap_b) lies between (p_i) and (p_k). Put coordinates so that
+
+[
+p_i=(0,0),\qquad p_k=(d,0),\qquad d>0.
+]
+
+Because (p_a,p_b) are reflections across the (x)-axis, write
+
+[
+p_a=(t,u),\qquad p_b=(t,-u),\qquad u>0.
+]
+
+If (t<0), then (p_i=(0,0)) lies inside the triangle with vertices (p_k,p_a,p_b). Indeed,
+
+[
+p_i=\frac{-t}{d-t}p_k+\frac{d}{2(d-t)}p_a+\frac{d}{2(d-t)}p_b,
+]
+
+and all coefficients are positive. If (t=0), then (p_i) lies on the segment (p_ap_b). Both cases contradict strict convexity: a vertex of a strictly convex polygon is an extreme point, and no vertex lies in the convex hull of the other vertices; in the boundary case (t=0), strict convexity also excludes collinearity with two other vertices.
+
+Similarly, if (t>d), then (p_k) lies inside the triangle with vertices (p_i,p_a,p_b), and if (t=d), then (p_k) lies on (p_ap_b). Again this contradicts strict convexity.
+
+Thus
+
+[
+0<t<d.
+]
+
+Therefore the vertical segment (p_ap_b) crosses the horizontal segment (p_ip_k) in their interiors. Hence the chord (p_ip_k) crosses the chord (p_ap_b).
+
+Finally, for four vertices of a strictly convex polygon, two chords cross in their interiors if and only if their endpoints alternate in the cyclic order. Therefore the pair ({i,k}) separates the pair ({a,b}).
+
+The exact use of strict convexity is the step excluding (t\le 0) and (t\ge d): otherwise one of (p_i,p_k) lies inside or on the triangle/segment determined by the other three points, so it is not a strict convex vertex.
+
+---
+
+## 2. The exact theorem proved
+
+Let (M) be a cyclically indexed (0)-(1) matrix with row supports
+
+[
+R_i={j:M_{ij}=1}.
+]
+
+Assume:
+
+[
+|R_i\cap R_k|\le 2
+]
+
+for all (i\ne k), and whenever (R_i\cap R_k={a,b}), the pairs ({i,k}) and ({a,b}) separate each other in the cyclic order.
+
+Then the following hold.
+
+**Theorem.**
+
+1. The following cyclic submatrices are forbidden:
+
+   * a (2\times 3) all-one submatrix;
+   * a (3\times 2) all-one submatrix;
+   * a (2\times 2) all-one submatrix whose two row indices do not separate its two column indices.
+
+2. If (d_i=|R_i|), then
+
+[
+\sum_i \binom{d_i}{2}\le n(n-2).
+]
+
+Consequently, if (m=\sum_i d_i), then
+
+[
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+3. In particular, if every row has size at least (4), then
+
+[
+n\ge 8.
+]
+
+4. For (n=8), the bound is sharp in the matrix sense. If every row has size at least (4), then in fact every row has size exactly (4), every column also has size (4), adjacent row pairs meet in exactly one column, nonadjacent row pairs meet in exactly two columns, adjacent column pairs occur in exactly one row, and nonadjacent column pairs occur in exactly two rows.
+
+5. No contradiction can be derived from facts (A) and (B) alone. There are cyclic (0)-(1) matrices satisfying all the above rules with every row of size (4). Thus any proof of geometric nonexistence must use additional metric geometry beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+Write (R_i) for row (i).
+
+### Forbidden (2\times 3)
+
+If two rows (i,k) had three common columns (a,b,c), then
+
+[
+|R_i\cap R_k|\ge 3,
+]
+
+contradicting fact (A). Therefore no (2\times 3) all-one submatrix is possible.
+
+### Forbidden noncrossing (2\times 2)
+
+If rows (i,k) both contain columns (a,b), then (R_i\cap R_k) contains ({a,b}). By (A), it contains exactly those two columns. By the crossing lemma, ({i,k}) must separate ({a,b}). Hence a (2\times 2) all-one submatrix is allowed only in the alternating cyclic pattern
+
+[
+i,\ a,\ k,\ b
+]
+
+up to reversal and rotation. In particular, adjacent rows cannot share two columns, and adjacent columns cannot occur together in two rows.
+
+### Forbidden (3\times 2)
+
+Suppose three rows (i,k,\ell) all contain the same two columns (a,b). Then each pair of rows among (i,k,\ell) shares (a,b), so by (B) each pair among (i,k,\ell) must separate (a,b).
+
+But the two columns (a,b) cut the cyclic order into two arcs. Among three row indices (i,k,\ell), two lie on the same arc. That pair does not separate (a,b), contradiction.
+
+Thus every pair of columns is contained in at most two rows.
+
+### Discharging count
+
+For each row (i), put one unit of charge on every unordered pair of columns inside (R_i). Row (i) contributes
+
+[
+\binom{d_i}{2}
+]
+
+units of charge. Thus the total charge is
+
+[
+X=\sum_i \binom{d_i}{2}.
+]
+
+Now fix a column pair ({a,b}). Let
+
+[
+\lambda_{ab}=#{i:\ a,b\in R_i}.
+]
+
+The previous (3\times 2) argument gives
+
+[
+\lambda_{ab}\le 2.
+]
+
+A column pair with (\lambda_{ab}=2) corresponds to two rows (i,k) sharing (a,b). By (B), ({i,k}) must separate ({a,b}). Therefore (i,k) cannot be adjacent. Also, two different repeated column pairs cannot correspond to the same row pair, because then that row pair would share at least three columns, contradicting (A).
+
+Hence the number of repeated column pairs is at most the number of nonadjacent row pairs:
+
+[
+\binom n2-n.
+]
+
+There are (\binom n2) column pairs total. Each column pair can receive one first charge, and at most (\binom n2-n) column pairs can receive a second charge. Therefore
+
+[
+X\le \binom n2+\left(\binom n2-n\right)=n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_i \binom{d_i}{2}\le n(n-2).}
+]
+
+If all (d_i\ge 4), then
+
+[
+\sum_i \binom{d_i}{2}\ge 6n.
+]
+
+Thus
+
+[
+6n\le n(n-2),
+]
+
+so
+
+[
+n\ge 8.
+]
+
+For the total number of ones (m=\sum_i d_i), use convexity:
+
+[
+\sum_i \binom{d_i}{2}
+=\frac12\left(\sum_i d_i^2-\sum_i d_i\right)
+\ge \frac12\left(\frac{m^2}{n}-m\right).
+]
+
+Since the left side is at most (n(n-2)),
+
+[
+\frac12\left(\frac{m^2}{n}-m\right)\le n(n-2).
+]
+
+Solving gives
+
+[
+\boxed{m\le \frac n2\left(1+\sqrt{8n-15}\right).}
+]
+
+### The extremal (n=8) structure
+
+Assume now (n=8) and all (d_i\ge 4). The inequality gives
+
+[
+\sum_i \binom{d_i}{2}\le 8\cdot 6=48.
+]
+
+But each row contributes at least (6). Hence equality holds, and every row has size exactly (4).
+
+Equality in the discharging argument forces the following:
+
+* every column pair appears in at least one row;
+* exactly (20=\binom82-8) column pairs appear in two rows;
+* those (20) repeated column pairs correspond bijectively to the (20) nonadjacent row pairs.
+
+Adjacent column pairs cannot be repeated, because adjacent column indices cannot be separated by any pair of row indices. Since there are exactly (8) singleton column pairs, the singleton column pairs are precisely the adjacent column pairs. Therefore every nonadjacent column pair appears in exactly two rows.
+
+Fix a column (j). The two adjacent column pairs involving (j) occur once, and the five nonadjacent column pairs involving (j) occur twice. Hence the number of pair-incidences involving (j) is
+
+[
+2\cdot 1+5\cdot 2=12.
+]
+
+Each row containing (j) contributes (3) such pair-incidences, because every row has size (4). Therefore column (j) appears in (4) rows. Thus every column has size (4).
+
+Now count row intersections:
+
+[
+\sum_{i<k}|R_i\cap R_k|
+=\sum_j \binom{4}{2}
+=8\cdot 6
+=48.
+]
+
+The (20) nonadjacent row pairs each contribute (2), giving (40). The remaining (8) adjacent row pairs can contribute at most (1) each, and therefore each adjacent row pair contributes exactly (1).
+
+Finally, for any (i), rows (i) and (i+2) are nonadjacent and therefore share exactly two columns. By (B), those two columns must separate (i) and (i+2). The open arc from (i) to (i+2) contains only (i+1), so (i+1\in R_i). Similarly, using rows (i) and (i-2), we get (i-1\in R_i). Thus in the extremal (n=8) case every row contains its two cyclic neighbors.
+
+---
+
+## 4. Configurations that remain unresolved by the ((A),(B)) argument
+
+The matrix-only contradiction fails. Here is an exact (8\times 8) cyclic pattern satisfying all constraints, with every row of size (4). Indices are taken modulo (8), and
+
+[
+R_i={i+1,\ i+2,\ i+5,\ i+7}.
+]
+
+Equivalently,
+
+[
+M=
+\begin{pmatrix}
+0&1&1&0&0&1&0&1\
+1&0&1&1&0&0&1&0\
+0&1&0&1&1&0&0&1\
+1&0&1&0&1&1&0&0\
+0&1&0&1&0&1&1&0\
+0&0&1&0&1&0&1&1\
+1&0&0&1&0&1&0&1\
+1&1&0&0&1&0&1&0
+\end{pmatrix}.
+]
+
+For row difference (d), the common columns of rows (0) and (d) are:
+
+[
+\begin{array}{c|c}
+d & R_0\cap R_d\
+\hline
+1 & {2}\
+2 & {1,7}\
+3 & {2,5}\
+4 & {1,5}\
+5 & {2,7}\
+6 & {5,7}\
+7 & {1}
+\end{array}
+]
+
+Whenever the intersection has size (2), one common column lies on each side of the pair ({0,d}), so the crossing condition (B) is satisfied.
+
+There are also infinite unresolved matrix patterns. For every (n\ge 29), define
+
+[
+R_i={i+1,\ i+3,\ i+7,\ i+15}\pmod n.
+]
+
+The difference set
+
+[
+D={1,3,7,15}
+]
+
+has all nonzero pairwise differences distinct modulo (n) for (n\ge 29), because the positive differences are
+
+[
+2,4,6,8,12,14
+]
+
+and no positive difference equals another or the negative of another modulo (n). Hence two rows share at most one column. Fact (A) holds, and fact (B) is vacuous. Every row still has size (4).
+
+So the cyclic-matrix/discharging method proves a sharp lower bound (n\ge 8), strong forbidden submatrix rules, and a rigid extremal structure at (n=8), but it cannot prove full nonexistence from facts (A) and (B) alone. Any final geometric contradiction must use additional metric input beyond the radical-axis crossing lemma.

--- a/incoming/chatgpt-runs/run-08.md
+++ b/incoming/chatgpt-runs/run-08.md
@@ -1,0 +1,371 @@
+## 1. Convex-position crossing lemma
+
+Let (C_i) be the circle centered at (p_i) with radius (r_i). Suppose (i\ne k) and
+
+[
+S_i\cap S_k={a,b}.
+]
+
+Thus (p_a,p_b) lie on both circles (C_i) and (C_k).
+
+**Lemma.** The chord (p_ip_k) crosses the chord (p_ap_b). Equivalently, in the cyclic order of the strictly convex polygon, the pair ({i,k}) separates the pair ({a,b}).
+
+**Proof.** Let (L) be the line through (p_i) and (p_k). Reflection in (L) fixes the two centers (p_i,p_k), hence preserves both circles (C_i,C_k). Since two distinct circles have at most two intersection points and (p_a,p_b) are two distinct common points, reflection in (L) swaps (p_a) and (p_b). Thus (p_a,p_b) are mirror images across (L).
+
+Choose coordinates with
+
+[
+p_i=(0,0),\qquad p_k=(d,0),\qquad d>0.
+]
+
+By the reflection property,
+
+[
+p_a=(x,h),\qquad p_b=(x,-h)
+]
+
+for some (h>0). The chord (p_ap_b) is vertical, and its midpoint is (q=(x,0)).
+
+We claim
+
+[
+0<x<d.
+]
+
+If (x<0), then (q) lies to the left of (p_i), so (p_i) lies on the segment joining (q) to (p_k). Since (q\in p_ap_b), this places (p_i) inside the triangle (\operatorname{conv}{p_a,p_b,p_k}). If (x=0), then (p_i) lies on the segment (p_ap_b). Both are impossible because the vertices of a strictly convex polygon are extreme points and no vertex lies on a segment determined by two other vertices. This is the first exact use of strict convexity.
+
+Similarly, if (x>d), then (p_k\in \operatorname{conv}{p_a,p_b,p_i}), and if (x=d), then (p_k\in p_ap_b). Again this contradicts strict convexity. Hence (0<x<d).
+
+Therefore (q=(x,0)) lies in the relative interior of both segments (p_ip_k) and (p_ap_b). Thus the two chords cross. For vertices in strictly convex position, two chords cross in their interiors exactly when their endpoints alternate in the cyclic order; this uses strict convexity again to exclude boundary or collinearity degeneracies. Hence ({i,k}) separates ({a,b}). (\square)
+
+The important point is that the radical-axis/reflection argument gives the symmetry of (p_a,p_b) across (p_ip_k), while strict convexity forces the radical axis to meet the segment (p_ip_k), not merely its supporting line.
+
+---
+
+## 2. The exact theorem proved here
+
+Call a cyclic (0)-(1) matrix (M) an **AB-matrix** if:
+
+1. (M_{ii}=0);
+2. any two rows have at most two common (1)’s;
+3. if rows (i,k) have exactly two common (1)’s in columns (a,b), then ({i,k}) separates ({a,b}) cyclically.
+
+Every geometric matrix in the problem is an AB-matrix by Fact (A) and the crossing lemma above.
+
+**Theorem.** Let (d_i=|S_i|). For every AB-matrix,
+
+[
+\sum_i \binom{d_i}{2}\le n(n-2).
+]
+
+Consequently,
+
+[
+\sum_i d_i\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+In particular, if every row has size at least (4), then necessarily
+
+[
+n\ge 8.
+]
+
+This is sharp for the AB-axioms alone: for every (n\ge 8) there exists a cyclic AB-matrix with every row sum equal to (4). Therefore no contradiction for all (n) can be derived from Facts (A) and (B) alone. Any full geometric contradiction would need additional metric input beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+For an unordered column-pair (q={a,b}), define its **codegree**
+
+[
+\lambda(q)=|{i:\ a,b\in S_i}|.
+]
+
+Equivalently, (\lambda(q)) is the number of rows containing (1)’s in both columns (a,b).
+
+### Forbidden submatrices
+
+The AB-axioms immediately forbid the following.
+
+**F1. No (2\times 3) all-one submatrix.**
+This is exactly Fact (A): two rows cannot share three columns.
+
+**F2. No noncrossing (2\times 2) all-one submatrix.**
+If rows (i,k) and columns (a,b) form
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+then the cyclic order must alternate:
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a.
+]
+
+After rotating so that (i=0<k), this means one of (a,b) must lie in the open arc ((i,k)), and the other must lie in the complementary open arc.
+
+**F3. No (3\times 2) all-one submatrix.**
+Indeed, suppose three rows all contain the same two columns (a,b). Those three row-indices lie in the two open arcs determined by (a,b). Two of them must lie in the same arc, so those two rows do not separate (a,b), contradicting F2.
+
+A useful refinement is this:
+
+[
+\lambda({a,b})\le
+\begin{cases}
+1, & a,b \text{ adjacent cyclically},\
+2, & a,b \text{ nonadjacent}.
+\end{cases}
+]
+
+For adjacent (a,b), one of the two arcs between them is empty, so two rows could not possibly separate them.
+
+### Discharging
+
+Put one unit of charge on every unordered pair of (1)’s inside a row. Thus row (i) contributes
+
+[
+\binom{d_i}{2}
+]
+
+units of charge. Now discharge each such unit to the corresponding unordered column-pair ({a,b}).
+
+The total charge is
+
+[
+Q=\sum_i \binom{d_i}{2}.
+]
+
+There are (n) adjacent column-pairs, each with capacity at most (1), and
+
+[
+\binom n2-n
+]
+
+nonadjacent column-pairs, each with capacity at most (2). Therefore
+
+[
+Q\le n+2\left(\binom n2-n\right)=n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_i \binom{d_i}{2}\le n(n-2)}.
+]
+
+If every (d_i\ge 4), then
+
+[
+\binom{d_i}{2}\ge 6,
+]
+
+so
+
+[
+6n\le n(n-2),
+]
+
+hence
+
+[
+n\ge 8.
+]
+
+For the bound on total row sum, let
+
+[
+E=\sum_i d_i.
+]
+
+By Cauchy,
+
+[
+\sum_i d_i^2\ge \frac{E^2}{n}.
+]
+
+Therefore
+
+[
+\sum_i \binom{d_i}{2}
+=\frac12\left(\sum_i d_i^2-E\right)
+\ge \frac12\left(\frac{E^2}{n}-E\right).
+]
+
+Combining with the discharging bound gives
+
+[
+\frac12\left(\frac{E^2}{n}-E\right)\le n(n-2),
+]
+
+so
+
+[
+E^2-nE-2n^2(n-2)\le 0.
+]
+
+Solving the quadratic inequality,
+
+[
+\boxed{E\le \frac n2\left(1+\sqrt{8n-15}\right)}.
+]
+
+### Sharpness of the AB-axioms
+
+For (n\ge 8), index rows and columns by (\mathbb Z/n\mathbb Z), and define
+
+[
+S_i={i+1,\ i+2,\ i-3,\ i-1}.
+]
+
+Every row has size (4), and (i\notin S_i).
+
+Let
+
+[
+D={1,2,-3,-1}.
+]
+
+Rows (0) and (t) intersect in
+
+[
+D\cap (t+D).
+]
+
+For (n\ge 11), the only repeated nonzero differences inside (D-D) are (\pm 2). Thus the only two-column intersections are:
+
+[
+t=2:\quad {1,-1},
+]
+
+and
+
+[
+t=n-2:\quad {-3,-1}.
+]
+
+In both cases, one common column lies in the open arc ((0,t)), and the other lies in the complementary arc.
+
+For (n=8,9,10), the modular coincidences create a few more two-column intersections, all still crossing:
+
+[
+\begin{array}{c|c}
+n & \text{two-column intersections for rows }0,t\ \hline
+8 &
+\begin{array}{l}
+t=2:{1,-1}\
+t=3:{2,-3}\
+t=4:{1,-3}\
+t=5:{2,-1}\
+t=6:{-3,-1}
+\end{array}
+[2em]
+9 &
+\begin{array}{l}
+t=2:{1,-1}\
+t=4:{1,-3}\
+t=5:{2,-3}\
+t=7:{-3,-1}
+\end{array}
+[2em]
+10 &
+\begin{array}{l}
+t=2:{1,-1}\
+t=5:{2,-3}\
+t=8:{-3,-1}
+\end{array}
+\end{array}
+]
+
+In each listed case, after representing (0<t<n), one of the two shared columns lies between (0) and (t), and the other lies outside. Hence every (2\times 2) all-one submatrix is crossing. Therefore these matrices satisfy (A) and (B), with every row sum equal to (4).
+
+So the AB-axioms alone cannot prove the desired contradiction for (n\ge 8).
+
+---
+
+## 4. Remaining unresolved configurations
+
+The following patterns survive all consequences of (A) and (B). Eliminating them requires additional geometric information, such as the metric fact that all (1)’s in row (i) lie on one circle centered at (p_i).
+
+### U1. A crossing (2\times 2)
+
+If the cyclic order is
+
+[
+i,\ a,\ k,\ b,
+]
+
+then the submatrix
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is allowed by (B). Geometrically, this corresponds to an orthogonal kite configuration: (p_a,p_b) are mirror images across (p_ip_k), and the two chords cross.
+
+### U2. A pairwise-linear four-row block
+
+The following local pattern has row sums (4), but every pair of rows intersects in only one column, so (B) never activates:
+
+[
+\begin{array}{c|cccccccccc}
+& a&b&c&d&e&f&g&h&\ell&m\ \hline
+r_1&1&1&1&1&0&0&0&0&0&0\
+r_2&1&0&0&0&1&1&1&0&0&0\
+r_3&0&1&0&0&1&0&0&1&1&0\
+r_4&0&0&1&0&0&1&0&1&0&1
+\end{array}
+]
+
+Facts (A) and (B) do not rule this out. A geometric proof would need to use that each row’s four columns are concyclic with a prescribed center.
+
+### U3. The full (8\times 8) AB-pattern
+
+Using the construction
+
+[
+S_i={i+1,i+2,i-3,i-1}
+]
+
+modulo (8), one obtains the matrix
+
+[
+\begin{array}{c|cccccccc}
+&1&2&3&4&5&6&7&8\ \hline
+1&0&1&1&0&0&1&0&1\
+2&1&0&1&1&0&0&1&0\
+3&0&1&0&1&1&0&0&1\
+4&1&0&1&0&1&1&0&0\
+5&0&1&0&1&0&1&1&0\
+6&0&0&1&0&1&0&1&1\
+7&1&0&0&1&0&1&0&1\
+8&1&1&0&0&1&0&1&0
+\end{array}
+]
+
+This satisfies every forbidden-submatrix rule derived from (A) and (B), and every row has size (4). The reversed cyclic pattern
+
+[
+S_i={i+1,i+3,i-2,i-1}
+]
+
+also survives the AB-axioms.
+
+These are not asserted to be geometrically realizable. In fact, to eliminate even this example one must use metric information not present in (A) and (B): in the displayed pattern, each row contains its two cyclic neighbors and also (i+2), which would force all sides equal and every triangle (p_i p_{i+1}p_{i+2}) to be equilateral, impossible for a strictly convex (n)-gon with (n\ge 8). That argument uses the actual distance equalities row-by-row, not just the cyclic crossing rule.
+
+Thus the strongest conclusion from the prescribed matrix axioms is the sharp bound above and the nonexistence for (n\le 7). A full contradiction for all (n), if true, must use additional geometric constraints beyond Facts (A) and (B).

--- a/incoming/chatgpt-runs/run-09.md
+++ b/incoming/chatgpt-runs/run-09.md
@@ -1,0 +1,423 @@
+## 1. Convex-position crossing lemma
+
+Let the vertices (p_1,\dots,p_n) be in cyclic order. I will say that two unordered pairs ({x,y}) and ({u,v}) **separate** each other if, after deleting (x,y) from the cyclic order, the two remaining open arcs contain (u) and (v) in different arcs. Equivalently, in a strictly convex polygon, the chords (p_xp_y) and (p_up_v) cross in their relative interiors.
+
+### Lemma B
+
+If (S_i\cap S_k={a,b}) with (i\neq k), then ({i,k}) separates ({a,b}). Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+### Proof
+
+The four indices (i,k,a,b) are distinct: (i\notin S_i), (k\notin S_k), and (a,b\in S_i\cap S_k).
+
+Let (L) be the line through (p_i,p_k). Put coordinates so that
+
+[
+p_i=(0,0),\qquad p_k=(d,0),\qquad d>0.
+]
+
+A common point (q=(x,y)) of the two circles satisfies
+
+[
+x^2+y^2=r_i^2,
+]
+[
+(x-d)^2+y^2=r_k^2.
+]
+
+Subtracting gives
+
+[
+2dx=d^2+r_i^2-r_k^2,
+]
+
+so every common point of the two circles has the same (x)-coordinate. Thus the common chord is a vertical line, perpendicular to (L); this is the radical-axis property. Since the two circles have the two distinct common points (p_a,p_b), they must be
+
+[
+p_a=(x_0,h),\qquad p_b=(x_0,-h)
+]
+
+for some (h\neq 0), after perhaps swapping (a,b). Therefore (p_a,p_b) are reflections of one another across (L), and they lie in opposite open half-planes bounded by (L).
+
+Now use convexity. The chord (p_ip_k) splits the boundary of the convex polygon into two polygonal chains from (p_i) to (p_k). Convexity puts these two chains in opposite closed half-planes bounded by (L).
+
+**This is the exact point where strict convexity is used:** because the polygon is strictly convex, no vertex other than (p_i,p_k) lies on (L). Hence the two chains actually lie in opposite **open** half-planes, except for their endpoints (p_i,p_k).
+
+Since (p_a) and (p_b) are on opposite sides of (L), they must lie on opposite boundary arcs between (p_i) and (p_k). Therefore ({i,k}) separates ({a,b}), and the chords (p_ip_k) and (p_ap_b) cross. (\square)
+
+---
+
+## 2. Exact theorem proved
+
+Let (M) be a cyclic (n\times n) zero-diagonal (0)-(1) matrix with row supports
+
+[
+R_i={j:M_{ij}=1},
+]
+
+satisfying:
+
+[
+\tag{A} |R_i\cap R_k|\le 2\quad\text{for }i\neq k,
+]
+
+and
+
+[
+\tag{B} |R_i\cap R_k|=2\implies {i,k}\text{ separates }R_i\cap R_k.
+]
+
+Then the following hold.
+
+[
+\boxed{\sum_{i=1}^n \binom{|R_i|}{2}\le n(n-2).}
+]
+
+Consequently, if every row has size at least (4), then
+
+[
+6n\le n(n-2),
+]
+
+so
+
+[
+\boxed{n\ge 8.}
+]
+
+This is the strongest possible conclusion from only (A) and (B): for every (n\ge 8), there exists a cyclic zero-diagonal matrix satisfying (A), (B), and (|R_i|=4) for every row.
+
+Thus a full contradiction cannot be obtained from (A) and (B) alone. Any proof that the original geometric configuration is impossible must use additional metric geometry beyond the crossing lemma.
+
+A general bound on the total number of ones (m=\sum_i |R_i|) is
+
+[
+\boxed{
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+For (n=8), equality in the counting argument forces strong structure: every row and every column has sum (4), every adjacent column-pair occurs in exactly one row, every non-adjacent column-pair occurs in exactly two rows, every adjacent row-pair intersects in exactly one column, every non-adjacent row-pair intersects in exactly two columns, and in particular
+
+[
+i-1,\ i+1\in R_i
+]
+
+for every (i), with indices taken cyclically.
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Work with indices modulo (n).
+
+### Forbidden (2\times 2) cyclic submatrix
+
+Suppose rows (i,k) and columns (a,b) contain the all-one submatrix
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+Then (a,b\in R_i\cap R_k). By (A), this is already the full intersection unless there is an immediate violation. By (B), the only allowed case is that ({i,k}) separates ({a,b}). Therefore the following all-one (2\times 2) pattern is forbidden whenever (a,b) lie on the same cyclic arc between (i) and (k):
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+\qquad
+\text{with }a,b\text{ not separated by }i,k.
+]
+
+In particular:
+
+* two adjacent rows cannot have two common (1)’s;
+* two adjacent columns cannot be contained together in two different rows.
+
+Also, by (A), the all-one (2\times 3) pattern
+
+[
+\begin{array}{c|ccc}
+& a & b & c\ \hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+is forbidden.
+
+A useful derived forbidden pattern is the all-one (3\times 2) pattern
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+because if three rows all contain (a,b), then any two of those rows would have to be separated by (a,b), but the two arcs between (a,b) can contain at most one such row each.
+
+### Column-pair capacity
+
+For distinct columns (a,b), define
+
+[
+q_{ab}=#{i:a,b\in R_i}.
+]
+
+If two rows (i,k) both contain (a,b), then by (B), ({i,k}) must be separated by ({a,b}). Therefore one of (i,k) lies on one arc between (a,b), and the other lies on the other arc.
+
+Hence
+
+[
+q_{ab}\le 2.
+]
+
+If (a,b) are adjacent cyclically, one of the arcs between them is empty, so
+
+[
+q_{ab}\le 1.
+]
+
+Now count pairs of (1)’s inside rows. Each row (i) contributes (\binom{|R_i|}{2}) unordered column-pairs. On the other hand, each adjacent column-pair can be counted at most once, and each non-adjacent column-pair can be counted at most twice. There are (n) adjacent column-pairs and (\binom n2-n) non-adjacent column-pairs. Thus
+
+[
+\sum_i \binom{|R_i|}{2}
+=======================
+
+\sum_{{a,b}} q_{ab}
+\le
+n+2\left(\binom n2-n\right)
+===========================
+
+n(n-2).
+]
+
+This is the main discharging inequality: every row distributes one unit of charge to each pair of its (1)’s; adjacent column-pairs have capacity (1), and non-adjacent column-pairs have capacity (2).
+
+If (|R_i|\ge 4) for all (i), then
+
+[
+\sum_i \binom{|R_i|}{2}\ge 6n.
+]
+
+Therefore
+
+[
+6n\le n(n-2),
+]
+
+so (n\ge 8).
+
+### Bound on the total number of ones
+
+Let
+
+[
+m=\sum_i |R_i|.
+]
+
+By convexity of (x\mapsto \binom x2),
+
+[
+\sum_i \binom{|R_i|}{2}
+\ge
+n\binom{m/n}{2}
+===============
+
+\frac{m^2}{2n}-\frac m2.
+]
+
+Together with the upper bound (n(n-2)), this gives
+
+[
+\frac{m^2}{2n}-\frac m2\le n(n-2).
+]
+
+Solving the quadratic inequality,
+
+[
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+### Dual row-pair inequality
+
+Let (c_j) be the column sum of column (j). Counting pairs of rows inside columns gives
+
+[
+\sum_j \binom{c_j}{2}
+=====================
+
+\sum_{{i,k}} |R_i\cap R_k|.
+]
+
+By (A), a non-adjacent row-pair has intersection at most (2). If (i,k) are adjacent, then they cannot share two columns, because two common columns would have to be separated by adjacent indices (i,k), impossible. Therefore adjacent row-pairs have intersection at most (1). Hence
+
+[
+\sum_j \binom{c_j}{2}\le n(n-2).
+]
+
+### Extremal structure when (n=8)
+
+Assume (n=8) and every row has size at least (4). The inequality gives
+
+[
+\sum_i \binom{|R_i|}{2}\le 48.
+]
+
+But each row contributes at least (6), so equality holds. Therefore every row has size exactly (4).
+
+The total number of ones is (32), so the average column sum is (4). The dual inequality gives
+
+[
+\sum_j \binom{c_j}{2}\le 48.
+]
+
+Convexity gives
+
+[
+\sum_j \binom{c_j}{2}\ge 8\binom 42=48,
+]
+
+so equality holds, and every column has sum (4).
+
+Also, every row-pair capacity is saturated: adjacent row-pairs meet in exactly one column, and non-adjacent row-pairs meet in exactly two columns.
+
+Now fix (i). Rows (i) and (i+2) are non-adjacent, so they share exactly two columns. By (B), those two common columns must be separated by ({i,i+2}). The short arc from (i) to (i+2) contains only (i+1), so one of the two common columns must be (i+1). Hence
+
+[
+i+1\in R_i.
+]
+
+Similarly, applying the same argument to rows (i) and (i-2), we get
+
+[
+i-1\in R_i.
+]
+
+Thus, in the extremal (n=8) case,
+
+[
+\boxed{i-1,\ i+1\in R_i\quad\text{for every }i.}
+]
+
+### Why the full contradiction fails at the matrix level
+
+For (n=8), define
+
+[
+R_i={i+1,i+2,i+5,i+7}\pmod 8.
+]
+
+Every row has size (4). Comparing row (0) with row (t), the intersections of size (2) are:
+
+[
+\begin{array}{c|c}
+t & R_0\cap R_t\ \hline
+2 & {1,7}\
+3 & {2,5}\
+4 & {1,5}\
+5 & {2,7}\
+6 & {5,7}
+\end{array}
+]
+
+In every case, one common column lies on the arc from (0) to (t), and the other lies on the complementary arc. Thus (B) holds. For (t=1,7), the intersection has size (1). Therefore (A) also holds.
+
+For every (n\ge 9), define instead
+
+[
+R_i={i+1,i+2,i+4,i+8}\pmod n.
+]
+
+Again every row has size (4). For (n\ge 15), the nonzero differences among
+
+[
+{1,2,4,8}
+]
+
+are
+
+[
+\pm1,\ \pm2,\ \pm3,\ \pm4,\ \pm6,\ \pm7,
+]
+
+all distinct modulo (n). Hence two different rows share at most one column, so (B) is vacuous and (A) holds.
+
+For (9\le n\le 14), the only row differences producing two common columns are listed below; each listed pair is separated:
+
+[
+\begin{array}{c|c}
+n & (t,\ R_0\cap R_t)\ \hline
+9 & (2,{1,4}),\ (3,{2,4}),\ (6,{1,8}),\ (7,{2,8})\
+10 & (3,{1,4}),\ (4,{2,8}),\ (6,{4,8}),\ (7,{1,8})\
+11 & (4,{1,8}),\ (7,{4,8})\
+12 & (6,{2,8})\
+13 & (6,{1,8}),\ (7,{2,8})\
+14 & (7,{1,8})
+\end{array}
+]
+
+In every listed case, if (R_0\cap R_t={x,y}), then
+
+[
+0<x<t<y<n,
+]
+
+so the two common columns lie on opposite arcs between rows (0) and (t). Thus (B) holds. All other row intersections have size at most (1).
+
+Therefore cyclic matrices satisfying (A), (B), and (|R_i|=4) exist for every (n\ge 8). The desired matrix-level contradiction is false.
+
+---
+
+## 4. Remaining unresolved configurations
+
+The cyclic-matrix argument rules out noncrossing (2\times 2) all-one rectangles, but it does **not** rule out crossing rectangles. The basic allowed local pattern is:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+\qquad
+\text{with cyclic order } i<a<k<b.
+]
+
+The exact formal patterns not eliminated by (A) and (B) include the following.
+
+For (n=8):
+
+[
+\boxed{
+R_i={i+1,i+2,i+5,i+7}\pmod 8.
+}
+]
+
+Its reflection is also allowed:
+
+[
+\boxed{
+R_i={i+1,i+3,i+6,i+7}\pmod 8.
+}
+]
+
+For every (n\ge 9):
+
+[
+\boxed{
+R_i={i+1,i+2,i+4,i+8}\pmod n.
+}
+]
+
+and its reflected version is also allowed.
+
+These are formal cyclic (0)-(1) matrices satisfying all consequences of (A) and (B) used above. They are not asserted to be geometrically realizable as equal-radius data of a strictly convex polygon. To rule them out geometrically, one must use additional metric input, for example actual side-length equalities forced by entries such as (i-1,i+1\in R_i), angle-sum constraints, or other distance consistency conditions not encoded in (A) and (B).

--- a/incoming/chatgpt-runs/run-10.md
+++ b/incoming/chatgpt-runs/run-10.md
@@ -1,0 +1,298 @@
+## 1. Convex-position crossing lemma
+
+Let (P={p_1,\dots,p_n}) be in strictly convex cyclic position. Suppose (i\ne k) and that
+
+[
+S_i\cap S_k\supset {a,b},\qquad a\ne b.
+]
+
+Thus
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+In particular, both (p_i) and (p_k) are equidistant from (p_a) and (p_b). Therefore the line (p_i p_k) is the perpendicular bisector of the segment (p_a p_b). Equivalently, (p_a) and (p_b) are reflections of one another across the line (p_i p_k). This is the radical-axis/perpendicular-bisector property.
+
+Let (q) be the midpoint of (p_a p_b). Then (q\in p_i p_k). Choose coordinates with
+
+[
+p_i=(0,0),\qquad p_k=(d,0),\qquad d>0,
+]
+
+and write
+
+[
+q=(t,0),\qquad p_a=(t,h),\qquad p_b=(t,-h),
+]
+
+with (h>0). We claim (0<t<d).
+
+If (t=0), then (p_i) lies on the segment (p_a p_b), so (p_a,p_i,p_b) are collinear. If (t=d), then (p_k) lies on the segment (p_a p_b), so (p_a,p_k,p_b) are collinear. Both cases are forbidden by **strict convexity**, namely by the no-three-collinear part of strict convex position.
+
+If (t<0), then (p_i=(0,0)) lies in the interior of the triangle with vertices (p_k,p_a,p_b). Indeed, the vertical cross-section of that triangle at (x=0) has positive length and contains ((0,0)). Thus (p_i) would not be an extreme point of the convex hull, contradicting convex position. Similarly, if (t>d), then (p_k) lies in the interior of the triangle with vertices (p_i,p_a,p_b). This again contradicts convex position.
+
+Hence (0<t<d). Therefore the segment (p_i p_k) meets the segment (p_a p_b) at the interior point (q). So the chords (p_i p_k) and (p_a p_b) cross. For four distinct vertices of a strictly convex polygon, two chords cross if and only if their endpoints alternate in the cyclic order. Therefore the pair ({i,k}) separates the pair ({a,b}).
+
+The exact uses of strict convexity were: first, to exclude the degenerate cases (t=0,d), where three vertices would be collinear; second, to ensure every listed vertex is an extreme point, excluding (t<0) and (t>d).
+
+---
+
+## 2. The exact theorem proved
+
+The full contradiction does **not** follow from facts (A) and (B) alone. The strongest clean theorem I can prove from them is the following.
+
+### Theorem
+
+Let (M) be a cyclically indexed (n\times n) zero-diagonal (0)-(1) matrix satisfying the alternating (K_{2,2}) rule:
+
+[
+M_{ia}=M_{ib}=M_{ka}=M_{kb}=1
+\quad\Longrightarrow\quad
+{i,k}\text{ separates }{a,b}.
+]
+
+Let (d_i=|S_i|). Then
+
+[
+\sum_{i=1}^n \binom{d_i}{2}\le n(n-2).
+]
+
+Consequently, if every row has size at least (4), then necessarily
+
+[
+n\ge 8.
+]
+
+Moreover,
+
+[
+\sum_{i=1}^n d_i
+\le
+\frac n2\bigl(1+\sqrt{8n-15}\bigr).
+]
+
+The condition (n\ge 8) is sharp at the cyclic-matrix level: there are explicit cyclic matrices satisfying all consequences of (A) and (B) with every row sum equal to (4). Hence no contradiction can be derived from (A) and (B) alone.
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Write indices cyclically. A (2\times 2) all-one submatrix using rows (i,k) and columns (a,b) is allowed only when the four indices alternate cyclically:
+
+[
+i,a,k,b
+\quad\text{or}\quad
+i,b,k,a.
+]
+
+Equivalently, (a,b) must lie on opposite open arcs between (i) and (k).
+
+Thus the following cyclic (2\times2) pattern is forbidden:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+whenever (a,b) lie on the same side of the chord (ik).
+
+Several immediate forbidden submatrices follow.
+
+First, no two rows can share three columns. Indeed, if rows (i,k) shared three columns, two of those columns would lie on the same open arc between (i) and (k), contradicting the alternating (K_{2,2}) rule. This recovers fact (A):
+
+[
+|S_i\cap S_k|\le 2.
+]
+
+Second, dually, no two columns can occur together in three rows. If columns (a,b) occurred together in rows (i,k,\ell), then two of (i,k,\ell) would lie on the same open arc between (a) and (b), again contradicting the alternating rule. Thus every (3\times2) all-one submatrix is forbidden.
+
+Third, if (i,k) are adjacent rows, then no pair of columns can separate them, so
+
+[
+|S_i\cap S_k|\le 1.
+]
+
+Similarly, if (a,b) are adjacent columns, then at most one row can contain both (a) and (b).
+
+Now discharge as follows. For every row (i), place one token on every unordered pair of columns contained in (S_i). Row (i) emits
+
+[
+\binom{d_i}{2}
+]
+
+tokens, so the total number of emitted tokens is
+
+[
+T=\sum_i \binom{d_i}{2}.
+]
+
+Fix an unordered column-pair ({a,b}). If (a,b) are nonadjacent, then the two arcs between (a) and (b) are both nonempty. By the alternating rule, at most one row from each arc can contain both (a) and (b). Hence ({a,b}) receives at most (2) tokens.
+
+If (a,b) are adjacent, then one of the two arcs between them is empty, so ({a,b}) receives at most (1) token.
+
+There are (n) adjacent column-pairs and (\binom n2-n) nonadjacent column-pairs. Therefore
+
+[
+T
+\le
+1\cdot n+2\left(\binom n2-n\right)
+==================================
+
+# n+2\left(\frac{n(n-1)}2-n\right)
+
+n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_i \binom{d_i}{2}\le n(n-2).}
+]
+
+If every (d_i\ge 4), then
+
+[
+\sum_i \binom{d_i}{2}\ge 6n.
+]
+
+Thus
+
+[
+6n\le n(n-2),
+]
+
+so
+
+[
+n\ge 8.
+]
+
+For the total number of ones (E=\sum_i d_i), Cauchy gives
+
+[
+\sum_i d_i^2\ge \frac{E^2}{n}.
+]
+
+Since
+
+[
+\sum_i \binom{d_i}{2}
+=====================
+
+\frac12\left(\sum_i d_i^2-E\right),
+]
+
+we get
+
+[
+\frac12\left(\frac{E^2}{n}-E\right)\le n(n-2).
+]
+
+Equivalently,
+
+[
+E^2-nE-2n^2(n-2)\le 0.
+]
+
+Solving the quadratic inequality gives
+
+[
+\boxed{
+E\le \frac n2\bigl(1+\sqrt{8n-15}\bigr).
+}
+]
+
+For (n=8), the inequality is tight if all rows have size (4). In that extremal case every adjacent column-pair must occur in exactly one row, and every nonadjacent column-pair must occur in exactly two rows.
+
+---
+
+## 4. Surviving configurations and unresolved patterns
+
+The matrix contradiction fails. Here is an explicit (8\times8) cyclic matrix satisfying all the above forbidden-submatrix rules and having every row sum equal to (4). Index rows and columns by (\mathbb Z_8), and set
+
+[
+S_i={i-2,i-1,i+1,i+3}\pmod 8.
+]
+
+The matrix is
+
+[
+\begin{pmatrix}
+0&1&0&1&0&0&1&1\
+1&0&1&0&1&0&0&1\
+1&1&0&1&0&1&0&0\
+0&1&1&0&1&0&1&0\
+0&0&1&1&0&1&0&1\
+1&0&0&1&1&0&1&0\
+0&1&0&0&1&1&0&1\
+1&0&1&0&0&1&1&0
+\end{pmatrix}.
+]
+
+Every row has four (1)’s. A direct cyclic check shows that whenever two rows share two columns, the row-pair separates the column-pair.
+
+For every (n\ge 9), another explicit cyclic family is
+
+[
+S_i={i-2,i-1,i+2,i+4}\pmod n.
+]
+
+For (n\ge 13), the difference set is Sidon modulo (n), so two rows share at most one column; hence fact (B) is vacuous. For (9\le n\le 12), the only double intersections are the following row separations, checked relative to row (0):
+
+[
+\begin{array}{c|c|c}
+n & t & S_0\cap S_t\ \hline
+9 & 3 & {-2,2}\
+9 & 4 & {-1,2}\
+9 & 5 & {-2,4}\
+9 & 6 & {-1,4}\
+10 & 4 & {-2,2}\
+10 & 5 & {-1,4}\
+10 & 6 & {-2,4}\
+11 & 5 & {-2,4}\
+11 & 6 & {-1,4}\
+12 & 6 & {-2,4}.
+\end{array}
+]
+
+In every listed case, one common column lies inside the arc ((0,t)) and the other lies outside it, so the crossing/separation rule is satisfied.
+
+These examples show that facts (A) and (B), even with the common cyclic indexing of rows and columns, do not force a contradiction.
+
+Some of these surviving matrix patterns are killed by extra metric geometry. For example, in the pattern
+
+[
+S_i={i-2,i-1,i+2,i+4},
+]
+
+the row centered at (p_i) contains both (p_{i-2}) and (p_{i-1}). Thus
+
+[
+|p_i-p_{i-2}|=|p_i-p_{i-1}|.
+]
+
+Applied cyclically, this forces every consecutive triangle (p_{i-2}p_{i-1}p_i) to have the polygon angle at (p_{i-1}) acute. If this happened for every (i), every interior angle of the polygon would be (<90^\circ), impossible for (n\ge 5), since the average interior angle of a convex (n)-gon is
+
+[
+\frac{(n-2)180^\circ}{n}>90^\circ.
+]
+
+But that argument uses additional metric information beyond (A) and (B).
+
+A genuinely unresolved-by-this-argument exact pattern is any cyclic Sidon translate pattern such as
+
+[
+S_i={i+1,i+3,i+7,i+12}\pmod n,\qquad n\ge 23.
+]
+
+The six positive differences
+
+[
+2,4,5,6,9,11
+]
+
+are distinct, and for (n\ge 23) no positive difference is congruent to the negative of another. Therefore two rows share at most one column. All (2\times2) obstructions disappear, so facts (A) and (B) give no further information. Ruling out such a pattern geometrically would require additional distance/angle constraints not contained in (A) and (B).

--- a/incoming/chatgpt-runs/run-11.md
+++ b/incoming/chatgpt-runs/run-11.md
@@ -1,0 +1,420 @@
+## 1. Convex-position crossing lemma
+
+Let (P={p_1,\dots,p_n}) be in strictly convex position, indexed cyclically. Suppose two distinct rows (i\ne k) share two indices (a,b), so
+
+[
+a,b\in S_i\cap S_k.
+]
+
+Then
+
+[
+|p_a-p_i|=|p_b-p_i|,\qquad |p_a-p_k|=|p_b-p_k|.
+]
+
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of the segment (p_ap_b). Since (p_i\ne p_k), the line (p_ip_k) is exactly that perpendicular bisector. Equivalently, (p_a) and (p_b) are mirror images across the line (p_ip_k). Let (m) be the midpoint of (p_ap_b). Then
+
+[
+m\in p_ip_k,\qquad p_ap_b\perp p_ip_k.
+]
+
+It remains to show that (m) lies between (p_i) and (p_k). If not, then (p_i) and (p_k) lie on the same side of the line (p_ap_b), or one of them equals (m).
+
+If one of (p_i,p_k) equals (m), then that vertex lies on the segment (p_ap_b), so three vertices are collinear. **This is impossible by strict convexity.**
+
+Otherwise, assume without loss of generality that the points on the line (p_ip_k) occur in the order
+
+[
+p_i,\ p_k,\ m.
+]
+
+Then (p_k) lies strictly inside the triangle (\triangle p_ip_ap_b): indeed, the median from (p_i) to the base (p_ap_b) is the segment (p_im), and every point of the open segment ((p_i,m)) lies in the interior of that triangle. Hence (p_k) is in the convex hull of three other vertices. **This is the main strict-convexity step:** in a strictly convex polygon, every listed point is an extreme point of the convex hull, so no vertex may lie in the interior of a triangle formed by three other vertices.
+
+Therefore (m) must lie in the open segment (p_ip_k). Since (p_a,p_b) are on opposite sides of the line (p_ip_k), and (p_i,p_k) are on opposite sides of the line (p_ap_b), the segments (p_ip_k) and (p_ap_b) cross at (m). For four vertices of a strictly convex polygon, two chords cross if and only if their endpoints alternate in the cyclic order. Thus the pair ({i,k}) separates the pair ({a,b}).
+
+That proves Fact (B).
+
+---
+
+## 2. Exact theorem proved
+
+The full contradiction does **not** follow from Facts (A) and (B). The strongest clean theorem obtainable from those two facts alone is the following sharp cyclic-matrix statement.
+
+**Theorem.** Let (M) be a cyclically indexed zero-diagonal (0)-(1) matrix satisfying:
+
+[
+\tag{A} |S_i\cap S_k|\le 2\quad\text{for all }i\ne k,
+]
+
+and
+
+[
+\tag{B} \text{if }S_i\cap S_k={a,b},\text{ then }{i,k}\text{ separates }{a,b}.
+]
+
+Let (s_i=|S_i|). Then
+
+[
+\sum_i \binom{s_i}{2}\le n(n-2).
+]
+
+Consequently,
+
+[
+\sum_i s_i\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+In particular, if every (s_i\ge 4), then necessarily
+
+[
+n\ge 8.
+]
+
+This is sharp for the matrix problem determined by (A) and (B): for every (n\ge 8), there exists a cyclically indexed zero-diagonal (0)-(1) matrix satisfying (A), (B), and (s_i=4) for every row.
+
+Therefore no proof using only (A) and (B) can rule out all row sums being at least (4). Any genuine geometric contradiction would need additional metric information beyond (A) and (B), such as the actual row-wise concyclicity constraints.
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Write cyclic intervals as
+
+[
+(x,y)={z:\ z\text{ occurs after }x\text{ and before }y\text{ in cyclic order}}.
+]
+
+### Forbidden (2\times 3) pattern
+
+Fact (A) immediately forbids a (2\times 3) all-one submatrix:
+
+[
+\begin{array}{c|ccc}
+& a&b&c\ \hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+]
+
+because that would give (|S_i\cap S_k|\ge 3).
+
+### Forbidden noncrossing (2\times 2) pattern
+
+If two rows (i,k) share two columns (a,b), then by (B), the four labels must alternate cyclically. Thus the all-one submatrix
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is allowed only when the cyclic order is one of
+
+[
+i,\ a,\ k,\ b
+\qquad\text{or}\qquad
+i,\ b,\ k,\ a.
+]
+
+It is forbidden when the order is nonalternating, for example
+
+[
+i,\ k,\ a,\ b
+\qquad\text{or}\qquad
+i,\ a,\ b,\ k.
+]
+
+Equivalently, two rows may share two columns only if one shared column lies in ((i,k)) and the other lies in ((k,i)).
+
+A useful corollary: adjacent rows cannot share two columns. If (k=i+1), then one of the two arcs between (i) and (k) is empty, so no two shared columns can be separated by ({i,k}). Hence
+
+[
+|S_i\cap S_{i+1}|\le 1.
+]
+
+### Forbidden (3\times 2) pattern
+
+Fix two columns (a,b). Suppose three distinct rows (i,k,\ell) all contain both (a) and (b). Then each pair of those rows would have to separate ({a,b}). But the two columns (a,b) split the cyclic order into two open arcs. At most one of (i,k,\ell) can lie in each arc if every pair is to be separated by ({a,b}). Three rows cannot be placed that way.
+
+Therefore the all-one pattern
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1\
+\ell&1&1
+\end{array}
+]
+
+is forbidden.
+
+Even more sharply, if (a,b) are adjacent columns, then no two rows can both contain (a,b). One of the arcs between (a) and (b) is empty, so two rows cannot be separated by the adjacent pair ({a,b}).
+
+### Discharging
+
+Place one unit of charge on every unordered pair of (1)’s in a row. Row (i) contributes
+
+[
+\binom{s_i}{2}
+]
+
+units of charge, so the total charge is
+
+[
+Q=\sum_i \binom{s_i}{2}.
+]
+
+Now redistribute that charge to column pairs: a row (i) charges the column pair ({a,b}) whenever (a,b\in S_i).
+
+For a fixed column pair ({a,b}):
+
+* if (a,b) are adjacent cyclically, then at most one row contains both;
+* otherwise, at most two rows contain both, and if two do, they must lie on opposite sides of the chord (p_ap_b) in the cyclic sense.
+
+There are (n) adjacent column pairs and
+
+[
+\binom n2-n
+]
+
+nonadjacent column pairs. Hence
+
+[
+Q
+\le n\cdot 1+2\left(\binom n2-n\right)
+= n+n(n-1)-2n
+= n(n-2).
+]
+
+Thus
+
+[
+\boxed{\sum_i \binom{s_i}{2}\le n(n-2).}
+]
+
+If every (s_i\ge 4), then
+
+[
+\sum_i \binom{s_i}{2}\ge n\binom42=6n,
+]
+
+so
+
+[
+6n\le n(n-2),
+]
+
+hence
+
+[
+n\ge 8.
+]
+
+For the bound on total row sum, let
+
+[
+m=\sum_i s_i.
+]
+
+By Cauchy,
+
+[
+\sum_i s_i^2\ge \frac{m^2}{n}.
+]
+
+Since
+
+[
+\sum_i \binom{s_i}{2}
+=\frac12\left(\sum_i s_i^2-\sum_i s_i\right),
+]
+
+we get
+
+[
+\frac12\left(\frac{m^2}{n}-m\right)\le n(n-2).
+]
+
+Solving the quadratic inequality gives
+
+[
+\boxed{
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+This is much weaker than (m<4n) for large (n), so it cannot prove the desired contradiction.
+
+### Sharpness: explicit matrices with every row sum (4)
+
+For (n=8), define indices modulo (8) and set
+
+[
+S_i={i+1,\ i+2,\ i+5,\ i+7}.
+]
+
+Equivalently, the matrix is
+
+[
+\begin{array}{c|cccccccc}
+&0&1&2&3&4&5&6&7\ \hline
+0&0&1&1&0&0&1&0&1\
+1&1&0&1&1&0&0&1&0\
+2&0&1&0&1&1&0&0&1\
+3&1&0&1&0&1&1&0&0\
+4&0&1&0&1&0&1&1&0\
+5&0&0&1&0&1&0&1&1\
+6&1&0&0&1&0&1&0&1\
+7&1&1&0&0&1&0&1&0
+\end{array}
+]
+
+Every row has sum (4). For row (0), the only double intersections with row (q) are:
+
+[
+\begin{array}{c|c}
+q & S_0\cap S_q\ \hline
+2&{1,7}\
+3&{2,5}\
+4&{1,5}\
+5&{2,7}\
+6&{5,7}
+\end{array}
+]
+
+In every case, one shared column lies in ((0,q)) and the other lies in ((q,0)), so (B) holds. By cyclic symmetry, the same is true for every pair of rows. Thus this (8\times 8) matrix satisfies (A), (B), and all row sums equal (4).
+
+For every (n\ge 9), define indices modulo (n) and set
+
+[
+S_i={i+1,\ i+2,\ i+4,\ i+8}.
+]
+
+Again every row has sum (4). For (n\ge 15), the nonzero differences among
+
+[
+D={1,2,4,8}
+]
+
+are
+
+[
+\pm1,\ \pm2,\ \pm3,\ \pm4,\ \pm6,\ \pm7,
+]
+
+which are all distinct modulo (n). Hence two rows intersect in at most one column, so (A) holds and (B) is vacuous.
+
+For (9\le n\le 14), the only double intersections for row (0) are as follows:
+
+[
+\begin{array}{c|c|c}
+n&q&S_0\cap S_q\ \hline
+9&2&{1,4}\
+9&3&{2,4}\
+9&6&{1,8}\
+9&7&{2,8}\ \hline
+10&3&{1,4}\
+10&4&{2,8}\
+10&6&{4,8}\
+10&7&{1,8}\ \hline
+11&4&{1,8}\
+11&7&{4,8}\ \hline
+12&6&{2,8}\ \hline
+13&6&{1,8}\
+13&7&{2,8}\ \hline
+14&7&{1,8}
+\end{array}
+]
+
+Each listed pair is separated by ({0,q}), and all other intersections have size at most (1). By cyclic symmetry, (A) and (B) hold for all row pairs.
+
+Thus, for every (n\ge 8), there are cyclic matrices satisfying exactly the two allowed facts and having all row sums equal to (4). Therefore the desired contradiction is impossible from (A) and (B) alone.
+
+---
+
+## 4. Remaining unresolved configurations and extra geometric input
+
+The cyclic-matrix method leaves many (4)-regular patterns alive. The simplest exact survivor families are the circulant ones above:
+
+[
+\boxed{
+S_i={i+1,i+2,i+5,i+7}\pmod 8
+}
+]
+
+and, for (n\ge 9),
+
+[
+\boxed{
+S_i={i+1,i+2,i+4,i+8}\pmod n.
+}
+]
+
+These satisfy every forbidden submatrix rule derived from (A) and (B). Hence they are genuine obstructions to an ((A)+(B))-only proof.
+
+However, these particular circulant patterns are not automatically geometrically realizable. In fact, they contain the metric condition
+
+[
+i+1,i+2\in S_i\quad\text{for every }i,
+]
+
+so a geometric realization would force
+
+[
+|p_i p_{i+1}|=|p_i p_{i+2}|
+\quad\text{for every }i.
+]
+
+Let (s_i=|p_ip_{i+1}|) and let (\theta_{i+1}) be the interior angle at (p_{i+1}). In triangle (p_ip_{i+1}p_{i+2}),
+
+[
+|p_ip_{i+2}|^2
+=s_i^2+s_{i+1}^2-2s_is_{i+1}\cos\theta_{i+1}.
+]
+
+If (|p_ip_{i+2}|=s_i), then
+
+[
+s_i^2=s_i^2+s_{i+1}^2-2s_is_{i+1}\cos\theta_{i+1},
+]
+
+so
+
+[
+\cos\theta_{i+1}=\frac{s_{i+1}}{2s_i}>0.
+]
+
+Hence every interior angle would be acute. That is impossible for a convex (n)-gon with (n\ge 4), since the sum of the interior angles is
+
+[
+(n-2)\pi,
+]
+
+whose average is at least (\pi/2) for (n\ge 4), and strictly larger for (n>4). This argument uses additional metric geometry, not merely (A) and (B).
+
+A more robust unresolved-by-((A)+(B)) pattern avoids that local acute-angle obstruction. For example, for (n\ge 35), set
+
+[
+\boxed{
+S_i={i+1,\ i+4,\ i+10,\ i+18}\pmod n.
+}
+]
+
+The positive differences among ({1,4,10,18}) are
+
+[
+3,6,8,9,14,17,
+]
+
+all distinct, and for (n\ge 35) their negatives are also distinct modulo (n). Hence any two rows intersect in at most one column. Thus (A) holds and (B) is vacuous. This exact (0)-(1) pattern has every row sum (4), no forbidden (2\times 3), no forbidden noncrossing (2\times 2), and no forbidden (3\times 2).
+
+To eliminate such patterns one must use geometric information not encoded by (A) and (B), for example:
+
+[
+\text{for each row }i,\text{ the four marked vertices must lie on one Euclidean circle centered at }p_i,
+]
+
+so the perpendicular bisectors of all six chords among those four vertices must concur at the vertex (p_i). That row-wise metric/concurrency constraint is absent from the cyclic-matrix axioms.

--- a/incoming/chatgpt-runs/run-12.md
+++ b/incoming/chatgpt-runs/run-12.md
@@ -1,0 +1,328 @@
+I will use indices in (\mathbb Z_n) for the matrix part. Thus “(i+1)” means cyclic successor. This is only notation; it is equivalent to the problem’s (1,\dots,n) indexing.
+
+## 1. Convex-position crossing lemma
+
+**Lemma B.** Let (P={p_1,\dots,p_n}) be the vertices of a strictly convex (n)-gon in cyclic order. Suppose (i\ne k), and suppose two distinct indices (a,b) lie in (S_i\cap S_k). Then the chord (p_i p_k) crosses the chord (p_a p_b). Equivalently, in cyclic order the pair ({i,k}) separates the pair ({a,b}).
+
+**Proof.** Since (a,b\in S_i), we have
+[
+|p_i-p_a|=|p_i-p_b|.
+]
+Therefore (p_i) lies on the perpendicular bisector of segment (p_a p_b). Similarly, since (a,b\in S_k),
+[
+|p_k-p_a|=|p_k-p_b|,
+]
+so (p_k) also lies on the perpendicular bisector of (p_a p_b). Because (p_i\ne p_k), the line (p_i p_k) is exactly that perpendicular bisector. Hence (p_a) and (p_b) are reflections of each other across the line (p_i p_k). This is the common-chord/radical-axis geometry: the common chord (p_a p_b) is perpendicular to the line of centers (p_i p_k), and here the line of centers bisects the common chord.
+
+So (p_a) and (p_b) lie on opposite sides of the line (p_i p_k), and (p_a p_b) meets (p_i p_k) at the midpoint (m) of (p_a p_b).
+
+It remains to show that (p_i) and (p_k) lie on opposite sides of the line (p_a p_b). Suppose not. Then (p_i,p_k) lie on the same side of the line (p_a p_b). Put coordinates so that
+[
+p_a=(-1,0),\qquad p_b=(1,0),
+]
+and the perpendicular bisector is the (y)-axis. Then
+[
+p_i=(0,s),\qquad p_k=(0,t)
+]
+with (s,t) on the same side of (0). If (0<t<s), then (p_k) lies strictly inside the triangle with vertices (p_a,p_b,p_i). If (0<s<t), then (p_i) lies strictly inside the triangle with vertices (p_a,p_b,p_k). If one of (s,t) is (0), then one of (p_i,p_k) lies on the segment (p_a p_b).
+
+This is the exact point where strict convexity is used: in a strictly convex polygon, every listed vertex is an extreme point of the convex hull; no vertex may lie in the interior of the triangle formed by three other vertices, and no vertex may lie on the segment between two other vertices. Therefore (p_i,p_k) cannot be on the same side of the line (p_a p_b).
+
+Thus (p_i,p_k) lie on opposite sides of the line (p_a p_b), while (p_a,p_b) lie on opposite sides of the line (p_i p_k). Hence the two segments (p_i p_k) and (p_a p_b) cross. For four vertices of a strictly convex polygon, crossing of the two chords is equivalent to cyclic alternation of the endpoints, so ({i,k}) separates ({a,b}). (\square)
+
+---
+
+## 2. Exact theorem proved here
+
+The full contradiction cannot be derived from facts (A) and (B) alone. In fact, there are cyclic (0)-(1) matrices with all row sums equal to (4) satisfying both (A) and (B). Therefore, any proof of geometric nonexistence must use additional metric information beyond (A) and (B).
+
+Here is the sharp matrix-level theorem.
+
+**Theorem.** Let (R_i\subset \mathbb Z_n\setminus{i}) be row supports of a cyclically indexed (0)-(1) matrix satisfying:
+
+[
+\text{(A)}\qquad |R_i\cap R_k|\le 2\quad\text{for }i\ne k,
+]
+and
+[
+\text{(B)}\qquad \text{if }R_i\cap R_k={a,b},\text{ then }{i,k}\text{ separates }{a,b}.
+]
+
+Let (d_i=|R_i|). Then
+[
+\sum_i \binom{d_i}{2}\le n(n-2).
+]
+Consequently, if every (d_i\ge 4), then (n\ge 8).
+
+This is sharp at the level of (A) and (B): for every (n\ge 8), there is such a cyclic matrix with every row sum exactly (4).
+
+A useful incidence bound also follows. If (m=\sum_i d_i), then
+[
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+For an unordered column pair (e={a,b}), define
+[
+\lambda(e)=|{i: a,b\in R_i}|.
+]
+Think of each row (R_i) sending one unit of charge to every unordered pair of columns inside (R_i). Then the total charge is
+[
+Q=\sum_i \binom{d_i}{2}
+=\sum_{{a,b}}\lambda({a,b}).
+]
+
+### Forbidden cyclic submatrices
+
+The following are immediate consequences of (A) and (B).
+
+**Forbidden pattern 1: (2\times 3) all-ones.**
+For two distinct rows (i,k), three common columns are impossible:
+[
+\begin{array}{c|ccc}
+& a&b&c\ \hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+]
+because this violates (A).
+
+**Forbidden pattern 2: noncrossing (2\times 2) all-ones.**
+If two rows (i,k) share two columns (a,b), then the cyclic order must alternate. Thus the pattern
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+is forbidden whenever (a,b) lie in the same open cyclic interval cut out by (i,k). Equivalently, after cyclic rotation, orders such as
+[
+i<k<a<b
+\qquad\text{or}\qquad
+i<a<b<k
+]
+are forbidden. The only allowed case is alternation:
+[
+i<a<k<b
+\quad\text{or}\quad
+i<b<k<a.
+]
+
+**Forbidden pattern 3: adjacent-column (2\times 2) all-ones.**
+If (a,a+1) are adjacent cyclic columns, then no two rows can both contain them:
+[
+\begin{array}{c|cc}
+& a&a+1\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+is forbidden. Indeed, ({a,a+1}) cannot be separated by any pair ({i,k}), because one of the two cyclic intervals between (a) and (a+1) is empty.
+
+**Forbidden pattern 4: (3\times 2) all-ones.**
+Three rows cannot all contain the same two columns:
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1\
+\ell&1&1
+\end{array}
+]
+because the two arcs cut out by (a,b) cannot place three row indices pairwise on opposite sides. Two of (i,k,\ell) must lie in the same arc, and that pair would fail the crossing condition (B).
+
+So every adjacent column pair has capacity at most (1), and every nonadjacent column pair has capacity at most (2). There are (n) adjacent unordered column pairs and (\binom n2-n) nonadjacent unordered column pairs. Therefore
+[
+Q
+=\sum_{{a,b}}\lambda({a,b})
+\le n+2\left(\binom n2-n\right)
+=n(n-2).
+]
+Hence
+[
+\boxed{\sum_i\binom{d_i}{2}\le n(n-2).}
+]
+
+If every (d_i\ge 4), then every row sends at least (\binom42=6) units of charge, so
+[
+6n\le \sum_i\binom{d_i}{2}\le n(n-2).
+]
+Thus
+[
+6\le n-2,
+]
+so
+[
+\boxed{n\ge 8.}
+]
+
+The incidence bound follows from Cauchy:
+[
+\sum_i\binom{d_i}{2}
+=\frac12\left(\sum_i d_i^2-\sum_i d_i\right)
+\ge \frac12\left(\frac{m^2}{n}-m\right).
+]
+Combining this with (\sum_i\binom{d_i}{2}\le n(n-2)) gives
+[
+\frac12\left(\frac{m^2}{n}-m\right)\le n(n-2),
+]
+so
+[
+m^2-nm-2n^2(n-2)\le 0.
+]
+Solving the quadratic inequality,
+[
+\boxed{
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+There is also a dual version. If (c_j) is the column sum of column (j), then
+[
+\sum_j\binom{c_j}{2}
+=\sum_{i<k}|R_i\cap R_k|
+\le n(n-2),
+]
+because adjacent row pairs can share at most one column, while nonadjacent row pairs can share at most two.
+
+For (n=8), the inequalities force a strong structure: if all row sums are at least (4), then in fact every row sum and every column sum is exactly (4), every adjacent column pair occurs in exactly one row, every nonadjacent column pair occurs in exactly two rows, every adjacent row pair intersects in exactly one column, and every nonadjacent row pair intersects in exactly two columns.
+
+### Sharpness: matrices satisfying (A), (B), and row sum (4)
+
+For every (n\ge 8), define
+[
+R_i={i-3,\ i-1,\ i+1,\ i+2}\pmod n.
+]
+Equivalently,
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\equiv -3,-1,1,2\pmod n.
+]
+Every row has size (4).
+
+It remains to check (A) and (B). By translation, compare (R_0) with (R_t). Let
+[
+D={-3,-1,1,2}.
+]
+Then
+[
+R_0\cap R_t=D\cap(t+D).
+]
+For (n\ge 11), the only shifts with intersection size (2) are
+[
+t=2,\qquad R_0\cap R_2={-1,1},
+]
+and
+[
+t=n-2,\qquad R_0\cap R_{n-2}={-3,-1}.
+]
+In both cases, the two shared columns lie one on each side of the row pair, so the crossing condition holds.
+
+For (n=8,9,10), the exceptional shifts are finite and are checked directly:
+
+[
+\begin{array}{c|c|c}
+n&t&R_0\cap R_t\ \hline
+8&2&{7,1}\
+8&3&{2,5}\
+8&4&{1,5}\
+8&5&{2,7}\
+8&6&{5,7}\ \hline
+9&2&{8,1}\
+9&4&{1,6}\
+9&5&{2,6}\
+9&7&{6,8}\ \hline
+10&2&{9,1}\
+10&5&{2,7}\
+10&8&{7,9}
+\end{array}
+]
+
+In every listed case, one common column lies in the open interval from (0) to (t), and the other lies in the complementary open interval. Thus ({0,t}) separates the shared column pair. All omitted shifts have intersection size at most (1). Therefore (A) and (B) both hold.
+
+For (n=8), the matrix is explicitly
+[
+\begin{array}{c|cccccccc}
+&0&1&2&3&4&5&6&7\ \hline
+0&0&1&1&0&0&1&0&1\
+1&1&0&1&1&0&0&1&0\
+2&0&1&0&1&1&0&0&1\
+3&1&0&1&0&1&1&0&0\
+4&0&1&0&1&0&1&1&0\
+5&0&0&1&0&1&0&1&1\
+6&1&0&0&1&0&1&0&1\
+7&1&1&0&0&1&0&1&0
+\end{array}
+]
+and it satisfies all matrix-level constraints. Hence no contradiction can follow from (A) and (B) alone.
+
+This particular circulant family is not necessarily geometrically realizable. In fact, if it were realized geometrically, the row condition would give
+[
+|p_i p_{i-1}|=|p_i p_{i+1}|=|p_i p_{i+2}|
+]
+for every (i). The first equality forces all side lengths to be equal, and then (|p_i p_{i+2}|=|p_i p_{i+1}|) makes every triangle (p_i p_{i+1}p_{i+2}) equilateral. Thus every interior angle would be (60^\circ), impossible for a strictly convex (n)-gon with (n\ge 4). This uses metric information not contained in (A) or (B).
+
+---
+
+## 4. Configurations still unresolved by the A/B method
+
+The following patterns survive the crossing/discharging argument. I do not claim they are geometrically realizable; the point is that (A) and (B) alone do not rule them out.
+
+### Unresolved pattern 1: linked (2\times2) block
+
+For cyclic order
+[
+i<a<k<b,
+]
+the block
+[
+\begin{array}{c|cc}
+&a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+is allowed by (B), because (p_i p_k) crosses (p_a p_b). Any proof must use more than the crossing lemma to eliminate such a block.
+
+### Unresolved pattern 2: alternating four-row block
+
+For cyclic order
+[
+a<b<c<d,
+]
+the pattern
+[
+\begin{array}{c|cccc}
+&a&b&c&d\ \hline
+a&0&1&0&1\
+b&1&0&1&0\
+c&0&1&0&1\
+d&1&0&1&0
+\end{array}
+]
+is compatible with (A) and (B). The row pair ({a,c}) shares columns ({b,d}), and the row pair ({b,d}) shares columns ({a,c}); both are crossing pairs.
+
+### Unresolved pattern 3: a Sidon-type cyclic pattern where (B) is vacuous
+
+For (n\ge 15), define
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\equiv 1,2,4,8\pmod n.
+]
+Then every row has size (4), and two distinct rows share at most one column. Indeed, the ordered differences among ({1,2,4,8}) are
+[
+\pm1,\ \pm2,\ \pm3,\ \pm4,\ \pm6,\ \pm7,
+]
+all distinct modulo (n) for (n\ge 15). Therefore there is no (2\times2) all-one submatrix at all, so (B) never even triggers. This family is completely invisible to the crossing-discharge argument.
+
+A geometric proof of full nonexistence would need extra input beyond (A) and (B), for example the actual metric equalities
+[
+|p_i-p_{i+1}|=|p_i-p_{i+2}|=|p_i-p_{i+4}|=|p_i-p_{i+8}|
+]
+and their interaction with strict convexity.

--- a/incoming/chatgpt-runs/run-13.md
+++ b/incoming/chatgpt-runs/run-13.md
@@ -1,0 +1,510 @@
+## 1. Convex-position crossing lemma
+
+Let the vertices be in strictly convex position and let (i\ne k). Suppose
+
+[
+a,b\in S_i\cap S_k,\qquad a\ne b.
+]
+
+Thus
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+So (p_a,p_b) are the two common points of the two circles centered at (p_i,p_k).
+
+### Lemma B
+
+If (S_i\cap S_k={a,b}), then the endpoints (i,k,a,b) alternate in the cyclic order. Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+### Proof
+
+Let (L) be the line through (p_i,p_k). Reflection in (L) fixes both circle centers (p_i,p_k), hence fixes both circles. Therefore it preserves their intersection set ({p_a,p_b}). Since (p_a\ne p_b), reflection in (L) interchanges them. Thus (p_a,p_b) are mirror images across (L), and the segment (p_ap_b) is perpendicular to (L).
+
+Choose coordinates with
+
+[
+p_i=(0,0),\qquad p_k=(d,0),\qquad d>0,
+]
+
+and write
+
+[
+p_a=(t,h),\qquad p_b=(t,-h),
+]
+
+with (h\ne 0). The chord (p_ap_b) crosses the line (L) at ((t,0)). We must show
+
+[
+0<t<d.
+]
+
+This is the exact place where strict convexity is used.
+
+If (t=0), then (p_i) lies on the segment (p_ap_b), contradicting strict convexity: no vertex of a strictly convex polygon lies on a segment joining two other vertices. Similarly, (t=d) would put (p_k) on the segment (p_ap_b), again impossible.
+
+If (t<0), then (p_i) lies in the interior of the triangle with vertices (p_k,p_a,p_b). Indeed,
+
+[
+p_i=\alpha p_k+\beta p_a+\beta p_b
+]
+
+with
+
+[
+\alpha=\frac{-t}{d-t}>0,\qquad \beta=\frac{d}{2(d-t)}>0,\qquad \alpha+2\beta=1.
+]
+
+So (p_i) is a convex combination with all positive coefficients, contradicting that (p_i) is an extreme vertex of the convex polygon.
+
+Likewise, if (t>d), then (p_k) lies in the interior of the triangle with vertices (p_i,p_a,p_b), since
+
+[
+p_k=\alpha p_i+\beta p_a+\beta p_b
+]
+
+with
+
+[
+\beta=\frac{d}{2t}>0,\qquad \alpha=1-\frac dt>0.
+]
+
+Again this contradicts strict convexity/convex position.
+
+Therefore (0<t<d). Hence the segment (p_ip_k) crosses the segment (p_ap_b) at ((t,0)). In a strictly convex polygon, two chords cross in their interiors exactly when their endpoints alternate in the cyclic order. Thus the pair ({i,k}) separates the pair ({a,b}). ∎
+
+---
+
+## 2. Exact theorem proved
+
+The full contradiction does **not** follow from facts (A) and (B) alone. The strongest general cyclic-matrix theorem I can prove from them is the following.
+
+Let (M) be a zero-diagonal cyclic (0)-(1) matrix satisfying:
+
+1. for all (i\ne k),
+
+[
+|S_i\cap S_k|\le 2;
+]
+
+2. if (S_i\cap S_k={a,b}), then ({i,k}) separates ({a,b}) cyclically.
+
+Let
+
+[
+m_i=|S_i|
+]
+
+be the row sums. Then
+
+[
+\boxed{\sum_{i=1}^n \binom{m_i}{2}\le n(n-2).}
+]
+
+Consequently, if every row has size at least (4), then
+
+[
+6n\le \sum_i \binom{m_i}{2}\le n(n-2),
+]
+
+so
+
+[
+\boxed{n\ge 8.}
+]
+
+More precisely,
+
+[
+\boxed{\sum_i (m_i-4)(m_i+3)\le 2n(n-8).}
+]
+
+Thus, for (n=8), every row must have size exactly (4), and every capacity in the counting argument below must be saturated.
+
+There is no contradiction for (n\ge 8) from (A) and (B) alone: explicit cyclic matrices satisfying both facts and having all row sums (4) exist.
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+Write indices modulo (n). Say that two indices (a,b) are adjacent if they are consecutive in the cyclic order.
+
+### Forbidden submatrices
+
+Facts (A) and (B) imply the following forbidden (0)-(1) patterns.
+
+First, by (A), no two rows can share three columns:
+
+[
+\begin{array}{c|ccc}
+& a&b&c\ \hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+]
+
+is forbidden.
+
+Second, by (B), a (2\times 2) all-one submatrix is allowed only if the row pair crosses the column pair. Thus
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is forbidden whenever ({i,k}) and ({a,b}) do not alternate cyclically.
+
+In particular, adjacent rows cannot share two columns:
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+i+1&1&1
+\end{array}
+]
+
+is forbidden, because the boundary edge (p_ip_{i+1}) crosses no chord.
+
+Dually, adjacent columns cannot occur together in two rows:
+
+[
+\begin{array}{c|cc}
+& a&a+1\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is forbidden, because the boundary edge (p_ap_{a+1}) crosses no chord.
+
+Finally, no three rows can contain the same two columns:
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1\
+\ell&1&1
+\end{array}
+]
+
+is forbidden. Indeed, if three rows all contain (a,b), then any two of those row indices must be separated by ({a,b}). But the pair ({a,b}) cuts the remaining vertices into two arcs, and among three row indices two lie on the same arc. Those two are not separated by ({a,b}), contradiction.
+
+### Pair-charge inequality
+
+Charge each row (i) one unit for every unordered pair of columns inside (S_i). The total charge is
+
+[
+\sum_i \binom{m_i}{2}.
+]
+
+Now fix a column pair ({a,b}). Let
+
+[
+d(a,b)=|{i:a,b\in S_i}|.
+]
+
+If (a,b) are adjacent, then (d(a,b)\le 1). If they are nonadjacent, then (d(a,b)\le 2), by the forbidden (3\times 2) pattern above.
+
+There are (n) adjacent column pairs and (\binom n2-n) nonadjacent column pairs. Therefore
+
+[
+\sum_i \binom{m_i}{2}
+=\sum_{{a,b}} d(a,b)
+\le n+2\left(\binom n2-n\right)
+=n(n-2).
+]
+
+This proves the main inequality.
+
+A dual inequality also follows. If (c_j) denotes the column sum of column (j), then
+
+[
+\boxed{\sum_j \binom{c_j}{2}\le n(n-2).}
+]
+
+Indeed, adjacent row pairs have intersection at most (1), and nonadjacent row pairs have intersection at most (2).
+
+### Consequences for row sums
+
+If (m_i\ge 4) for every (i), then
+
+[
+\binom{m_i}{2}\ge 6,
+]
+
+so
+
+[
+6n\le \sum_i \binom{m_i}{2}\le n(n-2),
+]
+
+hence (n\ge 8).
+
+Equivalently,
+
+[
+\sum_i\left(\binom{m_i}{2}-6\right)\le n(n-2)-6n=n(n-8),
+]
+
+and since
+
+[
+\binom{m_i}{2}-6=\frac{(m_i-4)(m_i+3)}2,
+]
+
+we get
+
+[
+\sum_i (m_i-4)(m_i+3)\le 2n(n-8).
+]
+
+Thus for (n=8), every (m_i=4), every adjacent column pair occurs in exactly one row, and every nonadjacent column pair occurs in exactly two rows. By the dual inequality, every column also has sum (4), adjacent row pairs intersect in exactly one column, and nonadjacent row pairs intersect in exactly two columns.
+
+A weaker but sometimes useful bound on the total number of ones (T=\sum_i m_i) is obtained from Jensen/Cauchy:
+
+[
+\sum_i \binom{m_i}{2}
+=\frac12\left(\sum_i m_i^2-T\right)
+\ge \frac12\left(\frac{T^2}{n}-T\right).
+]
+
+Together with (\sum_i \binom{m_i}{2}\le n(n-2)), this gives
+
+[
+\boxed{T\le \frac n2\left(1+\sqrt{8n-15}\right).}
+]
+
+This is only (O(n^{3/2})), not linear.
+
+### A small sharpening for row sums at least (5)
+
+The same counting gives
+
+[
+10n\le n(n-2),
+]
+
+so (n\ge 12). In fact (n=12) is impossible as a cyclic matrix satisfying (A) and (B).
+
+If (n=12) and all row sums were at least (5), equality would hold everywhere. Thus every row and every column would have sum (5), adjacent row pairs would intersect in (1) column, and nonadjacent row pairs would intersect in (2) columns.
+
+Then the Gram matrix (G=MM^T) would satisfy
+
+[
+G=2J+3I-A,
+]
+
+where (J) is the all-one matrix and (A) is the adjacency matrix of the (12)-cycle. The eigenvalues of (A) are (2\cos(2\pi k/12)). Hence the eigenvalues of (G) are
+
+[
+25
+]
+
+on the all-one vector, and
+
+[
+3-2\cos(2\pi k/12),\qquad k=1,\dots,11,
+]
+
+on the orthogonal complement. Therefore
+
+[
+\det G
+=25\prod_{k=1}^{11}\left(3-2\cos\frac{2\pi k}{12}\right)
+=2^8,3^4,5^3.
+]
+
+This is not a perfect square. But (G=MM^T) with (M) an integer square matrix, so
+
+[
+\det G=(\det M)^2
+]
+
+must be a perfect square integer. Contradiction. Thus all row sums at least (5) force
+
+[
+\boxed{n\ge 13}
+]
+
+as a purely cyclic-matrix consequence.
+
+---
+
+## 4. Why the full contradiction does not follow from (A) and (B)
+
+The following cyclic (8\times 8) matrix satisfies all consequences of (A) and (B), with every row sum exactly (4). Define
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod 8\in{1,2,5,7}.
+]
+
+Equivalently,
+
+[
+\begin{aligned}
+S_0&={1,2,5,7},\
+S_1&={0,2,3,6},\
+S_2&={1,3,4,7},\
+S_3&={0,2,4,5},\
+S_4&={1,3,5,6},\
+S_5&={2,4,6,7},\
+S_6&={0,3,5,7},\
+S_7&={0,1,4,6}.
+\end{aligned}
+]
+
+Because the matrix is circulant, it suffices to compare row (0) with row (h). With (D={1,2,5,7}),
+
+[
+S_0\cap S_h=D\cap(h+D).
+]
+
+The intersections are
+
+[
+\begin{array}{c|c}
+h & S_0\cap S_h\ \hline
+1&{2}\
+2&{1,7}\
+3&{2,5}\
+4&{1,5}\
+5&{2,7}\
+6&{5,7}\
+7&{1}.
+\end{array}
+]
+
+For (h=2,3,4,5,6), the two common columns lie on opposite sides of the chord ({0,h}), so condition (B) is satisfied. For (h=1,7), the adjacent rows share only one column. Thus this matrix satisfies (A) and (B), and all row sums are (4).
+
+Its mirror image also works:
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod 8\in{1,3,6,7}.
+]
+
+So facts (A) and (B) alone cannot prove the desired contradiction.
+
+There are even larger examples. For row sum (5), define a (13\times 13) circulant matrix by
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod {13}\in{1,2,5,10,12}.
+]
+
+The only row differences (h) producing two common columns are
+
+[
+\begin{array}{c|c}
+h & S_0\cap S_h\ \hline
+2&{1,12}\
+3&{2,5}\
+4&{1,5}\
+5&{2,10}\
+8&{5,10}\
+9&{1,10}\
+10&{2,12}\
+11&{10,12}.
+\end{array}
+]
+
+Each listed pair separates ({0,h}), so (B) holds. Thus the (n\ge 13) threshold for row sums at least (5) is sharp as a cyclic-matrix statement.
+
+More strongly, for any (r), choose (n>2^r) and define
+
+[
+D_r={1,2,4,\dots,2^{r-1}}\subset \mathbb Z/n\mathbb Z,
+]
+
+then set
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod n\in D_r.
+]
+
+Every row has sum (r). Moreover, two distinct rows share at most one column. Indeed, a two-column intersection would give two representations of the same nonzero cyclic difference as
+
+[
+2^a-2^b\pmod n.
+]
+
+Because (n>2^r), this congruence is an equality over the integers, and powers of two have unique nonzero differences: if
+
+[
+2^a-2^b=2^c-2^d,
+]
+
+then comparing signs and (2)-adic valuations gives (a=c) and (b=d). Hence no row pair has intersection (2), so (B) is vacuous. These matrices satisfy (A) and (B) with arbitrarily large row sums.
+
+Thus the full geometric contradiction, if true, needs additional geometric input beyond (A) and (B).
+
+### Extra geometric input for the (8\times 8) obstruction
+
+The displayed (8\times 8) circulant patterns themselves are not geometrically realizable. For the first one,
+
+[
+S_i={i+1,i+2,i+5,i+7}
+={i+1,i+2,i-3,i-1}.
+]
+
+Since (i-1,i+1\in S_i),
+
+[
+|p_i-p_{i-1}|=|p_i-p_{i+1}|.
+]
+
+Thus all side lengths of the polygon are equal. Also (i+1,i+2\in S_i), so
+
+[
+|p_i-p_{i+1}|=|p_i-p_{i+2}|.
+]
+
+But the side (p_{i+1}p_{i+2}) has the same common side length, so every triangle
+
+[
+p_i p_{i+1} p_{i+2}
+]
+
+is equilateral. Hence every interior angle of the octagon would be (60^\circ), impossible because the interior angle sum of a convex octagon is (6\pi=1080^\circ). The mirror pattern is ruled out similarly.
+
+This argument uses the full metric meaning of the rows, not merely (A) and (B).
+
+---
+
+## 5. Remaining unresolved configurations
+
+The matrix/discharging method leaves the following exact (0)-(1) patterns unresolved as cyclic matrices. They are not asserted to be realizable by convex polygons; they are obstructions to any proof using only (A) and (B).
+
+The cleanest row-sum-(4) unresolved family is
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod n\in{1,2,4,8},
+\qquad n>16.
+]
+
+Every row has size (4), every two rows share at most one column, and therefore (B) is vacuous.
+
+More generally,
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod n\in{1,2,4,\dots,2^{r-1}},
+\qquad n>2^r,
+]
+
+gives row sum (r) and satisfies (A) and (B). These Sidon-type circulant patterns show that the crossing lemma and the pair-intersection bound alone cannot yield the desired nonexistence theorem.

--- a/incoming/chatgpt-runs/run-14.md
+++ b/incoming/chatgpt-runs/run-14.md
@@ -1,0 +1,419 @@
+## 1. Convex-position crossing lemma
+
+Let the cyclic order be fixed, and say that two unordered pairs ({x,y}) and ({u,v}) **separate** each other if, going around the polygon, their endpoints alternate; equivalently the chord (p_xp_y) crosses the chord (p_up_v) in its relative interior.
+
+### Lemma B
+
+If (S_i\cap S_k={a,b}) with (i\ne k), then ({i,k}) separates ({a,b}). Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+### Proof
+
+Because (a,b\in S_i), we have
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i.
+]
+
+Because (a,b\in S_k), we also have
+
+[
+|p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of the segment (p_ap_b). Since (p_i\ne p_k), the line
+
+[
+L=\overleftrightarrow{p_ip_k}
+]
+
+is exactly that perpendicular bisector. Equivalently, if (C_i) and (C_k) are the two circles centered at (p_i,p_k), then (p_ap_b) is their common chord, hence their radical axis, and the line of centers (p_ip_k) is perpendicular to that radical axis. Therefore (p_a) and (p_b) are reflections of one another across (L).
+
+So (p_a) and (p_b) lie in opposite open half-planes bounded by (L). They cannot lie on (L), because reflection across (L) fixes points of (L), which would force (p_a=p_b).
+
+Now use strict convexity. For a strictly convex polygon, the line through two vertices (p_i,p_k) contains no other vertex, and the two polygonal boundary chains from (p_i) to (p_k) lie in the two opposite open half-planes bounded by (L). This is the exact point where strict convexity is invoked: without strict convexity, another vertex could lie on the chord line (L), and the open-half-plane separation of the two cyclic arcs could fail.
+
+Since (p_a) and (p_b) are in opposite open half-planes of (L), they belong to opposite cyclic arcs between (i) and (k). Hence the cyclic order alternates:
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a,
+]
+
+up to reversal and rotation. Thus ({i,k}) separates ({a,b}), and the chords (p_ip_k) and (p_ap_b) cross. (\square)
+
+---
+
+## 2. Exact theorem proved
+
+Let (M) be any cyclically indexed (0)-(1) matrix with (M_{ii}=0), satisfying:
+
+[
+\tag{A} |S_i\cap S_k|\le 2\quad\text{for }i\ne k,
+]
+
+and
+
+[
+\tag{B} \text{if }S_i\cap S_k={a,b},\text{ then }{i,k}\text{ separates }{a,b}.
+]
+
+Then:
+
+[
+\boxed{\sum_{i=1}^n \binom{|S_i|}{2}\le n(n-2).}
+]
+
+Consequently, if every row has size at least (4), then
+
+[
+6n\le \sum_i \binom{|S_i|}{2}\le n(n-2),
+]
+
+so necessarily
+
+[
+\boxed{n\ge 8.}
+]
+
+Moreover, this is sharp at the level of facts (A) and (B): for every (n\ge 8), there exists a cyclic matrix satisfying (A) and (B) with every row having size exactly (4). Thus no contradiction can be derived from (A) and (B) alone. Any proof of geometric nonexistence must use additional metric information beyond the two stated facts.
+
+A useful corollary is the edge bound
+
+[
+\boxed{\sum_i |S_i|
+\le \frac n2\left(1+\sqrt{8n-15}\right).}
+]
+
+This is only an (O(n^{3/2})) bound, so it is far too weak to contradict (\sum_i |S_i|\ge 4n) for large (n).
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+For an unordered column-pair ({a,b}), define
+
+[
+m_{ab}:=#{i:\ a,b\in S_i}.
+]
+
+Think of each row (i) as placing one unit of charge on every unordered pair inside (S_i). Thus row (i) contributes
+
+[
+\binom{|S_i|}{2}
+]
+
+charges, and the total charge is
+
+[
+\sum_i \binom{|S_i|}{2}
+=======================
+
+\sum_{{a,b}} m_{ab}.
+]
+
+We now bound the capacity of each column-pair ({a,b}).
+
+Fix two columns (a,b). Suppose two distinct rows (i,k) both contain (a,b). Then (S_i\cap S_k) contains ({a,b}), so by (A) their intersection is exactly ({a,b}). By (B), the pair ({i,k}) must separate ({a,b}). Therefore (i) and (k) must lie on opposite cyclic arcs between (a) and (b).
+
+Hence:
+
+[
+\boxed{\text{At most one row from each cyclic side of }{a,b}\text{ may contain both }a,b.}
+]
+
+So if (a,b) are adjacent columns, one cyclic side is empty, and therefore
+
+[
+m_{ab}\le 1.
+]
+
+If (a,b) are nonadjacent, both cyclic sides are nonempty, and therefore
+
+[
+m_{ab}\le 2.
+]
+
+There are exactly (n) adjacent column-pairs and
+
+[
+\binom n2-n
+]
+
+nonadjacent column-pairs. Therefore
+
+[
+\sum_i \binom{|S_i|}{2}
+=======================
+
+\sum_{{a,b}}m_{ab}
+\le
+n+2\left(\binom n2-n\right)
+===========================
+
+n(n-2).
+]
+
+This proves the main discharging inequality.
+
+If (|S_i|\ge 4) for every (i), then each row contributes at least
+
+[
+\binom42=6
+]
+
+charges, so
+
+[
+6n\le n(n-2),
+]
+
+hence (n\ge 8).
+
+For the bound on (\sum_i |S_i|), write
+
+[
+E:=\sum_i |S_i|.
+]
+
+By Cauchy,
+
+[
+\sum_i |S_i|^2\ge \frac{E^2}{n}.
+]
+
+Since
+
+[
+\sum_i \binom{|S_i|}{2}
+=======================
+
+\frac12\left(\sum_i |S_i|^2-E\right),
+]
+
+we get
+
+[
+\frac12\left(\frac{E^2}{n}-E\right)
+\le n(n-2).
+]
+
+Solving the resulting quadratic inequality gives
+
+[
+E\le \frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+---
+
+### Forbidden cyclic (0)-(1) submatrices
+
+The following configurations are forbidden by (A) and (B).
+
+#### Noncrossing (2\times 2) all-one rectangle
+
+If rows (i,k) and columns (a,b) satisfy
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+then ({i,k}) must separate ({a,b}). Thus the only allowed cyclic orders are
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a,
+]
+
+up to reversal. The nonalternating orders are forbidden.
+
+In particular:
+
+[
+\boxed{\text{Adjacent rows cannot share two columns.}}
+]
+
+and
+
+[
+\boxed{\text{Adjacent columns cannot occur together in two rows.}}
+]
+
+#### (2\times 3) all-one rectangle
+
+Two rows cannot share three columns, because that violates (A):
+
+[
+\begin{array}{c|ccc}
+& a & b & c\ \hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+is forbidden.
+
+#### (3\times 2) all-one rectangle
+
+Three rows cannot all contain the same two columns:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+Indeed, among three row indices (i,k,\ell), two lie on the same cyclic side of ({a,b}). Those two rows would contain both (a,b), but their pair would not separate ({a,b}), contradicting (B).
+
+---
+
+### Sharpness: a cyclic countermodel for every (n\ge 8)
+
+Index rows and columns by (\mathbb Z_n), cyclically. For (n\ge 8), define
+
+[
+S_i={i+1,\ i+2,\ i-1,\ i-3}\pmod n.
+]
+
+Equivalently,
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\in {1,2,-1,-3}\pmod n.
+]
+
+Every row has size (4), and (M_{ii}=0).
+
+Let
+
+[
+D={1,2,-1,-3}.
+]
+
+For rows (0) and (t), the common columns are
+
+[
+D\cap(t+D).
+]
+
+The difference multiset (D-D) has multiplicity at most (2) modulo (n) for (n\ge 8), so every two rows intersect in at most (2) columns. The only offsets (t) giving intersection size (2) are as follows:
+
+[
+\begin{array}{c|c|c}
+n & t & D\cap(t+D)\ \hline
+8 & 2,3,4,5,6
+& {1,-1},{2,-3},{1,-3},{2,-1},{-3,-1}\
+9 & 2,4,5,7
+& {1,-1},{1,-3},{2,-3},{-3,-1}\
+10 & 2,5,8
+& {1,-1},{2,-3},{-3,-1}\
+\ge 11 & 2,n-2
+& {1,-1},{-3,-1}
+\end{array}
+]
+
+In each listed case, one common column lies in the open cyclic interval from (0) to (t), and the other lies in the complementary interval from (t) back to (0). Thus the two common columns are separated by the two row indices. Therefore (B) holds.
+
+So the abstract cyclic-matrix model satisfying (A) and (B) admits row sum (4) for every (n\ge 8). Hence (A) and (B) alone cannot prove the desired contradiction.
+
+---
+
+## 4. Remaining unresolved configurations and exact patterns
+
+The obstruction is that (A) and (B) only control repeated column-pairs. They say almost nothing about rows whose internal pairs are mostly private.
+
+### Unresolved pattern 1: the (n=8) circulant pattern
+
+For (n=8), the sharp countermodel has row template
+
+[
+01100101,
+]
+
+meaning row (i) has ones in columns
+
+[
+i+1,\ i+2,\ i+5,\ i+7
+\pmod 8.
+]
+
+Explicitly,
+
+[
+S_i={i+1,i+2,i-3,i-1}.
+]
+
+This satisfies every cyclic consequence of (A) and (B), but it is not automatically geometrically realizable. In fact, ruling it out geometrically requires extra metric information: if this exact pattern came from distances, then each row would force
+
+[
+|p_i p_{i+1}|=|p_i p_{i-1}|=|p_i p_{i+2}|,
+]
+
+so all side lengths would be equal and every consecutive triple (p_i,p_{i+1},p_{i+2}) would form an equilateral triangle. A strictly convex octagon cannot have all exterior angles (60^\circ), because the total exterior angle sum must be (360^\circ). This argument uses actual distance equalities, not merely (A) and (B).
+
+### Unresolved pattern 2: linear (4)-uniform patterns
+
+Any cyclic matrix with
+
+[
+|S_i|=4
+]
+
+and
+
+[
+|S_i\cap S_k|\le 1
+\quad\text{for all }i\ne k
+]
+
+automatically satisfies (A), while (B) is vacuous. Thus such patterns are completely invisible to the crossing lemma.
+
+A concrete exact example on (13) cyclic indices is
+
+[
+S_i={i+1,\ i+2,\ i+4,\ i+10}\pmod {13}.
+]
+
+The row template is
+
+[
+0110100000100.
+]
+
+The difference set ({1,2,4,10}\subset \mathbb Z_{13}) has the property that every nonzero difference occurs exactly once, so distinct rows intersect in exactly one column. Hence (A) holds and (B) never fires. Whether such a pattern can arise from an actual strictly convex distance configuration requires additional geometry beyond the two supplied facts.
+
+### Unresolved pattern 3: the three-row Pasch-type pattern
+
+The following (3\times 6) pattern is not forbidden by (A) and (B) alone:
+
+[
+\begin{array}{c|cccccc}
+& a_1&a_2&b_1&b_2&c_1&c_2\ \hline
+R_1 & 1&1&0&0&1&1\
+R_2 & 1&1&1&1&0&0\
+R_3 & 0&0&1&1&1&1
+\end{array}
+]
+
+Here each pair of rows shares exactly two columns, but the three shared column-pairs are distinct. The crossing lemma merely requires each shared pair to separate the corresponding row-pair. There are cyclic placements satisfying those separation requirements, so this pattern is not eliminated by the current matrix argument.
+
+---
+
+The conclusion is therefore precise: the convex-position crossing lemma gives strong forbidden submatrices and the sharp discharging bound (n\ge 8) under minimum row size (4), but it does not prove geometric nonexistence. Any full contradiction must use further metric structure of equal distances, not just the circle-intersection bound (A) and the crossing rule (B).

--- a/incoming/chatgpt-runs/run-15.md
+++ b/incoming/chatgpt-runs/run-15.md
@@ -1,0 +1,305 @@
+I will use indices in (\mathbb Z_n) for the matrix part. Thus (i+1) means the next cyclic index, and (R_i:=S_i).
+
+## 1. Convex-position crossing lemma
+
+**Lemma.** Let (P={p_1,\dots,p_n}) be the vertices of a strictly convex polygon in cyclic order. Suppose (i\ne k), and suppose (S_i\cap S_k) contains two distinct indices (a,b). Then the pairs ({i,k}) and ({a,b}) separate each other in cyclic order. Equivalently, the chord (p_i p_k) crosses the chord (p_a p_b).
+
+**Proof.** Let (C_i) be the circle centered at (p_i) of radius (r_i), and let (C_k) be the circle centered at (p_k) of radius (r_k). Since (a,b\in S_i\cap S_k), the two points (p_a,p_b) lie on both circles.
+
+Let (L) be the line through (p_i) and (p_k). Reflection in (L) fixes both centers (p_i,p_k), and therefore preserves both circles (C_i,C_k). Hence it preserves their intersection. Since two distinct nonconcentric circles meet in at most two points, reflection in (L) must swap (p_a) and (p_b). Equivalently, (p_a) and (p_b) are mirror images across (L). In particular, (p_a) and (p_b) lie in opposite open half-planes bounded by (L), and the segment (p_a p_b) meets (L) at its midpoint.
+
+Now use strict convexity. For any chord (p_i p_k) of a strictly convex polygon, the two open polygonal chains from (p_i) to (p_k) lie in the two opposite open half-planes determined by the line (L=p_i p_k). The strictness is invoked exactly here: no vertex other than (p_i,p_k) is allowed to lie on (L), and no chain can cross to the other side of (L). Thus two vertices lying on opposite sides of (L) must lie on opposite cyclic arcs between (i) and (k).
+
+Since (p_a) and (p_b) are on opposite sides of (L), the indices (a,b) lie on different cyclic arcs between (i) and (k). Therefore ({i,k}) separates ({a,b}). In a convex quadrilateral, alternating endpoints are exactly the condition that the two chords cross, so (p_i p_k) crosses (p_a p_b). (\square)
+
+---
+
+## 2. The exact theorem proved from (A) and (B)
+
+The full desired contradiction does **not** follow from (A) and (B) alone. There are cyclic (0)-(1) matrices with all row sums equal to (4) satisfying both conditions. Therefore any proof of geometric nonexistence must use extra metric geometry beyond (A) and the crossing lemma.
+
+Here is the strongest general statement obtained from (A) and (B).
+
+**Theorem.** Let (M) be a zero-diagonal cyclic (n\times n) (0)-(1) matrix with row supports (R_i), satisfying:
+
+[
+|R_i\cap R_k|\le 2
+]
+
+for all (i\ne k), and whenever (R_i\cap R_k) contains two indices (a,b), the pair ({i,k}) separates ({a,b}) cyclically. Then:
+
+[
+\sum_{i=1}^n \binom{|R_i|}{2}\le n(n-2).
+]
+
+Consequently, if every row has size at least (4), then
+
+[
+6n\le n(n-2),
+]
+
+so necessarily
+
+[
+n\ge 8.
+]
+
+Moreover, if (n=8) and all row sums are at least (4), then in fact every row has size exactly (4), every column has size exactly (4), adjacent rows meet in exactly one column, nonadjacent rows meet in exactly two columns, and every row contains its two cyclic neighbors.
+
+So (A) and (B) prove nonexistence only for (n\le 7). They do not prove nonexistence in general.
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+Write (r_i=|R_i|). Think of row (i) as sending one unit of charge to each unordered pair of columns inside (R_i). Thus the total charge emitted is
+
+[
+\sum_i \binom{r_i}{2}.
+]
+
+We now bound how much charge any fixed unordered column pair ({a,b}) can receive.
+
+### Forbidden (2\times 2) pattern
+
+Suppose two rows (i,k) both contain two columns (a,b). Then the (2\times 2) submatrix on rows (i,k) and columns (a,b) is all (1)’s. By (B), the cyclic order of the four indices must alternate:
+
+[
+i,\ a,\ k,\ b
+]
+
+or
+
+[
+i,\ b,\ k,\ a.
+]
+
+Thus the following is forbidden:
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+whenever the row pair ({i,k}) does **not** separate the column pair ({a,b}).
+
+In particular:
+
+* adjacent rows cannot share two columns;
+* adjacent columns cannot occur together in two different rows.
+
+### Forbidden (2\times 3) pattern
+
+Fact (A) gives immediately:
+
+[
+\begin{array}{c|ccc}
+& a & b & c\ \hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+is impossible for (i\ne k). Two rows cannot have three common (1)’s.
+
+### Forbidden (3\times 2) pattern
+
+A second consequence of (B) is that three rows cannot all contain the same two columns. Indeed, suppose rows (i,k,\ell) all contain columns (a,b). Since the diagonal is zero, none of (i,k,\ell) equals (a) or (b). Removing (a,b) from the cycle leaves two arcs. Among three row indices, two must lie on the same arc. Those two rows do not separate (a,b), contradicting (B).
+
+Thus
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+is impossible.
+
+### Capacity count
+
+For a fixed column pair ({a,b}), let (m(a,b)) be the number of rows containing both (a) and (b).
+
+If (a,b) are adjacent cyclically, then (m(a,b)\le 1), because two rows containing both would give a forbidden (2\times2) pattern with adjacent columns.
+
+If (a,b) are nonadjacent, then (m(a,b)\le 2), because (m(a,b)\ge3) would give a forbidden (3\times2) pattern.
+
+There are (n) adjacent column pairs and (\binom n2-n) nonadjacent column pairs. Hence
+
+[
+\sum_i \binom{r_i}{2}
+=====================
+
+\sum_{{a,b}} m(a,b)
+\le
+n\cdot 1+\left(\binom n2-n\right)\cdot 2.
+]
+
+Therefore
+
+[
+\sum_i \binom{r_i}{2}
+\le
+n+n(n-3)
+========
+
+n(n-2).
+]
+
+If every (r_i\ge4), then (\binom{r_i}{2}\ge6), so
+
+[
+6n\le n(n-2),
+]
+
+and therefore (n\ge8).
+
+A useful corollary is the global bound
+
+[
+\sum_i |R_i|
+\le
+\frac n2\left(1+\sqrt{8n-15}\right).
+]
+
+Indeed, if (E=\sum_i r_i), convexity of (x\mapsto \binom{x}{2}) gives
+
+[
+\sum_i \binom{r_i}{2}
+\ge
+n\binom{E/n}{2}
+===============
+
+\frac{E^2}{2n}-\frac E2.
+]
+
+Combining this with (\sum_i \binom{r_i}{2}\le n(n-2)) and solving the resulting quadratic inequality gives the displayed bound.
+
+### The extremal (n=8) structure
+
+If (n=8) and every row has size at least (4), then the inequality is tight:
+
+[
+\sum_i \binom{r_i}{2}=8\cdot6=48=8(8-2).
+]
+
+Thus every row has size exactly (4), and every column-pair capacity is saturated. A symmetric row-pair count also gives every column size exactly (4), adjacent rows meet in exactly one column, and nonadjacent rows meet in exactly two columns.
+
+Now take rows (i-1) and (i+1). They are nonadjacent, so they share exactly two columns. By (B), one common column must lie on the short arc between (i-1) and (i+1), which consists only of (i). Therefore
+
+[
+i\in R_{i-1}\cap R_{i+1}.
+]
+
+Reindexing, every row (R_i) contains both (i-1) and (i+1).
+
+This is a genuine structural theorem, but it is still not a contradiction at the cyclic-matrix level.
+
+---
+
+## 4. Configurations left by the matrix argument
+
+The matrix contradiction is false. Here is an explicit family satisfying (A) and (B) with all row sums equal to (4).
+
+For (n\ge8), define
+
+[
+R_i={i+1,\ i+2,\ i+5,\ i+7}\pmod n.
+]
+
+Equivalently,
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod n\in{1,2,5,7}.
+]
+
+Every row has exactly four (1)’s.
+
+Because the construction is cyclic, it suffices to compare (R_0) and (R_t). The positive differences among
+
+[
+D={1,2,5,7}
+]
+
+are
+
+[
+1,2,3,4,5,6,
+]
+
+each occurring exactly once. Hence for (n\ge13), no two distinct rows share more than one column. Thus (A) holds, and (B) is vacuous.
+
+For (8\le n\le12), the only two-point intersections are as follows:
+
+[
+\begin{array}{c|c}
+n & \text{two-point intersections } R_0\cap R_t \ \hline
+8 &
+t=2:{1,7},
+t=3:{2,5},
+t=4:{1,5},
+t=5:{2,7},
+t=6:{5,7}
+[2mm]
+9 &
+t=3:{1,5},
+t=4:{2,5},
+t=5:{1,7},
+t=6:{2,7}
+[2mm]
+10 &
+t=4:{1,5},
+t=5:{2,7},
+t=6:{1,7}
+[2mm]
+11 &
+t=5:{1,7},
+t=6:{2,7}
+[2mm]
+12 &
+t=6:{1,7}.
+\end{array}
+]
+
+In every listed case, one common column lies in the arc ((0,t)), and the other lies in the complementary arc ((t,0)). Therefore (B) holds. So this is a valid cyclic matrix pattern with all row sums (4).
+
+For (n=8), the row supports are explicitly:
+
+[
+\begin{aligned}
+R_0&={1,2,5,7},\
+R_1&={0,2,3,6},\
+R_2&={1,3,4,7},\
+R_3&={0,2,4,5},\
+R_4&={1,3,5,6},\
+R_5&={2,4,6,7},\
+R_6&={0,3,5,7},\
+R_7&={0,1,4,6}.
+\end{aligned}
+]
+
+Thus the cyclic-matrix method based only on (A) and (B) cannot prove the desired geometric contradiction.
+
+A second, cleaner “B is completely vacuous” pattern is this: for (n\ge47), set
+
+[
+R_i={i+3,\ i+7,\ i+15,\ i+26}\pmod n.
+]
+
+The six positive differences among ({3,7,15,26}) are
+
+[
+4,8,11,12,19,23,
+]
+
+all distinct, and for (n\ge47) no signed differences collide modulo (n). Hence any two rows meet in at most one column. Again all rows have size (4), (A) holds, and (B) is vacuous.
+
+These patterns are not claimed to be geometrically realizable. They show exactly where the matrix argument stops: ruling them out would require additional geometric input, such as angle constraints, perpendicular-bisector constraints from the full radical-axis geometry, or other metric information not encoded in (A) and (B).

--- a/incoming/chatgpt-runs/run-16.md
+++ b/incoming/chatgpt-runs/run-16.md
@@ -1,0 +1,441 @@
+## 1. Convex-position crossing lemma
+
+**Lemma (convex-position crossing lemma).**
+Let (P={p_1,\dots,p_n}) be the vertices of a strictly convex (n)-gon in cyclic order. Suppose (i\ne k), and suppose (S_i\cap S_k) contains two indices (a,b). Then, in the cyclic order, the pair ({i,k}) separates the pair ({a,b}). Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+**Proof.**
+Since (a,b\in S_i\cap S_k), we have
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+Thus (p_a,p_b) are the two intersection points of the circle centered at (p_i) of radius (r_i) and the circle centered at (p_k) of radius (r_k).
+
+Let (L) be the line through (p_i,p_k). Reflection across (L) fixes both centers (p_i,p_k), and hence preserves both circles. Therefore it permutes their two common intersection points. Since the two points are distinct, reflection across (L) swaps (p_a) and (p_b). Equivalently, the common chord (p_ap_b) is perpendicular to (L), and (L) bisects (p_ap_b). This is the radical-axis/reflection step.
+
+Choose coordinates so that
+
+[
+p_i=(0,0),\qquad p_k=(1,0),
+]
+
+and hence, for some (t\in\mathbb R) and (h>0),
+
+[
+p_a=(t,h),\qquad p_b=(t,-h).
+]
+
+The midpoint of (p_ap_b) is (q=(t,0)). We claim that (0<t<1).
+
+If (t=0), then (p_i,q,p_a,p_b) are collinear, so (p_i,p_a,p_b) are three collinear vertices. This is impossible in a strictly convex polygon. This is one use of strict convexity.
+
+Similarly, (t=1) would put (p_k,p_a,p_b) collinear, again impossible by strict convexity.
+
+If (t<0), then (q) lies on the segment (p_ap_b), and (p_i=(0,0)) lies on the segment from (p_k=(1,0)) to (q=(t,0)). Hence
+
+[
+p_i\in \operatorname{conv}{p_k,p_a,p_b}.
+]
+
+That contradicts the fact that the listed points are vertices of a strictly convex polygon: no vertex may lie in the convex hull of the other vertices. This is the second use of strict convexity/convex-position extremality.
+
+Similarly, if (t>1), then (p_k\in \operatorname{conv}{p_i,p_a,p_b}), again impossible.
+
+Therefore (0<t<1). Hence the segment (p_ip_k), which is the horizontal segment from ((0,0)) to ((1,0)), meets the segment (p_ap_b), which is the vertical segment from ((t,-h)) to ((t,h)), at the interior point ((t,0)). So the chords (p_ip_k) and (p_ap_b) cross.
+
+For four vertices of a strictly convex polygon, two chords cross exactly when their endpoints alternate in the cyclic order. Therefore ({i,k}) separates ({a,b}). (\square)
+
+---
+
+## 2. Exact theorem proved from facts (A) and (B)
+
+Let (R_i=S_i). Abstract away the geometry and keep only the cyclic order plus the two rules:
+
+[
+\tag{A'} |R_i\cap R_k|\le 2\quad (i\ne k),
+]
+
+and
+
+[
+\tag{B'} \text{if }R_i\cap R_k={a,b},\text{ then }{i,k}\text{ separates }{a,b}.
+]
+
+The strongest conclusion obtainable from just these two rules is **not** a contradiction. In fact, the cyclic-matrix relaxation has examples with every row sum (4).
+
+Here is the exact theorem I prove.
+
+**Theorem.**
+Let (M) be a cyclically indexed (0)-(1) matrix with diagonal zero, row sets (R_i), satisfying ((A')) and ((B')). Then
+
+[
+\sum_{i=1}^n \binom{|R_i|}{2}\le n(n-2).
+]
+
+Consequently, if every row has size at least (4), then (n\ge 8). Moreover, this is sharp for the cyclic-matrix relaxation: for every (n\ge 8), there exists such a cyclic matrix satisfying ((A')), ((B')), and (|R_i|=4) for all (i).
+
+Thus facts (A) and (B), even with the common cyclic order of rows and columns, do **not** by themselves imply that the assumed matrix is impossible. Any full geometric contradiction would need additional metric information beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix forbidden configurations and discharging argument
+
+Write (I(i,k)) for the open cyclic interval from (i) to (k).
+
+### Forbidden (2\times 2) cyclic submatrix
+
+Suppose rows (i,k) both contain columns (a,b). Then, by (A), these are the only two common columns, and by (B), the pairs ({i,k}), ({a,b}) must alternate cyclically.
+
+Therefore the all-one (2\times 2) submatrix
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is forbidden unless the cyclic order is alternating:
+
+[
+i,a,k,b
+\quad\text{or}\quad
+i,b,k,a.
+]
+
+Equivalently,
+
+[
+|R_i\cap R_k\cap I(i,k)|\le 1,
+\qquad
+|R_i\cap R_k\cap I(k,i)|\le 1.
+]
+
+In particular, **adjacent rows cannot share two columns**, because if (i,k) are adjacent, one of the two cyclic intervals between them is empty.
+
+Dually, fix two columns (a,b), and let
+
+[
+C_{ab}={i:a,b\in R_i}.
+]
+
+If two rows (i,k\in C_{ab}), then ({i,k}) must separate ({a,b}). Hence (C_{ab}) contains at most one row in each of the two open arcs determined by (a,b). Therefore
+
+[
+|C_{ab}|\le 2.
+]
+
+If (a,b) are adjacent columns, then one of those arcs is empty, so
+
+[
+|C_{ab}|\le 1.
+]
+
+Thus adjacent column pairs cannot occur together in two different rows.
+
+### Forbidden (2\times 3) and (3\times 2) patterns
+
+A (2\times 3) all-one submatrix is forbidden directly by (A), because two rows cannot share three columns.
+
+A (3\times 2) all-one submatrix is also forbidden. Indeed, if three rows all contain the same two columns (a,b), then two of those three rows lie in the same open arc determined by (a,b), so they do not separate (a,b), contradicting (B).
+
+So the following patterns are forbidden:
+
+[
+\begin{array}{c|ccc}
+& a&b&c\ \hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+\qquad\text{and}\qquad
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1\
+\ell&1&1
+\end{array}.
+]
+
+### Pair-count discharging
+
+Let
+
+[
+d_i=|R_i|.
+]
+
+Each row (i) sends one unit of charge to every unordered pair of columns contained in (R_i). Thus row (i) sends
+
+[
+\binom{d_i}{2}
+]
+
+units of charge, and the total charge is
+
+[
+Q=\sum_{i=1}^n \binom{d_i}{2}.
+]
+
+Equivalently,
+
+[
+Q=\sum_{{a,b}} c_{ab},
+]
+
+where
+
+[
+c_{ab}=|{i:a,b\in R_i}|.
+]
+
+From the forbidden configurations above:
+
+[
+c_{ab}\le 2
+]
+
+for every pair ({a,b}), and if (a,b) are adjacent in the cyclic order, then
+
+[
+c_{ab}\le 1.
+]
+
+There are (n) adjacent column pairs and (\binom n2-n) nonadjacent column pairs. Therefore
+
+[
+Q
+\le n\cdot 1+2\left(\binom n2-n\right)
+= n+n(n-1)-2n
+= n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_{i=1}^n \binom{|R_i|}{2}\le n(n-2).}
+]
+
+If every row has size at least (4), then each row contributes at least (\binom42=6), so
+
+[
+6n\le n(n-2).
+]
+
+Thus
+
+[
+n\ge 8.
+]
+
+A slightly more global bound follows from convexity:
+
+[
+\sum_i \binom{d_i}{2}
+=====================
+
+\frac12\left(\sum_i d_i^2-\sum_i d_i\right).
+]
+
+Let (m=\sum_i d_i). Since (\sum_i d_i^2\ge m^2/n),
+
+[
+\frac12\left(\frac{m^2}{n}-m\right)\le n(n-2),
+]
+
+so
+
+[
+\boxed{
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+This is far too weak to contradict (m\ge 4n) for large (n), but it proves impossibility for (n\le 7).
+
+### Equality structure when (n=8)
+
+If (n=8) and every row has size at least (4), then the above inequalities force equality everywhere.
+
+Indeed,
+
+[
+\sum_i \binom{d_i}{2}\ge 8\binom42=48,
+]
+
+while
+
+[
+n(n-2)=8\cdot 6=48.
+]
+
+Hence every row has size exactly (4), every adjacent column pair occurs together in exactly one row, and every nonadjacent column pair occurs together in exactly two rows.
+
+There is also a dual equality. Let (q_j) be the column sum of column (j). Since the total number of ones is (32), the average column sum is (4). Also,
+
+[
+\sum_j \binom{q_j}{2}
+=====================
+
+\sum_{i<k}|R_i\cap R_k|.
+]
+
+Adjacent row pairs share at most one column, and nonadjacent row pairs share at most two columns, so the same upper bound gives
+
+[
+\sum_j \binom{q_j}{2}\le 48.
+]
+
+But Jensen gives
+
+[
+\sum_j \binom{q_j}{2}\ge 8\binom42=48.
+]
+
+Thus every column also has size exactly (4), adjacent row pairs share exactly one column, and nonadjacent row pairs share exactly two columns.
+
+So if (n=8), any abstract extremal matrix satisfying (A) and (B) must be a highly rigid (4)-regular configuration.
+
+### Sharpness: cyclic matrices exist for all (n\ge 8)
+
+Use indices modulo (n).
+
+For (n=8), define
+
+[
+R_i={i-3,\ i-1,\ i+1,\ i+2}.
+]
+
+Equivalently, the first row is
+
+[
+R_0={1,2,5,7}.
+]
+
+For (n\ge 9), define
+
+[
+R_i={i-1,\ i+1,\ i+2,\ i+4}.
+]
+
+Equivalently,
+
+[
+R_0={-1,1,2,4}\pmod n.
+]
+
+Each row has size (4), and the diagonal is zero.
+
+For (n\ge 9), take rows (0) and (t). The possible intersections are obtained from the difference set of
+
+[
+D={-1,1,2,4}.
+]
+
+The only two-point intersections occur for
+
+[
+t=2,\quad t=3,\quad t=n-2,\quad t=n-3,
+]
+
+and, in the special case (n=10), also for (t=5). They are respectively
+
+[
+{1,4},\quad {2,4},\quad {-1,2},\quad {-1,1},
+]
+
+and, when (n=10,t=5),
+
+[
+{-1,4}.
+]
+
+In every case, exactly one of the two common columns lies in the open interval from (0) to (t), and the other lies outside. Hence the common columns alternate with the row indices. All other intersections have size at most one. Therefore (A) and (B) hold.
+
+For (n=8), with
+
+[
+D={-3,-1,1,2},
+]
+
+a direct check gives the two-point intersections
+
+[
+\begin{array}{c|c}
+t & R_0\cap R_t\ \hline
+2 & {-1,1}\
+3 & {-3,2}\
+4 & {-3,1}\
+5 & {-1,2}\
+6 & {-3,-1},
+\end{array}
+]
+
+and each pair again alternates with ({0,t}). Thus (A) and (B) hold.
+
+So the matrix relaxation has examples with all row sums (4) for every (n\ge 8). Therefore the desired contradiction cannot be obtained from (A) and (B) alone.
+
+These matrices are not claimed to be geometrically realizable. In fact, the circulant examples above are ruled out by an additional metric input not contained in (A) or (B): since each row contains (i+1) and (i+2), and row (i+1) contains (i) and (i+2), the triangle
+
+[
+p_i p_{i+1} p_{i+2}
+]
+
+would be equilateral for every (i). Hence every interior angle would be (\pi/3), contradicting the angle sum ((n-2)\pi) for (n\ge 4). That argument uses actual distance equalities, not merely the intersection/crossing data.
+
+---
+
+## 4. Configurations left unresolved by the crossing/discharging method
+
+The following patterns are not eliminated by facts (A) and (B).
+
+### Circulant (4)-row patterns
+
+For (n\ge 9),
+
+[
+\boxed{
+M_{ij}=1
+\iff
+j-i\pmod n\in{-1,1,2,4}.
+}
+]
+
+For (n=8),
+
+[
+\boxed{
+M_{ij}=1
+\iff
+j-i\pmod 8\in{-3,-1,1,2}.
+}
+]
+
+These satisfy all cyclic crossing restrictions. They are killed only by extra metric input, as explained above.
+
+### A (B)-vacuous (13\times 13) pattern
+
+Here is an exact (13)-row pattern with every row sum (4), diagonal zero, and every pair of rows intersecting in at most one column. Therefore fact (B) never even applies.
+
+Rows are listed by their supports:
+
+[
+\begin{array}{c|c}
+1 & {2,5,8,10}\
+2 & {3,4,8,11}\
+3 & {1,4,7,10}\
+4 & {1,6,8,12}\
+5 & {2,4,9,12}\
+6 & {1,5,9,11}\
+7 & {1,2,3,13}\
+8 & {3,5,7,12}\
+9 & {10,11,12,13}\
+10 & {4,5,6,13}\
+11 & {7,8,9,13}\
+12 & {3,6,9,10}\
+13 & {2,6,7,11}.
+\end{array}
+]
+
+Every two listed supports meet in exactly one column, so (A) holds strongly and (B) is vacuous. This shows especially clearly why crossing data alone cannot force a contradiction: a full geometric proof would need to use additional constraints inside individual rows, or metric relations among distances, not just double intersections of rows.

--- a/incoming/chatgpt-runs/run-17.md
+++ b/incoming/chatgpt-runs/run-17.md
@@ -1,0 +1,314 @@
+## 1. Convex-position crossing lemma
+
+**Lemma (convex-position crossing lemma).**
+Let (P={p_1,\dots,p_n}) be the vertices of a strictly convex polygon in cyclic order. Suppose two distinct rows (S_i,S_k) share two distinct indices (a,b). Thus
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+Then the pair ({i,k}) separates the pair ({a,b}) in the cyclic order. Equivalently, the chords (p_ip_k) and (p_ap_b) cross.
+
+**Proof.**
+The four indices (i,k,a,b) are distinct: (a,b\in S_i\cap S_k), while (i\notin S_i) and (k\notin S_k).
+
+Consider the two circles
+
+[
+C_i={x:|x-p_i|=r_i},\qquad C_k={x:|x-p_k|=r_k}.
+]
+
+Both (p_a) and (p_b) lie on both circles. The radical axis of (C_i) and (C_k) is the common chord line (p_ap_b), and the radical-axis equation is obtained by subtracting
+
+[
+|x-p_i|^2-r_i^2=0,\qquad |x-p_k|^2-r_k^2=0.
+]
+
+Its normal vector is parallel to (p_k-p_i), so the line (p_ap_b) is perpendicular to the line (p_ip_k). Since (p_a,p_b) are also on the circle centered at (p_i), the perpendicular from (p_i) to the chord (p_ap_b) bisects that chord. Hence the line (p_ip_k) is the perpendicular bisector of the segment (p_ap_b). Therefore (p_a) and (p_b) are reflections of one another across the line (p_ip_k).
+
+Because (p_a\neq p_b), the reflected points lie in opposite open half-planes determined by the line (p_ip_k).
+
+Now use strict convexity. The line through two vertices (p_i,p_k) meets the strictly convex polygon only along the chord (p_ip_k), and no other vertex lies on this line. Thus the two open polygonal boundary arcs from (p_i) to (p_k) lie in the two opposite open half-planes determined by the line (p_ip_k). This is the exact step where strict convexity is invoked: it rules out a third vertex on the line (p_ip_k) and makes the half-plane/cyclic-arc correspondence nondegenerate.
+
+Since (p_a) and (p_b) lie in opposite open half-planes, their indices lie on opposite cyclic arcs between (i) and (k). Hence ({i,k}) separates ({a,b}), so the chords (p_ip_k) and (p_ap_b) cross. (\square)
+
+---
+
+## 2. The exact theorem proved
+
+The full contradiction does **not** follow from facts (A) and (B) alone. The strongest sharp matrix consequence obtainable from these two facts is the following.
+
+**Theorem.**
+Let (M) be an (n\times n) cyclically indexed (0)-(1) matrix with (M_{ii}=0). Suppose:
+
+1. for every two distinct rows (i,k),
+
+[
+|S_i\cap S_k|\le 2;
+]
+
+2. if (S_i\cap S_k={a,b}), then ({i,k}) separates ({a,b}) cyclically.
+
+If every row has at least (4) ones, then
+
+[
+n\ge 8.
+]
+
+This bound is sharp as a theorem about the matrix axioms: for every (n\ge 8), there exists a cyclic (0)-(1) matrix satisfying these axioms with every row sum exactly (4). Therefore facts (A) and (B), even together with the shared cyclic row/column order, cannot by themselves prove that the geometric configuration is impossible.
+
+The unresolved part is geometric: the sharp matrix examples below need not be realizable by strictly convex point sets with actual radii. To eliminate them one would need additional metric input beyond (A) and (B), such as perpendicular-bisector incidences, row-wise semicircle constraints, or length inequalities.
+
+---
+
+## 3. Cyclic-matrix / discharging argument
+
+For a column pair ({a,b}), let
+
+[
+\lambda(a,b)=|{i:a,b\in S_i}|
+]
+
+be the number of rows containing both columns (a,b).
+
+### Forbidden column-pair capacities
+
+First, facts (A) and (B) imply two useful forbidden submatrices.
+
+**Forbidden configuration 1: noncrossing (2\times 2).**
+If rows (i,k) and columns (a,b) satisfy
+
+[
+M_{ia}=M_{ib}=M_{ka}=M_{kb}=1,
+]
+
+then ({i,k}) must separate ({a,b}). Thus the all-one (2\times 2) pattern is forbidden whenever the row pair and column pair are not cyclically alternating.
+
+In cyclic notation, the pattern
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+is forbidden if, for example, the cyclic order is (i,k,a,b) or (i,a,b,k). It is only allowed when the cyclic order alternates, such as (i,a,k,b).
+
+**Forbidden configuration 2: three rows sharing two columns.**
+The pattern
+
+[
+\begin{array}{c|cc}
+& a & b\ \hline
+i & 1 & 1\
+k & 1 & 1\
+\ell & 1 & 1
+\end{array}
+]
+
+is impossible.
+
+Indeed, remove (a,b) from the cyclic order. The remaining vertices lie on two open arcs between (a) and (b). If three row indices (i,k,\ell) all contain both (a,b), then by the pigeonhole principle two of (i,k,\ell) lie on the same arc. Those two rows share the two columns (a,b), but their row pair does not separate ({a,b}), contradicting (B).
+
+Therefore
+
+[
+\lambda(a,b)\le 2
+]
+
+for every column pair ({a,b}).
+
+There is a stronger bound for adjacent column pairs. If (a,b) are adjacent cyclically, then no two rows can both contain (a,b), because the pair ({a,b}) has an empty open arc between its two vertices and cannot be separated by any row pair. Hence
+
+[
+\lambda(a,b)\le 1
+]
+
+when (a,b) are adjacent.
+
+### Discharging
+
+Each row (i) sends one unit of charge to every unordered pair of columns contained in (S_i). If (d_i=|S_i|), then row (i) sends
+
+[
+\binom{d_i}{2}
+]
+
+units of charge. Since (d_i\ge 4), each row sends at least
+
+[
+\binom{4}{2}=6
+]
+
+units. Hence the total charge is at least
+
+[
+\sum_i \binom{d_i}{2}\ge 6n.
+]
+
+Now bound how much charge the column pairs can receive.
+
+There are exactly (n) adjacent cyclic column pairs, each of capacity at most (1). There are
+
+[
+\binom n2-n
+]
+
+nonadjacent column pairs, each of capacity at most (2). Therefore the total capacity is at most
+
+[
+n\cdot 1+2\left(\binom n2-n\right)
+= n+ n(n-1)-2n
+= n(n-2).
+]
+
+Thus
+
+[
+6n\le n(n-2).
+]
+
+Since (n>0), this gives
+
+[
+6\le n-2,
+]
+
+so
+
+[
+n\ge 8.
+]
+
+This proves the theorem.
+
+A useful equality observation: if (n=8), equality must hold everywhere. Thus every row has size exactly (4), every adjacent column pair appears in exactly one row, and every nonadjacent column pair appears in exactly two rows. That is the strongest structural conclusion this discharging argument gives at the threshold case.
+
+---
+
+## 4. Configurations that remain unresolved
+
+The following matrices satisfy the cyclic matrix consequences of (A) and (B) with every row sum (4). They show that no contradiction can be derived from those facts alone.
+
+For the examples, index rows and columns by (\mathbb Z/n\mathbb Z).
+
+### Unresolved pattern for (n=8)
+
+Let
+
+[
+D_8={1,2,5,7}\subset \mathbb Z/8\mathbb Z
+]
+
+and define
+
+[
+M_{ij}=1 \iff j-i\in D_8.
+]
+
+Equivalently, the rows are
+
+[
+\begin{aligned}
+S_0&={1,2,5,7},\
+S_1&={0,2,3,6},\
+S_2&={1,3,4,7},\
+S_3&={0,2,4,5},\
+S_4&={1,3,5,6},\
+S_5&={2,4,6,7},\
+S_6&={0,3,5,7},\
+S_7&={0,1,4,6}.
+\end{aligned}
+]
+
+The full (0)-(1) matrix is
+
+[
+\begin{pmatrix}
+0&1&1&0&0&1&0&1\
+1&0&1&1&0&0&1&0\
+0&1&0&1&1&0&0&1\
+1&0&1&0&1&1&0&0\
+0&1&0&1&0&1&1&0\
+0&0&1&0&1&0&1&1\
+1&0&0&1&0&1&0&1\
+1&1&0&0&1&0&1&0
+\end{pmatrix}.
+]
+
+For row difference (t), the common columns of rows (0) and (t) are:
+
+[
+\begin{array}{c|c}
+t & D_8\cap(D_8+t)\ \hline
+1 & {2}\
+2 & {1,7}\
+3 & {2,5}\
+4 & {1,5}\
+5 & {2,7}\
+6 & {5,7}\
+7 & {1}
+\end{array}
+]
+
+Whenever the intersection has size (2), the two common columns lie on opposite sides of (t) in the cyclic order, so the crossing condition (B) is satisfied. Adjacent rows share only one column.
+
+Thus this matrix satisfies all the derived cyclic forbidden-pattern rules, with every row sum equal to (4).
+
+### Unresolved patterns for every (n\ge 9)
+
+Let
+
+[
+D={1,2,4,8}\subset \mathbb Z/n\mathbb Z
+]
+
+and define
+
+[
+M_{ij}=1 \iff j-i\in D.
+]
+
+Then every row and every column has exactly four ones, and (M_{ii}=0).
+
+For (n\ge 15), the nonzero differences among (1,2,4,8) are
+
+[
+\pm1,\ \pm2,\ \pm3,\ \pm4,\ \pm6,\ \pm7,
+]
+
+which are all distinct modulo (n). Hence two different rows share at most one column. Thus (A) holds and (B) is vacuous.
+
+For (9\le n\le 14), the only row differences producing two common columns are listed below, and in every case the two common columns straddle the row difference (t), so (B) holds.
+
+[
+\begin{array}{c|c}
+n & \text{two-column intersections } D\cap(D+t)\ \hline
+9 &
+t=2:{1,4},\
+t=3:{2,4},\
+t=6:{1,8},\
+t=7:{2,8}[2mm]
+10 &
+t=3:{1,4},\
+t=4:{2,8},\
+t=6:{4,8},\
+t=7:{1,8}[2mm]
+11 &
+t=4:{1,8},\
+t=7:{4,8}[2mm]
+12 &
+t=6:{2,8}[2mm]
+13 &
+t=6:{1,8},\
+t=7:{2,8}[2mm]
+14 &
+t=7:{1,8}
+\end{array}
+]
+
+All other row intersections have size at most (1).
+
+So for every (n\ge 8), there are exact cyclic (0)-(1) patterns satisfying all consequences of (A) and (B) with row sums (4). These are the configurations left unresolved by the matrix/discharging method. They are not asserted to be geometrically realizable; they show precisely where additional geometric input is needed.

--- a/incoming/chatgpt-runs/run-18.md
+++ b/incoming/chatgpt-runs/run-18.md
@@ -1,0 +1,416 @@
+## 1. Convex-position crossing lemma
+
+**Lemma (crossing lemma).**
+Let (P={p_1,\dots,p_n}) be in strictly convex position. Suppose (i\ne k), and suppose two distinct indices (a,b) lie in (S_i\cap S_k). Then the cyclic pairs ({i,k}) and ({a,b}) separate each other. Equivalently, the chord (p_ip_k) crosses the chord (p_ap_b).
+
+**Proof.**
+Since (a,b\in S_i\cap S_k),
+
+[
+|p_a-p_i|=|p_b-p_i|=r_i,\qquad |p_a-p_k|=|p_b-p_k|=r_k.
+]
+
+Thus both (p_i) and (p_k) are equidistant from (p_a) and (p_b). Therefore the line (L=p_ip_k) is the perpendicular bisector of the segment (p_ap_b). In particular, (p_a) and (p_b) are reflections of each other across (L), so they lie in opposite open half-planes bounded by (L).
+
+It remains to show that (p_i) and (p_k) lie on opposite sides of the line (p_ap_b). Let (m) be the midpoint of (p_ap_b). Since (L) is the perpendicular bisector of (p_ap_b), the points (p_i,p_k,m) are collinear.
+
+Assume for contradiction that (p_i) and (p_k) lie on the same side of the line (p_ap_b). Then one of (p_i,p_k) lies strictly between the other and (m) on the line (L). Say (p_i) lies between (m) and (p_k). Then for some (0<t<1),
+
+[
+p_i=(1-t)m+t p_k.
+]
+
+But
+
+[
+m=\frac{p_a+p_b}{2},
+]
+
+so
+
+[
+p_i=\frac{1-t}{2}p_a+\frac{1-t}{2}p_b+t p_k.
+]
+
+All three coefficients are positive and sum to (1). Hence (p_i) lies in the interior of the triangle (\triangle p_ap_bp_k).
+
+This is the exact point where strict convexity is used: in a strictly convex polygon, every listed vertex is an extreme point of the convex hull, so no vertex may lie in the convex hull, let alone the interior, of three other vertices. Contradiction.
+
+Therefore (p_i) and (p_k) lie on opposite sides of the line (p_ap_b). We already know (p_a) and (p_b) lie on opposite sides of the line (p_ip_k). Hence the two segments (p_ip_k) and (p_ap_b) cross in their interiors. For vertices of a convex polygon, two chords cross in their interiors exactly when their endpoints alternate in the cyclic order. Thus ({i,k}) separates ({a,b}). ∎
+
+---
+
+## 2. Exact theorem proved
+
+The full contradiction does **not** follow from facts (A) and (B) alone. The strongest cyclic-matrix theorem I can prove is the following.
+
+**Theorem.**
+Let (V=\mathbb Z/n\mathbb Z) be cyclically ordered, and let (S_i\subseteq V\setminus{i}). Assume:
+
+1. (|S_i\cap S_k|\le 2) for all (i\ne k);
+2. if (S_i\cap S_k={a,b}), then ({i,k}) separates ({a,b}) cyclically.
+
+Then
+
+[
+\sum_{i=1}^n \binom{|S_i|}{2}\le n(n-2).
+]
+
+Consequently, if every (|S_i|\ge 4), then necessarily
+
+[
+n\ge 8.
+]
+
+Moreover, this is sharp at the cyclic-matrix level: for every (n\ge 8), there exists a cyclic (0)-(1) matrix satisfying (A) and (B) with every row sum exactly (4). Therefore no contradiction can be obtained from (A) and (B) alone.
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Write
+
+[
+d_i=|S_i|.
+]
+
+For a column-pair ({a,b}), define
+
+[
+m(a,b)=|{i:\ a,b\in S_i}|.
+]
+
+Counting pairs inside rows gives
+
+[
+\sum_i \binom{d_i}{2}=\sum_{{a,b}} m(a,b).
+]
+
+Now use the cyclic crossing rule.
+
+If (a,b) are **adjacent** in the cyclic order, then no two rows can both contain (a,b). Indeed, if two rows (i,k) both contained (a,b), then by (B), the chord (p_ip_k) would have to cross the polygon edge (p_ap_b), impossible in cyclic order because an adjacent pair has an empty arc on one side. Hence
+
+[
+m(a,b)\le 1
+]
+
+for adjacent column-pairs.
+
+If (a,b) are **not adjacent**, then (B) implies at most one row containing both (a,b) can lie on each side of the chord (ab). Thus
+
+[
+m(a,b)\le 2
+]
+
+for non-adjacent column-pairs.
+
+There are (n) adjacent column-pairs and
+
+[
+\binom n2-n
+]
+
+non-adjacent column-pairs. Therefore
+
+[
+\sum_i \binom{d_i}{2}
+=\sum_{{a,b}}m(a,b)
+\le n+2\left(\binom n2-n\right)
+=n+n(n-1)-2n
+=n(n-2).
+]
+
+If every (d_i\ge 4), then
+
+[
+\sum_i\binom{d_i}{2}\ge n\binom42=6n.
+]
+
+Thus
+
+[
+6n\le n(n-2),
+]
+
+so
+
+[
+n\ge 8.
+]
+
+This proves the claimed bound.
+
+### Forbidden cyclic submatrices
+
+The following configurations are forbidden by (A) and (B).
+
+#### Forbidden (2\times 3) all-one submatrix
+
+For two distinct rows (i,k), one cannot have three common columns:
+
+[
+\begin{array}{c|ccc}
+& a&b&c\
+\hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+]
+
+because this would give (|S_i\cap S_k|\ge 3), contradicting (A).
+
+#### Forbidden (3\times 2) all-one submatrix
+
+For two fixed columns (a,b), at most two rows can contain both (a,b). Thus the following is forbidden:
+
+[
+\begin{array}{c|cc}
+& a&b\
+\hline
+i&1&1\
+k&1&1\
+\ell&1&1
+\end{array}
+]
+
+Indeed, if three rows contained (a,b), two of those rows would lie on the same side of the chord (ab), contradicting (B).
+
+#### Forbidden non-crossing (2\times 2) all-one submatrix
+
+A (2\times 2) all-one submatrix
+
+[
+\begin{array}{c|cc}
+& a&b\
+\hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is allowed only when the four cyclic positions alternate as
+
+[
+i,\ a,\ k,\ b
+]
+
+or the reverse. It is forbidden when the row-pair and column-pair do not alternate cyclically. In type notation, the only allowed cyclic type is
+
+[
+R,C,R,C.
+]
+
+The forbidden types are
+
+[
+R,R,C,C
+\qquad\text{and}\qquad
+R,C,C,R.
+]
+
+In particular:
+
+* adjacent rows cannot share two columns;
+* adjacent columns cannot be shared by two rows.
+
+---
+
+## 4. Why the full contradiction fails from (A) and (B)
+
+The cyclic-matrix obstruction is sharp. Here are explicit matrices satisfying all consequences of (A) and (B) with every row sum equal to (4).
+
+### Example for (n=8)
+
+Index rows and columns by (\mathbb Z/8\mathbb Z), and define
+
+[
+S_i={i+1,\ i+2,\ i+5,\ i+7}\pmod 8.
+]
+
+Thus the row-offset pattern is
+
+[
+0\ 1\ 1\ 0\ 0\ 1\ 0\ 1.
+]
+
+Explicitly:
+
+[
+\begin{aligned}
+S_0&={1,2,5,7},\
+S_1&={0,2,3,6},\
+S_2&={1,3,4,7},\
+S_3&={0,2,4,5},\
+S_4&={1,3,5,6},\
+S_5&={2,4,6,7},\
+S_6&={0,3,5,7},\
+S_7&={0,1,4,6}.
+\end{aligned}
+]
+
+For row (0), the only shifts (t) for which (|S_0\cap S_t|=2) are:
+
+[
+\begin{array}{c|c}
+t&S_0\cap S_t\
+\hline
+2&{1,7}\
+3&{2,5}\
+4&{1,5}\
+5&{2,7}\
+6&{5,7}
+\end{array}
+]
+
+In each case, exactly one of the two common columns lies between (0) and (t) cyclically. Hence the row-pair ({0,t}) separates the common column-pair. By cyclic translation, the same holds for every row-pair. Thus (A) and (B) hold.
+
+This example attains equality in the discharging bound:
+
+[
+\sum_i\binom{|S_i|}{2}=8\binom42=48=8(8-2).
+]
+
+### Examples for every (n\ge 9)
+
+For (n\ge 9), define
+
+[
+S_i={i+1,\ i+2,\ i+4,\ i+8}\pmod n.
+]
+
+The row-offset pattern is
+
+[
+0\ 1\ 1\ 0\ 1\ 0\ 0\ 0\ 1.
+]
+
+For (n\ge 15), the differences among ({1,2,4,8}) are all distinct modulo (n), so two rows intersect in at most one column. Thus (A) holds and (B) is vacuous.
+
+For (9\le n\le 14), the only double intersections for row (0) are:
+
+[
+\begin{array}{c|c|c}
+n&t&S_0\cap S_t\
+\hline
+9&2&{1,4}\
+9&3&{2,4}\
+9&6&{1,8}\
+9&7&{2,8}\
+\hline
+10&3&{1,4}\
+10&4&{2,8}\
+10&6&{4,8}\
+10&7&{1,8}\
+\hline
+11&4&{1,8}\
+11&7&{4,8}\
+\hline
+12&6&{2,8}\
+\hline
+13&6&{1,8}\
+13&7&{2,8}\
+\hline
+14&7&{1,8}
+\end{array}
+]
+
+Again, in every listed case, exactly one common column lies between (0) and (t), so the crossing condition holds. By cyclic translation, (A) and (B) hold for all row-pairs.
+
+Therefore, for every (n\ge 8), there exists a cyclic (0)-(1) matrix satisfying (A) and (B) with every row sum (4). This disproves the hope of obtaining a contradiction from (A) and (B) alone.
+
+---
+
+## 5. Additional geometric input needed
+
+The circulant examples above are not claimed to be geometrically realizable. To rule them out geometrically, one needs more than (A) and (B).
+
+For example, the pattern
+
+[
+S_i={i+1,i+2,i+4,i+8}
+]
+
+contains (i+1,i+2\in S_i) for every (i). If this came from geometry, then
+
+[
+|p_i-p_{i+1}|=|p_i-p_{i+2}|
+]
+
+for every (i). Let
+
+[
+e_i=p_{i+1}-p_i.
+]
+
+Then
+
+[
+|e_i|=|e_i+e_{i+1}|.
+]
+
+Squaring gives
+
+[
+|e_i|^2=|e_i|^2+|e_{i+1}|^2+2e_i\cdot e_{i+1},
+]
+
+so
+
+[
+e_i\cdot e_{i+1}=-\frac{|e_{i+1}|^2}{2}<0.
+]
+
+Thus the exterior angle between consecutive sides (e_i,e_{i+1}) is strictly larger than (\pi/2). Summing over all vertices would give total exterior angle strictly larger than (n\pi/2), impossible for (n\ge 4), since the total exterior angle of a convex polygon is (2\pi).
+
+This argument uses genuine metric information, not just (A) and (B).
+
+---
+
+## 6. Remaining unresolved exact patterns
+
+The following cyclic matrix patterns are not eliminated by the crossing/discharging argument.
+
+### Pattern U1: Sidon-type circulant rows
+
+For (n\ge 43), define
+
+[
+S_i={i+2,\ i+5,\ i+11,\ i+23}\pmod n.
+]
+
+The row-offset pattern is
+
+[
+\text{ones at offsets }2,5,11,23.
+]
+
+The pairwise differences among (2,5,11,23) are
+
+[
+3,6,9,12,18,21
+]
+
+up to sign, all distinct modulo (n) for (n\ge 43). Hence any two rows intersect in at most one column. Therefore (A) holds and (B) is vacuous.
+
+This gives an exact family of cyclic (0)-(1) matrices with all row sums (4) that remains completely untouched by the two-row crossing restrictions.
+
+### Pattern U2: the sharp (n=8) equality pattern
+
+The (n=8) circulant matrix
+
+[
+S_i={i+1,i+2,i+5,i+7}
+]
+
+is also unresolved by (A) and (B) alone. It realizes equality in the discharging bound and satisfies every forbidden-submatrix condition derived above.
+
+---
+
+**Conclusion.**
+The convex-position crossing lemma is valid and follows from strict convexity. From it one obtains strong forbidden (0)-(1) submatrices and the sharp bound
+
+[
+\sum_i \binom{|S_i|}{2}\le n(n-2).
+]
+
+However, (A) and (B) alone do not imply a contradiction with all row sums at least (4). A full geometric nonexistence proof, if true, must use additional metric information beyond the circle-intersection and crossing facts.

--- a/incoming/chatgpt-runs/run-19.md
+++ b/incoming/chatgpt-runs/run-19.md
@@ -1,0 +1,467 @@
+## 1. Convex-position crossing lemma
+
+**Lemma (crossing lemma).**
+Let (P={p_1,\dots,p_n}) be the vertices of a strictly convex polygon in cyclic order. Suppose (i\ne k), and suppose two distinct indices (a,b) satisfy
+
+[
+a,b\in S_i\cap S_k.
+]
+
+Then the four indices (i,k,a,b) are distinct, and in the cyclic order the pair ({i,k}) separates the pair ({a,b}). Equivalently, the chord (p_i p_k) crosses the chord (p_a p_b).
+
+**Proof.**
+Since (a,b\in S_i), neither (a) nor (b) equals (i). Since (a,b\in S_k), neither equals (k). Thus (i,k,a,b) are distinct.
+
+Let (C_i) be the circle centered at (p_i) with radius (r_i), and let (C_k) be the circle centered at (p_k) with radius (r_k). The points (p_a,p_b) lie on both circles.
+
+For any common point (x\in C_i\cap C_k),
+
+[
+|x-p_i|^2-r_i^2=0,\qquad |x-p_k|^2-r_k^2=0.
+]
+
+Subtracting gives
+
+[
+|x-p_i|^2-|x-p_k|^2=r_i^2-r_k^2,
+]
+
+which is the equation of a line perpendicular to (p_i p_k). This line is the radical axis of the two circles. Hence (p_a) and (p_b) lie on a line (L) perpendicular to the line (\ell=p_i p_k).
+
+Let
+
+[
+q=L\cap \ell.
+]
+
+Because (L) is a chord of the circle centered at (p_i), and the perpendicular from the center (p_i) to a chord bisects that chord, (q) is the midpoint of (p_a p_b). Thus (p_a) and (p_b) are reflections of one another across the line (\ell=p_i p_k). In particular, (p_a) and (p_b) lie on opposite sides of the line (p_i p_k), and (q) lies in the open segment (p_a p_b).
+
+It remains to prove that (q) lies in the open segment (p_i p_k). Suppose not.
+
+If (q=p_i), then (p_i) lies in the open segment (p_a p_b), contradicting strict convexity, because a vertex of a strictly convex polygon cannot lie on the segment between two other vertices. Similarly (q=p_k) is impossible.
+
+Now suppose (q) lies on the line (p_i p_k) but outside the segment (p_i p_k). If (q) is beyond (p_i), then (p_i) lies in the open segment (q p_k). Since (q) lies in the open segment (p_a p_b), the point (p_i) lies in the interior of the triangle
+
+[
+\triangle p_k p_a p_b.
+]
+
+That contradicts strict convexity: every vertex of a strictly convex polygon is an extreme point of the convex hull. The same argument applies if (q) lies beyond (p_k).
+
+This is the exact step where strict convexity is invoked: it rules out the possibility that (p_i) or (p_k) lies in the convex hull of the other three points.
+
+Therefore
+
+[
+q\in (p_i p_k)\cap (p_a p_b),
+]
+
+so the two chords cross in their interiors. For four vertices of a strictly convex polygon, two chords cross in their interiors exactly when their endpoints alternate in the cyclic order. Hence ({i,k}) separates ({a,b}). (\square)
+
+---
+
+## 2. The exact theorem proved
+
+The full contradiction does **not** follow from facts (A) and (B) alone. In fact, there are cyclic (0)-(1) matrices satisfying all consequences of (A) and (B) with every row sum at least (4).
+
+Here is the strongest matrix theorem I can prove from (A) and (B).
+
+**Theorem.**
+Let (M) be an (n\times n) cyclically indexed (0)-(1) matrix with zero diagonal, satisfying:
+
+1. for distinct rows (i,k),
+
+[
+|S_i\cap S_k|\le 2;
+]
+
+2. if (|S_i\cap S_k|=2), say (S_i\cap S_k={a,b}), then ({i,k}) separates ({a,b}) in the cyclic order.
+
+Let
+
+[
+s_i=|S_i|,\qquad m=\sum_i s_i.
+]
+
+Then
+
+[
+\boxed{\sum_i \binom{s_i}{2}\le n(n-2)}
+]
+
+and therefore
+
+[
+\boxed{m\le \frac n2\left(1+\sqrt{8n-15}\right)}.
+]
+
+In particular, such a matrix cannot have all row sums at least (4) unless
+
+[
+n\ge 8.
+]
+
+This lower bound (n\ge 8) is sharp at the level of the cyclic matrix axioms: there is an (8\times 8) example with every row sum equal to (4).
+
+Moreover, (A) and (B) cannot even force a constant upper bound on row sums: for every prime (q\ge 5), there is a cyclic matrix with (n=q^2) rows and columns, every row sum equal to (q), and every pair of rows intersecting in at most one column. For those matrices, condition (B) is vacuous.
+
+Thus any genuine geometric contradiction would require additional metric input beyond (A) and (B).
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Write (S_i={j:M_{ij}=1}). All indices are taken cyclically.
+
+### Forbidden submatrices
+
+The crossing lemma gives the following forbidden (0)-(1) patterns.
+
+First, by (A), no two rows may share three columns. Thus the pattern
+
+[
+\begin{array}{c|ccc}
+& a&b&c\ \hline
+i&1&1&1\
+k&1&1&1
+\end{array}
+]
+
+is forbidden for (i\ne k).
+
+Second, a (2\times 2) all-one submatrix is allowed only in the alternating cyclic position. If two rows (i,k) share two columns (a,b), then the cyclic order must alternate:
+
+[
+i,\ a,\ k,\ b
+]
+
+up to reversal and rotation. Therefore the nonalternating pattern
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is forbidden whenever (a,b) lie on the same side of the chord (ik).
+
+In particular, adjacent rows cannot share two columns. If (k=i+1), then the chord (p_i p_k) is a polygon side and cannot cross any chord (p_a p_b). Hence
+
+[
+|S_i\cap S_{i+1}|\le 1.
+]
+
+Dually, adjacent columns cannot appear together in two rows. If two rows both contain adjacent columns (a,a+1), then the crossing lemma would require some chord (ik) to cross the polygon side (a(a+1)), impossible.
+
+More generally, fix two columns (a,b), and let
+
+[
+T_{ab}={i: a,b\in S_i}.
+]
+
+If (|T_{ab}|\ge 3), then among three row indices in (T_{ab}), two lie in the same arc of the cycle cut by (a,b). Those two rows do not separate (a,b), contradicting (B). Therefore
+
+[
+|T_{ab}|\le 2.
+]
+
+If (a,b) are adjacent, then even (|T_{ab}|=2) is impossible, so
+
+[
+|T_{ab}|\le 1
+]
+
+for adjacent columns.
+
+Thus the exact column-pair capacity is
+
+[
+|T_{ab}|\le
+\begin{cases}
+1,& a,b\text{ adjacent},\
+2,& a,b\text{ nonadjacent}.
+\end{cases}
+]
+
+### Discharging count
+
+For each row (i), put one unit of charge on every unordered pair of (1)’s in that row. Row (i) contributes
+
+[
+\binom{s_i}{2}
+]
+
+units of charge.
+
+Now discharge each such unit to the corresponding unordered column pair ({a,b}). By the capacity rule above, an adjacent column pair receives at most (1) unit of charge, and a nonadjacent column pair receives at most (2).
+
+There are (n) adjacent unordered column pairs and
+
+[
+\binom n2-n
+]
+
+nonadjacent unordered column pairs. Hence
+
+[
+\sum_i\binom{s_i}{2}
+\le
+1\cdot n+2\left(\binom n2-n\right).
+]
+
+Simplifying,
+
+[
+\sum_i\binom{s_i}{2}
+\le
+n+n(n-1)-2n
+===========
+
+n(n-2).
+]
+
+This proves
+
+[
+\boxed{\sum_i\binom{s_i}{2}\le n(n-2)}.
+]
+
+Now let
+
+[
+m=\sum_i s_i.
+]
+
+Since
+
+[
+\sum_i s_i^2
+============
+
+2\sum_i\binom{s_i}{2}+\sum_i s_i,
+]
+
+we get
+
+[
+\sum_i s_i^2
+\le
+2n(n-2)+m.
+]
+
+By Cauchy–Schwarz,
+
+[
+m^2
+===
+
+\left(\sum_i s_i\right)^2
+\le
+n\sum_i s_i^2
+\le
+n\bigl(2n(n-2)+m\bigr).
+]
+
+Thus
+
+[
+m^2-nm-2n^2(n-2)\le 0.
+]
+
+Solving the quadratic inequality gives
+
+[
+\boxed{
+m\le \frac n2\left(1+\sqrt{8n-15}\right).
+}
+]
+
+If every row has size at least (4), then (m\ge 4n). Therefore
+
+[
+4n\le \frac n2\left(1+\sqrt{8n-15}\right),
+]
+
+so
+
+[
+8\le 1+\sqrt{8n-15},
+]
+
+hence
+
+[
+49\le 8n-15,
+]
+
+and therefore
+
+[
+n\ge 8.
+]
+
+So the discharging argument rules out (n\le 7), but it cannot rule out (n=8).
+
+### Sharp cyclic (8\times 8) matrix
+
+Let the indices be (\mathbb Z/8\mathbb Z), and define
+
+[
+S_i={i-1,\ i+1,\ i+2,\ i+5}\pmod 8.
+]
+
+Equivalently, the matrix is
+
+[
+\begin{array}{c|cccccccc}
+&0&1&2&3&4&5&6&7\ \hline
+0&0&1&1&0&0&1&0&1\
+1&1&0&1&1&0&0&1&0\
+2&0&1&0&1&1&0&0&1\
+3&1&0&1&0&1&1&0&0\
+4&0&1&0&1&0&1&1&0\
+5&0&0&1&0&1&0&1&1\
+6&1&0&0&1&0&1&0&1\
+7&1&1&0&0&1&0&1&0
+\end{array}
+]
+
+Every row has size (4). Because the construction is cyclic, it suffices to compare row (0) with row (d). Let
+
+[
+D={-1,1,2,5}\pmod 8={7,1,2,5}.
+]
+
+Then
+
+[
+S_0=D,\qquad S_d=d+D.
+]
+
+The intersections are:
+
+[
+\begin{array}{c|c}
+d&S_0\cap S_d\ \hline
+1&{2}\
+2&{1,7}\
+3&{2,5}\
+4&{1,5}\
+5&{2,7}\
+6&{5,7}\
+7&{1}
+\end{array}
+]
+
+Thus adjacent rows intersect in one column, and every nonadjacent row pair intersects in two columns. For (d=2,3,4,5,6), the two common columns lie on opposite arcs between (0) and (d), so the crossing condition (B) holds.
+
+Therefore this matrix satisfies all consequences of (A) and (B) and has every row sum equal to (4). So no contradiction can be proved from (A) and (B) alone.
+
+This matrix is not claimed to come from an actual convex polygon. In fact, this particular pattern is ruled out by extra metric information: because it has mutual adjacent entries (M_{i,i+1}=M_{i+1,i}=1), a genuine realization would force all (r_i) equal. Then the entries (M_{i,i+2}=1) would force every consecutive triangle (p_i p_{i+1} p_{i+2}) to be equilateral, making every interior angle (60^\circ), impossible for a convex octagon. That argument uses distance symmetry and angle sums, not merely (A) and (B).
+
+### Larger matrix examples: (A) and (B) cannot bound row sums by a constant
+
+Let (q\ge 5) be a prime, and let the row and column index set be
+
+[
+I=\mathbb F_q^2.
+]
+
+Choose any cyclic order on (I). Define a bijection
+
+[
+\phi:I\to \mathbb F_q^2,\qquad \phi(u,v)=(u,\ v+u^2+1).
+]
+
+For a row (i=(a,b)), define
+
+[
+S_{(a,b)}
+=========
+
+{(u,v)\in I:\ \phi(u,v)\text{ lies on the line }y=ax+b}.
+]
+
+Equivalently,
+
+[
+(u,v)\in S_{(a,b)}
+\iff
+v+u^2+1=au+b.
+]
+
+For each (u\in\mathbb F_q), there is exactly one (v), namely
+
+[
+v=au+b-u^2-1.
+]
+
+So every row has size (q).
+
+The diagonal is zero: for ((u,v)=(a,b)), the condition would be
+
+[
+b+a^2+1=a^2+b,
+]
+
+which is impossible in (\mathbb F_q).
+
+Two distinct rows ((a,b)) and ((a',b')) correspond to two affine lines
+
+[
+y=ax+b,\qquad y=a'x+b'.
+]
+
+If (a=a') and (b\ne b'), the lines are parallel and disjoint. If (a\ne a'), they meet in exactly one point. Since (\phi) is a bijection, the two rows share at most one column.
+
+Hence condition (A) holds strongly:
+
+[
+|S_i\cap S_k|\le 1
+]
+
+for all (i\ne k). Condition (B) is vacuous. Thus for (n=q^2), we obtain cyclic matrices with every row sum (q=\sqrt n). This proves that (A) and (B) alone cannot force row sums below (4).
+
+---
+
+## 4. Configurations that remain unresolved by (A) and (B)
+
+The following patterns are not eliminated by the crossing lemma/discharging method.
+
+### Unresolved local pattern: alternating (2\times 2)
+
+If the cyclic order is
+
+[
+i,\ a,\ k,\ b,
+]
+
+then the crossed rectangle
+
+[
+\begin{array}{c|cc}
+& a&b\ \hline
+i&1&1\
+k&1&1
+\end{array}
+]
+
+is allowed by (A) and (B). It is exactly the configuration produced by two circles meeting in two polygon vertices.
+
+### Unresolved saturated (8\times 8) pattern
+
+The cyclic matrix
+
+[
+S_i={i-1,\ i+1,\ i+2,\ i+5}\pmod 8
+]
+
+has every row sum (4) and satisfies all matrix consequences of (A) and (B). It remains unresolved by the cyclic crossing/discharging argument, although it is ruled out by extra metric constraints.
+
+### Unresolved sparse-intersection families
+
+Any matrix in which every two rows share at most one column automatically satisfies (A) and makes (B) vacuous. The affine-line construction above gives exact examples with row sum (\sqrt n). Such matrices cannot be attacked by any argument that only uses double intersections and the crossing lemma.
+
+Therefore, to prove a genuine geometric contradiction for the original distance problem, one needs additional geometric input beyond (A) and (B), such as constraints relating opposite directed entries (M_{ij}) and (M_{ji}), propagation of equal radii, angle-sum restrictions, or other metric constraints not visible in the cyclic (0)-(1) matrix alone.

--- a/incoming/chatgpt-runs/run-20.md
+++ b/incoming/chatgpt-runs/run-20.md
@@ -1,0 +1,413 @@
+## 1. Convex-position crossing lemma
+
+Let the vertices (p_1,\dots,p_n) be in strictly convex cyclic order. Suppose (i\neq k) and
+
+[
+a,b\in S_i\cap S_k,\qquad a\neq b.
+]
+
+Then
+
+[
+|p_a-p_i|=|p_b-p_i|,\qquad |p_a-p_k|=|p_b-p_k|.
+]
+
+Thus both (p_i) and (p_k) lie on the perpendicular bisector of segment (p_ap_b). Since (p_i\neq p_k), the line (p_ip_k) is exactly that perpendicular bisector. Equivalently, (p_a) and (p_b) are reflections of one another across the line (p_ip_k). In particular, (p_a,p_b) lie on opposite sides of the line (p_ip_k).
+
+It remains to prove that (p_i,p_k) lie on opposite sides of the line (p_ap_b). Let (m) be the midpoint of (p_ap_b). Since (p_ip_k) is the perpendicular bisector of (p_ap_b), we have
+
+[
+m\in p_ip_k\quad\text{as a line.}
+]
+
+If (m) is not between (p_i) and (p_k), then (p_i,p_k) lie on the same side of the line (p_ap_b). Assume, for example, that the order on the line (p_ip_k) is
+
+[
+p_i,\ p_k,\ m.
+]
+
+Because (m) lies in the open segment (p_ap_b), every point of the open segment (p_im) lies in the interior of the triangle (\triangle p_ip_ap_b). Hence (p_k) lies in the interior of (\triangle p_ip_ap_b).
+
+That is impossible.
+
+**Strict convexity is used exactly here:** every vertex of a strictly convex polygon is an extreme point of the convex hull; in particular, no vertex (p_k) can lie in the convex hull, let alone the interior of a triangle, formed by three other vertices (p_i,p_a,p_b).
+
+Therefore (m) lies between (p_i) and (p_k). Since (m) also lies between (p_a) and (p_b), the two chords (p_ip_k) and (p_ap_b) cross in their interiors.
+
+For vertices of a strictly convex polygon, two chords with four distinct endpoints cross in their interiors if and only if their endpoints alternate in the cyclic order. Hence the pair ({i,k}) separates the pair ({a,b}). This proves Fact (B).
+
+---
+
+## 2. The exact theorem proved here
+
+Let (R_i=S_i), and write (s_i=|R_i|). Assume the cyclic matrix (M) satisfies:
+
+[
+|R_i\cap R_k|\le 2
+]
+
+and the crossing rule from Fact (B). Then:
+
+[
+\boxed{\sum_{i=1}^n \binom{s_i}{2}\le n(n-2).}
+]
+
+Consequently,
+
+[
+\boxed{\sum_i s_i\le \frac n2\bigl(1+\sqrt{8n-15}\bigr).}
+]
+
+In particular, if every row has size at least (4), then
+
+[
+6n\le \sum_i \binom{s_i}{2}\le n(n-2),
+]
+
+so
+
+[
+\boxed{n\ge 8.}
+]
+
+Moreover, if (n=8) and all row sums are at least (4), then the matrix structure forced by (A) and (B), together with one additional elementary geometric angle argument, gives a contradiction. Therefore:
+
+[
+\boxed{\text{No strictly convex octagon can satisfy } |S_i|\ge 4 \text{ for every } i.}
+]
+
+Thus any genuine geometric counterexample, if one exists, must have
+
+[
+\boxed{n\ge 9.}
+]
+
+However, a full contradiction for all (n) **does not follow from (A) and (B) alone**. There are cyclic (0)-(1) matrices with all row sums (4) satisfying every consequence of (A) and (B). An explicit infinite family is given in Section 4.
+
+---
+
+## 3. Cyclic-matrix and discharging argument
+
+Work modulo (n). For distinct indices (x,y), let
+
+[
+I(x,y)={x+1,x+2,\dots,y-1}
+]
+
+denote the open clockwise interval from (x) to (y).
+
+Two unordered pairs ({x,y}) and ({u,v}) are said to cross cyclically if exactly one of (u,v) lies in (I(x,y)). This is equivalent to the corresponding chords crossing in the strictly convex polygon.
+
+### 3.1 Forbidden (2\times 2) cyclic submatrices
+
+Suppose rows (i,k) both contain columns (a,b). Then
+
+[
+a,b\in R_i\cap R_k.
+]
+
+If (a,b) lie on the same side of the pair ({i,k}), then ({i,k}) does not separate ({a,b}), contradicting Fact (B).
+
+So the following (2\times 2) all-one pattern is forbidden unless the row-pair and column-pair cross cyclically:
+
+[
+\begin{array}{c|cc}
+& a & b\
+\hline
+i & 1 & 1\
+k & 1 & 1
+\end{array}
+]
+
+Forbidden special cases:
+
+* Adjacent rows (i,i+1) cannot share two columns.
+* Adjacent columns (a,a+1) cannot occur together in two rows.
+* More generally, if (a,b\in I(i,k)) or (a,b\in I(k,i)), then rows (i,k) cannot both contain (a,b).
+
+Fact (A) also forbids every (2\times 3) all-one submatrix:
+
+[
+\begin{array}{c|ccc}
+& a & b & c\
+\hline
+i & 1 & 1 & 1\
+k & 1 & 1 & 1
+\end{array}
+]
+
+because two rows may have at most two common (1)’s.
+
+Fact (B) gives the dual-looking forbidden pattern: no (3\times 2) all-one submatrix. Indeed, if three rows all contained columns (a,b), then two of those three row indices would lie on the same cyclic side of ({a,b}), so those two rows would not separate (a,b), contradicting Fact (B).
+
+Thus
+
+[
+\boxed{\text{No }2\times 3\text{ or }3\times 2\text{ all-one submatrix is allowed.}}
+]
+
+### 3.2 Column-pair codegree bound
+
+Fix two columns (a,b). Let
+
+[
+T_{ab}={i: a,b\in R_i}.
+]
+
+If (|T_{ab}|\ge 3), then among three row indices in (T_{ab}), two lie on the same cyclic side of ({a,b}). Those two rows both contain (a,b), contradicting Fact (B). Hence
+
+[
+\boxed{|T_{ab}|\le 2.}
+]
+
+If (a,b) are adjacent cyclically, then one of the two arcs between them is empty, so no two row indices can separate them. Therefore
+
+[
+\boxed{|T_{a,a+1}|\le 1.}
+]
+
+### 3.3 Discharging bound
+
+For each row (i), distribute one unit of charge to every unordered pair of columns contained in (R_i). Row (i) sends
+
+[
+\binom{s_i}{2}
+]
+
+units of charge.
+
+A non-adjacent column-pair can receive charge from at most two rows. An adjacent column-pair can receive charge from at most one row.
+
+There are (n) adjacent column-pairs and
+
+[
+\binom n2-n
+]
+
+non-adjacent column-pairs. Hence
+
+[
+\sum_i \binom{s_i}{2}
+\le n+2\left(\binom n2-n\right)
+= n+n(n-1)-2n
+= n(n-2).
+]
+
+So
+
+[
+\boxed{\sum_i \binom{|S_i|}{2}\le n(n-2).}
+]
+
+Now let
+
+[
+m=\sum_i |S_i|.
+]
+
+By convexity of (x\mapsto \binom{x}{2}),
+
+[
+\sum_i \binom{s_i}{2}
+\ge n\binom{m/n}{2}
+= \frac{m^2}{2n}-\frac m2.
+]
+
+Therefore
+
+[
+\frac{m^2}{2n}-\frac m2\le n(n-2),
+]
+
+so
+
+[
+m^2-nm-2n^2(n-2)\le 0.
+]
+
+Solving the quadratic gives
+
+[
+\boxed{m\le \frac n2\left(1+\sqrt{8n-15}\right).}
+]
+
+In particular, if every (s_i\ge 4), then
+
+[
+6n\le \sum_i \binom{s_i}{2}\le n(n-2),
+]
+
+so
+
+[
+n\ge 8.
+]
+
+### 3.4 The extremal (n=8) case
+
+Assume (n=8) and every row has size at least (4). Then
+
+[
+\sum_i \binom{s_i}{2}\ge 8\binom42=48.
+]
+
+But the discharging bound gives
+
+[
+\sum_i \binom{s_i}{2}\le 8(8-2)=48.
+]
+
+So equality holds everywhere. Therefore:
+
+[
+s_i=4\quad\text{for every }i.
+]
+
+Also every adjacent column-pair occurs in exactly one row, and every non-adjacent column-pair occurs in exactly two rows.
+
+The same argument applied dually to column degrees shows that every column has degree (4), adjacent row-pairs intersect in exactly one column, and non-adjacent row-pairs intersect in exactly two columns.
+
+Now consider rows (i) and (i+2). They are non-adjacent, so
+
+[
+|R_i\cap R_{i+2}|=2.
+]
+
+By Fact (B), their two common columns must be separated by the pair ({i,i+2}). But the interval (I(i,i+2)) consists of the single index (i+1). Hence one common column must be (i+1). Therefore
+
+[
+i+1\in R_i.
+]
+
+Similarly, using rows (i) and (i-2), we get
+
+[
+i-1\in R_i.
+]
+
+Thus every row contains both neighboring columns:
+
+[
+\boxed{i-1,\ i+1\in R_i\quad\text{for every }i.}
+]
+
+Now fix a side ({j,j+1}). Consider rows (j-1) and (j+2). They are non-adjacent, so they share exactly two columns. By Fact (B), one of their common columns lies in the interval
+
+[
+I(j-1,j+2)={j,j+1}.
+]
+
+If the common column is (j), then row (j+2) contains (j). But row (j+2) already contains its neighbor (j+1). Hence row (j+2) contains both (j,j+1).
+
+If the common column is (j+1), then row (j-1) contains (j+1). But row (j-1) already contains its neighbor (j). Hence row (j-1) contains both (j,j+1).
+
+So every side ({j,j+1}) is contained in one of the two rows (j-1) or (j+2).
+
+Now use one additional geometric input beyond (A) and (B):
+
+If row (j-1) contains both (j) and (j+1), then
+
+[
+|p_{j-1}p_j|=|p_{j-1}p_{j+1}|.
+]
+
+Thus triangle (p_{j-1}p_jp_{j+1}) is isosceles with base (p_jp_{j+1}). Its base angle at (p_j) is strictly less than (90^\circ). But that base angle is exactly the polygon interior angle at (p_j). Hence angle (p_j) is acute.
+
+Similarly, if row (j+2) contains both (j,j+1), then the polygon interior angle at (p_{j+1}) is acute.
+
+Therefore every side of the octagon has at least one acute endpoint. Hence no two non-acute angles can be adjacent. In an (8)-cycle, that means there are at most (4) non-acute angles, so at least (4) acute angles.
+
+Strict convexity gives every interior angle (<180^\circ), and the acute angles are (<90^\circ). Thus the total angle sum is strictly less than
+
+[
+4\cdot 90^\circ+4\cdot 180^\circ=1080^\circ.
+]
+
+But a convex octagon has interior angle sum
+
+[
+(8-2)\cdot 180^\circ=1080^\circ.
+]
+
+Contradiction. Therefore no strictly convex octagon realizes the condition (|S_i|\ge 4) for every row.
+
+---
+
+## 4. Remaining unresolved configurations and exact patterns
+
+The matrix/discharging method above cannot prove a contradiction for all (n). In fact, (A) and (B) alone allow many cyclic (0)-(1) matrices with all row sums (4).
+
+### 4.1 A small (n=8) matrix surviving (A) and (B)
+
+Modulo (8), define
+
+[
+R_i={i+1,i+2,i+5,i+7}.
+]
+
+The matrix is:
+
+[
+\begin{array}{c|cccccccc}
+&0&1&2&3&4&5&6&7\
+\hline
+0&0&1&1&0&0&1&0&1\
+1&1&0&1&1&0&0&1&0\
+2&0&1&0&1&1&0&0&1\
+3&1&0&1&0&1&1&0&0\
+4&0&1&0&1&0&1&1&0\
+5&0&0&1&0&1&0&1&1\
+6&1&0&0&1&0&1&0&1\
+7&1&1&0&0&1&0&1&0
+\end{array}
+]
+
+This satisfies (A) and (B). It is not geometrically realizable, however, because every row contains (i+1) and (i+2), forcing every polygon interior angle to be acute, impossible for an octagon.
+
+The mirror pattern
+
+[
+R_i={i+1,i+3,i+6,i+7}
+]
+
+also satisfies (A) and (B), and is ruled out by the same extra angle argument.
+
+### 4.2 Infinite family not ruled out by (A), (B), or the discharging argument
+
+For every (n\ge 25), define indices modulo (n) and set
+
+[
+\boxed{R_i={i+2,\ i+5,\ i+9,\ i+14}.}
+]
+
+Equivalently,
+
+[
+M_{ij}=1
+\quad\Longleftrightarrow\quad
+j-i\pmod n\in{2,5,9,14}.
+]
+
+Every row has size (4).
+
+The positive differences among
+
+[
+D={2,5,9,14}
+]
+
+are
+
+[
+3,4,5,7,9,12,
+]
+
+all distinct. Since the largest sum of two of these is (24<n), the ordered differences are also distinct modulo (n). Therefore two shifted copies (i+D) and (k+D) intersect in at most one element. Hence
+
+[
+|R_i\cap R_k|\le 1
+]
+
+for all (i\neq k). Fact (A) holds, and Fact (B) is vacuous because no two rows ever share two columns.
+
+Thus this is an exact cyclic (0)-(1) pattern with all row sums (4) satisfying all consequences of (A) and (B). Resolving whether such patterns can or cannot arise from actual Euclidean distances in strictly convex position requires additional geometric input beyond the crossing lemma and the discharging argument above.

--- a/incoming/prompt0-runs/audit.md
+++ b/incoming/prompt0-runs/audit.md
@@ -1,0 +1,140 @@
+# Prompt 0 Run 01 Audit
+
+Status: heuristic/audit note. This file records local review of an AI-generated
+prompt result. It is not mathematical evidence for the full problem and does
+not claim a proof or counterexample.
+
+## Verdict
+
+This run is useful but not a new direction to promote as-is.
+
+Useful pieces:
+
+1. The centered-circle angle inequality is a real local constraint once the
+   cone statement is repaired.
+2. The row-intersection bound is standard and correct.
+3. The 10-point non-convex construction is valid and is already represented in
+   the repository's synthesis notes.
+
+Main correction:
+
+- The statement "all other vertices lie strictly inside the open cone" at a
+  hull vertex is false as written: the two adjacent vertices lie on the
+  boundary rays. The correct statement is that all other vertices lie in the
+  closed cone spanned by the two incident edges, only the adjacent vertices lie
+  on the boundary rays, and all non-adjacent vertices lie in the open cone.
+
+This correction has been applied to:
+
+- `docs/claims.md`;
+- `docs/vertex-circle-order-filter.md`;
+- `docs/canonical-synthesis.md`.
+
+## Claim Review
+
+### Lemma 1: Angular Order And Semicircle Containment
+
+The intended conclusion is correct, but the proof needs the boundary-ray
+correction above.
+
+Corrected form:
+
+- from a fixed polygon vertex `p`, all other vertices lie in the closed
+  interior angle at `p`;
+- the angular span is at most `alpha_p`, and `alpha_p < pi`;
+- therefore any equal-distance cohort at `p` lies in an open semicircle of the
+  circle centered at `p`;
+- strict convexity/no-three-collinear gives distinct polar rays;
+- boundary order agrees with angular order around `p`, up to reversal.
+
+The run states `delta_1 + delta_2 + delta_3 < alpha_p`. The universally safe
+version is
+
+`delta_1 + delta_2 + delta_3 <= alpha_p < pi`.
+
+Strict inequality can fail if the chosen four witnesses include both adjacent
+neighbors of `p`. This does not break the later middle-witness corollary,
+because `delta_1 + delta_2 < alpha_p` and `delta_2 + delta_3 < alpha_p` still
+hold whenever all three gaps are positive.
+
+### Lemma 2: Middle-Witness Angle Constraint
+
+After the Lemma 1 correction, the angle bound is valid:
+
+`epsilon_{q_2} <= (delta_1 + delta_2)/2`
+
+and
+
+`epsilon_{q_3} <= (delta_2 + delta_3)/2`.
+
+The inscribed-angle computation is sound: since the middle witness lies on the
+minor arc between its two neighboring witnesses, the angle at the middle
+witness sees the complementary major arc.
+
+### Corollary 3: Low-Angle Descent
+
+The corollary remains valid in corrected form. If `alpha_p < 2pi/3`, the two
+middle witnesses have strictly larger interior angle than `p`.
+
+This is a useful local obstruction, but it does not close the problem because
+large-angle vertices are compatible with convex polygons.
+
+### Lemma 4: Row-Intersection Bound
+
+The bound
+
+`|S_i cap S_j| <= 2`
+
+is correct. It is also already part of the repo's standard A/B matrix
+framework. It follows directly from the fact that two distinct circles meet in
+at most two points; the radical-axis/no-three-collinear explanation is
+compatible but stronger than needed.
+
+## Verified Near-Counterexample
+
+The 10-point construction with an outer regular pentagon and an inner rotated
+regular pentagon of radius
+
+`rho = phi^{-2} = (3 - sqrt(5))/2`
+
+was checked locally.
+
+Results:
+
+- each outer point has a distance class of size `4`;
+- each inner point has a distance class of size `4`;
+- the inner pentagon lies strictly inside the outer pentagon;
+- the convex hull has only the five outer vertices.
+
+The two algebraic identities used in the proof simplify to zero under exact
+symbolic checking:
+
+`1 + phi^{-3} + phi^{-4} = 2 - phi^{-1}`;
+
+`phi^{-4}(2 + phi) = 1 + phi^{-4} - phi^{-1}`.
+
+This example is not a counterexample to Erdos Problem #97. It is already
+represented in `docs/canonical-synthesis.md` as the 10-point concave/inner
+pentagon obstruction to dropping convex position.
+
+## Repository Value
+
+Worth keeping:
+
+- the raw run as provenance;
+- this audit;
+- the corrected cone wording in canonical docs;
+- possible future use of the Lemma 2 angle inequality as a finite-pattern
+  filter.
+
+Not worth promoting:
+
+- a standalone Prompt 0 proof route;
+- the near-counterexample as new evidence;
+- the uncorrected strict open-cone statement.
+
+Recommended next action:
+
+Use Prompt 0 only as a source of local filters. The better active path remains
+the certified fragile-hypergraph computation route, with metric filters added
+only when they can be encoded and tested.

--- a/incoming/prompt0-runs/run-01.md
+++ b/incoming/prompt0-runs/run-01.md
@@ -1,0 +1,386 @@
+# Prompt 0 Run 01
+
+I do **not** have a complete proof or counterexample for the original statement. Rather than give a false proof, I will state precisely what I can prove. The argument below gives a rigorous reduction, proves several necessary structural lemmas, and gives an exact near-counterexample showing why the strict-convexity hypothesis is doing real work.
+
+Let me call a vertex `(p_i)` **good** if
+
+`N_i(r) <= 3` for every `r > 0`,
+
+and **bad** otherwise. Thus `(p_i)` is bad exactly when there are four distinct other vertices lying on one circle centered at `(p_i)`.
+
+The desired statement is:
+
+Every finite strictly convex planar vertex set has at least one good vertex.
+
+I cannot honestly claim to have settled this. The strongest rigorous facts I obtained are the following.
+
+---
+
+## 1. A basic angular lemma for a bad vertex
+
+Let `P={p_1,...,p_n}` be the vertex set of a strictly convex polygon, listed in cyclic order. Fix a vertex `p in P`. Let the two polygonal edges incident to `p` determine the interior angle
+
+`alpha_p in (0, pi)`.
+
+All other vertices of the polygon lie strictly inside the open cone of angle `alpha_p` with apex `p`.
+
+### Lemma 1
+
+Suppose `p` is bad. Then there exist four distinct vertices
+
+`q_1,q_2,q_3,q_4 in P\{p}`
+
+lying on a common circle centered at `p`, and in their cyclic order around the polygon their polar angles around `p` also occur in the same order. Moreover they lie on an arc of angular length `< pi`.
+
+### Proof
+
+Since `p` is bad, there is some `r>0` such that at least four vertices of `P\{p}` lie on the circle
+
+`C(p,r)={x:|x-p|=r}`.
+
+Choose four of them and label them `q_1,q_2,q_3,q_4` according to the cyclic order of the polygon after deleting `p`.
+
+Because the polygon is strictly convex, all vertices different from `p` lie strictly inside the interior tangent cone at `p`. This cone has opening angle `alpha_p<pi`. Hence the four rays
+
+`p q_1, p q_2, p q_3, p q_4`
+
+are contained in an angular interval of length `alpha_p<pi`. In particular, the four points `q_1,q_2,q_3,q_4` lie on an open semicircle of `C(p,r)`.
+
+Strict convexity also prevents two distinct vertices from lying on the same ray from `p`, because then `p` and those two vertices would force a collinearity incompatible with all vertices being extreme. Thus the polar angles are distinct. Along the boundary chain opposite `p`, the radial projection from `p` preserves order, because two chords from `p` to boundary vertices cannot cross in the interior of a convex polygon. Therefore the cyclic order and polar order agree.
+
+---
+
+## 2. A quantitative angle constraint
+
+For a vertex `x`, write
+
+`epsilon_x := pi - alpha_x`
+
+for its exterior angle. Thus `epsilon_x > 0`, and
+
+`sum_{x in P} epsilon_x = 2pi`.
+
+### Lemma 2
+
+Let `p` be bad, and let `q_1,q_2,q_3,q_4` be four vertices lying on a circle centered at `p`, in the order given by Lemma 1. Define the angular gaps at `p` by
+
+`delta_1 = angle q_1 p q_2`, `delta_2 = angle q_2 p q_3`, `delta_3 = angle q_3 p q_4`.
+
+Then
+
+`delta_1 + delta_2 + delta_3 < alpha_p < pi`.
+
+Moreover the two middle vertices satisfy
+
+`epsilon_{q_2} <= (delta_1+delta_2)/2`,
+
+`epsilon_{q_3} <= (delta_2+delta_3)/2`.
+
+Equivalently,
+
+`alpha_{q_2} >= pi - (delta_1+delta_2)/2`,
+
+`alpha_{q_3} >= pi - (delta_2+delta_3)/2`.
+
+### Proof
+
+Because `q_1,q_2,q_3,q_4` lie in the interior cone at `p`, their total angular spread is less than `alpha_p`, so
+
+`delta_1 + delta_2 + delta_3 < alpha_p < pi`.
+
+Now consider `q_2`. The two vertices `q_1` and `q_3` lie on opposite sides of `q_2` along the boundary chain of the polygon. Since the polygon is convex, the diagonal rays
+
+`q_2 q_1`, `q_2 q_3`
+
+lie inside the interior angle at `q_2`. Therefore
+
+`alpha_{q_2} >= angle q_1 q_2 q_3`.
+
+The four points `q_1,q_2,q_3` lie on a circle centered at `p`. The central angle subtending the chord `q_1 q_3` is
+
+`angle q_1 p q_3 = delta_1 + delta_2`.
+
+Since `q_2` lies on the minor arc from `q_1` to `q_3`, the inscribed angle `angle q_1 q_2 q_3` subtends the complementary major arc. Hence
+
+`angle q_1 q_2 q_3 = pi - (delta_1+delta_2)/2`.
+
+Thus
+
+`alpha_{q_2} >= pi - (delta_1+delta_2)/2`,
+
+or equivalently,
+
+`epsilon_{q_2} <= (delta_1+delta_2)/2`.
+
+The proof for `q_3` is identical, using the triangle `q_2 q_3 q_4`.
+
+### Corollary 3
+
+If `p` is bad and
+
+`alpha_p < 2pi/3`,
+
+then at least one of the four equal-distance witnesses has interior angle strictly larger than `alpha_p`. In fact, both middle witnesses `q_2,q_3` in Lemma 2 satisfy
+
+`alpha_{q_2} > alpha_p`, `alpha_{q_3} > alpha_p`.
+
+### Proof
+
+Since
+
+`delta_1 + delta_2 < alpha_p`,
+
+Lemma 2 gives
+
+`alpha_{q_2} >= pi - (delta_1+delta_2)/2 > pi - alpha_p/2`.
+
+If `alpha_p < 2pi/3`, then
+
+`pi - alpha_p/2 > alpha_p`.
+
+Thus `alpha_{q_2} > alpha_p`. The same argument applies to `q_3`.
+
+This gives a genuine obstruction to local badness, but it does not by itself prove the theorem. In a hypothetical counterexample in which every vertex is bad, the maximum interior angle must be at least `2pi/3`, which is compatible with convex polygons.
+
+---
+
+## 3. A strong intersection restriction
+
+For each bad vertex `p_i`, choose one radius `r_i` for which
+
+`N_i(r_i) >= 4`,
+
+and choose a set
+
+`S_i subseteq P\{p_i}`, `|S_i|=4`,
+
+such that every point of `S_i` lies on the circle `C(p_i,r_i)`.
+
+### Lemma 4
+
+If `p_i != p_j` are two bad vertices, then
+
+`|S_i cap S_j| <= 2`.
+
+### Proof
+
+Suppose, toward a contradiction, that
+
+`|S_i cap S_j| >= 3`.
+
+Choose three distinct vertices
+
+`a,b,c in S_i cap S_j`.
+
+Because `a,b,c in S_i`, we have
+
+`|a-p_i|=|b-p_i|=|c-p_i|=r_i`.
+
+Because `a,b,c in S_j`, we also have
+
+`|a-p_j|=|b-p_j|=|c-p_j|=r_j`.
+
+Hence each of `a,b,c` lies on both circles
+
+`C(p_i,r_i)`, `C(p_j,r_j)`.
+
+Equivalently, subtracting squared-distance equations,
+
+`|x-p_i|^2-|x-p_j|^2=r_i^2-r_j^2`.
+
+This is a linear equation in `x`, so the common points of the two circles lie on a single line, namely the radical axis of the two circles. Thus `a,b,c` are collinear.
+
+But three collinear vertices cannot occur in a strictly convex polygon. Contradiction. Therefore
+
+`|S_i cap S_j| <= 2`.
+
+This lemma is quite restrictive: a putative all-bad configuration must carry four-element witness sets `S_i` with pairwise intersections at most `2`, and these sets must also satisfy the angular inequalities of Lemma 2.
+
+---
+
+## 4. An exact near-counterexample when convex position is dropped
+
+The strict-convexity hypothesis is highly load-bearing. If we merely take a finite planar point set and do not require every point to be a vertex of its convex hull, the corresponding statement is false.
+
+Let
+
+`phi=(1+sqrt(5))/2`, `rho=phi^{-2}=(3-sqrt(5))/2`.
+
+Let
+
+`zeta=e^{2pi i/5}`, `eta=e^{pi i/5}`.
+
+Define ten points in the complex plane by
+
+`A_k=zeta^k`, `0<=k<=4`,
+
+and
+
+`B_k=rho eta zeta^k`, `0<=k<=4`.
+
+Thus the `A_k` form a regular pentagon of radius `1`, while the `B_k` form a smaller regular pentagon of radius `rho`, rotated by `36` degrees.
+
+### Proposition 5
+
+For the ten-point set
+
+`Q={A_0,...,A_4,B_0,...,B_4}`,
+
+every point has four other points at the same distance.
+
+### Proof
+
+By fivefold rotational symmetry, it suffices to check `A_0` and `B_0`.
+
+First consider `A_0=1`. Its four equal-distance neighbors are
+
+`A_1, A_4, B_1, B_3`.
+
+Indeed,
+
+`|A_0-A_1|^2 = |1-zeta|^2 = 2-2 cos(2pi/5)`.
+
+Since
+
+`cos(2pi/5)=1/(2phi)`,
+
+this equals
+
+`2-1/phi`.
+
+On the other hand,
+
+`|A_0-B_1|^2 = |1-rho e^{3pi i/5}|^2 = 1+rho^2-2rho cos(3pi/5)`.
+
+Using
+
+`cos(3pi/5)=-1/(2phi)`,
+
+we get
+
+`|A_0-B_1|^2 = 1+rho^2+rho/phi`.
+
+Since `rho=phi^{-2}`, this is
+
+`1+phi^{-4}+phi^{-3}`.
+
+Using `phi^2=phi+1`, one checks that
+
+`1+phi^{-3}+phi^{-4} = 2-phi^{-1}`.
+
+Thus
+
+`|A_0-B_1|=|A_0-A_1|`.
+
+By symmetry,
+
+`|A_0-B_3|=|A_0-B_1|`, `|A_0-A_4|=|A_0-A_1|`.
+
+Therefore `A_0` has four equidistant neighbors.
+
+Now consider `B_0=rho e^{pi i/5}`. Its four equal-distance neighbors are
+
+`A_0, A_1, B_2, B_3`.
+
+We have
+
+`|B_0-A_0|^2 = 1+rho^2-2rho cos(pi/5)`.
+
+Since
+
+`cos(pi/5)=phi/2`,
+
+this becomes
+
+`|B_0-A_0|^2 = 1+rho^2-rho phi`.
+
+Because `rho=phi^{-2}`, this is
+
+`1+phi^{-4}-phi^{-1}`.
+
+Next,
+
+`|B_0-B_2|^2 = rho^2 |e^{pi i/5}-e^{5pi i/5}|^2`.
+
+The angle difference is `4pi/5`, so
+
+`|B_0-B_2|^2 = 2rho^2(1-cos(4pi/5))`.
+
+Using
+
+`cos(4pi/5)=-phi/2`,
+
+we obtain
+
+`|B_0-B_2|^2 = rho^2(2+phi)`.
+
+Since `rho=phi^{-2}`, this is
+
+`phi^{-4}(2+phi)`.
+
+Again using `phi^2=phi+1`, one checks that
+
+`phi^{-4}(2+phi) = 1+phi^{-4}-phi^{-1}`.
+
+Hence
+
+`|B_0-B_2|=|B_0-A_0|`.
+
+By symmetry,
+
+`|B_0-A_1|=|B_0-A_0|`, `|B_0-B_3|=|B_0-B_2|`.
+
+Thus `B_0` also has four equidistant neighbors. Rotating the whole construction proves the same for every `A_k` and every `B_k`.
+
+However, this is **not** a counterexample to the original problem. The points `B_k` lie strictly inside the regular pentagon with vertices `A_0,...,A_4`. Indeed, the inradius of the outer regular pentagon is
+
+`cos(pi/5)=phi/2`,
+
+whereas
+
+`rho=phi^{-2} < phi/2`.
+
+So `Q` is not the vertex set of a strictly convex polygon. This example shows that the convex-position assumption cannot simply be discarded.
+
+---
+
+## 5. What the proved lemmas reduce the problem to
+
+A genuine counterexample to the original problem would have to be a strictly convex polygon in which every vertex `p_i` is bad. For each `p_i`, choose four equal-distance witnesses `S_i`. Then the following conditions are forced:
+
+1. Each `S_i` lies on an open semicircle of the circle centered at `p_i`.
+2. If `S_i={q_1,q_2,q_3,q_4}` is written in cyclic order around the polygon, and `delta_1=angle q_1 p_i q_2`, `delta_2=angle q_2 p_i q_3`, `delta_3=angle q_3 p_i q_4`, then
+   `epsilon_{q_2} <= (delta_1+delta_2)/2` and
+   `epsilon_{q_3} <= (delta_2+delta_3)/2`.
+3. For distinct centers `p_i,p_j`, `|S_i cap S_j| <= 2`.
+
+The exact obstruction I could not overcome is this:
+
+I do not know how to rule out, or realize, a strictly convex configuration satisfying all these constraints simultaneously.
+
+The local angle inequalities are strong, but they do not immediately force an infinite descent, because once `alpha_p >= 2pi/3`, Lemma 2 no longer guarantees a witness of strictly larger interior angle. The intersection bound is also strong, but by itself it is only combinatorial and does not contradict the possible existence of `n` four-element witness sets with pairwise intersections at most `2`.
+
+---
+
+## 6. Role of the hypotheses
+
+The most load-bearing hypothesis is **strict convexity**.
+
+It is used in two essential places:
+
+1. To ensure that all other vertices lie inside an open cone of angle `<pi` at a chosen vertex. This is what makes the four equal-distance witnesses lie on an open semicircle and makes Lemma 2 possible.
+2. To forbid three collinear vertices. This is what proves the intersection bound `|S_i cap S_j| <= 2`.
+
+The exact ten-point construction above shows that if one drops the requirement that all points be vertices of a strictly convex polygon, the analogous statement is false.
+
+The hypothesis of **planarity** is also essential. In higher dimensions, the analogue is false in a very simple way: in `R^4`, the five vertices of a regular simplex have the property that every vertex is equidistant from the other four. Thus every vertex has a radius `r` with `N_i(r)=4`.
+
+The **centered-on-vertex condition** is also crucial. Lemma 1 and Lemma 2 both rely on the fact that the center of the relevant circle is itself one of the polygon vertices, so that the interior cone at that vertex controls the angular spread of the witnesses.
+
+The hypothesis of **finiteness** is needed for extremal arguments involving angles and for the witness-set formulation. Without finiteness, one can no longer reduce the problem to finitely many four-point witness configurations.
+
+So the status of my work is:
+
+No complete proof or disproof; the original statement remains unresolved by the argument above.
+
+But the strongest established local statement is Lemma 2, and the strongest established global restriction is Lemma 4.

--- a/incoming/prompt2-runs/audit.md
+++ b/incoming/prompt2-runs/audit.md
@@ -1,0 +1,263 @@
+# Prompt 2 Run 01 Audit
+
+Status: heuristic/audit note. This file records local review of an AI-generated
+prompt result. It is not a proof of Erdos Problem #97 and does not claim a
+counterexample.
+
+## Verdict
+
+This is a useful algebraic reduction.
+
+The main quotient statement is correct: for a non-concyclic configuration, the
+unavoidable kernel `U = span{1,x,y,x^2+y^2}` can be split off by choosing any
+four-point lifted base with nonsingular `Z_B`. Exotic syzygies are then exactly
+the kernel of the remaining-column matrix.
+
+The weighted two-core peeling is also correct as a linear-algebra reduction:
+singleton rows force active coordinates to vanish, so peeling preserves the
+kernel.
+
+What it does not do:
+
+- it does not prove rank rigidity;
+- it does not rule out exotic syzygies;
+- it does not give a base-independent combinatorial obstruction without the
+  signed-area weights.
+
+This is worth keeping as guidance for the affine-circuit/rank-rigidity path,
+especially as a specification for a future checker.
+
+## Checked Claims
+
+### Lifted Rank-Four Setup
+
+For each vertex, set
+
+`z_j = (1, x_j, y_j, x_j^2 + y_j^2)`.
+
+For a selected four-cohort `C_i={a,b,c,d}`, the signed-area coefficients
+
+```text
+Delta_bcd, -Delta_acd, Delta_abd, -Delta_abc
+```
+
+give the unique affine dependence among the four planar points, up to scalar.
+Since the cohort lies on a circle centered at `p_i`, the quadratic coordinate
+`q=x^2+y^2` is affine on that cohort:
+
+```text
+q_j = 2 p_i dot p_j + (r_i^2 - |p_i|^2).
+```
+
+Therefore the corresponding row of `L` annihilates the four columns
+`1,x,y,q`, so `LZ=0`.
+
+If the whole point set is not concyclic, then `rank Z=4`. More precisely,
+`rank Z <= 3` would give a nontrivial relation
+
+```text
+alpha + beta x + gamma y + delta (x^2+y^2) = 0
+```
+
+on all vertices. If `delta != 0`, all vertices lie on one circle; if
+`delta = 0`, all vertices lie on one line, impossible for a strict convex
+polygon with the sizes considered here.
+
+### Quotient Reduction
+
+Choose `B` with `det Z_B != 0` and let `N=[n]\B`.
+
+The evaluation map `U -> R^B` is an isomorphism. Hence every `h in R^n` has a
+unique decomposition
+
+```text
+h = u + g,
+```
+
+where `u in U` and `g` vanishes on `B`.
+
+Because `U subset ker L`,
+
+```text
+h in ker L iff g in ker L.
+```
+
+Thus
+
+```text
+ker L / U is isomorphic to ker L_N
+```
+
+and
+
+```text
+dim ker L = 4 + dim ker L_N.
+```
+
+This was also checked with a small exact rational linear-algebra script using
+random matrices satisfying `LU=0`.
+
+The phrase "for one equivalently every base" is acceptable only with this
+qualification: the base must satisfy `det Z_B != 0`. For such bases, the
+dimension `dim ker L_N` is independent of the base because it equals
+`dim ker L - 4`.
+
+### Weighted Two-Core Peeling
+
+For a current active column set `S`, if a row meets `S` in a singleton `{v}`,
+then the row equation forces
+
+```text
+lambda_v g_v = 0.
+```
+
+Strict convexity gives no three cohort points collinear, so all signed-area
+coefficients in a selected four-cohort are nonzero. Therefore `g_v=0`, and
+`v` can be deleted from the active support.
+
+Iterating this process produces the unique maximal active subset `S_B` for
+which every row meets `S_B` in either `0` or at least `2` vertices. Kernel
+dimension is preserved by extending core solutions by zero on peeled columns:
+
+```text
+ker L_N is isomorphic to ker A_B.
+```
+
+This was also checked locally on random sparse exact matrices.
+
+### Obstruction Components
+
+The component decomposition of the incidence graph is standard block-diagonal
+linear algebra:
+
+```text
+dim ker L = 4 + sum_nu (|S_nu| - rank A_nu).
+```
+
+The three listed obstruction types are valid for a fixed base and fixed chosen
+cohort system:
+
+1. An unused column outside the base is a zero column of `L_N`, hence an exotic
+   quotient vector.
+2. A pair-row-only component is a gain graph. A connected component has a
+   nonzero solution exactly when every cycle has gain product `1`; a tree
+   component automatically contributes one degree of freedom.
+3. A component with rows of size `3` or `4` is controlled exactly by the
+   maximal minors of its weighted coefficient matrix.
+
+Nuance for Pattern I: "unused column" is base-dependent in the quotient
+description. The immediate obstruction is an unused vertex that lies outside
+the chosen base `B`.
+
+## Repository Value
+
+Worth keeping:
+
+- the quotient reduction as a precise formulation of exotic syzygies;
+- the weighted two-core as a future checker target;
+- the pair-row gain-cycle criterion as a concrete rank-defect mechanism.
+
+Not worth claiming:
+
+- a proof that `ker L=U`;
+- a proof that all two-cores have full rank;
+- a weight-free combinatorial obstruction.
+
+Recommended next artifact:
+
+Implement a small checker that, for a selected witness pattern and symbolic or
+numeric coordinates, builds the affine-circuit matrix `L`, chooses valid lifted
+bases `B`, computes the weighted two-core, and reports pair-row gain cycles and
+rank-defective hypercore components.
+
+## Run 02 Continuation: Minimal Certificates
+
+The continuation in `run-02.md` refines the weighted two-core obstruction into
+a minimal-support circuit certificate. This refinement is mathematically sound
+with a few wording cautions.
+
+### What Is Correct
+
+Fix a valid lifted base `B` and write `N=[n]\B`. If `ker L_N` is nonzero, take
+a nonzero kernel vector `g` with minimal support `S`.
+
+Then:
+
+- no row can meet `S` in exactly one active vertex, because the corresponding
+  nonzero signed-area coefficient would force that coordinate of `g` to vanish;
+- the active matrix `A_S` has one-dimensional kernel;
+- equivalently, `rank A_S = |S|-1`;
+- one may choose `|S|-1` active rows `T` forming a row basis;
+- the usual cofactor vector of `A_{T,S}` spans the nullspace;
+- every remaining active row must satisfy the corresponding cofactor
+  determinant identity.
+
+Conversely, any such cofactor certificate gives a nonzero vector in `ker L_N`,
+hence an exotic class in `ker L/U`.
+
+A small exact rational sanity check over random sparse matrices found the
+expected behavior: every nonzero kernel contained a minimal-support certificate
+of this form.
+
+### Wording Cautions
+
+The statement "every exotic syzygy is exactly one of these finite cofactor
+certificates" should be read as:
+
+> every nonzero exotic quotient contains a minimal-support representative
+> producing one such certificate, and every such certificate yields an exotic
+> quotient vector.
+
+If `ker L_N` has dimension greater than one, a general exotic vector can be a
+linear combination of several circuit vectors and need not itself be a single
+minimal certificate.
+
+The phrase "for one, equivalently every, base" is valid only after restricting
+to bases `B` with `det Z_B != 0`. Under that restriction, the quotient
+dimension is base-independent:
+
+`dim ker L_N = dim ker L - 4`.
+
+Pattern I is likewise quotient-base dependent: the immediate zero-column
+certificate is an unused vertex lying outside the chosen base `B`.
+
+### Pair-Gain Components
+
+The gain-graph interpretation is correct for components whose active rows all
+meet the support in exactly two vertices.
+
+For a connected pair-gain component:
+
+- if the component is a tree, it contributes one degree of freedom;
+- if it has cycles, it contributes one degree of freedom exactly when all cycle
+  gain products are `1`;
+- if any cycle is unbalanced, that connected pair component has no nonzero
+  all-active solution.
+
+So "a cycle contributes one degree of freedom" should be understood at the
+connected-component level, not one independent degree for every balanced cycle.
+
+### Mixed Hypercore Components
+
+The proposed contraction of balanced pair-gain components is a valid way to
+compress the pair equations before applying the same cofactor-circuit test to
+the remaining hyperrows.
+
+This is best treated as an implementation plan:
+
+1. compute pair-equation connected components;
+2. reject supports containing unbalanced pair cycles;
+3. contract balanced pair components to component parameters;
+4. run the cofactor/minor certificate test on the contracted active matrix.
+
+### Repository Value
+
+This continuation makes Prompt 2 more useful, not more conclusive. It turns
+the rank-rigidity question into an explicit finite certificate search:
+
+- isolated quotient columns;
+- balanced pair-gain components;
+- mixed hypercore cofactor identities.
+
+That is a good target for a future script, but it remains a classification of
+possible defects rather than a proof that no defects occur.

--- a/incoming/prompt2-runs/run-01.md
+++ b/incoming/prompt2-runs/run-01.md
@@ -1,0 +1,327 @@
+# Prompt 2 Run 01
+
+The clean rigorous continuation is an exact obstruction theorem. I am **not**
+replacing the signed-area coefficients by symmetric ones; the obstruction is
+stated in terms of the original `Delta`-coefficients.
+
+## 1. Set up the lifted rank-four configuration
+
+Write
+
+```text
+q_j = x_j^2 + y_j^2,
+z_j = (1, x_j, y_j, q_j) in R^4,
+```
+
+and let `Z` be the `n x 4` matrix with rows `z_j`.
+
+For the row centered at `i`, with chosen cohort `C_i={a,b,c,d}`, define
+
+```text
+lambda^i_a = Delta_bcd,
+lambda^i_b = -Delta_acd,
+lambda^i_c = Delta_abd,
+lambda^i_d = -Delta_abc,
+```
+
+and `lambda^i_j=0` outside `C_i`. Thus the `i`-th row of `L` is `lambda^i`.
+
+Because `C_i` lies on a circle centered at `p_i`,
+
+```text
+q_j = 2 p_i dot p_j + (r_i^2 - |p_i|^2)  for j in C_i,
+```
+
+so `q` is affine on `C_i`. Therefore
+
+```text
+LZ = 0.
+```
+
+If `P` is non-concyclic, then `rank Z = 4`. Indeed, `rank Z <= 3` would mean
+that `q=x^2+y^2` is globally affine on `P`, i.e.
+
+```text
+x_j^2 + y_j^2 = alpha x_j + beta y_j + gamma
+```
+
+for all `j`, which is exactly the equation of one common circle. Thus, in the
+non-concyclic case,
+
+```text
+U := span{1,x,y,q}
+```
+
+is a genuine four-dimensional subspace of `ker L`.
+
+So the substantive lemma is equivalent to proving
+
+```text
+ker L = U.
+```
+
+Equivalently,
+
+```text
+ker L / U = 0.
+```
+
+The rest of the answer gives an exact finite obstruction to this quotient being
+nonzero.
+
+---
+
+## 2. Exact quotient reduction
+
+Choose any four indices
+
+```text
+B={b_1,b_2,b_3,b_4}
+```
+
+such that the `4 x 4` matrix `Z_B` is nonsingular. Such a `B` exists because
+`rank Z=4`. Let
+
+```text
+N=[n]\B.
+```
+
+Every vector `h in R^n` has a unique decomposition
+
+```text
+h = u + g,
+```
+
+where `u in U` and `g_b=0` for every `b in B`. Namely, `u` is the unique
+element of `U` agreeing with `h` on `B`.
+
+Since `U subseteq ker L`, we have
+
+```text
+h in ker L iff g in ker L.
+```
+
+But `g` is supported on `N`. Therefore, if `L_N` denotes the submatrix of `L`
+obtained by keeping only the columns indexed by `N`, then
+
+```text
+ker L / U is isomorphic to ker L_N.
+```
+
+Hence
+
+```text
+dim ker L = 4 + dim ker L_N.
+```
+
+So the desired rank rigidity lemma is equivalent to:
+
+```text
+L_N has full column rank n-4.
+```
+
+This is already a sharp reduction: exotic syzygies are exactly nonzero vectors
+in `ker L_N`.
+
+---
+
+## 3. Weighted two-core obstruction
+
+Now define a finite peeling process on the column set `N`.
+
+For a current subset `S subseteq N`, let
+
+```text
+E_i(S)=C_i cap S.
+```
+
+If for some row `i`,
+
+```text
+E_i(S)={v}
+```
+
+is a singleton, then the `i`-th equation reads
+
+```text
+lambda^i_v g_v = 0.
+```
+
+Because the polygon is strictly convex, no three cohort points are collinear,
+so every signed-area coefficient in a row is nonzero. Hence `lambda^i_v != 0`,
+and therefore `g_v=0`. Thus `v` cannot belong to the support of an exotic
+kernel vector.
+
+So we may delete `v`. Repeat this deletion until no row meets the remaining
+set in exactly one vertex.
+
+Let the final set be
+
+```text
+S_B subseteq N.
+```
+
+It is the maximal subset of `N` such that every row `C_i` meets `S_B` in either
+`0` or at least `2` vertices:
+
+```text
+|C_i cap S_B| in {0,2,3,4} for every i.
+```
+
+Call `S_B` the **weighted two-core** of the chosen cohort system after deleting
+the base `B`.
+
+Peeling preserves the kernel, so
+
+```text
+ker L_N is isomorphic to ker A_B,
+```
+
+where `A_B` is the matrix with columns indexed by `S_B`, rows indexed by those
+`i` with `C_i cap S_B != empty`, and entries
+
+```text
+(A_B)_{iv}=lambda^i_v.
+```
+
+Thus
+
+```text
+dim ker L = 4 + dim ker A_B.
+```
+
+This gives the promised exact classification:
+
+```text
+Exotic syzygies are exactly null vectors of the weighted two-core matrix A_B.
+```
+
+In particular, the rank rigidity lemma holds if and only if, for one
+equivalently every nonconcyclic base `B`,
+
+```text
+rank A_B = |S_B|.
+```
+
+---
+
+## 4. The finite obstruction list
+
+After peeling, decompose the incidence graph of `A_B` into connected
+components. A component consists of a vertex set `S_nu subseteq S_B` and the
+rows meeting it. Let `A_nu` be the corresponding block.
+
+Then
+
+```text
+dim ker L = 4 + sum_nu (|S_nu| - rank A_nu).
+```
+
+So every exotic syzygy belongs to one of the following explicit finite
+patterns.
+
+### Pattern I: unused columns
+
+If a vertex `v in N` is in no chosen cohort at all, then the corresponding
+column of `L_N` is zero. Then
+
+```text
+e_v in ker L_N,
+```
+
+so
+
+```text
+dim ker L > 4.
+```
+
+Thus any proof of the substantive lemma must first prove that no column can be
+unused by the chosen four-cohort system.
+
+### Pattern II: pair-row gain cycles
+
+Suppose a core component has only rows meeting the component in exactly two
+vertices. A row meeting `{u,v}` gives
+
+```text
+lambda^i_u g_u + lambda^i_v g_v = 0,
+```
+
+or
+
+```text
+g_v = -(lambda^i_u/lambda^i_v) g_u.
+```
+
+Thus the component is a signed weighted graph with edge gain
+
+```text
+gamma_i(u -> v) = -lambda^i_u/lambda^i_v.
+```
+
+A nonzero syzygy exists exactly when every cycle has gain product `1`:
+
+```text
+product_cycle gamma_i = 1.
+```
+
+If the pair-row component is a tree, it automatically contributes one exotic
+degree of freedom. If it has cycles, it contributes precisely when the
+signed-area gain products are balanced.
+
+This is a concrete rank-defect mechanism using the actual `Delta`-coefficients.
+
+### Pattern III: genuine hypercore components
+
+If a component contains a row meeting `3` or `4` active vertices, then the
+obstruction is exactly the vanishing of the maximal minors of its coefficient
+matrix.
+
+For a component with `m=|S_nu|` active vertices,
+
+```text
+dim ker A_nu > 0 iff rank A_nu < m.
+```
+
+Equivalently, all `m x m` minors of `A_nu` vanish. Each such minor is an
+explicit polynomial in the original signed-area coefficients
+
+```text
+Delta_rst.
+```
+
+If the component has fewer than `m` active rows, then it is automatically
+rank-defective. If it has at least `m` active rows, then the finite list of
+determinant tests gives the exact obstruction.
+
+---
+
+## 5. What remains to prove the original lemma
+
+The substantive rank rigidity lemma is therefore equivalent to the following
+purely finite statement:
+
+> For some nonconcyclic base `B` with `det Z_B != 0`, the weighted two-core
+> `A_B` has full column rank.
+
+Equivalently, every possible exotic support must be killed by one of the
+following mechanisms:
+
+```text
+a row meeting it in exactly one active vertex;
+an unbalanced pair-row gain cycle;
+a full-rank hypercore determinant.
+```
+
+Thus a complete proof of the proposed rigidity lemma must rule out all weighted
+two-core rank defects arising from the chosen centered four-cohorts.
+
+This reduction is exact and finite for every fixed polygon and chosen cohort
+system. It does not use generic dimension counting, and it keeps the actual
+affine-circuit coefficients
+
+```text
+Delta_bcd, -Delta_acd, Delta_abd, -Delta_abc
+```
+
+throughout.

--- a/incoming/prompt2-runs/run-02.md
+++ b/incoming/prompt2-runs/run-02.md
@@ -1,0 +1,351 @@
+# Prompt 2 Run 02
+
+Continuation result from the same Prompt 2 session.
+
+Continuing from the quotient reduction, the clean next step is to make the
+obstruction **minimal**. That gives an exact finite certificate for every
+possible exotic syzygy.
+
+I will write this as a theorem.
+
+---
+
+# The certificate theorem for exotic syzygies
+
+Let
+
+```text
+Z_j=(1,x_j,y_j,q_j), q_j=x_j^2+y_j^2,
+```
+
+and let `U=span{1,x,y,q} subseteq R^n`.
+
+For row `i`, with chosen cohort `C_i={a,b,c,d}`, write
+
+```text
+lambda^i_a = Delta_bcd,
+lambda^i_b = -Delta_acd,
+lambda^i_c = Delta_abd,
+lambda^i_d = -Delta_abc,
+```
+
+and `lambda^i_v=0` outside `C_i`. Thus
+
+```text
+(Lh)_i = sum_{v in C_i} lambda^i_v h_v.
+```
+
+Because the polygon is strictly convex, no three vertices are collinear, so
+every coefficient appearing in a row is nonzero.
+
+Also, under the four-cohort hypothesis, `P` cannot actually be globally
+concyclic. Indeed, if all `p_j` lay on one circle `Omega`, then the centered
+circle through `C_i` would meet `Omega` in four points, hence would equal
+`Omega`. Its center would then be `p_i`, but `p_i in Omega`, impossible for a
+nondegenerate circle. Thus `U` is automatically four-dimensional.
+
+---
+
+## Theorem
+
+Fix any four-point base
+
+```text
+B={b_1,b_2,b_3,b_4}
+```
+
+such that the `4 x 4` matrix `Z_B` is nonsingular, and put
+
+```text
+N=[n]\B.
+```
+
+Then
+
+```text
+ker L/U is isomorphic to ker L_N,
+```
+
+where `L_N` is the submatrix of `L` using only the columns in `N`.
+
+Moreover, `ker L/U != 0` if and only if there exists a finite certificate
+
+```text
+(B,S,T)
+```
+
+with the following data:
+
+- `S subseteq N`, `S != empty`;
+- no row meets `S` in exactly one vertex;
+- `T` is a set of `|S|-1` active rows;
+- the `(|S|-1) x |S|` matrix
+
+```text
+A_{T,S} = (lambda^i_v)_{i in T, v in S}
+```
+
+has rank `|S|-1`;
+
+- if `S={s_1,...,s_m}`, `m=|S|`, then the cofactor vector
+
+```text
+g_{s_j} = (-1)^j det A_{T,S\{s_j}}
+```
+
+has no zero coordinate and is annihilated by every active row:
+
+```text
+sum_{v in C_i cap S} lambda^i_v g_v = 0  for every row i.
+```
+
+Equivalently, for every active row `i notin T`,
+
+```text
+sum_{j=1}^m lambda^i_{s_j} (-1)^j det A_{T,S\{s_j}} = 0.
+```
+
+This is an explicit determinant identity in the original signed-area
+coefficients `Delta_rst`.
+
+Thus every exotic syzygy is exactly one of these finite cofactor certificates.
+
+---
+
+# Proof
+
+First, as before, `U subseteq ker L`. Since `Z_B` is nonsingular, every
+`h in R^n` has a unique decomposition
+
+```text
+h = u + g,
+```
+
+where `u in U` and `g_b=0` for all `b in B`. Namely, `u` is the unique element
+of `U` agreeing with `h` on `B`.
+
+Because `U subseteq ker L`,
+
+```text
+h in ker L iff g in ker L.
+```
+
+But `g` vanishes on `B`, so this is equivalent to
+
+```text
+L_N g_N = 0.
+```
+
+Therefore
+
+```text
+ker L/U is isomorphic to ker L_N.
+```
+
+Now suppose `ker L_N != 0`. Choose a nonzero vector `g in ker L_N` with
+minimal support
+
+```text
+S = supp g subseteq N.
+```
+
+If some row `i` met `S` in exactly one vertex `v`, then the `i`-th equation
+would be
+
+```text
+lambda^i_v g_v = 0.
+```
+
+Since `lambda^i_v != 0`, this would force `g_v=0`, contradicting `v in S`.
+Hence every row meets `S` in `0` or at least `2` vertices.
+
+Let `A_S` be the active matrix with columns `S` and rows those `i` for which
+`C_i cap S != empty`. The restriction `g_S` lies in `ker A_S`.
+
+By minimality of `S`,
+
+```text
+dim ker A_S = 1.
+```
+
+Indeed, if `dim ker A_S >= 2`, then we could take two independent null vectors
+and form a nontrivial linear combination cancelling one chosen coordinate of
+`g_S`, producing a nonzero kernel vector with strictly smaller support. That
+contradicts minimality.
+
+Thus
+
+```text
+rank A_S = |S|-1.
+```
+
+Choose `|S|-1` active rows `T` forming a full-rank row basis. Then `A_{T,S}`
+has rank `|S|-1`, so its nullspace is one-dimensional. The standard cofactor
+vector
+
+```text
+g_{s_j}=(-1)^j det A_{T,S\{s_j}}
+```
+
+spans that nullspace. Minimality forces every coordinate of this cofactor
+vector to be nonzero.
+
+Finally, because the original `g` is killed by every active row, every active
+row `i` must satisfy
+
+```text
+sum_{v in C_i cap S} lambda^i_v g_v = 0.
+```
+
+Substituting the cofactor formula gives the displayed determinant identities.
+
+Conversely, if such a certificate exists, define `g` on `S` by the cofactor
+formula and set `g=0` outside `S`. The certificate says every row annihilates
+`g`. Since `g` vanishes on `B`, and no nonzero element of `U` can vanish on
+`B`, this gives a genuine exotic element of `ker L/U`.
+
+That proves the theorem.
+
+---
+
+# The three actual obstruction patterns
+
+The theorem reduces everything to three concrete mechanisms.
+
+## Pattern 1: isolated quotient columns
+
+If `v in N` is not used by any active row after deleting `B`, then `S={v}` is
+a certificate.
+
+Equivalently,
+
+```text
+e_v in ker L_N.
+```
+
+So a proof of rank rigidity must first rule out the possibility that, after
+subtracting a four-point base, some vertex is invisible to all chosen cohorts.
+
+---
+
+## Pattern 2: pure pair-gain components
+
+Suppose every active row meets `S` in exactly two vertices. Then `S` carries a
+weighted graph structure.
+
+A row `i` meeting
+
+```text
+C_i cap S = {u,v}
+```
+
+gives
+
+```text
+lambda^i_u g_u + lambda^i_v g_v = 0,
+```
+
+so
+
+```text
+g_v = -(lambda^i_u/lambda^i_v) g_u.
+```
+
+Define the gain
+
+```text
+gamma_i(u -> v) := -lambda^i_u/lambda^i_v.
+```
+
+For a cycle
+
+```text
+v_0 -> v_1 -> ... -> v_k = v_0,
+```
+
+the propagated value is consistent if and only if
+
+```text
+prod_{r=1}^k gamma_{i_r}(v_{r-1} -> v_r) = 1.
+```
+
+Thus a pure pair component contributes an exotic syzygy precisely when its gain
+graph is balanced.
+
+In particular:
+
+- a pair-gain tree automatically contributes one exotic degree of freedom;
+- a pair-gain cycle contributes one exotic degree of freedom exactly when its
+  signed-area gain product is `1`;
+- an unbalanced pair cycle kills the would-be syzygy.
+
+All gains are the actual `Delta`-ratios, not symmetrized coefficients.
+
+---
+
+## Pattern 3: mixed hypercore determinants
+
+Now suppose some active row meets `S` in three or four vertices.
+
+First contract every balanced pair-gain component. More explicitly, inside a
+balanced pair component `K`, choose a root `r_K`. Every vertex `v in K` has a
+well-defined multiplier `eta_v` such that
+
+```text
+g_v = eta_v t_K.
+```
+
+The multipliers are products of the actual gains
+
+```text
+-lambda^i_u/lambda^i_v
+```
+
+along pair paths.
+
+Now take a row `i` meeting several pair components. It becomes the equation
+
+```text
+sum_K (sum_{v in C_i cap S cap K} lambda^i_v eta_v) t_K = 0.
+```
+
+Thus, after pair contraction, the remaining obstruction is an ordinary finite
+hypermatrix circuit. If the contracted active matrix has columns
+`K_1,...,K_m`, then an exotic syzygy exists exactly when some `(m-1)`-row
+submatrix has a nonzero cofactor null vector and every remaining row satisfies
+the corresponding cofactor determinant identity.
+
+So the mixed obstruction is:
+
+```text
+balanced pair propagation + one cofactor circuit in the contracted hypercore.
+```
+
+---
+
+# Final equivalence
+
+The substantive rank rigidity lemma is therefore equivalent to the following
+finite statement:
+
+> For one, equivalently every, base `B` with `det Z_B != 0`, there is no
+> nonempty set `S subseteq [n]\B` admitting one of the three certificates
+> above.
+
+Equivalently,
+
+```text
+ker L = U
+```
+
+if and only if all of the following are ruled out:
+
+```text
+(I) isolated quotient columns;
+(II) balanced pure pair-gain components;
+(III) mixed hypercore cofactor determinant identities.
+```
+
+This is the precise finite obstruction list. A full proof of the rank rigidity
+lemma must show that the geometry of strictly convex centered four-cohorts
+forbids all three; a counterexample must exhibit one of them.

--- a/incoming/prompt3-runs/audit.md
+++ b/incoming/prompt3-runs/audit.md
@@ -1,0 +1,164 @@
+# Prompt 3 Run 01 Audit
+
+Status: heuristic/audit note. This file records local review of an AI-generated
+prompt result. It is not a proof of Erdos Problem #97 and does not claim a
+counterexample.
+
+## Verdict
+
+The run is useful, but mostly as a clarification of what the
+minimal-counterexample/fragile-cover route can and cannot do.
+
+Safe takeaways:
+
+1. The fragile-cover lemma is valid and matches the existing
+   `docs/claims.md` "Minimal-counterexample critical tie" claim.
+2. The pointed `4`-uniform hypergraph translation is valid:
+   fragile centers cover all vertices, so a minimal bad polygon has at least
+   `n/4` fragile centers.
+3. The row-intersection, pair-codegree, overlap-counting, and directed-cycle
+   consequences are valid as structural filters.
+4. These ingredients are not by themselves contradictory. The run gives
+   explicit abstract and geometric warning examples showing why an additional
+   metric filter is needed.
+
+Promotion decision:
+
+- Do not add this run as a new theorem-style result.
+- Keep it as provenance for the fragile-hypergraph computation route.
+- If promoted later, promote only the reviewed filters, with generated
+  survivor artifacts or exact infeasibility certificates.
+
+## Checked Claims
+
+### Fragile-Cover Lemma
+
+Claim reviewed:
+
+For a bad polygon `P`, deleting `x` makes a surviving vertex `u` non-bad if
+and only if `u` has a unique distance class of size exactly `4` and `x` lies in
+that class.
+
+This is correct. The proof properly handles the possible shift of the
+maximizing radius after deletion. The key observation is row-local: deleting
+`x` removes exactly one entry from the distance multiset at `u`.
+
+For a minimal bad polygon, deleting any vertex `v` makes the remaining polygon
+non-bad. Therefore some surviving vertex loses badness, so every `v` lies in
+the unique critical `4`-tie of some fragile center.
+
+This is already represented in `docs/claims.md` as the
+"Minimal-counterexample critical tie" lemma.
+
+### Hypergraph Translation
+
+Let `F` be the set of fragile centers and let `S_u` be the unique size-`4`
+cohort for `u in F`.
+
+The conclusions are valid:
+
+- `|S_u| = 4`;
+- `u notin S_u`;
+- `V = union_{u in F} S_u`;
+- `sum_v d(v) = 4|F|`;
+- `|F| >= n/4`.
+
+### Intersection And Codegree Bounds
+
+For distinct fragile centers `u,w`,
+
+`|S_u cap S_w| <= 2`
+
+because two distinct centered circles meet in at most two points.
+
+If equality holds, the convex-position crossing lemma forces the row pair
+`{u,w}` to separate the shared column pair.
+
+For a fixed vertex pair `{a,b}`, at most two fragile cohorts can contain both
+`a` and `b`, because their centers must lie on the perpendicular bisector of
+`p_a p_b`, and strict convexity allows at most two polygon vertices on any
+line.
+
+These are valid, and they align with the existing pair-sharing discipline in
+the repo.
+
+### Overlap Counting
+
+The identity
+
+`O = sum_{u,w subset F} |S_u cap S_w| = sum_v binom(d(v), 2)`
+
+is valid. The convexity lower bound obtained by balancing cover degrees is
+also valid.
+
+Important limitation: overlap counting does not force a double row
+intersection. All overlap can be made of single intersections, in which case
+the crossing lemma never activates.
+
+### Directed Fragile-Dependency Cycle
+
+Define `u -> w` when `w in S_u`, restricted to `F`.
+
+Since every fragile center is covered by some fragile cohort, every vertex in
+this directed graph has indegree at least `1`, so a directed cycle exists.
+
+A shortest directed cycle has no directed chord among its cycle vertices. This
+is valid: any non-successor edge on the cycle would shortcut to a shorter
+directed cycle.
+
+Scope note: this chordlessness is only inside the selected cycle vertices. The
+cycle rows may still contain non-cycle vertices, and non-cycle fragile centers
+may interact with the cycle.
+
+## Verified Obstruction Examples
+
+### `Z_13` Linear Cover
+
+The abstract pattern
+
+`S_i = {i+2, i+3, i+5, i+11} mod 13`
+
+was checked locally:
+
+- every row has size `4`;
+- `i notin S_i`;
+- every column degree is `4`;
+- every two rows intersect in exactly one column.
+
+Thus it satisfies the fragile-cover style hypergraph constraints while making
+the double-intersection crossing lemma vacuous. It is not claimed to be
+geometrically realizable.
+
+### Convex Octagon Warning Example
+
+The run's octagon with cyclic order
+
+`c, u, w, d, e, f, a, b`
+
+was checked locally for strict convexity using oriented edge tests. The stated
+unit-distance cohorts also check out:
+
+- `S_u = {w, a, b, c}`;
+- `S_w = {u, d, e, f}`.
+
+This demonstrates that even a convex fragile-cover pattern with two disjoint
+fragile cohorts can be geometrically harmless. It is not a bad polygon, but it
+is a useful guardrail against overinterpreting the cover lemma.
+
+## Recommended Next Use
+
+This run supports the repo's Priority 1 direction: certified
+fragile-hypergraph computation.
+
+The next useful step is not more prose around cover/crossing alone. It is a
+finite abstraction with an additional metric filter, for example:
+
+1. enumerate pointed `4`-uniform covers satisfying self-exclusion,
+   row-intersection, pair-codegree, and cyclic crossing;
+2. add filters that encode more geometry than A/B, such as row-wise
+   perpendicular-bisector concurrence or angle/side constraints;
+3. emit JSON survivors and tests;
+4. hand surviving patterns to exact distance-system tooling.
+
+The current result is best treated as a validated filter plus a warning:
+fragility alone is real, but it does not close the problem.

--- a/incoming/prompt3-runs/run-01.md
+++ b/incoming/prompt3-runs/run-01.md
@@ -1,0 +1,335 @@
+## 1. Fragile-cover lemma
+
+Let (V) be the vertex set. For a surviving vertex (u) and a radius (\rho), write
+
+[
+C_P(u,\rho)={v\in V\setminus{u}: |p_v-p_u|=\rho},\qquad c_P(u,\rho)=|C_P(u,\rho)|.
+]
+
+Thus
+
+[
+m_u(P)=\max_\rho c_P(u,\rho).
+]
+
+Fix two distinct vertices (x,u). After deleting (x), the distances from (u) to all other surviving vertices do not change; one entry is merely removed from the distance multiset of (u). Hence
+
+[
+c_{P-x}(u,\rho)=
+\begin{cases}
+c_P(u,\rho)-1,& x\in C_P(u,\rho),\
+c_P(u,\rho),& x\notin C_P(u,\rho).
+\end{cases}
+]
+
+The maximum may shift to another radius, but the following exact characterization handles that.
+
+### Claim
+
+Assume (P) is bad. For (x\neq u), the vertex (u) is not bad in (P-x), i.e.
+
+[
+m_u(P-x)\le 3,
+]
+
+if and only if (u) is fragile in (P) and (x) lies in the unique four-cohort of (u).
+
+### Proof of the claim
+
+Suppose first that (m_u(P-x)\le 3). Since (P) is bad, (m_u(P)\ge 4). Let (\rho) be any radius with (c_P(u,\rho)\ge 4).
+
+If (x\notin C_P(u,\rho)), then deletion of (x) does not affect that radius, so
+
+[
+c_{P-x}(u,\rho)=c_P(u,\rho)\ge 4,
+]
+
+contradicting (m_u(P-x)\le 3). Therefore every radius of multiplicity at least (4) must be the single radius
+
+[
+\rho=|p_x-p_u|.
+]
+
+Moreover, at that radius we must have (c_P(u,\rho)=4), because if (c_P(u,\rho)\ge 5), then after deleting (x) the same radius would still have multiplicity at least (4). Thus (m_u(P)=4), and the radius (|p_x-p_u|) is the unique radius with multiplicity (4). Therefore (u) is fragile, and (x) belongs to its unique four-cohort.
+
+Conversely, if (u) is fragile and (x\in S_u), where (S_u) is the unique four-cohort of (u), then deletion of (x) reduces that unique cohort from size (4) to size (3), while every other radius already had multiplicity at most (3). Hence (m_u(P-x)\le 3).
+
+This proves the claim. (\square)
+
+Now let (v) be any vertex of a minimal bad polygon (P). By minimality, (P-v) is not bad. Therefore some surviving vertex (u\neq v) satisfies
+
+[
+m_u(P-v)\le 3.
+]
+
+Since (P) itself is bad, the claim applies: (u) is fragile in (P), and (v) lies in the unique four-cohort of (u).
+
+Thus every vertex (v) is contained in the unique four-cohort of at least one fragile center (u). This proves the fragile-cover lemma.
+
+The minimality assumption is used exactly once: to assert that for each deleted vertex (v), the polygon (P-v) is not bad, so some surviving vertex loses badness. The rest is a row-wise deletion characterization. In particular, the proof does not assume that deleting (v) preserves the value of (m) for other vertices; it explicitly allows the maximizing radius to shift.
+
+---
+
+## 2. Hypergraph translation
+
+Let (F\subseteq V) be the set of fragile centers. For each (u\in F), let
+
+[
+S_u={v\in V\setminus{u}: |p_v-p_u|=r_u}
+]
+
+be its unique four-cohort. Then
+
+[
+|S_u|=4.
+]
+
+The fragile-cover lemma says
+
+[
+V=\bigcup_{u\in F} S_u.
+]
+
+Thus the fragile centers define a pointed (4)-uniform hypergraph
+
+[
+H={(u;S_u):u\in F}.
+]
+
+Let
+
+[
+d(v)=|{u\in F:v\in S_u}|
+]
+
+be the number of fragile cohorts covering (v). The cover lemma gives
+
+[
+d(v)\ge 1\qquad\text{for every }v\in V.
+]
+
+Counting incidences,
+
+[
+\sum_{v\in V}d(v)=\sum_{u\in F}|S_u|=4|F|.
+]
+
+Hence
+
+[
+|F|\ge \frac n4.
+]
+
+So every minimal bad polygon has at least (n/4) fragile centers.
+
+---
+
+## 3. Row-intersection bounds
+
+For distinct fragile centers (u,w), the two cohort circles
+
+[
+\Gamma_u={x:|x-p_u|=r_u},\qquad \Gamma_w={x:|x-p_w|=r_w}
+]
+
+are distinct circles. Two distinct circles meet in at most two points, so
+
+[
+|S_u\cap S_w|\le 2.
+]
+
+If (|S_u\cap S_w|=2), say
+
+[
+S_u\cap S_w={a,b},
+]
+
+then both (u) and (w) are equidistant from (a) and (b). Thus (p_u,p_w) both lie on the perpendicular bisector of (p_ap_b). By the convex-position crossing lemma, the pair ({u,w}) separates the pair ({a,b}) in the cyclic order of the polygon.
+
+So every double intersection creates an alternating configuration
+
+[
+u,\ a,\ w,\ b
+]
+
+up to reversal and relabeling.
+
+There is also a useful pair-codegree bound. Fix two vertices (a,b). If both (a,b) lie in (S_u), then (p_u) lies on the perpendicular bisector of (p_ap_b). Since a strictly convex polygon has no three collinear vertices, at most two vertices of (P) can lie on that line. Hence a fixed pair ({a,b}) can occur together in at most two fragile cohorts.
+
+---
+
+## 4. Forced overlap counting
+
+Let
+
+[
+O=\sum_{{u,w}\subseteq F}|S_u\cap S_w|
+]
+
+be the total row-overlap count. Double-counting triples ((v,u,w)) with (v\in S_u\cap S_w) gives
+
+[
+O=\sum_{v\in V}\binom{d(v)}2.
+]
+
+Write
+
+[
+4|F|=qn+s,\qquad 0\le s<n.
+]
+
+Since (x\mapsto \binom{x}{2}) is convex on the nonnegative integers, the minimum possible value of (O) occurs when the cover degrees (d(v)) are as equal as possible. Therefore
+
+[
+O\ge (n-s)\binom q2+s\binom{q+1}{2}.
+]
+
+Some immediate consequences:
+
+[
+|F|\ge \frac n4.
+]
+
+If (|F|>n/4), then (O>0), so some two fragile cohorts overlap.
+
+If every vertex is fragile, so (|F|=n), then
+
+[
+O\ge n\binom 42=6n.
+]
+
+Because every pair of rows intersects in at most two vertices, the number of intersecting pairs of fragile cohorts is at least
+
+[
+\left\lceil \frac O2\right\rceil.
+]
+
+In particular, if all vertices are fragile, at least (3n) pairs of fragile centers have nonempty cohort intersection.
+
+However, this counting does **not** force a pair of rows to share two vertices. All overlap could, in principle, be made of single intersections. Therefore the crossing lemma alone does not automatically activate.
+
+---
+
+## 5. Forced directed cycle among fragile centers
+
+Now restrict the hypergraph to fragile centers themselves. Define a directed graph (D) on (F) by
+
+[
+u\to w \quad\Longleftrightarrow\quad w\in S_u.
+]
+
+Since every vertex of (P), in particular every fragile center, is covered by some fragile cohort, every (w\in F) has indegree at least (1) in (D). Therefore (D) contains a directed cycle.
+
+Choose a shortest directed cycle
+
+[
+u_0\to u_1\to \cdots \to u_{k-1}\to u_0.
+]
+
+Then this cycle is chordless inside (F): if (u_i\to u_j) with (j\not\equiv i+1\pmod k), then following the edge (u_i\to u_j) and then the original cycle from (u_j) back to (u_i) gives a shorter directed cycle, contradiction.
+
+Thus every minimal bad polygon forces a chordless fragile-dependency cycle
+
+[
+u_0\to u_1\to \cdots \to u_{k-1}\to u_0,
+]
+
+with
+
+[
+u_{i+1}\in S_{u_i}
+]
+
+and no other cohort-containment relations among those cycle vertices.
+
+This is a genuine structural consequence of minimality plus the fragile-cover lemma.
+
+---
+
+## 6. Why the stated stage-two ingredients do not yet force a contradiction
+
+The cover lemma, the row-intersection bound, and the crossing lemma are strong, but they are not by themselves contradictory.
+
+Here is an abstract pointed (4)-uniform hypergraph showing the obstruction. Let the vertex set be (\mathbb Z_{13}), and define
+
+[
+S_i={i+2,\ i+3,\ i+5,\ i+11}\pmod{13}.
+]
+
+Then:
+
+[
+|S_i|=4,
+]
+
+and
+
+[
+i\notin S_i.
+]
+
+Every vertex lies in exactly four of the sets (S_i). Also, for distinct (i,j),
+
+[
+|S_i\cap S_j|=1.
+]
+
+Indeed, the difference set
+
+[
+{2,3,5,11}
+]
+
+has every nonzero residue modulo (13) as a difference exactly once. Thus every pair of rows intersects in exactly one point. The cover condition holds perfectly, but no two rows share two vertices, so the crossing lemma never fires.
+
+This does not prove that such a hypergraph is geometrically realizable by fragile cohorts of a strictly convex polygon. It shows that the purely hypergraph-theoretic constraints obtained so far are insufficient to force contradiction.
+
+There is also a small geometric warning example. Take
+
+[
+u=(0,0),\qquad w=(1,0),
+]
+
+and the six further points
+
+[
+a=(0,1),\quad b=\left(-\frac12,\frac{\sqrt3}{2}\right),\quad c=\left(-\frac{\sqrt3}{2},\frac12\right),
+]
+
+[
+d=\left(1+\frac{\sqrt3}{2},\frac12\right),\quad e=\left(\frac32,\frac{\sqrt3}{2}\right),\quad f=(1,1).
+]
+
+In cyclic order,
+
+[
+c,\ u,\ w,\ d,\ e,\ f,\ a,\ b
+]
+
+these form a strictly convex octagon. The point (u) has exactly four vertices at distance (1):
+
+[
+S_u={w,a,b,c},
+]
+
+and (w) has exactly four vertices at distance (1):
+
+[
+S_w={u,d,e,f}.
+]
+
+Both (u) and (w) are fragile centers, and their two four-cohorts cover all eight vertices. The two cohorts are disjoint, so the crossing lemma is again silent. This octagon is not bad, but it demonstrates that a convex fragile-cover pattern itself need not be contradictory.
+
+Therefore, a full contradiction for minimal bad polygons needs an additional geometric ingredient beyond the fragile-cover lemma plus the double-intersection crossing rule. The strongest forced conclusions from those ingredients are:
+
+[
+|F|\ge \frac n4,
+]
+
+the fragile cohorts cover (V),
+
+[
+|S_u\cap S_w|\le 2,
+]
+
+double intersections are cyclically alternating, and the fragile-center dependency digraph contains a chordless directed cycle. These are substantial structural restrictions, but they do not alone rule out a minimal bad polygon.


### PR DESCRIPTION
## Summary

- Add archived prompt-run outputs and audits for Prompt 0, Prompt 1/A-B matrix, Prompt 2 rank rigidity, and Prompt 3 fragile-cover work.
- Add a prompt-derived roadmap that labels these outputs as heuristic planning notes, not mathematical evidence.
- Correct cone-containment wording in canonical docs: other vertices lie in the closed incident-edge cone, with only adjacent vertices on the boundary rays.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check origin/main...HEAD`
- `python -m pytest -q`