### PR TITLE
[codex] Add affine and two-orbit exact checkers

### DIFF
--- a/docs/exactification-plan.md
+++ b/docs/exactification-plan.md
@@ -64,6 +64,27 @@ current exactification frontier is to understand special rank-drop loci for
 fixed patterns, especially whether an ear-orderable pattern can be ruled out
 by combining a repaired rank theorem with the scaling-kernel lemma.[^rank]
 
+## Affine-circuit quotient checker
+
+The Prompt 2 affine-circuit reduction is implemented as an exact SymPy checker
+in `src/erdos97/affine_circuit_certificates.py`, with a CLI smoke test in
+`scripts/check_affine_circuit_certificates.py`.
+
+For a fixed coordinate set and chosen four-cohorts, the checker builds the
+signed affine-circuit matrix `L`, verifies the lifted kernel
+`span(1,x,y,x^2+y^2)`, quotients by a nonsingular four-point lifted base,
+peels singleton rows to a weighted two-core, and searches for minimal cofactor
+certificates. This is an exact finite diagnostic for a selected cohort system,
+not a proof of the general problem.
+
+Example commands:
+
+```bash
+python scripts/check_affine_circuit_certificates.py --example single-circle-row --assert-expected
+python scripts/check_affine_circuit_certificates.py --example golden-decagon --assert-expected
+python scripts/check_affine_circuit_certificates.py --example golden-decagon --json
+```
+
 ## Certificate format
 
 A certificate should contain:

--- a/docs/failed-ideas.md
+++ b/docs/failed-ideas.md
@@ -117,6 +117,16 @@ lifted affine circuits, row-linearity, or rank must fail on this construction.
 Any successful impossibility proof must use strict convexity, cyclic-order
 signs, one-sidedness, or another convexity-specific ingredient.[^p24]
 
+## 17. Half-step two-orbit near-regular ansatz
+
+Failure mode: the two concentric half-step-offset orbit construction can make
+the selected four-distance equations hold exactly, but the same equations force
+the inner radius below the alternating convexity threshold. In the notation of
+`docs/two-orbit-radius-propagation.md`, the equations force
+`S/R = sqrt(1 + sin^2 h) - sin h < cos h`, while strict convexity requires
+`S/R > cos h`. This is a useful perturbative base, not a live counterexample
+candidate.
+
 [^lit]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
 [^forest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/11_forest_lemma_counterexample_review.md`.
 [^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ put detailed reconciliation in the canonical synthesis.
   crossing CSP for two-overlap patterns.
 - [`vertex-circle-order-filter.md`](vertex-circle-order-filter.md): exact
   row-wise convexity-distance filter for cyclic orders.
+- [`two-orbit-radius-propagation.md`](two-orbit-radius-propagation.md): exact
+  obstruction for a half-step two-orbit near-regular ansatz.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible

--- a/docs/two-orbit-radius-propagation.md
+++ b/docs/two-orbit-radius-propagation.md
@@ -1,0 +1,164 @@
+# Two-orbit radius-propagation obstruction
+
+Trust label: `EXACT_OBSTRUCTION` for this ansatz only. This is not a proof of
+Erdos Problem #97 and is not a counterexample.
+
+## Pattern
+
+Fix `t >= 1`, set
+
+```text
+m = 4t,   h = pi/m.
+```
+
+Consider two concentric regular `m`-gons with half-step offset:
+
+```text
+A_j = R exp(2ijh),
+B_j = S exp((2j+1)ih),
+```
+
+listed in the alternating order
+
+```text
+A_0, B_0, A_1, B_1, ..., A_{m-1}, B_{m-1}.
+```
+
+The selected four-neighbor pattern is
+
+```text
+A_j: A_{j+t}, A_{j-t}, B_{j+t}, B_{j-t-1},
+B_j: B_{j+t}, B_{j-t}, A_{j+t}, A_{j-t+1}.
+```
+
+This gives `n = 2m = 8t` points.
+
+## Distance equations
+
+By scaling, set `R = 1` and write
+
+```text
+x = S/R,   s = sin h.
+```
+
+The same-orbit selected vertices are quarter-turns apart, so
+
+```text
+|A_j - A_{j +/- t}|^2 = 2,
+|B_j - B_{j +/- t}|^2 = 2x^2.
+```
+
+For an `A_j` row, the cross-orbit angular offsets are
+`+/- (pi/2 + h)`, hence
+
+```text
+|A_j - B_{j+t}|^2 = |A_j - B_{j-t-1}|^2
+                  = 1 + x^2 + 2x sin h.
+```
+
+Matching these to the same-orbit value gives
+
+```text
+x^2 + 2x sin h = 1.
+```
+
+For a `B_j` row, the cross-orbit angular offsets are `+/- (pi/2 - h)`, hence
+
+```text
+|B_j - A_{j+t}|^2 = |B_j - A_{j-t+1}|^2
+                  = 1 + x^2 - 2x sin h.
+```
+
+Matching these to `2x^2` gives the same equation:
+
+```text
+x^2 + 2x sin h = 1.
+```
+
+The positive solution is
+
+```text
+x = sqrt(1 + sin^2 h) - sin h.
+```
+
+Thus the four-distance condition is satisfied exactly inside this ansatz.
+
+## Convexity obstruction
+
+The two alternating signed turns are
+
+```text
+det(B_j - A_j, A_{j+1} - B_j) = 2 sin h (x - cos h),
+det(A_{j+1} - B_j, B_{j+1} - A_{j+1}) = 2x sin h (1 - x cos h).
+```
+
+So strict convexity of the alternating polygon requires
+
+```text
+cos h < x < sec h.
+```
+
+But the forced ratio satisfies `x < cos h`. Indeed,
+
+```text
+x < cos h
+<=> sqrt(1 + sin^2 h) < sin h + cos h,
+```
+
+and both sides are positive while
+
+```text
+(sin h + cos h)^2 - (1 + sin^2 h)
+  = 2 sin h cos h
+  > 0
+```
+
+for `0 < h <= pi/4`.
+
+Therefore the distance equations force every `B_j` turn to be negative. The
+inner orbit lies below the convexity threshold; the exact failure mode is
+concavity/inliers caused by radius propagation.
+
+As `t -> infinity`,
+
+```text
+x = 1 - h + O(h^2),
+cos h = 1 - h^2/2 + O(h^4).
+```
+
+The first-order inward term in `x` is the obstruction. Convexity needs only a
+quadratic radial drop, while the equality equations force a linear radial drop.
+
+## Reproducible checker
+
+The exact checker is implemented in
+`src/erdos97/two_orbit_radius_propagation.py`.
+
+Useful commands:
+
+```bash
+python scripts/check_two_orbit_radius_propagation.py --t 2 --assert-expected
+python scripts/check_two_orbit_radius_propagation.py --t 2 --assert-expected --verify-all-rows
+python scripts/check_two_orbit_radius_propagation.py --t 3 --json
+```
+
+The checker reports `status: exact_ansatz_obstruction_not_general_proof`.
+
+## Next perturbative test
+
+The exact ansatz is dead, but it is still a good deformation base. The useful
+next computation is local, not random:
+
+1. Let `A_j = r_j exp(i alpha_j)` and `B_j = rho_j exp(i beta_j)` near the
+   symmetric solution above.
+2. Keep the same selected equal-distance equations.
+3. Compute the Jacobian of those equations at the symmetric solution.
+4. Intersect its kernel with the linearized cone that increases the negative
+   `B_j` turns.
+5. Look for a rational or algebraic Farkas/stress certificate proving that no
+   first-order deformation can make all `B_j` turns positive.
+
+If this first-order obstruction exists, it becomes a reusable
+radius-propagation-versus-convexity filter. If it fails, the escaping tangent
+direction gives a much better perturbative ansatz than another symmetric
+guess.

--- a/scripts/check_affine_circuit_certificates.py
+++ b/scripts/check_affine_circuit_certificates.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Check Prompt 2 affine-circuit quotient and certificate reductions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.affine_circuit_certificates import (  # noqa: E402
+    affine_circuit_matrix,
+    analysis_to_json,
+    golden_decagon_example,
+    lifted_matrix,
+    matrix_is_zero,
+    minimal_cofactor_certificates,
+    pair_gain_components,
+    quotient_matrix,
+    quotient_reduction,
+    single_circle_row_example,
+    two_core_matrix,
+    valid_lifted_bases,
+    weighted_two_core,
+)
+
+
+EXAMPLES = {
+    "golden-decagon": golden_decagon_example,
+    "single-circle-row": single_circle_row_example,
+}
+
+
+def parse_base(raw: str) -> list[int]:
+    try:
+        base = [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated base: {raw}") from exc
+    if len(base) != 4:
+        raise argparse.ArgumentTypeError("base must contain exactly four labels")
+    return base
+
+
+def analyze(args: argparse.Namespace) -> dict[str, object]:
+    points, cohorts = EXAMPLES[args.example]()
+    L = affine_circuit_matrix(points, cohorts)
+    Z = lifted_matrix(points)
+    bases = valid_lifted_bases(points)
+    if not bases:
+        raise SystemExit(f"{args.example}: no nonsingular lifted base")
+    base = args.base if args.base is not None else bases[0]
+
+    quotient = quotient_reduction(L, Z, base)
+    LN, quotient_columns = quotient_matrix(L, base)
+    core = weighted_two_core(LN, quotient_columns)
+    A_core = two_core_matrix(LN, core)
+    certs = minimal_cofactor_certificates(
+        A_core,
+        core.core_columns,
+        max_support_size=args.max_support_size,
+        stop_after=args.stop_after,
+    )
+    pair_components = pair_gain_components(A_core, core.core_columns)
+
+    return analysis_to_json(
+        example=args.example,
+        base=base,
+        L=L,
+        Z=Z,
+        quotient=quotient,
+        core=core,
+        certificates=certs,
+        pair_components=pair_components,
+    )
+
+
+def assert_expected(row: dict[str, object]) -> None:
+    if not row["lz_zero"]:
+        raise AssertionError(f"{row['example']}: expected LZ=0")
+    if row["rank_z"] != 4:
+        raise AssertionError(f"{row['example']}: expected rank_z=4")
+    if row["kernel_dim_l"] != 4 + row["kernel_dim_quotient"]:
+        raise AssertionError(f"{row['example']}: quotient dimension mismatch")
+
+    if row["example"] == "single-circle-row":
+        core = row["two_core"]  # type: ignore[assignment]
+        if core["core_columns"] != [5]:  # type: ignore[index]
+            raise AssertionError("single-circle-row should leave isolated quotient column 5")
+        if not row["certificates"]:
+            raise AssertionError("single-circle-row should emit isolated-column certificate")
+
+
+def print_summary(row: dict[str, object]) -> None:
+    core = row["two_core"]  # type: ignore[assignment]
+    print("example  n  rankZ  LZ=0  kerL  kerQ  core cols  certs  pair comps")
+    print(
+        f"{row['example']}  {row['n']}  {row['rank_z']}  {row['lz_zero']}  "
+        f"{row['kernel_dim_l']}  {row['kernel_dim_quotient']}  "
+        f"{core['core_columns']}  {len(row['certificates'])}  "
+        f"{len(row['pair_gain_components'])}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--example", choices=sorted(EXAMPLES), default="golden-decagon")
+    parser.add_argument("--base", type=parse_base, help="comma-separated lifted base")
+    parser.add_argument("--json", action="store_true", help="print JSON instead of summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--max-support-size", type=int, default=8)
+    parser.add_argument("--stop-after", type=int, default=16)
+    args = parser.parse_args()
+
+    row = analyze(args)
+    if args.assert_expected:
+        assert_expected(row)
+
+    if args.json:
+        print(json.dumps(row, indent=2, sort_keys=True))
+    else:
+        print_summary(row)
+        if args.assert_expected:
+            print("OK: affine-circuit expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_two_orbit_radius_propagation.py
+++ b/scripts/check_two_orbit_radius_propagation.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Check the exact two-orbit radius-propagation obstruction."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.two_orbit_radius_propagation import (  # noqa: E402
+    alternating_turns,
+    selected_distance_residuals,
+    summary_to_json,
+    two_orbit_summary,
+)
+
+
+def _is_zero(value: object) -> bool:
+    import sympy as sp
+
+    return sp.simplify(value) == 0
+
+
+def _is_positive(value: object) -> bool:
+    import sympy as sp
+
+    simplified = sp.simplify(value)
+    if simplified.is_positive is True:
+        return True
+    if simplified.is_positive is False:
+        return False
+    return bool(sp.N(simplified, 80) > 0)
+
+
+def assert_expected(t: int, *, verify_all_rows: bool) -> None:
+    summary = two_orbit_summary(t)
+    if not _is_zero(summary.distance_equation):
+        raise AssertionError("forced ratio does not satisfy x^2+2x sin(h)-1=0")
+    if not _is_zero(summary.a_distance_gap):
+        raise AssertionError("A-row selected distances are not equal")
+    if not _is_zero(summary.b_distance_gap):
+        raise AssertionError("B-row selected distances are not equal")
+    if not _is_positive(summary.cos_minus_ratio):
+        raise AssertionError("expected forced ratio below cos(h)")
+    if not _is_positive(-summary.turn_at_b):
+        raise AssertionError("expected B-turn to be negative")
+    if not _is_positive(summary.turn_at_a):
+        raise AssertionError("expected A-turn to be positive")
+    if not summary.forced_concave:
+        raise AssertionError("summary should report forced concavity")
+
+    if verify_all_rows:
+        for residuals in selected_distance_residuals(t):
+            for residual in residuals:
+                if not _is_zero(residual):
+                    raise AssertionError(
+                        f"selected squared-distance residual is nonzero: {residual}"
+                    )
+        turns = alternating_turns(t)
+        if not any(_is_positive(-turn) for turn in turns):
+            raise AssertionError("expected at least one negative alternating turn")
+
+
+def print_summary(t: int) -> None:
+    summary = two_orbit_summary(t)
+    print("t  m  n  distance_eq  A_gap  B_gap  turn_B<0  turn_A>0  forced_concave")
+    print(
+        f"{summary.t}  {summary.m}  {summary.n}  "
+        f"{summary.distance_equation}  {summary.a_distance_gap}  "
+        f"{summary.b_distance_gap}  {_is_positive(-summary.turn_at_b)}  "
+        f"{_is_positive(summary.turn_at_a)}  {summary.forced_concave}"
+    )
+    print(f"S/R = {summary.ratio}")
+    print(f"cos(h) - S/R = {summary.cos_minus_ratio}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--t", type=int, default=2, help="positive integer with m=4t")
+    parser.add_argument("--json", action="store_true", help="print JSON")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument(
+        "--verify-all-rows",
+        action="store_true",
+        help="also verify all selected row distances and alternating turns",
+    )
+    args = parser.parse_args()
+
+    if args.assert_expected:
+        assert_expected(args.t, verify_all_rows=args.verify_all_rows)
+
+    summary = two_orbit_summary(args.t)
+    if args.json:
+        print(json.dumps(summary_to_json(summary), indent=2, sort_keys=True))
+    else:
+        print_summary(args.t)
+        if args.assert_expected:
+            print("OK: two-orbit obstruction verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/affine_circuit_certificates.py
+++ b/src/erdos97/affine_circuit_certificates.py
@@ -1,0 +1,532 @@
+"""Exact affine-circuit certificate checks for selected witness systems.
+
+This module implements the Prompt 2 reduction:
+
+* build the signed affine-circuit matrix ``L`` from selected four-cohorts;
+* split off the unavoidable lifted kernel ``span(1, x, y, x^2 + y^2)`` by a
+  nonsingular four-point base;
+* peel singleton rows to a weighted two-core;
+* search for minimal-support cofactor certificates;
+* analyze pure pair-gain components.
+
+The code is exact SymPy linear algebra. It is a checker for fixed coordinates
+and selected cohorts; it is not a proof that all possible systems have full
+rank.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Sequence
+
+
+def _sympy():
+    try:
+        import sympy as sp  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dev dependency
+        raise RuntimeError("SymPy is required for affine-circuit certificates") from exc
+    return sp
+
+
+@dataclass(frozen=True)
+class QuotientReduction:
+    base: list[int]
+    quotient_columns: list[int]
+    rank_z: int
+    det_z_base: object
+    kernel_dim_l: int
+    kernel_dim_quotient: int
+
+
+@dataclass(frozen=True)
+class TwoCoreResult:
+    """Result of singleton peeling.
+
+    ``peeled_columns`` records the deterministic order used by this checker:
+    rows are scanned from low to high index, and the first current singleton
+    column is removed at each step. The remaining core and kernel dimension are
+    the invariant data; the exact peel order is a diagnostic trace.
+    """
+
+    initial_columns: list[int]
+    core_columns: list[int]
+    active_rows: list[int]
+    peeled_columns: list[int]
+    kernel_dim_before: int
+    kernel_dim_after: int
+
+
+@dataclass(frozen=True)
+class CofactorCertificate:
+    support: list[int]
+    basis_rows: list[int]
+    active_rows: list[int]
+    cofactors: list[object]
+
+
+@dataclass(frozen=True)
+class PairGainComponent:
+    vertices: list[int]
+    rows: list[int]
+    edge_count: int
+    is_tree: bool
+    balanced: bool
+    witness_values: dict[int, object]
+    conflict: dict[str, object] | None
+
+
+def _as_points(points: Sequence[Sequence[object]]):
+    sp = _sympy()
+    out = []
+    for idx, point in enumerate(points):
+        if len(point) != 2:
+            raise ValueError(f"point {idx} must have length 2")
+        out.append((sp.sympify(point[0]), sp.sympify(point[1])))
+    return out
+
+
+def _is_zero(value: object) -> bool:
+    sp = _sympy()
+    return value == 0 or sp.simplify(value) == 0
+
+
+def lifted_matrix(points: Sequence[Sequence[object]]):
+    """Return the matrix with rows ``(1, x, y, x^2+y^2)``."""
+    sp = _sympy()
+    pts = _as_points(points)
+    return sp.Matrix([[1, x, y, sp.expand(x * x + y * y)] for x, y in pts])
+
+
+def affine_area_delta(points: Sequence[Sequence[object]], a: int, b: int, c: int):
+    """Return ``det [[1,x,y]_a, [1,x,y]_b, [1,x,y]_c]``."""
+    sp = _sympy()
+    pts = _as_points(points)
+    n = len(pts)
+    for label in (a, b, c):
+        if label < 0 or label >= n:
+            raise ValueError(f"point index out of range: {label}")
+    return sp.factor(
+        sp.Matrix([[1, pts[idx][0], pts[idx][1]] for idx in (a, b, c)]).det()
+    )
+
+
+def affine_circuit_row(
+    points: Sequence[Sequence[object]],
+    cohort: Sequence[int],
+    n: int | None = None,
+):
+    """Return one signed affine-circuit row for a selected four-cohort.
+
+    Empty cohorts are accepted and produce a zero row. Nonempty cohorts must
+    contain exactly four distinct labels.
+    """
+    sp = _sympy()
+    pts = _as_points(points)
+    if n is None:
+        n = len(pts)
+    if len(cohort) == 0:
+        return sp.zeros(1, n)
+    if len(cohort) != 4:
+        raise ValueError(f"cohort must be empty or length 4, got {len(cohort)}")
+    if len(set(cohort)) != 4:
+        raise ValueError(f"cohort contains duplicate labels: {list(cohort)}")
+    for label in cohort:
+        if label < 0 or label >= n:
+            raise ValueError(f"cohort label out of range: {label}")
+
+    a, b, c, d = cohort
+    coeffs = {
+        a: affine_area_delta(pts, b, c, d),
+        b: -affine_area_delta(pts, a, c, d),
+        c: affine_area_delta(pts, a, b, d),
+        d: -affine_area_delta(pts, a, b, c),
+    }
+    row = sp.zeros(1, n)
+    for col, value in coeffs.items():
+        row[0, col] = sp.factor(value)
+    return row
+
+
+def affine_circuit_matrix(points: Sequence[Sequence[object]], cohorts: Sequence[Sequence[int]]):
+    """Return the signed affine-circuit matrix ``L`` for all selected rows."""
+    sp = _sympy()
+    pts = _as_points(points)
+    n = len(pts)
+    rows = [affine_circuit_row(pts, row, n) for row in cohorts]
+    if not rows:
+        return sp.zeros(0, n)
+    return sp.Matrix.vstack(*rows)
+
+
+def matrix_is_zero(matrix) -> bool:
+    """Return True if every entry simplifies to zero."""
+    return all(_is_zero(entry) for entry in matrix)
+
+
+def valid_lifted_bases(points: Sequence[Sequence[object]]) -> list[list[int]]:
+    """Return all four-label bases with nonsingular lifted matrix."""
+    Z = lifted_matrix(points)
+    bases: list[list[int]] = []
+    for base in combinations(range(Z.rows), 4):
+        if not _is_zero(Z.extract(base, range(4)).det()):
+            bases.append(list(base))
+    return bases
+
+
+def quotient_reduction(L, Z, base: Sequence[int]) -> QuotientReduction:
+    """Return rank/nullity data for one lifted base quotient."""
+    sp = _sympy()
+    n = Z.rows
+    if len(base) != 4:
+        raise ValueError("base must contain four labels")
+    if len(set(base)) != 4:
+        raise ValueError(f"base contains duplicate labels: {list(base)}")
+    for label in base:
+        if label < 0 or label >= n:
+            raise ValueError(f"base label out of range: {label}")
+    det_base = sp.factor(Z.extract(base, range(4)).det())
+    if _is_zero(det_base):
+        raise ValueError(f"lifted base is singular: {list(base)}")
+    quotient_columns = [idx for idx in range(n) if idx not in set(base)]
+    return QuotientReduction(
+        base=list(base),
+        quotient_columns=quotient_columns,
+        rank_z=int(Z.rank()),
+        det_z_base=det_base,
+        kernel_dim_l=int(L.cols - L.rank()),
+        kernel_dim_quotient=int(len(quotient_columns) - L.extract(range(L.rows), quotient_columns).rank()),
+    )
+
+
+def quotient_matrix(L, base: Sequence[int]):
+    """Return ``(L_N, N)`` for columns outside ``base``."""
+    n = L.cols
+    base_set = set(base)
+    columns = [idx for idx in range(n) if idx not in base_set]
+    return L.extract(range(L.rows), columns), columns
+
+
+def _kernel_dim(matrix) -> int:
+    return int(matrix.cols - matrix.rank())
+
+
+def weighted_two_core(matrix, columns: Sequence[int] | None = None) -> TwoCoreResult:
+    """Peel columns hit by singleton rows until no singleton row remains."""
+    if columns is None:
+        columns = list(range(matrix.cols))
+    if len(columns) != matrix.cols:
+        raise ValueError("columns length must match matrix column count")
+
+    active: set[int] = set(range(matrix.cols))
+    peeled: list[int] = []
+    changed = True
+    while changed:
+        changed = False
+        for row_idx in range(matrix.rows):
+            nonzero = [
+                col for col in sorted(active) if not _is_zero(matrix[row_idx, col])
+            ]
+            if len(nonzero) == 1:
+                col = nonzero[0]
+                active.remove(col)
+                peeled.append(columns[col])
+                changed = True
+                break
+
+    core_local = sorted(active)
+    core_columns = [columns[col] for col in core_local]
+    active_rows = [
+        row_idx
+        for row_idx in range(matrix.rows)
+        if any(not _is_zero(matrix[row_idx, col]) for col in core_local)
+    ]
+    core = matrix.extract(active_rows, core_local)
+    return TwoCoreResult(
+        initial_columns=list(columns),
+        core_columns=core_columns,
+        active_rows=active_rows,
+        peeled_columns=peeled,
+        kernel_dim_before=_kernel_dim(matrix),
+        kernel_dim_after=_kernel_dim(core),
+    )
+
+
+def two_core_matrix(matrix, core: TwoCoreResult):
+    """Return the active-row/core-column submatrix described by ``core``."""
+    local_columns = [core.initial_columns.index(col) for col in core.core_columns]
+    return matrix.extract(core.active_rows, local_columns)
+
+
+def _active_rows_for_support(matrix, support: Sequence[int]) -> list[int]:
+    support_set = set(support)
+    return [
+        row_idx
+        for row_idx in range(matrix.rows)
+        if any(not _is_zero(matrix[row_idx, col]) for col in support_set)
+    ]
+
+
+def _has_singleton_row(matrix, support: Sequence[int]) -> bool:
+    support_set = set(support)
+    for row_idx in range(matrix.rows):
+        count = sum(1 for col in support_set if not _is_zero(matrix[row_idx, col]))
+        if count == 1:
+            return True
+    return False
+
+
+def _independent_row_indices(matrix, rank: int) -> list[int]:
+    if rank == 0:
+        return []
+    _rref, pivots = matrix.T.rref()
+    return [int(idx) for idx in pivots[:rank]]
+
+
+def cofactor_vector(matrix):
+    """Return the cofactor null vector for a full-row-rank (m-1) x m matrix."""
+    sp = _sympy()
+    if matrix.cols != matrix.rows + 1:
+        raise ValueError("cofactor vector needs an (m-1) x m matrix")
+    values = []
+    for col in range(matrix.cols):
+        sub = matrix.copy()
+        sub.col_del(col)
+        values.append(sp.factor((-1) ** col * sub.det()))
+    return values
+
+
+def minimal_cofactor_certificates(
+    matrix,
+    columns: Sequence[int] | None = None,
+    *,
+    max_support_size: int | None = None,
+    stop_after: int | None = None,
+) -> list[CofactorCertificate]:
+    """Return minimal-support cofactor certificates for ``ker(matrix)``.
+
+    The search is exponential and intended for small cores or tests. It reports
+    circuit supports: rank ``|S|-1``, one-dimensional kernel, no zero cofactor,
+    and no singleton row against the support.
+    """
+    if columns is None:
+        columns = list(range(matrix.cols))
+    if len(columns) != matrix.cols:
+        raise ValueError("columns length must match matrix column count")
+    if max_support_size is None:
+        max_support_size = matrix.cols
+    if stop_after is not None and stop_after <= 0:
+        return []
+
+    certificates: list[CofactorCertificate] = []
+    for size in range(1, min(max_support_size, matrix.cols) + 1):
+        for support in combinations(range(matrix.cols), size):
+            if _has_singleton_row(matrix, support):
+                continue
+            active_rows = _active_rows_for_support(matrix, support)
+            sub = matrix.extract(active_rows, support)
+            if sub.rank() != size - 1:
+                continue
+            if _kernel_dim(sub) != 1:
+                continue
+            basis_local = _independent_row_indices(sub, size - 1)
+            basis_rows = [active_rows[idx] for idx in basis_local]
+            basis_matrix = matrix.extract(basis_rows, support)
+            cofactors = cofactor_vector(basis_matrix)
+            if any(_is_zero(value) for value in cofactors):
+                continue
+            certificates.append(
+                CofactorCertificate(
+                    support=[columns[col] for col in support],
+                    basis_rows=basis_rows,
+                    active_rows=active_rows,
+                    cofactors=cofactors,
+                )
+            )
+            if stop_after is not None and len(certificates) >= stop_after:
+                return certificates
+    return certificates
+
+
+def pair_gain_components(matrix, columns: Sequence[int] | None = None) -> list[PairGainComponent]:
+    """Analyze connected components consisting only of pair rows.
+
+    Rows meeting other than two active columns are ignored by this helper. Use
+    it on a pure pair-row component, or as a diagnostic before mixed hypercore
+    handling.
+    """
+    sp = _sympy()
+    if columns is None:
+        columns = list(range(matrix.cols))
+    if len(columns) != matrix.cols:
+        raise ValueError("columns length must match matrix column count")
+
+    adjacency: dict[int, list[tuple[int, int, object]]] = defaultdict(list)
+    edge_rows: set[int] = set()
+    for row_idx in range(matrix.rows):
+        nz = [col for col in range(matrix.cols) if not _is_zero(matrix[row_idx, col])]
+        if len(nz) != 2:
+            continue
+        u, v = nz
+        gain_uv = sp.factor(-matrix[row_idx, u] / matrix[row_idx, v])
+        gain_vu = sp.factor(-matrix[row_idx, v] / matrix[row_idx, u])
+        adjacency[u].append((v, row_idx, gain_uv))
+        adjacency[v].append((u, row_idx, gain_vu))
+        edge_rows.add(row_idx)
+
+    seen: set[int] = set()
+    components: list[PairGainComponent] = []
+    for start in sorted(adjacency):
+        if start in seen:
+            continue
+        values = {start: sp.Integer(1)}
+        rows: set[int] = set()
+        vertices: set[int] = set()
+        balanced = True
+        conflict: dict[str, object] | None = None
+        q: deque[int] = deque([start])
+        seen.add(start)
+        while q:
+            u = q.popleft()
+            vertices.add(u)
+            for v, row_idx, gain in adjacency[u]:
+                rows.add(row_idx)
+                expected = sp.factor(values[u] * gain)
+                if v not in values:
+                    values[v] = expected
+                    seen.add(v)
+                    q.append(v)
+                elif sp.simplify(values[v] - expected) != 0:
+                    balanced = False
+                    if conflict is None:
+                        conflict = {
+                            "row": row_idx,
+                            "from": columns[u],
+                            "to": columns[v],
+                            "existing": values[v],
+                            "expected": expected,
+                        }
+        edge_count = len(rows)
+        vertex_list = sorted(vertices)
+        components.append(
+            PairGainComponent(
+                vertices=[columns[col] for col in vertex_list],
+                rows=sorted(rows),
+                edge_count=edge_count,
+                is_tree=edge_count == len(vertex_list) - 1,
+                balanced=balanced,
+                witness_values={columns[col]: sp.factor(values[col]) for col in vertex_list},
+                conflict=conflict,
+            )
+        )
+    return components
+
+
+def golden_decagon_example():
+    """Return the exact 10-point nonconvex all-bad example and cohorts.
+
+    The outer five points form a regular pentagon and the inner five points
+    lie strictly inside it, so this is a negative-control example for the
+    algebraic checker, not a convex-polygon candidate.
+    """
+    sp = _sympy()
+    sqrt5 = sp.sqrt(5)
+    rho = (sp.Integer(3) - sqrt5) / 2
+    points = []
+    for idx in range(10):
+        radius = sp.Integer(1) if idx % 2 == 0 else rho
+        theta = sp.pi * idx / 5
+        points.append((sp.simplify(radius * sp.cos(theta)), sp.simplify(radius * sp.sin(theta))))
+
+    cohorts: list[list[int]] = []
+    for idx in range(10):
+        offsets = [-3, -2, 2, 3] if idx % 2 == 0 else [-4, -1, 1, 4]
+        cohorts.append(sorted((idx + offset) % 10 for offset in offsets))
+    return points, cohorts
+
+
+def single_circle_row_example():
+    """Return a small exact example with one selected concyclic four-cohort."""
+    sp = _sympy()
+    points = [
+        (sp.Integer(1), sp.Integer(0)),
+        (sp.Integer(0), sp.Integer(1)),
+        (sp.Integer(-1), sp.Integer(0)),
+        (sp.Integer(0), sp.Integer(-1)),
+        (sp.Integer(2), sp.Integer(3)),
+        (sp.Integer(3), sp.Integer(5)),
+    ]
+    cohorts = [[], [], [], [], [], [0, 1, 2, 3]]
+    return points, cohorts
+
+
+def _json_value(value: object) -> str:
+    return str(value)
+
+
+def certificate_to_json(certificate: CofactorCertificate) -> dict[str, object]:
+    return {
+        "support": certificate.support,
+        "basis_rows": certificate.basis_rows,
+        "active_rows": certificate.active_rows,
+        "cofactors": [_json_value(value) for value in certificate.cofactors],
+    }
+
+
+def pair_component_to_json(component: PairGainComponent) -> dict[str, object]:
+    return {
+        "vertices": component.vertices,
+        "rows": component.rows,
+        "edge_count": component.edge_count,
+        "is_tree": component.is_tree,
+        "balanced": component.balanced,
+        "witness_values": {
+            str(vertex): _json_value(value)
+            for vertex, value in sorted(component.witness_values.items())
+        },
+        "conflict": None
+        if component.conflict is None
+        else {
+            key: _json_value(value) if key in {"existing", "expected"} else value
+            for key, value in component.conflict.items()
+        },
+    }
+
+
+def analysis_to_json(
+    *,
+    example: str,
+    base: Sequence[int],
+    L,
+    Z,
+    quotient: QuotientReduction,
+    core: TwoCoreResult,
+    certificates: Sequence[CofactorCertificate],
+    pair_components: Sequence[PairGainComponent],
+) -> dict[str, object]:
+    return {
+        "type": "affine_circuit_certificate_analysis",
+        "status": "exact_checker_not_a_proof",
+        "example": example,
+        "n": int(Z.rows),
+        "rank_z": quotient.rank_z,
+        "lz_zero": matrix_is_zero(L * Z),
+        "base": list(base),
+        "det_z_base": _json_value(quotient.det_z_base),
+        "kernel_dim_l": quotient.kernel_dim_l,
+        "kernel_dim_quotient": quotient.kernel_dim_quotient,
+        "quotient_columns": quotient.quotient_columns,
+        "two_core": {
+            "initial_columns": core.initial_columns,
+            "core_columns": core.core_columns,
+            "active_rows": core.active_rows,
+            "peeled_columns": core.peeled_columns,
+            "kernel_dim_before": core.kernel_dim_before,
+            "kernel_dim_after": core.kernel_dim_after,
+        },
+        "certificates": [certificate_to_json(cert) for cert in certificates],
+        "pair_gain_components": [
+            pair_component_to_json(component) for component in pair_components
+        ],
+    }

--- a/src/erdos97/two_orbit_radius_propagation.py
+++ b/src/erdos97/two_orbit_radius_propagation.py
@@ -1,0 +1,221 @@
+"""Exact checks for the half-step two-orbit radius-propagation ansatz.
+
+This module verifies a narrow obstruction, not the general Erdos #97 problem.
+The ansatz has two concentric regular ``m``-gons with half-step offset:
+
+``A_j = R exp(2ijh)``, ``B_j = S exp((2j+1)ih)``, with ``m=4t`` and
+``h=pi/m``.
+
+The selected four-neighbor pattern matches same-orbit quarter-turn chords to
+cross-orbit chords one half-step away. The distance equations force
+``S/R = sqrt(1+sin(h)^2) - sin(h)``, while convexity of the alternating
+polygon would require ``S/R > cos(h)``. The forced ratio is strictly smaller
+than ``cos(h)``, so this symmetric ansatz is exactly concave.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+def _sympy():
+    try:
+        import sympy as sp  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dev dependency
+        raise RuntimeError("SymPy is required for two-orbit exact checks") from exc
+    return sp
+
+
+@dataclass(frozen=True)
+class TwoOrbitSummary:
+    """Formula summary for one half-step two-orbit ansatz."""
+
+    t: int
+    m: int
+    n: int
+    h: object
+    ratio: object
+    distance_equation: object
+    a_distance_gap: object
+    b_distance_gap: object
+    turn_at_b: object
+    turn_at_a: object
+    cos_minus_ratio: object
+    sec_minus_ratio: object
+    lower_convexity_certificate: object
+    forced_concave: bool
+
+
+def _check_t(t: int) -> None:
+    if not isinstance(t, int) or t < 1:
+        raise ValueError("t must be a positive integer")
+
+
+def forced_ratio(t: int):
+    """Return the forced ratio ``S/R`` for ``m=4t``."""
+    _check_t(t)
+    sp = _sympy()
+    h = sp.pi / (4 * t)
+    s = sp.sin(h)
+    return sp.simplify(sp.sqrt(1 + s * s) - s)
+
+
+def two_orbit_summary(t: int) -> TwoOrbitSummary:
+    """Return exact symbolic identities and turn signs for one ``t``."""
+    _check_t(t)
+    sp = _sympy()
+    m = 4 * t
+    n = 2 * m
+    h = sp.pi / m
+    s = sp.sin(h)
+    c = sp.cos(h)
+    ratio = forced_ratio(t)
+
+    distance_equation = sp.simplify(ratio * ratio + 2 * ratio * s - 1)
+    a_distance_gap = sp.simplify(1 + ratio * ratio + 2 * ratio * s - 2)
+    b_distance_gap = sp.simplify(1 + ratio * ratio - 2 * ratio * s - 2 * ratio * ratio)
+
+    turn_at_b = sp.factor(2 * s * (ratio - c))
+    turn_at_a = sp.factor(2 * ratio * s * (1 - ratio * c))
+
+    cos_minus_ratio = sp.simplify(c - ratio)
+    sec_minus_ratio = sp.simplify(1 / c - ratio)
+    lower_convexity_certificate = sp.simplify((s + c) ** 2 - (1 + s * s))
+
+    return TwoOrbitSummary(
+        t=t,
+        m=m,
+        n=n,
+        h=h,
+        ratio=ratio,
+        distance_equation=distance_equation,
+        a_distance_gap=a_distance_gap,
+        b_distance_gap=b_distance_gap,
+        turn_at_b=turn_at_b,
+        turn_at_a=turn_at_a,
+        cos_minus_ratio=cos_minus_ratio,
+        sec_minus_ratio=sec_minus_ratio,
+        lower_convexity_certificate=lower_convexity_certificate,
+        forced_concave=_is_positive(cos_minus_ratio) and _is_positive(-turn_at_b),
+    )
+
+
+def two_orbit_points(t: int):
+    """Return exact alternating points ``A_0,B_0,A_1,B_1,...`` with ``R=1``."""
+    _check_t(t)
+    sp = _sympy()
+    m = 4 * t
+    h = sp.pi / m
+    ratio = forced_ratio(t)
+    points = []
+    for j in range(m):
+        a_theta = 2 * j * h
+        b_theta = (2 * j + 1) * h
+        points.append((sp.cos(a_theta), sp.sin(a_theta)))
+        points.append((sp.simplify(ratio * sp.cos(b_theta)), sp.simplify(ratio * sp.sin(b_theta))))
+    return points
+
+
+def two_orbit_cohorts(t: int) -> list[list[int]]:
+    """Return selected cohorts for the two-orbit pattern.
+
+    Labels are the alternating point labels returned by ``two_orbit_points``:
+    ``2*j`` is ``A_j`` and ``2*j+1`` is ``B_j``.
+    """
+    _check_t(t)
+    m = 4 * t
+    cohorts: list[list[int]] = [[] for _ in range(2 * m)]
+    for j in range(m):
+        cohorts[2 * j] = [
+            2 * ((j + t) % m),
+            2 * ((j - t) % m),
+            2 * ((j + t) % m) + 1,
+            2 * ((j - t - 1) % m) + 1,
+        ]
+        cohorts[2 * j + 1] = [
+            2 * ((j + t) % m) + 1,
+            2 * ((j - t) % m) + 1,
+            2 * ((j + t) % m),
+            2 * ((j - t + 1) % m),
+        ]
+    return cohorts
+
+
+def selected_distance_residuals(t: int) -> list[list[object]]:
+    """Return exact selected squared-distance residuals for all rows.
+
+    Each row contains the differences between every selected squared distance
+    and the first selected squared distance in that row.
+    """
+    sp = _sympy()
+    points = two_orbit_points(t)
+    cohorts = two_orbit_cohorts(t)
+    residuals = []
+    for center, row in enumerate(cohorts):
+        values = [_squared_distance(points[center], points[target]) for target in row]
+        residuals.append([sp.simplify(value - values[0]) for value in values[1:]])
+    return residuals
+
+
+def alternating_turns(t: int) -> list[object]:
+    """Return exact signed consecutive turns in alternating cyclic order."""
+    sp = _sympy()
+    points = two_orbit_points(t)
+    turns = []
+    n = len(points)
+    for idx in range(n):
+        p = points[idx]
+        q = points[(idx + 1) % n]
+        r = points[(idx + 2) % n]
+        turns.append(sp.factor(_det(_sub(q, p), _sub(r, q))))
+    return turns
+
+
+def summary_to_json(summary: TwoOrbitSummary) -> dict[str, object]:
+    """Return a JSON-friendly exact summary."""
+    return {
+        "type": "two_orbit_radius_propagation",
+        "status": "exact_ansatz_obstruction_not_general_proof",
+        "t": summary.t,
+        "m": summary.m,
+        "n": summary.n,
+        "h": str(summary.h),
+        "ratio": str(summary.ratio),
+        "distance_equation": str(summary.distance_equation),
+        "a_distance_gap": str(summary.a_distance_gap),
+        "b_distance_gap": str(summary.b_distance_gap),
+        "turn_at_b": str(summary.turn_at_b),
+        "turn_at_a": str(summary.turn_at_a),
+        "cos_minus_ratio": str(summary.cos_minus_ratio),
+        "sec_minus_ratio": str(summary.sec_minus_ratio),
+        "lower_convexity_certificate": str(summary.lower_convexity_certificate),
+        "forced_concave": summary.forced_concave,
+        "interpretation": (
+            "The equality equations force S/R below cos(h), while strict "
+            "convexity of the alternating polygon requires S/R > cos(h)."
+        ),
+    }
+
+
+def _squared_distance(p: Sequence[object], q: Sequence[object]):
+    sp = _sympy()
+    return sp.simplify((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2)
+
+
+def _sub(p: Sequence[object], q: Sequence[object]) -> tuple[object, object]:
+    return (p[0] - q[0], p[1] - q[1])
+
+
+def _det(u: Sequence[object], v: Sequence[object]):
+    return u[0] * v[1] - u[1] * v[0]
+
+
+def _is_positive(value: object) -> bool:
+    sp = _sympy()
+    simplified = sp.simplify(value)
+    if simplified.is_positive is True:
+        return True
+    if simplified.is_positive is False:
+        return False
+    return bool(sp.N(simplified, 80) > 0)

--- a/tests/test_affine_circuit_certificates.py
+++ b/tests/test_affine_circuit_certificates.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sympy as sp
+
+from erdos97.affine_circuit_certificates import (
+    affine_circuit_matrix,
+    golden_decagon_example,
+    lifted_matrix,
+    matrix_is_zero,
+    minimal_cofactor_certificates,
+    pair_gain_components,
+    quotient_matrix,
+    quotient_reduction,
+    single_circle_row_example,
+    two_core_matrix,
+    valid_lifted_bases,
+    weighted_two_core,
+)
+
+
+def test_single_concyclic_row_annihilates_lifted_columns() -> None:
+    points, cohorts = single_circle_row_example()
+
+    L = affine_circuit_matrix(points, cohorts)
+    Z = lifted_matrix(points)
+
+    assert Z.rank() == 4
+    assert matrix_is_zero(L * Z)
+
+
+def test_quotient_and_two_core_detect_isolated_column() -> None:
+    points, cohorts = single_circle_row_example()
+    L = affine_circuit_matrix(points, cohorts)
+    Z = lifted_matrix(points)
+    base = [0, 1, 2, 4]
+
+    quotient = quotient_reduction(L, Z, base)
+    LN, columns = quotient_matrix(L, base)
+    core = weighted_two_core(LN, columns)
+    A_core = two_core_matrix(LN, core)
+    certs = minimal_cofactor_certificates(A_core, core.core_columns)
+
+    assert quotient.kernel_dim_l == 4 + quotient.kernel_dim_quotient
+    assert core.kernel_dim_before == core.kernel_dim_after
+    assert core.peeled_columns == [3]
+    assert core.core_columns == [5]
+    assert certs
+    assert certs[0].support == [5]
+    assert certs[0].cofactors == [1]
+
+
+def test_golden_decagon_exact_example_has_lifted_kernel() -> None:
+    points, cohorts = golden_decagon_example()
+    L = affine_circuit_matrix(points, cohorts)
+    Z = lifted_matrix(points)
+
+    assert Z.rank() == 4
+    assert matrix_is_zero(L * Z)
+    assert valid_lifted_bases(points)
+
+
+def test_pair_gain_tree_and_balanced_cycle_components() -> None:
+    tree = sp.Matrix([[1, -2, 0], [0, 3, -4]])
+    tree_components = pair_gain_components(tree)
+    assert len(tree_components) == 1
+    assert tree_components[0].is_tree
+    assert tree_components[0].balanced
+
+    balanced_cycle = sp.Matrix([[1, -1, 0], [0, 1, -1], [-1, 0, 1]])
+    balanced_components = pair_gain_components(balanced_cycle)
+    assert len(balanced_components) == 1
+    assert not balanced_components[0].is_tree
+    assert balanced_components[0].balanced
+
+    unbalanced_cycle = sp.Matrix([[1, -1, 0], [0, 1, -1], [-2, 0, 1]])
+    unbalanced_components = pair_gain_components(unbalanced_cycle)
+    assert len(unbalanced_components) == 1
+    assert not unbalanced_components[0].balanced
+
+
+def test_minimal_cofactor_certificate_for_pair_tree() -> None:
+    matrix = sp.Matrix([[1, -2, 0], [0, 3, -4]])
+
+    certs = minimal_cofactor_certificates(matrix)
+
+    assert len(certs) == 1
+    assert certs[0].support == [0, 1, 2]
+    assert certs[0].basis_rows == [0, 1]
+    assert all(value != 0 for value in certs[0].cofactors)

--- a/tests/test_two_orbit_radius_propagation.py
+++ b/tests/test_two_orbit_radius_propagation.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sympy as sp
+
+from erdos97.two_orbit_radius_propagation import (
+    alternating_turns,
+    selected_distance_residuals,
+    summary_to_json,
+    two_orbit_summary,
+)
+
+
+def test_forced_ratio_solves_both_distance_equations() -> None:
+    for t in (1, 2, 3):
+        summary = two_orbit_summary(t)
+
+        assert sp.simplify(summary.distance_equation) == 0
+        assert sp.simplify(summary.a_distance_gap) == 0
+        assert sp.simplify(summary.b_distance_gap) == 0
+
+
+def test_forced_ratio_violates_convexity_threshold() -> None:
+    for t in (1, 2, 3):
+        summary = two_orbit_summary(t)
+
+        assert sp.N(summary.cos_minus_ratio, 50) > 0
+        assert sp.N(summary.sec_minus_ratio, 50) > 0
+        assert sp.N(summary.turn_at_b, 50) < 0
+        assert sp.N(summary.turn_at_a, 50) > 0
+        assert summary.forced_concave
+
+
+def test_explicit_selected_distances_for_t2_are_exactly_equal() -> None:
+    residuals = selected_distance_residuals(2)
+
+    assert len(residuals) == 16
+    assert all(
+        sp.simplify(residual) == 0
+        for row_residuals in residuals
+        for residual in row_residuals
+    )
+
+
+def test_alternating_turns_for_t2_have_reflex_b_vertices() -> None:
+    turns = alternating_turns(2)
+
+    assert len(turns) == 16
+    assert all(sp.N(turns[2 * j], 50) < 0 for j in range(8))
+    assert all(sp.N(turns[2 * j + 1], 50) > 0 for j in range(8))
+
+
+def test_json_summary_keeps_claim_boundary_explicit() -> None:
+    row = summary_to_json(two_orbit_summary(2))
+
+    assert row["status"] == "exact_ansatz_obstruction_not_general_proof"
+    assert row["forced_concave"] is True


### PR DESCRIPTION
## Summary

- add an exact affine-circuit quotient/certificate checker for selected four-cohort systems
- add an exact two-orbit radius-propagation obstruction checker and documentation
- document the new exactification tooling and record the half-step two-orbit ansatz as a failed/live perturbative base rather than a counterexample claim

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check --cached`
- `python -m pytest tests/test_affine_circuit_certificates.py tests/test_two_orbit_radius_propagation.py -q`
- `python scripts/check_affine_circuit_certificates.py --example single-circle-row --assert-expected`
- `python scripts/check_affine_circuit_certificates.py --example golden-decagon --assert-expected`
- `python scripts/check_two_orbit_radius_propagation.py --t 2 --assert-expected --verify-all-rows`
- `python scripts/check_two_orbit_radius_propagation.py --t 3 --json`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`

## Claim Boundary

This PR adds exact diagnostics for fixed cohort systems and one symmetric ansatz obstruction. It does not claim a general proof or a counterexample for Erdos Problem #97.