### PR TITLE
[codex] Harden n8 review artifacts

### DIFF
--- a/data/llm_runs/codex_local_pilot_2026-04-28/manifest.json
+++ b/data/llm_runs/codex_local_pilot_2026-04-28/manifest.json
@@ -1,7 +1,7 @@
 {
   "run_set": "codex_local_pilot_2026-04-28",
   "created_date": "2026-04-28",
-  "source_prompt_pack": "C:\\Users\\User\\Desktop\\code\\erd archive\\outputs\\data\\erdos97_prompt_pack_comparison_and_v3.md",
+  "source_prompt_pack": "local archived prompt pack: erdos97_prompt_pack_comparison_and_v3.md",
   "runner": "Codex local conversation, not isolated API batch runs",
   "status": "research_artifact_only",
   "interpretation_warning": "These outputs are not independent fresh GPT-5.5 Pro runs and must not be treated as proof, disproof, or official status evidence.",

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -3,9 +3,19 @@
 This file is proof-facing. Numerical near-misses live in `data/runs/` and in the
 candidate/failed-route docs, not as proofs of equality.
 
-## Theorems
+## Proof-facing claims
+
+This ledger records local proof-facing claims and their current trust posture.
+It is not a paper-style theorem list. In particular, the `n <= 8`
+selected-witness result is a repo-local machine-checked finite-case artifact
+pending independent review, and the global Erdos #97 problem remains
+falsifiable/open.
 
 ### No selected-witness counterexample for n <= 8
+
+Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT` in the repo-local sense;
+independent review is required before paper-style or public theorem-style
+claims.
 
 For `n=5`, every selected witness set is `V \ {i}`. Two distinct rows
 therefore share three vertices, contradicting the two-circle cap below.[^small]
@@ -36,7 +46,8 @@ all selected-witness systems under the necessary incidence and
 forced-perpendicularity filters, obtaining 15 canonical survivor classes. The
 exact obstruction checker kills all 15 by cyclic-order noncrossing,
 perpendicular-bisector algebra, equal-distance algebra, duplicate vertices,
-collinearity, or strict-convexity failure. See
+collinearity, or strict-convexity failure. These are machine-checked
+repo-local artifacts, not standalone public proof certificates. See
 `docs/n8-incidence-enumeration.md` and `docs/n8-exact-survivors.md`.
 
 ### Proof-note draft: geometric no-go for n <= 8

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`n8-geometric-proof.md`](n8-geometric-proof.md): proof-note draft giving a
   compact geometric obstruction for bad convex octagons via isosceles-triangle
   counting and exterior-turn angles.
+- [`reproduction-log.md`](reproduction-log.md): fast, artifact, and exhaustive
+  check commands with current environment notes.
 - [`failed-ideas.md`](failed-ideas.md): rejected proof routes and stale claims
   that should not be retried without a genuinely new idea.
 

--- a/docs/n8-geometric-proof.md
+++ b/docs/n8-geometric-proof.md
@@ -2,10 +2,11 @@
 
 Status: proof-note draft; independent review requested.
 
-This note gives a human-readable geometric proof that no bad convex polygon
-exists with `n <= 8`. It is independent of the selected-witness incidence
-enumeration retained in `docs/n8-incidence-enumeration.md` and
-`docs/n8-exact-survivors.md`.
+This note records a proposed human-readable geometric proof that no bad convex
+polygon exists with `n <= 8`. It is independent of the selected-witness
+incidence enumeration retained in `docs/n8-incidence-enumeration.md` and
+`docs/n8-exact-survivors.md`, but it should still be treated as a proof-note
+draft until it has independent mathematical review.
 
 It does not prove Erdos Problem #97. The case `n >= 9` remains open.
 
@@ -88,9 +89,9 @@ so `n >= 8`. In particular, no bad convex polygon exists with `n <= 7`.
 For the selected-witness incidence-count counterpart, see the sharpened
 incidence counting lower bound in `docs/claims.md`.
 
-This is an independent human proof of the small-case exclusion. The repository
-still retains the incidence and Fano material because those artifacts are
-structurally useful and reproducible.
+This count is the independent geometric small-case exclusion for `n <= 7`.
+The repository still retains the incidence and Fano material because those
+artifacts are structurally useful and reproducible.
 
 ## No bad convex octagon
 
@@ -102,7 +103,34 @@ T(A) >= 48
 T(A) <= 48,
 ```
 
-so equality holds everywhere. Thus:
+so equality holds in both sums. Since each vertex contribution to the lower
+bound is at least `6`, every vertex contribution is exactly `6`. Equivalently,
+if the distance-class sizes from a vertex are
+
+```text
+m_1, m_2, ..., m_r
+```
+
+with `sum m_k = 7`, then
+
+```text
+sum_k binom(m_k,2) = 6.
+```
+
+Because the octagon is bad, some `m_k >= 4`. The only partition of the seven
+other vertices with this property and with exactly six equal-distance base
+pairs is
+
+```text
+4,1,1,1.
+```
+
+Any class of size at least `5`, or any second nontrivial distance class, would
+make the sum exceed `6`.
+
+Equality also holds in the base-apex upper bound. Each base-pair capacity is an
+individual upper bound, so no side or diagonal can fall short: otherwise the
+total would be less than `48`. Thus:
 
 1. Every polygon side is the base of exactly one isosceles triangle.
 2. Every diagonal is the base of exactly two isosceles triangles, one apex on

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -1,0 +1,69 @@
+# Reproduction Log
+
+Status: operational guide, not a mathematical certificate.
+
+This repository separates fast checks, artifact/certificate checks, and fresh
+exhaustive enumeration. The split is intentional: a reviewer should be able to
+run the default suite quickly without accidentally starting the full `n=8`
+incidence search.
+
+## Current Environment Note
+
+The metadata file records the known-good local snapshot:
+
+```text
+Python: 3.12.2
+Dependencies: requirements-lock.txt
+Snapshot date: 2026-04-29
+```
+
+The lock file is a local dependency snapshot. It does not make the repository
+offline-reproducible by itself, and it is not a proof certificate.
+
+## Fast Checks
+
+Plain pytest now runs the fast suite:
+
+```bash
+pytest -q
+```
+
+The repository hygiene checks are:
+
+```bash
+python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
+git diff --check
+```
+
+## Artifact Checks
+
+Run checked-in artifact and certificate validators explicitly:
+
+```bash
+pytest -q -m artifact
+python scripts/independent_check_n8_incidence_json.py --json
+python scripts/analyze_n8_exact_survivors.py --check --json
+python scripts/analyze_n8_exact_survivors.py --check --json \
+  --check-compatible-orders-data data/incidence/n8_compatible_orders.json \
+  --check-exact-analysis-data certificates/n8_exact_analysis.json
+```
+
+The independent incidence JSON checker validates the 15 stored survivor
+representatives and brute-force canonical forms. It does not prove the
+completeness of the enumeration.
+
+## Slow Or Exhaustive Checks
+
+Run fresh enumeration separately:
+
+```bash
+pytest -q -m "slow or exhaustive"
+python scripts/enumerate_n8_incidence.py --summary
+python scripts/enumerate_n8_incidence.py --summary \
+  --check-data data/incidence/n8_incidence_completeness.json
+```
+
+The `n=8` incidence enumeration is the expensive part of the current local
+pipeline. Its checked-in result should eventually be supplemented with a compact
+branch-count or independent completeness certificate.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -9,7 +9,7 @@ problem:
     - distances
     - convex
   official_page_last_edited: "2025-10-27"
-  official_status_last_checked: "2026-04-27"
+  official_status_last_checked: "2026-04-30"
 
 upstream_database:
   repository: "https://github.com/teorth/erdosproblems"
@@ -37,6 +37,7 @@ local_repo:
     - "docs/n8-incidence-enumeration.md"
     - "docs/n8-exact-survivors.md"
     - "docs/n8-geometric-proof.md"
+    - "docs/reproduction-log.md"
     - "docs/verification-contract.md"
 
 reproducibility:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -m "not artifact and not slow and not exhaustive"
+markers =
+    artifact: checks that validate checked-in generated artifacts or certificates
+    slow: tests that are too expensive for the default fast suite
+    exhaustive: fresh exhaustive enumeration or full-search replay tests

--- a/scripts/independent_check_n8_incidence_json.py
+++ b/scripts/independent_check_n8_incidence_json.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Independently check the checked-in n=8 incidence survivor JSON.
+
+This verifier intentionally does not import ``erdos97.n8_incidence``. It does
+not prove that the 15 classes are exhaustive; instead it checks that the
+checked-in survivor records are internally valid incidence matrices and that
+their representatives are true brute-force canonical representatives under all
+8! simultaneous relabellings.
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+from collections import deque
+from pathlib import Path
+from typing import Iterable
+
+N = 8
+CHORDS = tuple((a, b) for a in range(N) for b in range(a + 1, N))
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def chord(a: int, b: int) -> tuple[int, int]:
+    return (a, b) if a < b else (b, a)
+
+
+def bits(mask: int) -> list[int]:
+    return [idx for idx in range(N) if (mask >> idx) & 1]
+
+
+def row_masks(rows: Iterable[Iterable[int]]) -> tuple[int, ...]:
+    masks: list[int] = []
+    for row in rows:
+        mask = 0
+        for idx, value in enumerate(row):
+            if value not in (0, 1):
+                raise ValueError(f"matrix entries must be 0 or 1, got {value!r}")
+            if value:
+                mask |= 1 << idx
+        masks.append(mask)
+    return tuple(masks)
+
+
+def relabel_rows(rows: tuple[int, ...], permutation: tuple[int, ...]) -> tuple[int, ...]:
+    relabelled = [0] * N
+    for old_center, mask in enumerate(rows):
+        new_mask = 0
+        for old_target in range(N):
+            if (mask >> old_target) & 1:
+                new_mask |= 1 << permutation[old_target]
+        relabelled[permutation[old_center]] = new_mask
+    return tuple(relabelled)
+
+
+def brute_force_canonical_key(rows: tuple[int, ...]) -> tuple[int, ...]:
+    return min(relabel_rows(rows, permutation) for permutation in itertools.permutations(range(N)))
+
+
+def forced_perpendicularity_graph(rows: tuple[int, ...]) -> dict[tuple[int, int], set[tuple[int, int]]]:
+    graph = {edge: set() for edge in CHORDS}
+    for i in range(N):
+        for j in range(i + 1, N):
+            common = rows[i] & rows[j]
+            if common.bit_count() != 2:
+                continue
+            a, b = bits(common)
+            source = (i, j)
+            target = chord(a, b)
+            graph[source].add(target)
+            graph[target].add(source)
+    return graph
+
+
+def passes_forced_perpendicularity_filter(rows: tuple[int, ...]) -> bool:
+    graph = forced_perpendicularity_graph(rows)
+    color: dict[tuple[int, int], int] = {}
+    for start in CHORDS:
+        if start in color:
+            continue
+        color[start] = 0
+        q: deque[tuple[int, int]] = deque([start])
+        component: list[tuple[int, int]] = [start]
+        while q:
+            current = q.popleft()
+            for neighbor in graph[current]:
+                if neighbor not in color:
+                    color[neighbor] = 1 - color[current]
+                    component.append(neighbor)
+                    q.append(neighbor)
+                elif color[neighbor] == color[current]:
+                    return False
+
+        used_endpoints_by_color = [0, 0]
+        for edge in component:
+            edge_color = color[edge]
+            a, b = edge
+            endpoint_bits = (1 << a) | (1 << b)
+            if used_endpoints_by_color[edge_color] & endpoint_bits:
+                return False
+            used_endpoints_by_color[edge_color] |= endpoint_bits
+    return True
+
+
+def validate_incidence_record(
+    record: dict,
+) -> tuple[tuple[int, ...] | None, tuple[int, ...] | None, list[str]]:
+    errors: list[str] = []
+    record_id = record.get("id", "<missing id>")
+    rows_data = record.get("rows")
+    if not isinstance(rows_data, list) or len(rows_data) != N:
+        return None, None, [f"class {record_id}: rows should be an {N}x{N} matrix"]
+    if any(not isinstance(row, list) or len(row) != N for row in rows_data):
+        return None, None, [f"class {record_id}: rows should be an {N}x{N} matrix"]
+
+    try:
+        rows = row_masks(rows_data)
+    except ValueError as exc:
+        return None, None, [f"class {record_id}: {exc}"]
+
+    for i, mask in enumerate(rows):
+        if (mask >> i) & 1:
+            errors.append(f"class {record_id}: row {i} contains its own center")
+        if mask.bit_count() != 4:
+            errors.append(f"class {record_id}: row {i} has sum {mask.bit_count()}, expected 4")
+
+    column_sums = [
+        sum(1 for mask in rows if (mask >> target) & 1)
+        for target in range(N)
+    ]
+    if column_sums != [4] * N:
+        errors.append(f"class {record_id}: column sums are {column_sums}, expected all 4")
+
+    for i, j in itertools.combinations(range(N), 2):
+        overlap = (rows[i] & rows[j]).bit_count()
+        if overlap > 2:
+            errors.append(f"class {record_id}: rows {i},{j} overlap in {overlap} columns")
+
+    for a, b in itertools.combinations(range(N), 2):
+        pair_count = sum(1 for mask in rows if (mask >> a) & 1 and (mask >> b) & 1)
+        if pair_count > 2:
+            errors.append(f"class {record_id}: columns {a},{b} co-occur in {pair_count} rows")
+
+    if not passes_forced_perpendicularity_filter(rows):
+        errors.append(f"class {record_id}: failed forced-perpendicularity filter")
+
+    canonical = brute_force_canonical_key(rows)
+    if rows != canonical:
+        errors.append(f"class {record_id}: stored representative is not brute-force canonical")
+
+    return rows, canonical, errors
+
+
+def check_file(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    if not isinstance(data, list):
+        return {
+            "verified": False,
+            "path": str(path),
+            "errors": ["top-level JSON value should be a list"],
+        }
+
+    ids: list[int] = []
+    canonical_keys: list[tuple[int, ...]] = []
+    for record in data:
+        if not isinstance(record, dict):
+            errors.append("each survivor record should be an object")
+            continue
+        record_id = record.get("id")
+        if not isinstance(record_id, int):
+            errors.append(f"class {record_id!r}: id should be an integer")
+        else:
+            ids.append(record_id)
+        rows, canonical, record_errors = validate_incidence_record(record)
+        errors.extend(record_errors)
+        if canonical is not None:
+            canonical_keys.append(canonical)
+
+    if len(ids) != len(set(ids)):
+        errors.append("survivor ids are not unique")
+    if ids and sorted(ids) != list(range(len(ids))):
+        errors.append(f"survivor ids are {sorted(ids)}, expected contiguous ids 0..{len(ids) - 1}")
+    if len(canonical_keys) != len(set(canonical_keys)):
+        errors.append("two records have the same brute-force canonical representative")
+
+    return {
+        "verified": not errors,
+        "path": str(path),
+        "record_count": len(data),
+        "canonical_class_count": len(set(canonical_keys)),
+        "checked_conditions": [
+            "matrix shape, binary entries, row sums, and zero diagonal",
+            "column sums all equal 4",
+            "row-pair intersection cap",
+            "column-pair co-occurrence cap",
+            "forced-perpendicularity bipartiteness and same-color endpoint filter",
+            "brute-force canonical representatives over all 8! relabellings",
+            "distinct brute-force canonical classes",
+        ],
+        "errors": errors,
+        "status": "survivor_json_independent_consistency_check_not_completeness_proof",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=repo_root() / "data" / "incidence" / "n8_reconstructed_15_survivors.json",
+        help="survivor JSON file to verify",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args()
+
+    summary = check_file(args.path)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif summary["verified"]:
+        print(
+            "verified "
+            f"{summary['record_count']} n=8 survivor records; "
+            f"{summary['canonical_class_count']} brute-force canonical classes"
+        )
+    else:
+        print("independent incidence JSON check failed")
+        for error in summary["errors"]:
+            print(f"- {error}")
+    return 0 if summary["verified"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_n8_exact_survivors_artifact.py
+++ b/tests/test_n8_exact_survivors_artifact.py
@@ -5,6 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.artifact
+
 ARCHIVE_TO_RECONSTRUCTED = {
     2: 12,
     7: 11,

--- a/tests/test_n8_incidence.py
+++ b/tests/test_n8_incidence.py
@@ -31,6 +31,8 @@ def generated_n8_incidence_data() -> dict:
     return enumeration_data(reconstructed)
 
 
+@pytest.mark.slow
+@pytest.mark.exhaustive
 def test_n8_incidence_enumeration_counts_and_matches_reconstructed_survivors(
     generated_n8_incidence_data: dict,
 ) -> None:
@@ -40,6 +42,8 @@ def test_n8_incidence_enumeration_counts_and_matches_reconstructed_survivors(
     assert generated_n8_incidence_data["matches_existing_reconstructed_survivors"] is True
 
 
+@pytest.mark.slow
+@pytest.mark.exhaustive
 def test_checked_in_n8_incidence_artifact_matches_generator(
     generated_n8_incidence_data: dict,
 ) -> None:
@@ -50,6 +54,8 @@ def test_checked_in_n8_incidence_artifact_matches_generator(
     assert checked_in == generated_n8_incidence_data
 
 
+@pytest.mark.slow
+@pytest.mark.exhaustive
 def test_checked_in_reconstructed_survivors_are_exactly_the_incidence_survivors() -> None:
     root = Path(__file__).resolve().parents[1]
     artifact = root / "data" / "incidence" / "n8_incidence_completeness.json"
@@ -81,11 +87,12 @@ def brute_force_canonical_key(rows: tuple[int, ...]) -> tuple[int, ...]:
     return best
 
 
-def test_fast_canonical_key_matches_full_permutation_search_for_sample_classes() -> None:
+@pytest.mark.artifact
+def test_fast_canonical_key_matches_full_permutation_search_for_all_survivor_classes() -> None:
     root = Path(__file__).resolve().parents[1]
     reconstructed = root / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
     classes = json.loads(reconstructed.read_text(encoding="utf-8"))
 
-    for record in [classes[0], classes[5], classes[14]]:
+    for record in classes:
         rows = matrix_to_row_masks(record["rows"])
         assert canonical_key(rows) == brute_force_canonical_key(rows)

--- a/tests/test_n8_independent_incidence_json.py
+++ b/tests/test_n8_independent_incidence_json.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.artifact
+
+
+def test_independent_n8_incidence_json_checker_verifies_survivors() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "scripts" / "independent_check_n8_incidence_json.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--json"],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["verified"] is True
+    assert summary["record_count"] == 15
+    assert summary["canonical_class_count"] == 15
+    assert summary["errors"] == []
+    assert summary["status"] == "survivor_json_independent_consistency_check_not_completeness_proof"


### PR DESCRIPTION
## Summary

- tighten the `n <= 8` proof-note and claims-ledger wording so repo-local finite artifacts stay clearly separated from public theorem-style claims
- add an independent stdlib-only checker for the checked-in `n=8` survivor JSON, including brute-force canonical representatives over all `8!` relabellings
- split pytest into fast, artifact, slow, and exhaustive lanes, and document the reproduction commands
- remove a machine-specific local path from an existing run manifest

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check origin/main..HEAD`
- `python -m pytest -q`
- `python -m pytest -q -m artifact`
- `python -m pytest -q -m "slow or exhaustive"`
- `python scripts/independent_check_n8_incidence_json.py --json`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python scripts/analyze_n8_exact_survivors.py --check --json --check-compatible-orders-data data/incidence/n8_compatible_orders.json --check-exact-analysis-data certificates/n8_exact_analysis.json`

## Notes

The new independent incidence JSON checker is a survivor-record consistency and canonicalization verifier. It intentionally does not claim to prove completeness of the full `n=8` incidence enumeration.

This PR is a research-log/reproducibility update, not a global Erdős #97 proof or counterexample claim.