### PR TITLE
Add prompt-run synthesis and fragile-cover tooling

### DIFF
--- a/data/llm_runs/codex_local_fragile_hypergraph_2026-04-28/summary.md
+++ b/data/llm_runs/codex_local_fragile_hypergraph_2026-04-28/summary.md
@@ -1,0 +1,56 @@
+# Fragile hypergraph follow-up, 2026-04-28
+
+Status: research artifact only. This does not prove or disprove Erdos #97.
+
+## Main conclusion
+
+After the fragile-cover lemma is repaired, the deletion-critical witness map
+does not add a new independent constraint. If a fragile row S_u covers v, then
+deleting v already makes u non-bad: the unique four-cohort of u drops to size
+three, and there is no other rich radius for u.
+
+Thus a witness map is just a choice of one covering fragile center for each
+vertex.
+
+## Consequence
+
+The current second-stage axioms are too weak by themselves. There are abstract
+covering pointed 4-uniform hypergraphs satisfying:
+
+- self-exclusion;
+- cover;
+- pairwise intersection at most two;
+- the two-overlap cyclic crossing rule;
+- a valid witness map.
+
+The new `block6` family gives examples for every n divisible by 6. In each
+six-vertex block b,...,b+5, use fragile centers b and b+3 with rows
+
+```text
+b   -> {b+1,b+2,b+3,b+4}
+b+3 -> {b,b+2,b+4,b+5}
+```
+
+The two rows share {b+2,b+4}; the center pair {b,b+3} separates that shared
+pair in cyclic order. Different blocks are disjoint.
+
+## Added tooling
+
+`src/erdos97/fragile_hypergraph.py` checks the fragile-cover hypergraph layer.
+`scripts/check_fragile_hypergraph.py` emits or verifies the block-6 family.
+
+Passing this checker is not a geometric realization certificate. Its purpose is
+to show that the fragile-cover route needs a stronger metric or cyclic
+constraint beyond the currently isolated hypergraph axioms.
+
+## Next target
+
+Look for an additional condition that uses the fact that fragile centers are
+part of a full minimal bad polygon, not just an abstract cover. Good candidates:
+
+1. constraints involving non-fragile centers and their selected cohorts;
+2. a stronger cyclic rule for disjoint or one-overlap fragile cohorts;
+3. metric inequalities involving two fragile centers in the same block-like
+   component;
+4. exact finite enumeration of fragile covers plus full selected rows for
+   small n.

--- a/data/llm_runs/codex_local_metric_fragility_2026-04-28/summary.md
+++ b/data/llm_runs/codex_local_metric_fragility_2026-04-28/summary.md
@@ -1,0 +1,49 @@
+# n=8 metric-fragility probe, 2026-04-28
+
+Status: research artifact only. This is a symbolic diagnostic on the n=8
+survivor classes, not a general proof and not a counterexample.
+
+## Main result
+
+Metric fragility uniqueness was tested in the only n=8 place where it can be
+made exact from the current artifacts: the 15 selected-row survivor classes.
+
+The full selected equal-distance equations are already inconsistent for classes
+0 through 13 under the standard normalization p0=(0,0), p1=(1,0). For those
+classes, any fragility-uniqueness question is vacuous: there is no selected-row
+metric realization even over the complex numbers.
+
+Class 14 is the only class whose full selected equal-distance ideal is
+consistent. In that class, no selected row is algebraically forced to have an
+alternate equal-distance four-subset at the same center. So metric fragility
+uniqueness does not kill class 14. The existing exact n=8 artifact kills class
+14 by solving the PB+ED system and showing every branch has only four hull
+vertices, hence no strict convex octagon.
+
+## Added tooling
+
+`scripts/analyze_n8_metric_fragility.py` computes:
+
+- which n=8 survivor classes have inconsistent full selected ED equations;
+- for consistent classes, which rows are forced non-fragile by alternate
+  equal-distance four-subsets;
+- whether rows not forced non-fragile can still cover all vertices.
+
+Expected fingerprint:
+
+```text
+selected_ed_inconsistent_classes = 0,1,...,13
+selected_ed_consistent_classes = 14
+consistent_classes_with_eligible_fragile_cover = 14
+```
+
+## Interpretation
+
+This closes the current n=8 fragile-cover branch: incidence cover is too weak,
+and exact metric uniqueness does not add a new obstruction beyond the existing
+selected ED and strict-convexity checks.
+
+For larger n, the analogous condition is a real semialgebraic constraint:
+fragile centers require selected equality plus disequalities excluding every
+other rich four-subset. A future solver should encode those disequalities by
+saturation or interval separation rather than as prose.

--- a/data/llm_runs/codex_local_n8_fragile_cover_2026-04-28/summary.md
+++ b/data/llm_runs/codex_local_n8_fragile_cover_2026-04-28/summary.md
@@ -1,0 +1,47 @@
+# n=8 fragile-cover follow-up, 2026-04-28
+
+Status: research artifact only. This is an incidence-level finite check, not a
+metric realization certificate and not a proof of the global problem.
+
+## Main result
+
+The repaired fragile-cover lemma does not add a new incidence-only obstruction
+to the existing n=8 survivor classes.
+
+For each of the 15 reconstructed n=8 selected-row survivor classes, there is a
+subset of rows that covers all eight vertices. If those rows are allowed to be
+the fragile centers, the fragile-cover condition is satisfied.
+
+The minimum number of fragile centers needed to cover is:
+
+```text
+2 fragile centers: 6 classes
+3 fragile centers: 9 classes
+```
+
+No class requires more than three possible fragile rows at the incidence level.
+
+## Added tooling
+
+`scripts/analyze_n8_fragile_covers.py` loads
+`data/incidence/n8_reconstructed_15_survivors.json` and computes row-subset
+cover statistics for every survivor class.
+
+This answers a narrow question:
+
+```text
+Does fragile-cover eliminate any n=8 full selected-row incidence survivor if
+any selected row is eligible to be fragile?
+```
+
+The answer is no.
+
+## Interpretation
+
+Actual fragility is metric data: a center has a unique rich radius and exact
+cohort size four. The selected-row incidence matrix records only one chosen
+four-cohort per center, so it cannot certify or refute actual fragility.
+
+The next useful condition must therefore involve metric facts about uniqueness
+of a rich radius, not merely the existence of a covering subset of selected
+rows.

--- a/data/llm_runs/codex_local_pilot_2026-04-28/manifest.json
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/manifest.json
@@ -1,0 +1,31 @@
+{
+  "run_set": "codex_local_pilot_2026-04-28",
+  "created_date": "2026-04-28",
+  "source_prompt_pack": "C:\\Users\\User\\Desktop\\code\\erd archive\\outputs\\data\\erdos97_prompt_pack_comparison_and_v3.md",
+  "runner": "Codex local conversation, not isolated API batch runs",
+  "status": "research_artifact_only",
+  "interpretation_warning": "These outputs are not independent fresh GPT-5.5 Pro runs and must not be treated as proof, disproof, or official status evidence.",
+  "primary_prompts_run": [0, 1, 2, 3],
+  "runs": [
+    {
+      "run_id": "p00_codex_local_01",
+      "prompt_id": 0,
+      "output_file": "p00_method_free_control.md"
+    },
+    {
+      "run_id": "p01_codex_local_01",
+      "prompt_id": 1,
+      "output_file": "p01_centered_circle_matrix.md"
+    },
+    {
+      "run_id": "p02_codex_local_01",
+      "prompt_id": 2,
+      "output_file": "p02_affine_circuit_rank.md"
+    },
+    {
+      "run_id": "p03_codex_local_01",
+      "prompt_id": 3,
+      "output_file": "p03_minimal_counterexample_fragility.md"
+    }
+  ]
+}

--- a/data/llm_runs/codex_local_pilot_2026-04-28/p00_method_free_control.md
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/p00_method_free_control.md
@@ -1,0 +1,95 @@
+# Prompt 0 local output: method-free control
+
+Status: partial progress only. No proof or counterexample is claimed.
+
+Let
+
+```text
+m_i(P)=max_{r>0} #{j != i : |p_j-p_i|=r}.
+```
+
+The target statement is that every strictly convex finite polygon has some
+vertex i with m_i(P) <= 3.
+
+## A local obstruction to naive proofs
+
+It is possible for a single vertex of a strictly convex polygon to have four
+other vertices at one common distance. Put p_0=(0,0) and, for angles
+
+```text
+-60 deg < theta_1 < theta_2 < theta_3 < theta_4 < 60 deg,
+```
+
+put q_t=(cos theta_t, sin theta_t). For a sufficiently separated choice of the
+four angles, the polygon
+
+```text
+p_0, q_1, q_2, q_3, q_4
+```
+
+in this cyclic order is strictly convex: the q_t form a strictly convex arc of
+the unit circle and p_0 lies strictly outside the chordal hull of that arc.
+Every q_t is at distance 1 from p_0. Thus a proof cannot show that every vertex
+has multiplicity at most three. The obstruction, if true, is necessarily global.
+
+## Selected-cohort reduction
+
+Assume for contradiction that P is bad, so m_i(P) >= 4 for every i. For each i,
+choose a radius r_i for which
+
+```text
+S_i={j != i : |p_j-p_i|=r_i}
+```
+
+has size at least four. If necessary, choose an arbitrary four-subset of this
+set; this gives a pointed four-uniform system (i;S_i).
+
+The selected system satisfies the following exact constraints.
+
+Lemma 1, self-exclusion. i is not in S_i.
+
+This is immediate from the definition j != i.
+
+Lemma 2, pairwise intersection. If i != k, then |S_i cap S_k| <= 2.
+
+Proof. S_i is contained in the circle centered at p_i with radius r_i, and
+S_k is contained in the circle centered at p_k with radius r_k. Since p_i != p_k,
+the two circles are distinct. Two distinct circles in the plane intersect in at
+most two points. Hence they contain at most two common vertices of P.
+
+Lemma 3, two-shared-cohort crossing. Suppose S_i cap S_k contains two distinct
+indices a,b. Then the cyclic pair {i,k} separates the cyclic pair {a,b}.
+
+Proof. The points p_a and p_b are the two intersections of the circles centered
+at p_i and p_k. In coordinates with p_i and p_k on the x-axis, the equations of
+the two circles subtract to give a linear equation x=c. Thus p_a and p_b have
+the same projection to the line p_i p_k and opposite signed distances from that
+line. Equivalently, they are reflections across the line p_i p_k.
+
+Here strict convexity is load-bearing: for a chord p_i p_k of a strictly convex
+polygon, every other vertex lies strictly in one of the two open half-planes
+cut out by the line p_i p_k, and the two open arcs between i and k in the cyclic
+order lie on opposite sides of that line. Since p_a and p_b lie on opposite
+sides, they lie on opposite cyclic arcs between i and k. This is exactly the
+separation statement.
+
+## Strongest theorem obtained
+
+The method-free attempt proves only this reduction:
+
+If a counterexample to the target statement exists, then there exists a cyclic
+pointed four-uniform hypergraph with one edge (i;S_i) at each vertex satisfying
+self-exclusion, pairwise intersection at most two, and the two-shared-cohort
+crossing rule.
+
+This is not enough to prove a contradiction. The missing step is a global
+classification or discharging theorem for such cyclic pointed four-uniform
+systems, plus a metric realization test for surviving systems.
+
+## Load-bearing hypotheses
+
+Strict convexity is used only in Lemma 3, where sides of a chord correspond to
+cyclic arcs. Finiteness is used to select maximum radii. Planarity is used in
+the two-circle intersection bound. The centered-on-vertex condition is used in
+both the circle-intersection bound and the crossing lemma; without fixed centers
+at vertices, the selected incidence system loses its strongest constraints.

--- a/data/llm_runs/codex_local_pilot_2026-04-28/p01_centered_circle_matrix.md
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/p01_centered_circle_matrix.md
@@ -1,0 +1,109 @@
+# Prompt 1 local output: centered-circle incidence matrix
+
+Status: partial progress only. No proof of the full theorem is claimed.
+
+Let the cyclically ordered vertices be indexed modulo n. For each row i, let
+S_i be the selected cohort and let s_i=|S_i|.
+
+## Convex-position crossing lemma
+
+Lemma. If i != k and S_i cap S_k contains distinct a,b, then {i,k} separates
+{a,b} in the cyclic order.
+
+Proof. The points p_a and p_b lie on both selected circles
+
+```text
+|x-p_i|=r_i,     |x-p_k|=r_k.
+```
+
+Subtracting the squared equations gives
+
+```text
+2 x dot (p_k-p_i) = |p_k|^2-|p_i|^2+r_i^2-r_k^2.
+```
+
+Thus p_a and p_b lie on the same radical axis, a line perpendicular to
+p_k-p_i. In coordinates whose x-axis is the line p_i p_k, the two circle
+intersections have the form (c,y) and (c,-y), with y != 0 because a and b are
+distinct. Hence p_a and p_b lie on opposite sides of the line p_i p_k.
+
+Strict convexity is now used. For the chord p_i p_k of a strictly convex
+polygon, all vertices different from i,k lie strictly off the line p_i p_k.
+Moreover the two cyclic arcs from i to k lie in the two opposite open halfplanes
+bounded by that line. Since p_a and p_b are in opposite halfplanes, they lie on
+opposite arcs. Equivalently, {i,k} separates {a,b}.
+
+## Consequences for the cyclic matrix
+
+Corollary 1. If i and k are adjacent cyclically, then |S_i cap S_k| <= 1.
+
+If they shared a,b, the pair {i,k} would have to separate {a,b}. Adjacent
+cyclic vertices leave one open arc empty, so no two other vertices can be
+separated by {i,k}.
+
+Corollary 2. If a and b are adjacent cyclically, then at most one row contains
+both a and b.
+
+If two rows i,k both contained a,b, then {i,k} would have to separate {a,b}.
+Again an adjacent pair cannot be separated by any other pair.
+
+Corollary 3. For every unordered pair {a,b}, at most two rows contain both
+a and b.
+
+If three rows i,k,l contained a,b, then each pair among i,k,l would have to be
+separated by {a,b}. But the two arcs cut by a,b give only two sides. Two of
+i,k,l lie on the same arc, and that pair is not separated by {a,b}.
+
+Combining Corollaries 2 and 3 gives a pair-count inequality. Let t_ab be the
+number of selected rows containing both a and b. Then
+
+```text
+sum_i binom(s_i,2) = sum_{a<b} t_ab
+                  <= n + 2 (binom(n,2)-n)
+                  = n(n-2),
+```
+
+where the n adjacent cyclic pairs have t_ab <= 1 and the nonadjacent pairs have
+t_ab <= 2.
+
+If every selected row has size at least four, then
+
+```text
+6n <= sum_i binom(s_i,2) <= n(n-2).
+```
+
+Therefore the axioms alone already rule out such a selected system for n <= 7.
+
+## Exact theorem proved
+
+The theorem proved here is:
+
+Given only the circle-intersection constraint and the convex-position crossing
+lemma, no cyclic selected-cohort matrix with all row sums at least four exists
+for n <= 7. For n = 8, any surviving matrix must have all row sums exactly four,
+every adjacent column-pair appearing in exactly one row, and every nonadjacent
+column-pair appearing in exactly two rows.
+
+The n = 8 conclusion follows because equality must hold throughout
+
+```text
+6n <= sum_i binom(s_i,2) <= n(n-2).
+```
+
+At n=8, both sides are 48, so no row can have size greater than four and every
+allowed pair-count bound must be saturated.
+
+## Remaining unresolved patterns
+
+The unresolved n=8 pattern class is exact:
+
+1. M is an 8-by-8 zero-diagonal 0-1 matrix.
+2. Every row has sum 4.
+3. Every adjacent column-pair occurs together in exactly one row.
+4. Every nonadjacent column-pair occurs together in exactly two rows.
+5. Adjacent rows have intersection size at most 1.
+6. Whenever rows i,k share exactly columns a,b, the pairs {i,k} and {a,b}
+   alternate in cyclic order.
+
+This is a strong finite combinatorial target, but it is not yet a contradiction.
+It also does not address metric realizability of any surviving matrix.

--- a/data/llm_runs/codex_local_pilot_2026-04-28/p02_affine_circuit_rank.md
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/p02_affine_circuit_rank.md
@@ -1,0 +1,110 @@
+# Prompt 2 local output: affine-circuit rank rigidity
+
+Status: reformulation and obstruction classification only. No rank-rigidity
+proof or geometric counterexample is claimed.
+
+Let L(P) be the selected four-cohort affine-circuit matrix. The unavoidable
+kernel contains
+
+```text
+1, x, y, q=x^2+y^2.
+```
+
+The question is whether, in the non-concyclic case, these are the only kernel
+vectors.
+
+## Equivalent lifting formulation
+
+For any vector h=(h_1,...,h_n), the row equation
+
+```text
+Delta_bcd h_a - Delta_acd h_b + Delta_abd h_c - Delta_abc h_d = 0
+```
+
+is exactly the condition that the four lifted points
+
+```text
+(x_a,y_a,h_a), (x_b,y_b,h_b), (x_c,y_c,h_c), (x_d,y_d,h_d)
+```
+
+are coplanar in R^3. Thus
+
+```text
+h in ker L(P)
+```
+
+if and only if h is a height assignment for which every selected four-cohort is
+coplanar after lifting.
+
+The four unavoidable height functions correspond to the plane liftings
+1,x,y and the paraboloid lifting q=x^2+y^2. The reason q works is special:
+on a circle centered at p_i=(alpha,beta), the equation
+
+```text
+x^2+y^2 = 2 alpha x + 2 beta y + (r_i^2-alpha^2-beta^2)
+```
+
+is affine in x,y.
+
+Therefore an exotic kernel vector is exactly an exotic lifting that makes every
+selected four-cohort coplanar without being a global affine-plus-paraboloid
+height function.
+
+## Why the rank claim needs extra hypotheses
+
+The rank statement cannot plausibly be attacked from geometry alone without
+also controlling the selected support pattern. The matrix L(P) has no entries
+in a column j unless vertex j appears in at least one selected four-cohort. If a
+column were unused, then the coordinate vector e_j would lie in ker L(P), giving
+an immediate extra kernel direction unrelated to concyclicity.
+
+More generally, if the selected four-cohort support hypergraph decomposes into
+two column sets that are never linked by a row, then piecewise unavoidable
+height functions produce additional kernel vectors. This is a combinatorial
+rank-defect mechanism, not a metric one.
+
+Thus a corrected rigidity target must include at least:
+
+1. column coverage;
+2. no support decomposition into independent column components;
+3. enough overlapping four-cohorts to make the affine-circuit matroid connected;
+4. a rank certificate for the actual Delta-weighted matrix, not merely for the
+   unweighted support pattern.
+
+## Classification of exotic syzygies
+
+Every exotic syzygy falls into one of the following linear-algebraic mechanisms.
+
+1. Uncovered-column syzygy. Some vertex never appears in any selected cohort.
+   Then its height is unconstrained.
+
+2. Component syzygy. The selected four-cohort hypergraph splits into column
+   components. Each component can carry its own affine-plus-paraboloid height
+   assignment, producing extra global kernel dimensions.
+
+3. Hinge syzygy. A small separator T of vertices is the only overlap between two
+   large groups of rows. If the separator does not force the affine and
+   paraboloid pieces to agree across the groups, a piecewise lifting survives.
+
+4. Metric cancellation syzygy. The support pattern is connected, but the signed
+   Delta coefficients satisfy a special algebraic dependency. This is the truly
+   geometric case: it must be detected by computing rank over the coordinate
+   field or by an exact symbolic certificate.
+
+## Strongest output
+
+The substantive rank rigidity lemma is best restated as a certificate problem:
+
+For each selected four-cohort pattern that survives the combinatorial filters,
+form L(P) with exact signed-area coefficients. Prove that
+
+```text
+ker L(P) / span{1,x,y,x^2+y^2} = 0
+```
+
+by an exact rank certificate, or else extract a nonzero exotic lifting h and
+classify it by the mechanisms above.
+
+This run did not prove that the quotient kernel vanishes in general. It
+identifies the missing object as an affine-circuit rigidity certificate for
+the selected support pattern.

--- a/data/llm_runs/codex_local_pilot_2026-04-28/p03_minimal_counterexample_fragility.md
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/p03_minimal_counterexample_fragility.md
@@ -1,0 +1,111 @@
+# Prompt 3 local output: minimal-counterexample fragility
+
+Status: fragile-cover lemma not proved. The first gap is identified precisely.
+
+Let
+
+```text
+m_u(P)=max_r #{v != u : |p_v-p_u|=r}.
+```
+
+Assume P is a minimal bad polygon: m_u(P) >= 4 for every vertex u, but P-v is
+not bad for every deleted vertex v.
+
+## What minimality actually proves
+
+Lemma, weak deletion cover. For every vertex v, there exists a remaining center
+u != v such that:
+
+1. m_u(P-v) <= 3;
+2. every radius r with #{w != u : |p_w-p_u|=r} >= 4 in P has exact count 4;
+3. every such rich radius contains v in its cohort.
+
+Proof. Since P-v is not bad, some remaining center u has m_u(P-v) <= 3. Since P
+is bad, u has at least one rich radius in P. Let r be any radius for u whose
+cohort in P has size at least 4. After deleting v, the same radius has cohort
+size either unchanged or reduced by one. Since m_u(P-v) <= 3, this reduced size
+is at most 3. Therefore the original size was exactly 4 and v belonged to that
+cohort. This holds for every rich radius r of u.
+
+This is the exact place where minimality is used.
+
+## Why this does not imply fragility
+
+Fragility requires that u have a unique radius r_u whose cohort has exact size
+four. The weak deletion cover only says that all rich radii of u are exact
+four-cohorts and all contain the deleted vertex v. It does not say there is only
+one such radius.
+
+The deletion scenario not excluded by minimality is:
+
+```text
+S_u(r) = {v,a,b,c},
+S_u(s) = {v,d,e,f},
+r != s,
+```
+
+with no radius for u having five or more vertices, and with every rich radius of
+u containing v. Then deleting v drops all rich cohorts of u from size 4 to size
+3, so u certifies that P-v is not bad. But u is not fragile, because there are
+two distinct exact four-cohorts.
+
+Minimality does not rule this out. It only requires that after deleting v at
+least one remaining center becomes non-bad. It does not require that this center
+had a unique maximum radius before deletion.
+
+## Consequence for the proposed fragile-cover lemma
+
+The proposed lemma says:
+
+```text
+Every vertex v is contained in the unique four-cohort of at least one fragile
+center u.
+```
+
+The proof attempt breaks exactly at "unique". A correct lemma currently
+available from minimality is:
+
+```text
+Every vertex v is contained in every rich cohort of at least one center u whose
+rich cohorts all have exact size four.
+```
+
+Call such a center v-pinned rather than fragile.
+
+## Stage two under the original fragile-cover assumption
+
+If the fragile-cover lemma were assumed, one obtains a pointed 4-uniform
+hypergraph on the cyclic vertex set: each fragile center u contributes its
+unique cohort S_u. This hypergraph satisfies:
+
+1. cover: every vertex lies in at least one S_u;
+2. self-exclusion: u not in S_u;
+3. pairwise intersection: |S_u cap S_w| <= 2;
+4. crossing: if S_u cap S_w = {a,b}, then {u,w} separates {a,b}.
+
+This alone gives only weak counting. If F is the set of fragile centers, then
+4|F| cohort incidences cover n vertices, so |F| >= ceil(n/4). Pair-counting also
+gives
+
+```text
+6|F| <= n(n-2),
+```
+
+using the same adjacent/nonadjacent pair bounds as in the centered-matrix
+route. Neither inequality contradicts large n.
+
+## Strongest conclusion
+
+The fragile-cover route should be rewritten around the weaker deletion-cover
+lemma. The key new subproblem is:
+
+Can the multi-rich-radius scenario
+
+```text
+S_u(r_1), S_u(r_2), ..., all exact four-cohorts, all containing v
+```
+
+be ruled out by strict convexity, or does it create a finite obstruction pattern
+for enumeration?
+
+Until that question is answered, the fragile-cover lemma is not justified.

--- a/data/llm_runs/codex_local_pilot_2026-04-28/summary.md
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/summary.md
@@ -1,0 +1,52 @@
+# Codex-local pilot summary, 2026-04-28
+
+Status: research artifact only. This is not a fresh-chat API batch and not a
+GPT-5.5 Pro reproducibility run.
+
+## Prompt 0
+
+No proof or counterexample was obtained. The strongest useful output is a
+self-contained reduction: any bad polygon yields a pointed selected-cohort
+system satisfying self-exclusion, pairwise intersection at most two, and the
+two-shared-cohort crossing rule. A local five-point convex fan shows that one
+vertex can have four equidistant vertices, so any proof must be global.
+
+## Prompt 1
+
+The convex-position crossing lemma was proved in detail. The run derives useful
+two-row consequences: adjacent centers cannot share two cohort vertices,
+adjacent cohort vertices cannot be a shared pair for two rows, and any unordered
+cohort-pair appears in at most two rows. The resulting pair-count inequality
+rules out the selected-row axioms for n <= 7 and forces a very rigid extremal
+profile at n = 8, but it does not prove the full problem.
+
+## Prompt 2
+
+No rank-rigidity proof was obtained. The useful reformulation is that an
+extra kernel vector is exactly an exotic lifting h_j for which every selected
+four-cohort is coplanar in the lifted point set (x_j,y_j,h_j). This identifies
+the missing certificate as an affine-circuit rigidity check for the selected
+four-uniform support pattern. The prompt's stated rank lemma needs additional
+coverage/connectivity hypotheses before it can plausibly be true for arbitrary
+chosen four-cohorts.
+
+## Prompt 3
+
+The fragile-cover lemma was not proved. Minimality gives a weaker but exact
+lemma: for every deleted vertex v, there is some remaining center u such that
+every rich radius of u in the original polygon contains v and has exact size
+four. This does not imply u is fragile, because u may have two or more distinct
+four-cohorts, all containing v. That is the first fatal gap in the proposed
+fragile-cover route.
+
+Erratum, superseded by `../codex_local_prompt3b_2026-04-28/summary.md`: the
+last sentence is wrong. A fixed vertex v has only one distance from a fixed
+center u, so two distinct radii centered at u cannot both contain v. The
+fragile-cover lemma is valid.
+
+## Recommended next action
+
+Use Prompt 3's weaker deletion lemma to rewrite the fragility path. The next
+prompt should ask whether the "multi-fragile through v" scenario can be ruled
+out geometrically, or whether it produces a concrete obstruction pattern for
+the finite-case enumerator.

--- a/data/llm_runs/codex_local_prompt3b_2026-04-28/manifest.json
+++ b/data/llm_runs/codex_local_prompt3b_2026-04-28/manifest.json
@@ -1,0 +1,22 @@
+{
+  "run_set": "codex_local_prompt3b_2026-04-28",
+  "created_date": "2026-04-28",
+  "source": "Follow-up to codex_local_pilot_2026-04-28 Prompt 3 output",
+  "runner": "Codex local conversation, not isolated API batch runs",
+  "status": "research_artifact_only",
+  "interpretation_warning": "This artifact proves only the fragile-cover lemma from the stated definitions. It does not prove Erdos Problem #97 and does not change the repository's global/open status.",
+  "outputs": [
+    {
+      "run_id": "p03b_codex_local_proof_01",
+      "output_file": "run_a_fragile_cover_repair.md"
+    },
+    {
+      "run_id": "p03b_codex_local_audit_01",
+      "output_file": "run_b_obstruction_audit.md"
+    },
+    {
+      "run_id": "p03b_codex_local_consequence_01",
+      "output_file": "run_c_hypergraph_consequences.md"
+    }
+  ]
+}

--- a/data/llm_runs/codex_local_prompt3b_2026-04-28/prompt_3b.md
+++ b/data/llm_runs/codex_local_prompt3b_2026-04-28/prompt_3b.md
@@ -1,0 +1,35 @@
+# Prompt 3b: fragile-cover repair audit
+
+This is a focused follow-up to the minimal-counterexample fragility prompt.
+Work self-contained. Do not search the internet.
+
+Let P be a strictly convex n-gon. For a vertex u, let
+
+```text
+m_u(P) = max_r #{w != u : |p_w-p_u| = r}.
+```
+
+Call P bad if m_u(P) >= 4 for every vertex u. Call P minimal bad if P is bad
+but deleting any vertex gives a polygon that is not bad.
+
+For a fixed deleted vertex v, minimality gives a remaining center u such that
+m_u(P-v) <= 3. Since P is bad, u has at least one rich radius in P.
+
+Question. Prove or disprove the following stronger conclusion:
+
+```text
+u is fragile: m_u(P)=4 and there is a unique radius r_u whose cohort has size
+exactly four. Moreover v belongs to this unique four-cohort.
+```
+
+The apparent obstruction is that u might have multiple rich radii in P, all
+reduced below 4 after deleting v. Check this scenario carefully. In particular,
+track the fact that a fixed vertex v has only one distance from the fixed center
+u.
+
+Output:
+
+1. A rigorous proof of the fragile-cover lemma, or the exact first fatal gap.
+2. If the proof succeeds, state precisely where minimality is used.
+3. If the proof succeeds, restate the hypergraph consequences available for the
+   second stage.

--- a/data/llm_runs/codex_local_prompt3b_2026-04-28/run_a_fragile_cover_repair.md
+++ b/data/llm_runs/codex_local_prompt3b_2026-04-28/run_a_fragile_cover_repair.md
@@ -1,0 +1,81 @@
+# Run A: fragile-cover repair
+
+Status: the fragile-cover lemma is proved from minimality. This does not prove
+the original Erdos #97 statement.
+
+## Lemma
+
+Let P be a minimal bad polygon. Then every vertex v of P is contained in the
+unique four-cohort of at least one fragile center u.
+
+## Proof
+
+For a center u and radius r, write
+
+```text
+C_P(u,r) = {w in P : w != u and |p_w-p_u| = r}.
+```
+
+Fix a vertex v. By minimality, P-v is not bad. Therefore there is some remaining
+vertex u != v such that
+
+```text
+m_u(P-v) <= 3.
+```
+
+This is the only use of minimality.
+
+Since P is bad, there exists at least one radius r with
+
+```text
+|C_P(u,r)| >= 4.
+```
+
+For any such rich radius r, compare the same radius after deleting v:
+
+```text
+|C_{P-v}(u,r)| = |C_P(u,r)| - 1_{v in C_P(u,r)}.
+```
+
+Because m_u(P-v) <= 3, the left side is at most 3. Since |C_P(u,r)| >= 4, the
+only possibility is
+
+```text
+|C_P(u,r)| = 4
+```
+
+and
+
+```text
+v in C_P(u,r).
+```
+
+Thus every rich radius r for u in P contains v. But v has only one distance from
+the fixed center u. Hence every rich radius r equals
+
+```text
+|p_v-p_u|.
+```
+
+So there is exactly one rich radius for u. Its cohort has exact size 4. Hence
+m_u(P)=4, u is fragile, and v lies in the unique four-cohort of u.
+
+This proves the fragile-cover lemma.
+
+## Correction to the earlier pilot
+
+The earlier local Prompt 3 output suggested the possible obstruction
+
+```text
+S_u(r) = {v,a,b,c},
+S_u(s) = {v,d,e,f},
+r != s.
+```
+
+This obstruction is impossible. If v belongs to both cohorts centered at u, then
+
+```text
+r = |p_v-p_u| = s.
+```
+
+So the two radii are not distinct.

--- a/data/llm_runs/codex_local_prompt3b_2026-04-28/run_b_obstruction_audit.md
+++ b/data/llm_runs/codex_local_prompt3b_2026-04-28/run_b_obstruction_audit.md
@@ -1,0 +1,54 @@
+# Run B: obstruction audit
+
+Status: no counter-scenario survives the fixed-distance check.
+
+## Candidate obstruction
+
+The only apparent way for minimality to fail to imply fragility is:
+
+```text
+u has two different rich radii r and s in P,
+deleting v drops both rich cohorts below size 4.
+```
+
+For deletion of v to drop the cohort at radius r, v must lie in C_P(u,r). For
+deletion of v to drop the cohort at radius s, v must lie in C_P(u,s). These two
+conditions imply
+
+```text
+r = |p_v-p_u| = s.
+```
+
+Therefore r and s are the same radius. The obstruction is not geometrically
+possible, independent of convexity.
+
+## Other edge cases
+
+1. Could a radius with five or more points drop below four after deleting v?
+
+No. Deleting one point can reduce a fixed-radius cohort by at most one. If the
+original size were at least five, the remaining size would be at least four,
+contradicting m_u(P-v) <= 3.
+
+2. Could the maximizing radius for u change after deleting v?
+
+Yes, but that does not matter. The proof compares every rich radius of u in P
+against the same radius in P-v. It does not assume the maximum radius is
+preserved.
+
+3. Does strict convexity enter the fragile-cover proof?
+
+Not directly, except as part of the ambient class and to ensure the deletion is
+still interpreted as a convex-position subpolygon. The proof itself is a
+finite metric argument.
+
+4. Does the lemma require u to be unique for v?
+
+No. For each v, minimality guarantees at least one witness u. There may be
+several.
+
+## Audit conclusion
+
+The fragile-cover lemma is valid as stated. The earlier pilot's fatal-gap claim
+was an error caused by overlooking that a fixed deleted vertex has a unique
+distance to a fixed center.

--- a/data/llm_runs/codex_local_prompt3b_2026-04-28/run_c_hypergraph_consequences.md
+++ b/data/llm_runs/codex_local_prompt3b_2026-04-28/run_c_hypergraph_consequences.md
@@ -1,0 +1,84 @@
+# Run C: hypergraph consequences after fragile-cover
+
+Status: second-stage setup only. No contradiction is proved here.
+
+Once the fragile-cover lemma is established, any minimal bad polygon gives a
+pointed four-uniform hypergraph.
+
+## Construction
+
+Let F be the set of fragile centers. For each u in F, let S_u be its unique
+four-cohort. Then:
+
+1. Self-exclusion: u not in S_u.
+2. Uniformity: |S_u| = 4.
+3. Cover: every vertex v belongs to S_u for at least one u in F.
+4. Pairwise intersection: for u != w, |S_u cap S_w| <= 2.
+5. Crossing rule: if S_u cap S_w = {a,b}, then {u,w} separates {a,b} in the
+   cyclic order.
+
+The cover property is exactly the fragile-cover lemma. Pairwise intersection
+comes from two-circle intersection. The crossing rule comes from the
+convex-position crossing lemma.
+
+## Immediate counting consequences
+
+Since the S_u cover n vertices and each has size 4,
+
+```text
+|F| >= ceil(n/4).
+```
+
+Pair-counting gives
+
+```text
+sum_{u in F} binom(|S_u|,2) = 6|F|
+```
+
+and every adjacent vertex-pair can appear in at most one cohort, while every
+nonadjacent pair can appear in at most two cohorts. Therefore
+
+```text
+6|F| <= n + 2 (binom(n,2)-n) = n(n-2).
+```
+
+This is not strong enough to contradict large n.
+
+## Stronger data retained from minimality
+
+The proof gives more than bare cover. For each vertex v, there is at least one
+witness center u such that:
+
+```text
+v in S_u,
+u is fragile,
+deleting v makes u non-bad.
+```
+
+Equivalently, every vertex is not just covered by fragile cohorts; it is covered
+by a fragile cohort for which it is deletion-critical.
+
+This suggests a sharper second-stage object: a covered pointed hypergraph
+together with a witness map
+
+```text
+phi(v) = u, where v in S_u.
+```
+
+The map phi records which fragile center certifies failure after deleting v.
+The next useful question is whether phi imposes additional cyclic or metric
+constraints beyond ordinary cover.
+
+## Next target
+
+The next prompt or computation should test whether the following data can
+exist:
+
+1. a cyclic vertex set [n];
+2. pointed four-sets (u;S_u) for a subset F of centers;
+3. a witness map phi:[n] -> F with v in S_{phi(v)};
+4. pairwise intersection and crossing constraints;
+5. any additional metric constraints derived from "deleting v makes phi(v)
+   non-bad."
+
+This is now a valid continuation of the minimal-counterexample route.

--- a/data/llm_runs/codex_local_prompt3b_2026-04-28/summary.md
+++ b/data/llm_runs/codex_local_prompt3b_2026-04-28/summary.md
@@ -1,0 +1,34 @@
+# Prompt 3b local summary, 2026-04-28
+
+Status: research artifact only. This is not an independent API batch run and
+does not prove the global Erdos #97 statement.
+
+## Main result
+
+The fragile-cover lemma is valid. The earlier local Prompt 3 pilot incorrectly
+identified a "multi-rich through v" obstruction. That obstruction is impossible:
+if two rich cohorts centered at the same u both contain the same deleted vertex
+v, then their radii both equal |p_v-p_u|, so they are the same radius.
+
+## Exact lemma proved
+
+In a minimal bad polygon, every vertex v is contained in the unique four-cohort
+of at least one fragile center u.
+
+Minimality is used exactly once: after deleting v, choose a remaining center u
+with m_u(P-v) <= 3. Comparing every rich radius of u in P with the same radius
+in P-v forces each rich radius to have exact size 4 and to contain v. Since v
+has only one distance from u, there is only one rich radius.
+
+## Consequence
+
+The minimal-counterexample route is alive again. A minimal bad polygon gives a
+covering pointed 4-uniform hypergraph of fragile cohorts satisfying:
+
+- self-exclusion;
+- cover;
+- pairwise intersection at most two;
+- the convex-position crossing rule for two-row overlaps.
+
+The next meaningful task is not to repair fragile-cover, but to exploit the
+second-stage hypergraph plus the deletion-critical witness map.

--- a/data/llm_runs/ten_prompt_review_2026-04-29/audit.md
+++ b/data/llm_runs/ten_prompt_review_2026-04-29/audit.md
@@ -1,0 +1,52 @@
+# Second-pass audit of corrected synthesis
+
+Date: 2026-04-29
+
+## Scope
+
+This audit checks `corrected_synthesis.md` for overclaiming and for reuse of
+the known false claims from the ten prompt outputs.
+
+## Findings
+
+No complete proof or counterexample is claimed. The artifact correctly treats
+the full problem as open.
+
+The n <= 6 proof uses the common-witness cap and exception-map argument, not
+the unsupported middle-witness uniqueness claim. This is the reliable route
+from Outputs 8 and 9.
+
+Output 10 is explicitly rejected. The tangent-support lemma is not reused.
+
+The alpha/3 exterior-angle descent is explicitly rejected. The retained local
+angle statement is the weaker alpha/2-style bound and the obtuse-middle lemma.
+
+The false chord claim from Output 2 is explicitly corrected.
+
+The parabola case is marked as a model-case theorem, not as evidence for the
+general theorem. The convex-position caveat is included.
+
+The minimal-counterexample lemma is stated as a dependency/fragile-cover
+structure, not as a contradiction.
+
+The diameter and octagon examples are marked as corrected/rejected search
+notes, not as proof ingredients.
+
+## Residual risks
+
+The tangent-support counterexample is included as an explicit coordinate
+example, but the artifact does not independently certify its convexity by exact
+symbolic determinant inequalities. It is used only to reject a lemma already
+known false, not as a positive theorem.
+
+The parabola model-case proof should receive a standalone formal write-up if it
+is promoted into `docs/claims.md` or `RESULTS.md`.
+
+The fragile-cover lemma is summarized from the earlier local repair. If this
+artifact is moved into canonical docs, it should link to or include that proof
+in full.
+
+## Audit verdict
+
+The synthesis is safe as a reviewed research artifact. It should not be
+presented as a proof of the full problem.

--- a/data/llm_runs/ten_prompt_review_2026-04-29/corrected_synthesis.md
+++ b/data/llm_runs/ten_prompt_review_2026-04-29/corrected_synthesis.md
@@ -1,0 +1,286 @@
+# Corrected synthesis of the ten prompt outputs
+
+Date: 2026-04-29
+
+Status: reviewed research artifact only. No complete proof and no
+counterexample to Erdos Problem #97 are claimed here.
+
+## Verdict
+
+None of the ten outputs gives a valid complete proof or counterexample for the
+full problem.
+
+The strongest reliable partial outputs are Outputs 8 and 9. Outputs 6 and 7
+also contain useful standalone lemmas. Output 10 must be rejected as a proof:
+its central supporting-tangent lemma is false.
+
+## Reliable components
+
+### Favorite-distance reformulation
+
+The original problem is equivalent to the following selected-radius statement.
+
+For every assignment of one positive radius rho_i to each vertex p_i of a
+strictly convex polygon, at least one assigned circle
+
+```text
+C_i = {x : |x-p_i| = rho_i}
+```
+
+contains at most three vertices of P \ {p_i}.
+
+This is a logical equivalence, not a simplification by itself. If every vertex
+were bad, choose one rich radius at each vertex. Conversely, a vertex that is
+good for every radius is good for every selected radius.
+
+### Common-witness rigidity
+
+If two distinct centers x,y are both equidistant from the same three
+non-collinear points a,b,c, then x=y, because a nondegenerate triangle has a
+unique circumcenter.
+
+Since a strictly convex polygon has no three collinear vertices, any selected
+four-cohorts S_i,S_j in a hypothetical counterexample satisfy
+
+```text
+|S_i cap S_j| <= 2      for i != j.
+```
+
+This is one of the core exact incidence constraints.
+
+### Small cases n <= 6
+
+The theorem is true for n <= 6.
+
+For n <= 4 this is immediate. For n=5, if every vertex were bad, each vertex
+would be equidistant from all four other vertices. Taking any two centers, the
+remaining three vertices would be common witnesses, contradicting
+common-witness rigidity.
+
+For n=6, suppose every vertex is bad and choose one rich radius at each vertex.
+No vertex can have all five other vertices at that radius: if p did, then any
+other bad vertex q would need four witnesses, at least three of which lie on
+the circle centered at p, again contradicting common-witness rigidity.
+
+Thus each row has exactly four selected witnesses and one exceptional vertex.
+Write
+
+```text
+S_i = P \ {p_i, p_{f(i)}}.
+```
+
+The map f has no fixed points. If f has a 2-cycle i <-> j, then S_i and S_j
+share the four vertices P \ {p_i,p_j}, contradicting |S_i cap S_j| <= 2.
+If f has no 2-cycle, then because f is a finite fixed-point-free map, it has a
+directed cycle of length at least 3. For consecutive vertices i -> j -> k in
+that cycle,
+
+```text
+S_i = P \ {p_i,p_j}
+S_j = P \ {p_j,p_k}
+```
+
+and these two selected sets share the three vertices P \ {p_i,p_j,p_k}, again
+contradicting |S_i cap S_j| <= 2.
+
+Therefore no all-bad strictly convex polygon exists for n=6.
+
+### Middle-angle lemma
+
+Let p be a bad vertex, and let q_1,...,q_m be equal-distance witnesses ordered
+by the boundary chain after removing p. For each middle index 2 <= t <= m-1,
+the polygonal interior angle at q_t is greater than pi/2.
+
+More quantitatively, if q_{t-1},q_t,q_{t+1} subtend angle theta at p through
+q_t, then
+
+```text
+epsilon(q_t) <= theta/2,
+```
+
+where epsilon is the exterior angle.
+
+This is a valid local restriction. It is not enough by itself, because large
+convex polygons can have many obtuse vertices.
+
+### Safe exterior-angle descent
+
+The reviewed outputs support the weaker local descent
+
+```text
+p bad => some witness w has epsilon(w) < (pi - epsilon(p)) / 2.
+```
+
+The stronger claimed bound
+
+```text
+epsilon(w) <= (pi - epsilon(p)) / 3
+```
+
+from Output 1 is not justified in general and should not be used.
+
+### Minimal-counterexample indispensability
+
+If a counterexample exists, choose one with the minimum number of vertices.
+Then every vertex v is indispensable for some other center u: after deleting v,
+some remaining vertex u becomes good, while in the original polygon u was bad.
+Therefore v lies in an exact four-cohort centered at u.
+
+The stronger repaired form is:
+
+```text
+In a minimal counterexample, every vertex v lies in the unique four-cohort
+of at least one fragile center u.
+```
+
+The uniqueness follows because every rich radius of u in the original polygon
+must contain v; a fixed vertex v has only one distance from u.
+
+This gives a real dependency structure, but it is not a contradiction by
+itself.
+
+### Parabola model case
+
+For points
+
+```text
+p(t_i) = (t_i, t_i^2)
+```
+
+with distinct real t_i, the vertex with minimal |t_i| is good.
+
+For fixed t, the squared distance to p(u) is
+
+```text
+|p(u)-p(t)|^2 = (u-t)^2 (1 + (u+t)^2).
+```
+
+If four other parameters a,b,c,d were at one common distance from p(t), then
+they would be the four roots of a quartic with zero cubic coefficient, so
+
+```text
+a + b + c + d = 0.
+```
+
+Vieta's formula also gives
+
+```text
+a^2 + b^2 + c^2 + d^2 = 4t^2 - 2.
+```
+
+If |t| is minimal among the parameters, then the left side is at least 4t^2,
+a contradiction. Hence p(t) is good.
+
+The convex-position justification is that finite points on the strictly convex
+graph y=x^2, ordered by t and closed by the endpoint chord, are all hull
+vertices.
+
+## Rejected or corrected claims
+
+### Output 10 is not a proof
+
+Output 10 claimed that if y is a middle point of an equal-radius set centered
+at x, then the tangent at y to that circle is a supporting line of the whole
+polygon. This is false.
+
+One explicit counterexample is:
+
+```text
+x = (0,0)
+a = (1/2, -sqrt(3)/2)
+y = (1,0)
+z = (11/10, 3/10)
+b = (1/2, sqrt(3)/2)
+c = (0,1)
+```
+
+in cyclic order
+
+```text
+x, a, y, z, b, c.
+```
+
+The vertices form a strictly convex hexagon. The points a,y,b,c all lie on the
+unit circle centered at x, and y is a middle element of that equal-radius set.
+But the tangent at y is X=1, while z has X=11/10. Thus the tangent is not a
+supporting line of the polygon.
+
+Therefore Output 10's Lemma 2, Lemma 3, and final middle-incidence count all
+collapse.
+
+### Output 1's alpha/3 descent is not established
+
+The claimed descent
+
+```text
+epsilon(q) <= (pi - epsilon(p)) / 3
+```
+
+depends on choosing a small middle gap among four witnesses. But the middle
+gap can be large, for example in a gap pattern like
+
+```text
+0.1, 0.8, 0.1.
+```
+
+The safe general bound from this local method is the weaker alpha/2 form above.
+
+### Output 2 has a false chord-length claim
+
+For two points on a circle of radius r separated by central angle theta, the
+chord length is
+
+```text
+2r sin(theta/2).
+```
+
+It is less than r only when theta < pi/3, not merely when theta < pi.
+
+### Output 5's n=6 proof is not acceptable
+
+The middle-angle lemma is valid, but Output 5's n=6 proof uses an unsupported
+claim that a vertex can be a middle witness at most once. That kind of claim is
+unsafe and is invalid in the stronger tangent-support form used in Output 10.
+
+The n <= 6 proof should instead use the exception-map argument recorded above.
+
+### Output 8's diameter example is mislabeled
+
+The displayed bad vertices in Output 8 are not actually diameter endpoints for
+the stated parameters. The example may still show two specified bad vertices,
+but it should not be used as a diameter-endpoint counterexample.
+
+### Output 9's alternating octagon discussion has a multiplicity error
+
+The equality discussed there gives only three vertices at the target distance
+from the coordinate-axis vertex, not four. The octagon discussion should be
+treated only as a failed search note after correction.
+
+## Best current obstruction
+
+After correction, the strongest useful formulation is:
+
+Can a finite strictly convex polygon support selected four-cohorts S_i at every
+vertex such that:
+
+```text
+|S_i| = 4,
+i notin S_i,
+all points of S_i are equidistant from p_i,
+|S_i cap S_j| <= 2 for i != j,
+and the fragile-cover dependency from minimality can be satisfied?
+```
+
+The known local angle facts and the n <= 6 argument do not rule this out for
+all n. A full proof still needs a genuinely global incidence, cyclic-order, or
+metric rigidity argument.
+
+## Recommended next directions
+
+1. Use Outputs 8 and 9 as the base partial write-up.
+2. Add the parabola model case from Output 6.
+3. Add the minimal-counterexample fragile-cover lemma from Output 7.
+4. Treat Output 10 as a failed proof route with the explicit tangent-support
+   counterexample above.
+5. Do not use the alpha/3 descent, the false chord claim, the mislabeled
+   diameter example, or the octagon multiplicity claim.

--- a/data/llm_runs/ten_prompt_review_2026-04-29/manifest.json
+++ b/data/llm_runs/ten_prompt_review_2026-04-29/manifest.json
@@ -1,0 +1,11 @@
+{
+  "run_set": "ten_prompt_review_2026-04-29",
+  "created_date": "2026-04-29",
+  "source": "User-supplied ten local prompt outputs and GPT Pro review",
+  "status": "reviewed_research_artifact_only",
+  "interpretation_warning": "No complete proof or counterexample is claimed. This artifact records reliable partial lemmas, rejected claims, and next obstructions from the ten outputs.",
+  "files": [
+    "corrected_synthesis.md",
+    "audit.md"
+  ]
+}

--- a/scripts/analyze_n8_fragile_covers.py
+++ b/scripts/analyze_n8_fragile_covers.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Analyze fragile-cover compatibility for the n=8 incidence survivors."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.fragile_hypergraph import (  # noqa: E402
+    covering_subsets,
+    rows_from_zero_one_matrix,
+)
+
+EXPECTED_MIN_COVER_DISTRIBUTION = {"2": 6, "3": 9}
+
+
+def analyze_survivors(path: Path) -> dict[str, object]:
+    survivors = json.loads(path.read_text(encoding="utf-8"))
+    classes = []
+    min_cover_distribution: Counter[str] = Counter()
+    all_cover = True
+
+    for record in survivors:
+        rows = rows_from_zero_one_matrix(record["rows"])
+        stats = covering_subsets(8, rows)
+        all_cover = all_cover and bool(stats["cover_exists"])
+        min_cover_distribution[str(stats["min_cover_size"])] += 1
+        classes.append(
+            {
+                "class_id": int(record["id"]),
+                **stats,
+            }
+        )
+
+    return {
+        "type": "n8_fragile_cover_analysis",
+        "n": 8,
+        "source": str(path),
+        "survivor_classes": len(survivors),
+        "all_survivors_admit_incidence_fragile_cover": all_cover,
+        "min_cover_size_distribution": dict(sorted(min_cover_distribution.items())),
+        "interpretation": (
+            "The fragile-cover lemma adds no incidence-only obstruction to the "
+            "n=8 survivor classes when any selected row is allowed to be fragile. "
+            "Actual fragility is metric data and is not certified here."
+        ),
+        "classes": classes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--survivors",
+        type=Path,
+        default=ROOT / "data" / "incidence" / "n8_reconstructed_15_survivors.json",
+        help="n=8 reconstructed survivor JSON",
+    )
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument("--check", action="store_true", help="assert expected fingerprints")
+    parser.add_argument("--write-artifact", type=Path, help="write JSON artifact")
+    args = parser.parse_args()
+
+    data = analyze_survivors(args.survivors)
+
+    if args.check:
+        assert data["survivor_classes"] == 15
+        assert data["all_survivors_admit_incidence_fragile_cover"] is True
+        assert data["min_cover_size_distribution"] == EXPECTED_MIN_COVER_DISTRIBUTION
+
+    if args.write_artifact:
+        args.write_artifact.parent.mkdir(parents=True, exist_ok=True)
+        args.write_artifact.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        print("survivor classes:", data["survivor_classes"])
+        print(
+            "all admit incidence fragile cover:",
+            data["all_survivors_admit_incidence_fragile_cover"],
+        )
+        print("min cover size distribution:", data["min_cover_size_distribution"])
+        if args.check:
+            print("OK: n=8 fragile-cover fingerprints verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_n8_metric_fragility.py
+++ b/scripts/analyze_n8_metric_fragility.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Probe metric fragility uniqueness on the n=8 survivor classes.
+
+This script is deliberately narrow. It checks full selected equal-distance
+equations for the 15 n=8 incidence survivors. If those equations are
+inconsistent, fragility questions are vacuous for that class. If they are
+consistent, it asks whether any selected row is algebraically forced to have an
+alternate equal-distance four-subset at the same center, which would rule out
+fragility for that row in n=8.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+SCRIPTS = ROOT / "scripts"
+for path in [SRC, SCRIPTS]:
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import analyze_n8_exact_survivors as exact  # noqa: E402
+from erdos97.fragile_hypergraph import covering_subsets, rows_from_zero_one_matrix  # noqa: E402
+
+EXPECTED_INCONSISTENT_CLASSES = list(range(14))
+EXPECTED_CONSISTENT_CLASSES = [14]
+
+
+def _contains_one(groebner_basis) -> bool:
+    return any(poly.as_expr() == 1 for poly in groebner_basis.polys)
+
+
+def _alternate_foursets(rows: list[list[int]], center: int) -> list[tuple[int, ...]]:
+    selected = set(exact.witnesses(rows, center))
+    return [
+        tuple(candidate)
+        for candidate in itertools.combinations([idx for idx in range(exact.N) if idx != center], 4)
+        if set(candidate) != selected
+    ]
+
+
+def _equal_distance_equations(center: int, witnesses: tuple[int, ...]) -> list[object]:
+    sp, _symbols, coords, _vars = exact.sympy_context()
+    pix, piy = coords[center]
+    base = witnesses[0]
+    pbx, pby = coords[base]
+    base_dist = (pix - pbx) ** 2 + (piy - pby) ** 2
+    equations = []
+    for other in witnesses[1:]:
+        pox, poy = coords[other]
+        equations.append(
+            sp.expand((pix - pox) ** 2 + (piy - poy) ** 2 - base_dist)
+        )
+    return equations
+
+
+def _forced_alternate_foursets(rows: list[list[int]], groebner_basis) -> dict[int, list[tuple[int, ...]]]:
+    sp, _symbols, _coords, _vars = exact.sympy_context()
+    forced: dict[int, list[tuple[int, ...]]] = {}
+    for center in range(exact.N):
+        center_forced = []
+        for candidate in _alternate_foursets(rows, center):
+            equations = _equal_distance_equations(center, candidate)
+            if all(sp.expand(groebner_basis.reduce(eq)[1]) == 0 for eq in equations):
+                center_forced.append(candidate)
+        forced[center] = center_forced
+    return forced
+
+
+def _json_forced(forced: dict[int, list[tuple[int, ...]]]) -> dict[str, list[list[int]]]:
+    return {
+        str(center): [[int(label) for label in candidate] for candidate in candidates]
+        for center, candidates in sorted(forced.items())
+    }
+
+
+def analyze_class(record: dict) -> dict[str, object]:
+    sp, _symbols, _coords, vars_order = exact.sympy_context()
+    class_id = int(record["id"])
+    rows = record["rows"]
+    equations = exact.ed_equations(rows)
+    basis = sp.groebner(equations, *vars_order, order="grevlex", domain=sp.QQ)
+    inconsistent = _contains_one(basis)
+
+    payload: dict[str, object] = {
+        "class_id": class_id,
+        "selected_ed_equation_count": len(equations),
+        "selected_ed_ideal_inconsistent": inconsistent,
+    }
+    if inconsistent:
+        payload["metric_fragility_probe"] = "vacuous_inconsistent_selected_ed_ideal"
+        return payload
+
+    forced = _forced_alternate_foursets(rows, basis)
+    forced_counts = {str(center): len(candidates) for center, candidates in sorted(forced.items())}
+    forced_nonfragile_rows = [
+        center for center, candidates in sorted(forced.items()) if candidates
+    ]
+    eligible_rows = {
+        center: row
+        for center, row in rows_from_zero_one_matrix(rows).items()
+        if center not in forced_nonfragile_rows
+    }
+    cover_stats = covering_subsets(exact.N, eligible_rows)
+    payload.update(
+        {
+            "metric_fragility_probe": "consistent_selected_ed_ideal",
+            "forced_alternate_foursets_by_center": _json_forced(forced),
+            "forced_alternate_fourset_counts": forced_counts,
+            "algebraically_forced_nonfragile_rows": forced_nonfragile_rows,
+            "eligible_fragile_rows_not_forced_nonfragile": sorted(eligible_rows),
+            "eligible_rows_cover_all_vertices": cover_stats["cover_exists"],
+            "eligible_min_cover_size": cover_stats["min_cover_size"],
+            "eligible_cover_counts_by_size": cover_stats["cover_counts_by_size"],
+            "eligible_example_covers_by_size": cover_stats["example_covers_by_size"],
+        }
+    )
+    return payload
+
+
+def analyze_survivors(path: Path) -> dict[str, object]:
+    survivors = json.loads(path.read_text(encoding="utf-8"))
+    classes = [analyze_class(record) for record in survivors]
+    inconsistent = [
+        int(row["class_id"])
+        for row in classes
+        if row["selected_ed_ideal_inconsistent"]
+    ]
+    consistent = [
+        int(row["class_id"])
+        for row in classes
+        if not row["selected_ed_ideal_inconsistent"]
+    ]
+    consistent_with_cover = [
+        int(row["class_id"])
+        for row in classes
+        if row.get("eligible_rows_cover_all_vertices") is True
+    ]
+    return {
+        "type": "n8_metric_fragility_probe",
+        "n": exact.N,
+        "source": str(path),
+        "survivor_classes": len(survivors),
+        "selected_ed_inconsistent_classes": inconsistent,
+        "selected_ed_consistent_classes": consistent,
+        "consistent_classes_with_eligible_fragile_cover": consistent_with_cover,
+        "interpretation": (
+            "For inconsistent classes, full selected equal-distance equations "
+            "already have no complex solution under the p0=(0,0), p1=(1,0) "
+            "normalization. For consistent classes, the probe reports whether "
+            "fragility is algebraically forced to fail by alternate rich "
+            "four-subsets. It does not certify existence of a strict convex "
+            "realization."
+        ),
+        "classes": classes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--survivors",
+        type=Path,
+        default=ROOT / "data" / "incidence" / "n8_reconstructed_15_survivors.json",
+        help="n=8 reconstructed survivor JSON",
+    )
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument("--check", action="store_true", help="assert expected fingerprints")
+    parser.add_argument("--write-artifact", type=Path, help="write JSON artifact")
+    args = parser.parse_args()
+
+    data = analyze_survivors(args.survivors)
+
+    if args.check:
+        assert data["survivor_classes"] == 15
+        assert data["selected_ed_inconsistent_classes"] == EXPECTED_INCONSISTENT_CLASSES
+        assert data["selected_ed_consistent_classes"] == EXPECTED_CONSISTENT_CLASSES
+        assert data["consistent_classes_with_eligible_fragile_cover"] == [14]
+        class14 = data["classes"][14]
+        assert class14["algebraically_forced_nonfragile_rows"] == []
+        assert class14["eligible_rows_cover_all_vertices"] is True
+        assert class14["eligible_min_cover_size"] == 3
+
+    if args.write_artifact:
+        args.write_artifact.parent.mkdir(parents=True, exist_ok=True)
+        args.write_artifact.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        print("survivor classes:", data["survivor_classes"])
+        print("selected ED inconsistent classes:", data["selected_ed_inconsistent_classes"])
+        print("selected ED consistent classes:", data["selected_ed_consistent_classes"])
+        print(
+            "consistent classes with eligible fragile cover:",
+            data["consistent_classes_with_eligible_fragile_cover"],
+        )
+        if args.check:
+            print("OK: n=8 metric-fragility fingerprints verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_fragile_hypergraph.py
+++ b/scripts/check_fragile_hypergraph.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Check fragile-cover hypergraph constraints for the block-6 family."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.fragile_hypergraph import (  # noqa: E402
+    block6_family,
+    canonical_witness_map,
+    check_fragile_hypergraph,
+    check_to_json,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--blocks", type=int, default=2, help="number of six-vertex blocks")
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a summary")
+    parser.add_argument("--assert-ok", action="store_true", help="assert the checks pass")
+    parser.add_argument("--write-certificate", help="write JSON result to this path")
+    args = parser.parse_args()
+
+    n, rows = block6_family(args.blocks)
+    witness_map = canonical_witness_map(n, rows)
+    result = check_fragile_hypergraph(n, rows, witness_map=witness_map)
+    payload = {
+        **check_to_json(result),
+        "family": "block6",
+        "blocks": args.blocks,
+        "rows": {str(center): row for center, row in sorted(rows.items())},
+        "witness_map": {str(vertex): center for vertex, center in sorted(witness_map.items())},
+        "interpretation": (
+            "abstract hypergraph only; passing this check is not a Euclidean "
+            "realization or counterexample"
+        ),
+    }
+
+    if args.assert_ok and not result.ok:
+        raise AssertionError("expected block6 fragile hypergraph checks to pass")
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        status = "PASS" if result.ok else "FAIL"
+        print("family  blocks  n  fragile centers  result")
+        print(f"block6  {args.blocks}  {n}  {len(rows)}  {status}")
+        if args.assert_ok:
+            print("OK: fragile hypergraph expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/fragile_hypergraph.py
+++ b/src/erdos97/fragile_hypergraph.py
@@ -1,0 +1,293 @@
+"""Combinatorial checks for fragile-cover hypergraphs.
+
+These checks model only the consequences proved from the fragile-cover lemma:
+fragile centers give pointed four-sets that cover all vertices, two fragile
+cohorts overlap in at most two vertices, and a two-overlap forces the cyclic
+crossing rule. Passing these checks is not a geometric realization certificate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Mapping, Sequence
+
+from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
+
+Rows = dict[int, list[int]]
+WitnessMap = dict[int, int]
+
+
+@dataclass(frozen=True)
+class FragileHypergraphCheck:
+    n: int
+    fragile_centers: list[int]
+    cover_ok: bool
+    self_exclusion_ok: bool
+    uniformity_ok: bool
+    pairwise_intersection_ok: bool
+    crossing_ok: bool
+    witness_map_ok: bool | None
+    cover_missing: list[int]
+    self_exclusion_violations: list[int]
+    uniformity_violations: list[dict[str, object]]
+    pairwise_intersection_violations: list[dict[str, object]]
+    crossing_violations: list[dict[str, object]]
+    witness_map_violations: list[dict[str, object]]
+
+    @property
+    def ok(self) -> bool:
+        witness_ok = True if self.witness_map_ok is None else self.witness_map_ok
+        return (
+            self.cover_ok
+            and self.self_exclusion_ok
+            and self.uniformity_ok
+            and self.pairwise_intersection_ok
+            and self.crossing_ok
+            and witness_ok
+        )
+
+
+def _validate_labels(n: int, rows: Mapping[int, Sequence[int]]) -> None:
+    if n <= 0:
+        raise ValueError(f"n must be positive, got {n}")
+    for center, row in rows.items():
+        if center < 0 or center >= n:
+            raise ValueError(f"center out of range: {center}")
+        for label in row:
+            if label < 0 or label >= n:
+                raise ValueError(f"row {center} has out-of-range label {label}")
+
+
+def covered_vertices(rows: Mapping[int, Sequence[int]]) -> set[int]:
+    """Return all vertices that appear in at least one fragile cohort."""
+    out: set[int] = set()
+    for row in rows.values():
+        out.update(row)
+    return out
+
+
+def canonical_witness_map(n: int, rows: Mapping[int, Sequence[int]]) -> WitnessMap:
+    """Choose the smallest fragile center covering each vertex."""
+    _validate_labels(n, rows)
+    witnesses: WitnessMap = {}
+    for vertex in range(n):
+        centers = sorted(center for center, row in rows.items() if vertex in row)
+        if not centers:
+            raise ValueError(f"vertex {vertex} is not covered")
+        witnesses[vertex] = centers[0]
+    return witnesses
+
+
+def check_fragile_hypergraph(
+    n: int,
+    rows: Mapping[int, Sequence[int]],
+    order: Sequence[int] | None = None,
+    witness_map: Mapping[int, int] | None = None,
+) -> FragileHypergraphCheck:
+    """Check fragile-cover axioms for a partial pointed four-uniform system."""
+    _validate_labels(n, rows)
+    if order is None:
+        order = list(range(n))
+    if sorted(order) != list(range(n)):
+        raise ValueError("order must be a permutation of range(n)")
+
+    normalized_rows: Rows = {int(center): [int(v) for v in row] for center, row in rows.items()}
+    centers = sorted(normalized_rows)
+
+    cover = covered_vertices(normalized_rows)
+    cover_missing = [vertex for vertex in range(n) if vertex not in cover]
+
+    self_exclusion_violations = [
+        center for center, row in normalized_rows.items() if center in row
+    ]
+
+    uniformity_violations: list[dict[str, object]] = []
+    for center, row in sorted(normalized_rows.items()):
+        if len(row) != 4 or len(set(row)) != 4:
+            uniformity_violations.append(
+                {
+                    "center": center,
+                    "row": row,
+                    "size": len(row),
+                    "distinct_size": len(set(row)),
+                }
+            )
+
+    pairwise_intersection_violations: list[dict[str, object]] = []
+    crossing_violations: list[dict[str, object]] = []
+    row_sets = {center: set(row) for center, row in normalized_rows.items()}
+    for left, right in combinations(centers, 2):
+        inter = sorted(row_sets[left] & row_sets[right])
+        if len(inter) > 2:
+            pairwise_intersection_violations.append(
+                {
+                    "centers": [left, right],
+                    "intersection": inter,
+                    "intersection_size": len(inter),
+                }
+            )
+        if len(inter) == 2:
+            source = normalize_chord(left, right)
+            target = normalize_chord(inter[0], inter[1])
+            if not chords_cross_in_order(source, target, order):
+                crossing_violations.append(
+                    {
+                        "source": [source[0], source[1]],
+                        "target": [target[0], target[1]],
+                        "order": list(order),
+                    }
+                )
+
+    witness_map_violations: list[dict[str, object]] = []
+    witness_map_ok: bool | None
+    if witness_map is None:
+        witness_map_ok = None
+    else:
+        witness_map_ok = True
+        for vertex in range(n):
+            if vertex not in witness_map:
+                witness_map_ok = False
+                witness_map_violations.append(
+                    {"vertex": vertex, "reason": "missing witness"}
+                )
+                continue
+            center = int(witness_map[vertex])
+            if center not in normalized_rows:
+                witness_map_ok = False
+                witness_map_violations.append(
+                    {
+                        "vertex": vertex,
+                        "center": center,
+                        "reason": "witness center is not fragile",
+                    }
+                )
+            elif vertex not in normalized_rows[center]:
+                witness_map_ok = False
+                witness_map_violations.append(
+                    {
+                        "vertex": vertex,
+                        "center": center,
+                        "reason": "witness center does not cover vertex",
+                    }
+                )
+
+    return FragileHypergraphCheck(
+        n=n,
+        fragile_centers=centers,
+        cover_ok=not cover_missing,
+        self_exclusion_ok=not self_exclusion_violations,
+        uniformity_ok=not uniformity_violations,
+        pairwise_intersection_ok=not pairwise_intersection_violations,
+        crossing_ok=not crossing_violations,
+        witness_map_ok=witness_map_ok,
+        cover_missing=cover_missing,
+        self_exclusion_violations=self_exclusion_violations,
+        uniformity_violations=uniformity_violations,
+        pairwise_intersection_violations=pairwise_intersection_violations,
+        crossing_violations=crossing_violations,
+        witness_map_violations=witness_map_violations,
+    )
+
+
+def block6_family(blocks: int) -> tuple[int, Rows]:
+    """Return an abstract covering family satisfying the fragile hypergraph rules.
+
+    Each block of six vertices has two fragile centers. In local coordinates
+    b,b+1,...,b+5, the rows are
+
+        b   -> {b+1,b+2,b+3,b+4}
+        b+3 -> {b,b+2,b+4,b+5}
+
+    The two rows intersect in {b+2,b+4}; the center chord {b,b+3}
+    separates that pair in the natural cyclic order. Different blocks are
+    disjoint, so all cross-block intersection constraints are vacuous.
+    """
+    if blocks <= 0:
+        raise ValueError(f"blocks must be positive, got {blocks}")
+    rows: Rows = {}
+    for block in range(blocks):
+        base = 6 * block
+        rows[base] = [base + 1, base + 2, base + 3, base + 4]
+        rows[base + 3] = [base, base + 2, base + 4, base + 5]
+    return 6 * blocks, rows
+
+
+def check_to_json(result: FragileHypergraphCheck) -> dict[str, object]:
+    """Return a JSON-serializable check result."""
+    return {
+        "type": "fragile_hypergraph_check",
+        "n": result.n,
+        "fragile_centers": result.fragile_centers,
+        "ok": result.ok,
+        "cover_ok": result.cover_ok,
+        "self_exclusion_ok": result.self_exclusion_ok,
+        "uniformity_ok": result.uniformity_ok,
+        "pairwise_intersection_ok": result.pairwise_intersection_ok,
+        "crossing_ok": result.crossing_ok,
+        "witness_map_ok": result.witness_map_ok,
+        "cover_missing": result.cover_missing,
+        "self_exclusion_violations": result.self_exclusion_violations,
+        "uniformity_violations": result.uniformity_violations,
+        "pairwise_intersection_violations": result.pairwise_intersection_violations,
+        "crossing_violations": result.crossing_violations,
+        "witness_map_violations": result.witness_map_violations,
+    }
+
+
+def rows_from_zero_one_matrix(matrix: Sequence[Sequence[int]]) -> Rows:
+    """Convert a full zero-one selected-row matrix to row-set form."""
+    rows: Rows = {}
+    for center, row in enumerate(matrix):
+        rows[center] = [idx for idx, value in enumerate(row) if value]
+    return rows
+
+
+def covering_subsets(
+    n: int,
+    rows: Mapping[int, Sequence[int]],
+    max_examples: int = 8,
+) -> dict[str, object]:
+    """Return small-n cover statistics for possible fragile centers.
+
+    The subset size is the number of rows declared fragile. This is purely an
+    incidence-level calculation: it assumes any listed row is eligible to be
+    fragile and asks only whether the fragile rows cover every vertex.
+    """
+    _validate_labels(n, rows)
+    if max_examples < 0:
+        raise ValueError("max_examples must be nonnegative")
+
+    centers = sorted(rows)
+    row_sets = {center: set(row) for center, row in rows.items()}
+    counts_by_size: dict[int, int] = {}
+    examples_by_size: dict[int, list[list[int]]] = {}
+    min_size: int | None = None
+    total = 0
+
+    for size in range(len(centers) + 1):
+        for subset in combinations(centers, size):
+            covered: set[int] = set()
+            for center in subset:
+                covered.update(row_sets[center])
+            if len(covered) != n:
+                continue
+            total += 1
+            counts_by_size[size] = counts_by_size.get(size, 0) + 1
+            if min_size is None:
+                min_size = size
+            bucket = examples_by_size.setdefault(size, [])
+            if len(bucket) < max_examples:
+                bucket.append([int(center) for center in subset])
+
+    return {
+        "cover_exists": total > 0,
+        "min_cover_size": min_size,
+        "total_cover_subsets": total,
+        "cover_counts_by_size": {
+            str(size): count for size, count in sorted(counts_by_size.items())
+        },
+        "example_covers_by_size": {
+            str(size): examples for size, examples in sorted(examples_by_size.items())
+        },
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/test_fragile_hypergraph.py
+++ b/tests/test_fragile_hypergraph.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from erdos97.fragile_hypergraph import (
+    block6_family,
+    canonical_witness_map,
+    check_fragile_hypergraph,
+)
+
+
+def test_block6_family_satisfies_fragile_hypergraph_axioms() -> None:
+    n, rows = block6_family(2)
+    witness_map = canonical_witness_map(n, rows)
+
+    result = check_fragile_hypergraph(n, rows, witness_map=witness_map)
+
+    assert result.ok
+    assert result.fragile_centers == [0, 3, 6, 9]
+    assert witness_map[0] == 3
+    assert witness_map[5] == 3
+    assert witness_map[6] == 9
+    assert witness_map[11] == 9
+
+
+def test_crossing_violation_is_reported() -> None:
+    rows = {
+        0: [1, 2, 3, 4],
+        6: [0, 2, 3, 5],
+    }
+
+    result = check_fragile_hypergraph(7, rows)
+
+    assert not result.ok
+    assert result.pairwise_intersection_ok
+    assert not result.crossing_ok
+    assert result.crossing_violations == [
+        {
+            "source": [0, 6],
+            "target": [2, 3],
+            "order": [0, 1, 2, 3, 4, 5, 6],
+        }
+    ]
+
+
+def test_witness_map_must_choose_a_covering_fragile_center() -> None:
+    n, rows = block6_family(1)
+    bad_witness_map = {vertex: 0 for vertex in range(n)}
+
+    result = check_fragile_hypergraph(n, rows, witness_map=bad_witness_map)
+
+    assert not result.ok
+    assert result.witness_map_ok is False
+    assert {
+        "vertex": 0,
+        "center": 0,
+        "reason": "witness center does not cover vertex",
+    } in result.witness_map_violations

--- a/tests/test_n8_fragile_covers.py
+++ b/tests/test_n8_fragile_covers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.analyze_n8_fragile_covers import analyze_survivors
+
+
+def test_n8_survivors_all_admit_incidence_fragile_cover() -> None:
+    root = Path(__file__).resolve().parents[1]
+    survivors = root / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+
+    data = analyze_survivors(survivors)
+
+    assert data["survivor_classes"] == 15
+    assert data["all_survivors_admit_incidence_fragile_cover"] is True
+    assert data["min_cover_size_distribution"] == {"2": 6, "3": 9}
+
+
+def test_n8_class0_has_four_two_row_fragile_covers() -> None:
+    root = Path(__file__).resolve().parents[1]
+    survivors = root / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+
+    data = analyze_survivors(survivors)
+    class0 = data["classes"][0]
+
+    assert class0["class_id"] == 0
+    assert class0["min_cover_size"] == 2
+    assert class0["cover_counts_by_size"]["2"] == 4
+    assert [0, 4] in class0["example_covers_by_size"]["2"]

--- a/tests/test_n8_metric_fragility.py
+++ b/tests/test_n8_metric_fragility.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.analyze_n8_metric_fragility import analyze_survivors
+
+
+def test_n8_metric_fragility_probe_fingerprints() -> None:
+    root = Path(__file__).resolve().parents[1]
+    survivors = root / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+
+    data = analyze_survivors(survivors)
+
+    assert data["survivor_classes"] == 15
+    assert data["selected_ed_inconsistent_classes"] == list(range(14))
+    assert data["selected_ed_consistent_classes"] == [14]
+    assert data["consistent_classes_with_eligible_fragile_cover"] == [14]
+
+
+def test_class14_has_no_forced_alternate_fourcohort() -> None:
+    root = Path(__file__).resolve().parents[1]
+    survivors = root / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+
+    data = analyze_survivors(survivors)
+    class14 = data["classes"][14]
+
+    assert class14["class_id"] == 14
+    assert class14["selected_ed_ideal_inconsistent"] is False
+    assert class14["algebraically_forced_nonfragile_rows"] == []
+    assert class14["eligible_rows_cover_all_vertices"] is True
+    assert class14["eligible_min_cover_size"] == 3


### PR DESCRIPTION
## Summary

- Add archived local prompt-run outputs and the ten-output review/corrected synthesis for the vertex-centered repeated-distance prompt.
- Add fragile-cover hypergraph tooling plus n=8 fragile-cover and metric-fragility analyzers.
- Record the results as partial/reproducible research artifacts only; this PR does not claim a general proof or counterexample.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --cached --check`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
