### PR TITLE
[codex] Add minimum-radius filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/upstream-alignment.md`](docs/upstream-alignment.md).
 - For independent audit instructions, read
   [`docs/reviewer-guide.md`](docs/reviewer-guide.md).
+- For current review priorities, read
+  [`docs/review-priorities.md`](docs/review-priorities.md).
 - For canonical status metadata, see
   [`metadata/erdos97.yaml`](metadata/erdos97.yaml).
 - For documentation navigation, read [`docs/index.md`](docs/index.md).
@@ -31,6 +33,8 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the crossing-bisector, mutual-rhombus, and vertex-circle fixed-pattern
   filters, read [`docs/mutual-rhombus-filter.md`](docs/mutual-rhombus-filter.md)
   and [`docs/vertex-circle-order-filter.md`](docs/vertex-circle-order-filter.md).
+- For the weak exact minimum-radius short-chord filter, read
+  [`docs/minimum-radius-filter.md`](docs/minimum-radius-filter.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).
 - For known bad proof routes, read [`docs/failed-ideas.md`](docs/failed-ideas.md).
 - For the verification standard, read [`docs/verification-contract.md`](docs/verification-contract.md).
@@ -210,6 +214,17 @@ erdos97-search --list-patterns
 erdos97-search --verify data/runs/best_B12_slsqp_m1e-6.json --tol 1e-6
 python scripts/check_mutual_rhombus_filter.py --assert-expected
 python scripts/check_vertex_circle_order_filter.py --pattern P18_parity_balanced --search --assert-obstructed
+python scripts/check_min_radius_filter.py --pattern C19_skew --assert-pass
+```
+
+For a version-matched reproduction environment, install the checked snapshot
+before installing this package:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-lock.txt
+pip install -e . --no-deps
 ```
 
 Run a small search:

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -7,11 +7,14 @@ designs only; geometric realization is a separate problem.
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse, with no `phi` edges and no mutual-rhombus, forced-perpendicularity, or vertex-circle obstruction currently known[^repo] |
+| 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | natural-order status: exactly killed by Altman diagonal-order sums; abstract-incidence status: live/sparse, with no `phi` edges and no mutual-rhombus, forced-perpendicularity, vertex-circle, or minimum-radius obstruction currently known[^repo] |
 
 The live abstract-incidence pattern above should pass the row-overlap filter
 `|S_i cap S_j| <= 2` before numerical optimization. Its natural-order
-realization is already exactly obstructed.[^comp]
+realization is already exactly obstructed.[^comp] The minimum-radius
+short-chord filter is also recorded as a weak exact necessary test, but it does
+not kill `C19_skew` in natural order or as currently implemented; see
+`docs/minimum-radius-filter.md`.
 
 ## Natural-order killed / abstract-order status patterns
 

--- a/docs/failed-ideas.md
+++ b/docs/failed-ideas.md
@@ -102,6 +102,21 @@ settles the uniform-radius subcase. The canonical synthesis records this as a
 direction-of-bound error: `2n-7` is a lower-bound construction, not the needed
 `< 2n` upper bound.[^canon]
 
+## 16. Metric-linear rank obstruction without convexity
+
+Failure mode: exact selected-distance equations, the strong linear row
+condition `|S_i cap S_j| <= 1`, and local Jacobian rigidity modulo
+similarities do not by themselves force a strictly convex polygon. The
+24-point radial-alternating construction checked by
+`scripts/verify_p24_metric_linear_nonconvex.py` satisfies every selected
+equal-distance row and has exact Jacobian rank `44` in `48` coordinate
+variables, but its signed turns alternate and it is not convex.
+
+Use this as a negative control: a proof route based only on metric equations,
+lifted affine circuits, row-linearity, or rank must fail on this construction.
+Any successful impossibility proof must use strict convexity, cyclic-order
+signs, one-sidedness, or another convexity-specific ingredient.[^p24]
+
 [^lit]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
 [^forest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/11_forest_lemma_counterexample_review.md`.
 [^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.
@@ -111,3 +126,4 @@ direction-of-bound error: `2n-7` is a lower-bound construction, not the needed
 [^paper]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/05_rank_scaling_and_verifier_review.md`.
 [^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
 [^canon]: Source file: `docs/canonical-synthesis.md`.
+[^p24]: Source files: `erd archive/outputs/data/1/linear_case_geometry_handoff.md` and `erd archive/outputs/data/1/verify_24_point_near_counterexample.py`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@ put detailed reconciliation in the canonical synthesis.
   `teorth/erdosproblems` and the official problem page.
 - [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case
   artifacts and exact certificates.
+- [`review-priorities.md`](review-priorities.md): current independent-review
+  priorities; planning guidance only, not mathematical evidence.
 - [`canonical-synthesis.md`](canonical-synthesis.md): long-form canonical
   synthesis, claim taxonomy, failed-route reconciliation, and source/hash
   inventory.
@@ -29,6 +31,9 @@ put detailed reconciliation in the canonical synthesis.
   crossing CSP for two-overlap patterns.
 - [`vertex-circle-order-filter.md`](vertex-circle-order-filter.md): exact
   row-wise convexity-distance filter for cyclic orders.
+- [`minimum-radius-filter.md`](minimum-radius-filter.md): weak exact
+  minimum-radius short-chord filter; records why it does not kill `C19_skew`
+  by itself.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible
@@ -47,6 +52,8 @@ put detailed reconciliation in the canonical synthesis.
   killed incidence patterns.
 - [`verification-contract.md`](verification-contract.md): requirements for
   numerical candidates and certified counterexamples.
+- [`../requirements-lock.txt`](../requirements-lock.txt): known-good direct
+  dependency snapshot for reproduction.
 - [`exactification-plan.md`](exactification-plan.md): route from numerical
   artifacts to exact or certified verification.
 - [`sat-smt-plan.md`](sat-smt-plan.md): finite abstraction and solver plan.

--- a/docs/minimum-radius-filter.md
+++ b/docs/minimum-radius-filter.md
@@ -1,0 +1,90 @@
+# Minimum-radius short-chord filter
+
+Status: `LEMMA` / exact necessary filter for fixed cyclic orders.
+
+No general proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+## Lemma
+
+Fix a selected-witness pattern `S_i` and a cyclic order of a strict convex
+polygon realizing it. Let `r_i` be the selected radius at row `i`. If `i` has
+globally minimum selected radius, then in the angular order of the four
+witnesses `S_i` around `i`, at least one consecutive witness pair `{a,b}` is
+uncovered by selected incidence:
+
+```text
+b notin S_a and a notin S_b.
+```
+
+Equivalently, if every consecutive witness pair around `i` is selected in at
+least one direction, then `i` cannot be a minimum-radius center. If this blocks
+every possible minimum center in a fixed cyclic order, that order is
+impossible.
+
+## Proof
+
+At a strict convex hull vertex, all other vertices lie in the open angular cone
+between the two incident edges, except for the two adjacent boundary vertices.
+The angular span is therefore less than `pi` for the four selected witnesses.
+
+Put the four witnesses in angular order around center `i`, with consecutive
+angular gaps `delta_1, delta_2, delta_3`. Since
+
+```text
+delta_1 + delta_2 + delta_3 < pi,
+```
+
+at least one gap is smaller than `pi/3`. If `{a,b}` is the witness pair across
+that gap, then
+
+```text
+|p_a - p_b| = 2 r_i sin(delta/2) < r_i.
+```
+
+If `b in S_a`, then `r_a = |p_a-p_b| < r_i`. If `a in S_b`, then
+`r_b = |p_a-p_b| < r_i`. Either case contradicts global minimality of `r_i`.
+Thus at least one consecutive witness pair around a minimum-radius center must
+be uncovered in both directions.
+
+## What the filter proves and does not prove
+
+This is only a necessary condition. A row that has an uncovered consecutive
+witness pair is not geometrically certified; it merely survives this one
+minimum-radius test.
+
+The order-free version is stronger but rare: if all six pairs among the four
+witnesses of row `i` are selected in at least one direction, then `i` is blocked
+for every possible cyclic order. If every center is order-free blocked, the
+fixed selected pattern is impossible. The complete `n=5` all-other-vertices
+pattern is a toy example killed this way.
+
+## Current impact on built-in patterns
+
+The current built-in candidate patterns all pass the natural-order version of
+this filter; every center remains compatible with being the minimum-radius
+center under this filter alone. This includes the main live abstract-incidence
+pattern `C19_skew`.
+
+For `C19_skew` in the natural order, row `0` has
+
+```text
+S_0 = {5, 9, 11, 16}
+witness order = [5, 9, 11, 16]
+consecutive pairs = {5,9}, {9,11}, {11,16}
+uncovered consecutive pairs = {5,9}, {9,11}
+```
+
+Thus the minimum-radius idea does not by itself kill `C19_skew`. It should be
+recorded as a weak exact filter, not promoted as a central route unless it is
+combined with additional cyclic-order or radius-inequality propagation.
+
+## Reproducible check
+
+```bash
+python scripts/check_min_radius_filter.py --pattern C19_skew --assert-pass
+python scripts/check_min_radius_filter.py --pattern C19_skew --json
+```
+
+The first command should report `PASS`, with all 19 centers still possible as
+minimum centers. This is not evidence for realizability; it is a negative
+result for this particular proposed attack.

--- a/docs/repo-roadmap.md
+++ b/docs/repo-roadmap.md
@@ -29,3 +29,16 @@ Only attempt exactification for robust candidates with tiny residual and nondege
 
 For finite obstruction work, exactification may also start from a complete
 incidence survivor list, as in the checked `n=8` pipeline.
+
+## Near-term review push
+
+- Treat `docs/n8-geometric-proof.md` as the main human-readable small-case proof
+  target, pending independent review.
+- Build a minimal independent checker for the checked `n=8` incidence and exact
+  obstruction data.
+- Isolate the class `14` PB+ED and strict-interior certificate into a small
+  standalone verifier.
+- Extend the minimum-radius short-chord idea only if it grows into
+  radius-inequality propagation or cyclic-order search; by itself it does not
+  kill `C19_skew`.
+- Keep `n >= 9` exploration separate from the repo-local `n <= 8` artifact.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -1,0 +1,84 @@
+# Review priorities
+
+Status: planning guidance only; not mathematical evidence.
+
+This file turns current review feedback into concrete work items. It does not
+change the repository claims: no general proof and no counterexample are
+claimed, the official/global status remains falsifiable/open, and the local
+`n <= 8` selected-witness result remains repo-local and machine-checked pending
+independent review.
+
+## Priority 1 - review the octagon proof note
+
+Target: `docs/n8-geometric-proof.md`.
+
+Ask independent geometry reviewers to check:
+
+- the base-apex lemma and its strict-convexity use;
+- the isosceles-triangle count `T(A) <= n(n-2)`;
+- equality saturation in the octagon case;
+- the length-2 diagonal step forcing all side lengths equal;
+- the length-3 diagonal step forcing a cover of adjacent exterior-turn pairs;
+- the final vertex-cover and total-turn contradiction.
+
+Acceptance standard: a written review should identify every accepted lemma and
+any exact gap. If the note survives review, keep it as the main human-readable
+small-case proof route, with the computational pipeline as an audit appendix.
+
+## Priority 2 - build an independent n=8 checker
+
+Build a minimal checker for the `n=8` finite artifact that treats the checked-in
+JSON and certificate data as inputs, not as generated truth. It should avoid
+reusing the current canonicalization and algebra-helper code except where the
+input format forces it.
+
+Suggested inputs:
+
+- `data/incidence/n8_reconstructed_15_survivors.json`;
+- `data/incidence/n8_incidence_completeness.json`;
+- `certificates/n8_exact_analysis.json`.
+
+Suggested checks:
+
+- the 15 survivor classes are valid selected-witness incidence systems;
+- claimed cyclic-order eliminations are reproducible;
+- named exact certificates for classes `3`, `4`, `5`, and `14` verify from the
+  certificate data;
+- the checker reports only `EXACT_OBSTRUCTION` or explicit uncertainty.
+
+## Priority 3 - isolate class 14
+
+Class `14` is the most delicate current survivor obstruction because it uses
+PB+ED Groebner reasoning plus a strict-interior conclusion. Move toward a short,
+standalone certificate file with a minimal verifier that checks:
+
+- the polynomial system under the stated normalization;
+- the claimed Groebner basis or an equivalent exact contradiction;
+- every solution branch used in the argument;
+- the strict-interior or non-strict-convexity conclusion.
+
+This should be small enough for an external reviewer to audit without reading
+the full search pipeline.
+
+## Priority 4 - pin literature coverage
+
+Before any paper-style or public theorem-style claim, run a literature sweep
+covering repeated distances in convex polygons, isosceles-triangle counts,
+metric oriented matroids, and order-k Voronoi degeneracies. Record both found
+references and negative search results in `docs/literature-risk.md`.
+
+Do not use unchecked literature summaries to alter the official/global status.
+Recheck the official Erdos Problems page before any status update.
+
+## Priority 5 - keep the frontier separate
+
+Keep `n >= 9`, `C19_skew`, and broader SAT/SMT work separate from the small-case
+claim. They are research-frontier workstreams, not prerequisites for the
+repo-local `n <= 8` artifact.
+
+## Priority 6 - strengthen only productive filters
+
+The minimum-radius short-chord filter in `docs/minimum-radius-filter.md` is a
+valid exact necessary condition, but it is weak: it does not kill `C19_skew`.
+Treat it as recorded negative information unless it is extended into a genuine
+radius-inequality propagation system or combined with cyclic-order search.

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -25,6 +25,13 @@ python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
 ```
 
+For a version-matched reproduction run, replace `pip install -e .[dev]` with:
+
+```bash
+pip install -r requirements-lock.txt
+pip install -e . --no-deps
+```
+
 ## Expected `n=8` outputs
 
 For `python scripts/enumerate_n8_incidence.py --summary`, expected invariants:
@@ -58,6 +65,8 @@ invariants:
 4. `docs/n8-incidence-enumeration.md`
 5. `docs/n8-exact-survivors.md`
 6. `docs/verification-contract.md`
+7. `docs/n8-geometric-proof.md`
+8. `docs/review-priorities.md`
 
 ## Review target A - `n=7`
 
@@ -87,11 +96,24 @@ Check:
 - the strict-convexity obstruction cases;
 - the archived-ID provenance mapping.
 
+## Review target D - `n=8` geometric proof note
+
+Check:
+
+- the base-apex lemma and its strict-convexity hypothesis;
+- the isosceles-triangle count and octagon equality saturation;
+- the length-2 diagonal argument forcing equal side lengths;
+- the length-3 diagonal argument forcing a cover of adjacent turn-angle pairs;
+- the exterior-turn contradiction.
+
 ## Known weak points / independent review requests
 
 - Independent audit of `scripts/enumerate_n8_incidence.py`.
 - Independent audit of exact certificates, especially classes `3`, `4`, and
   `14` if those remain singled out in `RESULTS.md`.
+- A minimal standalone class `14` checker would be especially valuable because
+  that obstruction combines Groebner reasoning with a strict-interior
+  conclusion.
 - Independent reproduction of `certificates/n8_exact_analysis.json`.
 - A Lean, SMT, interval, or algebraic certificate checker would be high value.
 

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -33,9 +33,17 @@ local_repo:
   main_entry_points:
     - "STATE.md"
     - "RESULTS.md"
+    - "docs/review-priorities.md"
     - "docs/n8-incidence-enumeration.md"
     - "docs/n8-exact-survivors.md"
+    - "docs/n8-geometric-proof.md"
     - "docs/verification-contract.md"
+
+reproducibility:
+  known_good_dependency_snapshot: "requirements-lock.txt"
+  known_good_python: "3.12.2"
+  snapshot_date: "2026-04-29"
+  note: "Dependency snapshot records a reproduced local environment only; it is not a mathematical certificate."
 
 trust_policy:
   no_overclaiming: true

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,9 @@
+# Known-good direct dependency snapshot for finite-artifact reproduction.
+# Generated from the local environment on 2026-04-29 with Python 3.12.2.
+# This is a reproducibility aid, not a mathematical certificate.
+numpy==2.4.4
+scipy==1.17.1
+pytest==9.0.3
+PyYAML==6.0.3
+sympy==1.14.0
+z3-solver==4.16.0.0

--- a/scripts/check_min_radius_filter.py
+++ b/scripts/check_min_radius_filter.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Check the minimum-radius short-chord filter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.min_radius_filter import (  # noqa: E402
+    minimum_radius_order_obstruction,
+    result_to_json,
+)
+from erdos97.search import built_in_patterns  # noqa: E402
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
+
+
+def assert_obstructed(row: dict[str, object]) -> None:
+    if not row["obstructed"]:
+        raise AssertionError(f"{row['pattern']}: expected obstruction")
+
+
+def assert_pass(row: dict[str, object]) -> None:
+    if row["obstructed"]:
+        raise AssertionError(f"{row['pattern']}: expected pass")
+
+
+def print_summary(row: dict[str, object]) -> None:
+    result = "OBSTRUCTED" if row["obstructed"] else "PASS"
+    print(
+        "pattern  n  result      blocked centers  possible minimum centers  "
+        "order-free blocked"
+    )
+    print(
+        f"{row['pattern']}  {row['n']}  {result:<10}  "
+        f"{len(row['blocked_centers'])}  "
+        f"{len(row['possible_min_centers'])}  "
+        f"{len(row['order_free_blocked_centers'])}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pattern", required=True, help="built-in pattern name")
+    parser.add_argument(
+        "--order",
+        type=parse_order,
+        help="comma-separated cyclic order; defaults to natural label order",
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a summary")
+    parser.add_argument("--assert-obstructed", action="store_true", help="assert obstruction")
+    parser.add_argument("--assert-pass", action="store_true", help="assert no obstruction")
+    parser.add_argument("--write-certificate", help="write JSON result to this path")
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern not in patterns:
+        raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+    pattern = patterns[args.pattern]
+
+    result = minimum_radius_order_obstruction(
+        pattern.S,
+        order=args.order,
+        pattern=pattern.name,
+    )
+    row = result_to_json(result)
+
+    if args.assert_obstructed:
+        assert_obstructed(row)
+    if args.assert_pass:
+        assert_pass(row)
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(row, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(row, indent=2, sort_keys=True))
+    else:
+        print_summary(row)
+        if args.assert_obstructed or args.assert_pass:
+            print("OK: minimum-radius expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_p24_metric_linear_nonconvex.py
+++ b/scripts/verify_p24_metric_linear_nonconvex.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Exact verifier for a 24-point metric-linear nonconvex control.
+
+This is a negative-control artifact for Erdos Problem #97. It verifies an
+exact 24-point configuration with four equal selected distances from every
+center and pairwise row intersections of size at most one. The cyclic angular
+order is not a strictly convex polygon, so this is not a counterexample.
+
+Arithmetic is exact in Q(sqrt(3)), represented as a + b*sqrt(3) with rational
+coefficients.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import combinations
+
+N = 24
+
+
+@dataclass(frozen=True)
+class Q3:
+    """Element a + b*sqrt(3), with rational a and b."""
+
+    a: Fraction = Fraction(0)
+    b: Fraction = Fraction(0)
+
+    def __add__(self, other: Q3) -> Q3:
+        return Q3(self.a + other.a, self.b + other.b)
+
+    def __sub__(self, other: Q3) -> Q3:
+        return Q3(self.a - other.a, self.b - other.b)
+
+    def __neg__(self) -> Q3:
+        return Q3(-self.a, -self.b)
+
+    def __mul__(self, other: Q3) -> Q3:
+        return Q3(
+            self.a * other.a + 3 * self.b * other.b,
+            self.a * other.b + self.b * other.a,
+        )
+
+    def inv(self) -> Q3:
+        den = self.a * self.a - 3 * self.b * self.b
+        if den == 0:
+            raise ZeroDivisionError(self)
+        return Q3(self.a / den, -self.b / den)
+
+    def __truediv__(self, other: Q3) -> Q3:
+        return self * other.inv()
+
+    def is_zero(self) -> bool:
+        return self.a == 0 and self.b == 0
+
+    def __repr__(self) -> str:
+        if self.b == 0:
+            return str(self.a)
+        if self.a == 0:
+            return f"{self.b}*sqrt(3)"
+        sign = "+" if self.b > 0 else "-"
+        return f"{self.a} {sign} {abs(self.b)}*sqrt(3)"
+
+
+ZERO = Q3()
+ONE = Q3(Fraction(1))
+TWO = Q3(Fraction(2))
+HALF = Q3(Fraction(1, 2))
+SQRT3_OVER_2 = Q3(Fraction(0), Fraction(1, 2))
+
+COS30 = [
+    ONE,
+    SQRT3_OVER_2,
+    HALF,
+    ZERO,
+    -HALF,
+    -SQRT3_OVER_2,
+    -ONE,
+    -SQRT3_OVER_2,
+    -HALF,
+    ZERO,
+    HALF,
+    SQRT3_OVER_2,
+]
+SIN30 = [
+    ZERO,
+    HALF,
+    SQRT3_OVER_2,
+    ONE,
+    SQRT3_OVER_2,
+    HALF,
+    ZERO,
+    -HALF,
+    -SQRT3_OVER_2,
+    -ONE,
+    -SQRT3_OVER_2,
+    -HALF,
+]
+
+
+def c30(k: int) -> Q3:
+    return COS30[k % 12]
+
+
+def s30(k: int) -> Q3:
+    return SIN30[k % 12]
+
+
+def construction_points() -> list[tuple[Q3, Q3]]:
+    """Return p_j = rho_j exp(i*j*pi/12) in exact Q(sqrt(3)) coordinates."""
+
+    points: list[tuple[Q3, Q3]] = []
+    for j in range(N):
+        if j % 2 == 0:
+            k = j // 2
+            points.append((c30(k), s30(k)))
+        else:
+            k = (j - 1) // 2
+            points.append((c30(k) + c30(k + 1), s30(k) + s30(k + 1)))
+    return points
+
+
+POINTS = construction_points()
+
+
+def support(j: int) -> set[int]:
+    offsets = (-4, -1, 1, 4) if j % 2 == 0 else (-5, -4, 4, 5)
+    return {(j + offset) % N for offset in offsets}
+
+
+def supports() -> list[set[int]]:
+    return [support(j) for j in range(N)]
+
+
+def sqdist(a: int, b: int) -> Q3:
+    ax, ay = POINTS[a]
+    bx, by = POINTS[b]
+    dx = ax - bx
+    dy = ay - by
+    return dx * dx + dy * dy
+
+
+def det(u: tuple[Q3, Q3], v: tuple[Q3, Q3]) -> Q3:
+    return u[0] * v[1] - u[1] * v[0]
+
+
+def exact_rank(matrix: list[list[Q3]]) -> int:
+    """Return matrix rank by Gaussian elimination over Q(sqrt(3))."""
+
+    reduced = [row[:] for row in matrix]
+    m = len(reduced)
+    n = len(reduced[0]) if m else 0
+    rank = 0
+    for col in range(n):
+        pivot = None
+        for row_index in range(rank, m):
+            if not reduced[row_index][col].is_zero():
+                pivot = row_index
+                break
+        if pivot is None:
+            continue
+        if pivot != rank:
+            reduced[rank], reduced[pivot] = reduced[pivot], reduced[rank]
+        pivot_value = reduced[rank][col]
+        for row_index in range(rank + 1, m):
+            if reduced[row_index][col].is_zero():
+                continue
+            factor = reduced[row_index][col] / pivot_value
+            for c in range(col, n):
+                reduced[row_index][c] = reduced[row_index][c] - factor * reduced[rank][c]
+        rank += 1
+        if rank == m:
+            break
+    return rank
+
+
+def equal_distance_rows() -> bool:
+    for center in range(N):
+        distances = [sqdist(center, witness) for witness in sorted(support(center))]
+        if not all((distance - distances[0]).is_zero() for distance in distances):
+            return False
+    return True
+
+
+def max_support_intersection() -> int:
+    all_supports = supports()
+    return max(
+        len(all_supports[i] & all_supports[j])
+        for i, j in combinations(range(N), 2)
+    )
+
+
+def signed_turns() -> list[Q3]:
+    turns: list[Q3] = []
+    for j in range(N):
+        x0, y0 = POINTS[j]
+        x1, y1 = POINTS[(j + 1) % N]
+        x2, y2 = POINTS[(j + 2) % N]
+        v1 = (x1 - x0, y1 - y0)
+        v2 = (x2 - x1, y2 - y1)
+        turns.append(det(v1, v2))
+    return turns
+
+
+def jacobian_matrix() -> list[list[Q3]]:
+    rows: list[list[Q3]] = []
+    for center in range(N):
+        witnesses = sorted(support(center))
+        base = witnesses[0]
+        center_x, center_y = POINTS[center]
+        base_x, base_y = POINTS[base]
+        for witness in witnesses[1:]:
+            witness_x, witness_y = POINTS[witness]
+            row = [ZERO] * (2 * N)
+
+            row[2 * center] = row[2 * center] + TWO * (base_x - witness_x)
+            row[2 * center + 1] = row[2 * center + 1] + TWO * (base_y - witness_y)
+
+            row[2 * witness] = row[2 * witness] + TWO * (witness_x - center_x)
+            row[2 * witness + 1] = row[2 * witness + 1] + TWO * (witness_y - center_y)
+
+            row[2 * base] = row[2 * base] - TWO * (base_x - center_x)
+            row[2 * base + 1] = row[2 * base + 1] - TWO * (base_y - center_y)
+
+            rows.append(row)
+    return rows
+
+
+def jacobian_rank() -> int:
+    return exact_rank(jacobian_matrix())
+
+
+def run_checks() -> dict[str, object]:
+    turns = signed_turns()
+    even_turns = {turns[j] for j in range(N) if j % 2 == 0}
+    odd_turns = {turns[j] for j in range(N) if j % 2 == 1}
+    jacobian = jacobian_matrix()
+    rank = exact_rank(jacobian)
+
+    result = {
+        "equal_distance_rows": equal_distance_rows(),
+        "max_support_intersection": max_support_intersection(),
+        "even_turns": even_turns,
+        "odd_turns": odd_turns,
+        "jacobian_shape": (len(jacobian), len(jacobian[0])),
+        "jacobian_rank": rank,
+    }
+    assert result["equal_distance_rows"] is True
+    assert result["max_support_intersection"] == 1
+    assert even_turns == {HALF}
+    assert odd_turns == {Q3(Fraction(0), Fraction(-1, 2))}
+    assert result["jacobian_shape"] == (72, 48)
+    assert rank == 44
+    return result
+
+
+def main() -> int:
+    result = run_checks()
+    print("Equal-distance rows: PASS")
+    print(
+        "Linearity |S_i cap S_k| <= 1: "
+        f"PASS; max intersection = {result['max_support_intersection']}"
+    )
+    print("Even turns:", result["even_turns"])
+    print("Odd turns:", result["odd_turns"])
+    print("Convexity failure by alternating turn signs: PASS")
+    print("Jacobian shape:", result["jacobian_shape"])
+    print("Exact Jacobian rank:", result["jacobian_rank"])
+    print("Local rigidity modulo similarities: PASS")
+    print("All checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/min_radius_filter.py
+++ b/src/erdos97/min_radius_filter.py
@@ -1,0 +1,245 @@
+"""Minimum-radius short-chord filter for selected-witness patterns.
+
+This module is exact finite combinatorics. It does not use coordinates,
+floating point arithmetic, or numerical optimization.
+
+The geometric input is the following necessary condition. Let ``r_i`` be the
+selected radius at center ``i``. If ``i`` has globally minimum selected radius,
+then the four selected witnesses around ``i`` must have at least one adjacent
+angular pair ``{a,b}`` such that neither endpoint selects the other. Otherwise
+the short pair forced by the four witnesses in an angle smaller than ``pi``
+would be a selected edge of smaller radius, contradicting minimality of
+``r_i``.
+
+The filter is intentionally weak: passing it is not evidence for realizability.
+It is useful mainly as a cheap way to record and test the minimum-radius idea.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Sequence
+
+Pair = tuple[int, int]
+Pattern = Sequence[Sequence[int]]
+
+
+@dataclass(frozen=True)
+class MinRadiusRowResult:
+    """Minimum-radius status for one potential minimum center."""
+
+    center: int
+    witness_order: list[int]
+    consecutive_pairs: list[Pair]
+    covered_consecutive_pairs: list[Pair]
+    uncovered_consecutive_pairs: list[Pair]
+    blocked: bool
+
+
+@dataclass(frozen=True)
+class MinRadiusOrderResult:
+    """Minimum-radius status for a fixed cyclic order."""
+
+    pattern: str
+    n: int
+    order: list[int]
+    rows: list[MinRadiusRowResult]
+    blocked_centers: list[int]
+    possible_min_centers: list[int]
+    order_free_blocked_centers: list[int]
+    obstructed: bool
+
+
+def pair(a: int, b: int) -> Pair:
+    """Return a normalized unordered pair. Reject loops."""
+
+    if a == b:
+        raise ValueError(f"loop pair is not allowed: ({a}, {b})")
+    return (a, b) if a < b else (b, a)
+
+
+def _validate_pattern(S: Pattern) -> None:
+    n = len(S)
+    for center, row in enumerate(S):
+        if len(row) != 4:
+            raise ValueError(f"row {center} has length {len(row)}, expected 4")
+        if len(set(row)) != 4:
+            raise ValueError(f"row {center} has repeated witnesses: {list(row)}")
+        if center in row:
+            raise ValueError(f"row {center} contains its own center")
+        for label in row:
+            if label < 0 or label >= n:
+                raise ValueError(f"row {center} contains out-of-range label {label}")
+
+
+def _positions(order: Sequence[int], n: int, require_full: bool = True) -> dict[int, int]:
+    pos: dict[int, int] = {}
+    for idx, label in enumerate(order):
+        if label in pos:
+            raise ValueError(f"cyclic order is not a permutation: repeated label {label}")
+        if label < 0 or label >= n:
+            raise ValueError(f"cyclic order label out of range: {label}")
+        pos[label] = idx
+    if require_full and set(pos) != set(range(n)):
+        missing = sorted(set(range(n)) - set(pos))
+        raise ValueError(f"cyclic order is incomplete; missing={missing}")
+    return pos
+
+
+def selected_pair_sources(S: Pattern, a: int, b: int) -> list[int]:
+    """Return endpoints among ``a,b`` whose selected row contains the other endpoint."""
+
+    _validate_pattern(S)
+    n = len(S)
+    if a < 0 or a >= n or b < 0 or b >= n:
+        raise ValueError(f"pair labels out of range: ({a}, {b})")
+    pair(a, b)
+
+    sources: list[int] = []
+    if b in S[a]:
+        sources.append(a)
+    if a in S[b]:
+        sources.append(b)
+    return sources
+
+
+def angular_witness_order(
+    order: Sequence[int],
+    center: int,
+    witnesses: Sequence[int],
+) -> list[int]:
+    """Return witnesses in angular order around a convex-hull vertex center.
+
+    For a strictly convex polygon, the angular order around a hull vertex is the
+    boundary order with the center removed, up to reversal. Reversal does not
+    change which witness pairs are consecutive.
+    """
+
+    n = len(order)
+    pos = _positions(order, n, require_full=True)
+    if center not in pos:
+        raise ValueError(f"center {center} is missing from cyclic order")
+    missing = [witness for witness in witnesses if witness not in pos]
+    if missing:
+        raise ValueError(f"witness {missing[0]} is missing from cyclic order")
+    center_pos = pos[center]
+    return sorted(witnesses, key=lambda witness: (pos[witness] - center_pos) % n)
+
+
+def consecutive_witness_pairs(
+    order: Sequence[int],
+    center: int,
+    witnesses: Sequence[int],
+) -> list[Pair]:
+    """Return the three linear consecutive witness pairs around ``center``.
+
+    There is no wraparound pair. The four witnesses lie in the open interior
+    cone at ``center``, whose angular width is smaller than ``pi``.
+    """
+
+    witness_order = angular_witness_order(order, center, witnesses)
+    return [pair(a, b) for a, b in zip(witness_order, witness_order[1:])]
+
+
+def minimum_radius_row_result(
+    S: Pattern,
+    order: Sequence[int],
+    center: int,
+) -> MinRadiusRowResult:
+    """Return the minimum-radius filter status for one center in one order."""
+
+    _validate_pattern(S)
+    n = len(S)
+    _positions(order, n, require_full=True)
+    if center < 0 or center >= n:
+        raise ValueError(f"center out of range: {center}")
+
+    witness_order = angular_witness_order(order, center, S[center])
+    consecutive = [pair(a, b) for a, b in zip(witness_order, witness_order[1:])]
+    covered = [item for item in consecutive if selected_pair_sources(S, *item)]
+    uncovered = [item for item in consecutive if not selected_pair_sources(S, *item)]
+    return MinRadiusRowResult(
+        center=center,
+        witness_order=witness_order,
+        consecutive_pairs=consecutive,
+        covered_consecutive_pairs=covered,
+        uncovered_consecutive_pairs=uncovered,
+        blocked=not uncovered,
+    )
+
+
+def row_is_order_free_blocked(S: Pattern, center: int) -> bool:
+    """Return True iff ``center`` is blocked for every cyclic order.
+
+    This happens exactly when every pair among the four witnesses is selected in
+    at least one direction. Then whatever the angular order is, all three
+    consecutive witness pairs are covered, so ``center`` cannot have the global
+    minimum selected radius.
+    """
+
+    _validate_pattern(S)
+    if center < 0 or center >= len(S):
+        raise ValueError(f"center out of range: {center}")
+    return all(selected_pair_sources(S, a, b) for a, b in combinations(S[center], 2))
+
+
+def minimum_radius_order_obstruction(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    pattern: str = "",
+) -> MinRadiusOrderResult:
+    """Return the fixed-order minimum-radius obstruction summary."""
+
+    _validate_pattern(S)
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    _positions(order, n, require_full=True)
+
+    rows = [minimum_radius_row_result(S, order, center) for center in range(n)]
+    blocked = [row.center for row in rows if row.blocked]
+    possible = [row.center for row in rows if not row.blocked]
+    order_free = [center for center in range(n) if row_is_order_free_blocked(S, center)]
+    return MinRadiusOrderResult(
+        pattern=pattern,
+        n=n,
+        order=list(order),
+        rows=rows,
+        blocked_centers=blocked,
+        possible_min_centers=possible,
+        order_free_blocked_centers=order_free,
+        obstructed=not possible,
+    )
+
+
+def _json_pair(item: Pair) -> list[int]:
+    return [int(item[0]), int(item[1])]
+
+
+def _json_row(row: MinRadiusRowResult) -> dict[str, object]:
+    return {
+        "center": int(row.center),
+        "witness_order": [int(label) for label in row.witness_order],
+        "consecutive_pairs": [_json_pair(item) for item in row.consecutive_pairs],
+        "covered_consecutive_pairs": [_json_pair(item) for item in row.covered_consecutive_pairs],
+        "uncovered_consecutive_pairs": [_json_pair(item) for item in row.uncovered_consecutive_pairs],
+        "blocked": row.blocked,
+    }
+
+
+def result_to_json(result: MinRadiusOrderResult) -> dict[str, object]:
+    """Return a JSON-serializable form of a minimum-radius result."""
+
+    return {
+        "type": "minimum_radius_order_result",
+        "pattern": result.pattern,
+        "n": int(result.n),
+        "order": [int(label) for label in result.order],
+        "result": "OBSTRUCTED" if result.obstructed else "PASS",
+        "obstructed": result.obstructed,
+        "blocked_centers": [int(center) for center in result.blocked_centers],
+        "possible_min_centers": [int(center) for center in result.possible_min_centers],
+        "order_free_blocked_centers": [int(center) for center in result.order_free_blocked_centers],
+        "rows": [_json_row(row) for row in result.rows],
+    }

--- a/tests/test_min_radius_filter.py
+++ b/tests/test_min_radius_filter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from erdos97.min_radius_filter import (
+    minimum_radius_order_obstruction,
+    row_is_order_free_blocked,
+    selected_pair_sources,
+)
+from erdos97.search import built_in_patterns
+
+
+def test_min_radius_filter_kills_all_other_pentagon_pattern() -> None:
+    S = [[j for j in range(5) if j != i] for i in range(5)]
+
+    result = minimum_radius_order_obstruction(S, list(range(5)), "K5_all_other")
+
+    assert result.obstructed
+    assert result.possible_min_centers == []
+    assert result.blocked_centers == list(range(5))
+    assert all(row.blocked for row in result.rows)
+    assert all(row_is_order_free_blocked(S, center) for center in range(5))
+
+
+def test_min_radius_filter_c19_survives_natural_order() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+
+    result = minimum_radius_order_obstruction(pattern.S, pattern=pattern.name)
+
+    assert not result.obstructed
+    assert result.blocked_centers == []
+    assert result.possible_min_centers == list(range(19))
+    assert result.rows[0].witness_order == [5, 9, 11, 16]
+    assert result.rows[0].uncovered_consecutive_pairs == [(5, 9), (9, 11)]
+    assert selected_pair_sources(pattern.S, 11, 16) == [11]

--- a/tests/test_p24_metric_linear_nonconvex.py
+++ b/tests/test_p24_metric_linear_nonconvex.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify_p24_metric_linear_nonconvex.py"
+
+
+def load_verifier():
+    spec = importlib.util.spec_from_file_location("verify_p24_metric_linear_nonconvex", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_p24_metric_linear_nonconvex_exact_facts() -> None:
+    verifier = load_verifier()
+
+    result = verifier.run_checks()
+
+    assert result["equal_distance_rows"] is True
+    assert result["max_support_intersection"] == 1
+    assert result["even_turns"] == {verifier.Q3(Fraction(1, 2))}
+    assert result["odd_turns"] == {verifier.Q3(Fraction(0), Fraction(-1, 2))}
+    assert result["jacobian_shape"] == (72, 48)
+    assert result["jacobian_rank"] == 44
+
+
+def test_p24_metric_linear_nonconvex_cli_reports_negative_control() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        check=True,
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert "Equal-distance rows: PASS" in completed.stdout
+    assert "Linearity |S_i cap S_k| <= 1: PASS; max intersection = 1" in completed.stdout
+    assert "Convexity failure by alternating turn signs: PASS" in completed.stdout
+    assert "Exact Jacobian rank: 44" in completed.stdout
+    assert "All checks passed." in completed.stdout


### PR DESCRIPTION
## Summary

- add an exact minimum-radius short-chord filter for fixed cyclic selected-witness patterns
- add a CLI checker and regression tests covering the toy all-other pentagon obstruction and the `C19_skew` natural-order pass
- document the filter as weak negative information and keep `C19_skew` framed as live under the current abstract-incidence filters
- add review-priority and dependency-snapshot scaffolding for reproducibility and independent audit work

## Review Notes

I reviewed the new filter for pattern validation, cyclic-order handling, the non-wrap consecutive-pair convention, and overclaiming risk. I did not find a blocking issue. The key mathematical claim remains deliberately narrow: the filter is an exact necessary condition and does not certify realizability.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check HEAD`
- `python -m pytest -q` (`54 passed`)
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`

The `C19_skew` check reports `PASS`, with no blocked centers and all 19 centers still possible as minimum-radius centers under this filter alone.