### PR TITLE
[codex] Harden literature risk notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ pip install sympy z3-solver
 
 The 3-neighbor version is false: Danzer produced a 9-point convex polygon where every vertex has 3 equidistant vertices, and Fishburn--Reeds produced a 20-point convex polygon where every vertex has 3 equidistant vertices at a common radius. These do not automatically extend to the 4-neighbor target.
 
-A 1975 Erdos paper reports an unpublished all-`k` Danzer claim, but the official #97 page says this was not repeated later and was presumably mistaken. This repository treats that statement as unverified literature risk, not as a `k=4` counterexample.
+A 1975 Erdos paper reports an unpublished all-`k` Danzer claim, but the official #97 page says this was not repeated later and was presumably mistaken. This repository treats that statement as unverified literature risk, not as a `k=4` counterexample; see [`docs/literature-risk.md`](docs/literature-risk.md).
 
 ## Contribution policy
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ pip install sympy z3-solver
 
 The 3-neighbor version is false: Danzer produced a 9-point convex polygon where every vertex has 3 equidistant vertices, and Fishburn--Reeds produced a 20-point convex polygon where every vertex has 3 equidistant vertices at a common radius. These do not automatically extend to the 4-neighbor target.
 
+A 1975 Erdos paper reports an unpublished all-`k` Danzer claim, but the official #97 page says this was not repeated later and was presumably mistaken. This repository treats that statement as unverified literature risk, not as a `k=4` counterexample.
+
 ## Contribution policy
 
 Contributions are welcome if they are reproducible and clearly labelled. Especially useful contributions:

--- a/STATE.md
+++ b/STATE.md
@@ -158,6 +158,8 @@ archived-ID provenance mapping when the archive JSON is available.
 
 - Recheck the public Erdos Problems listing before any solution claim.[^repo]
 - Pin exact citations and statements for Danzer's 9-point `k=3` example.[^digest]
+- Treat the Erdos 1975 unpublished all-`k` Danzer statement as unverified
+  literature risk unless a primary construction or exact certificate is found.
 - Pin exact citations and statements for the Fishburn--Reeds 20-point
   unit-distance `k=3` example.[^digest]
 - Keep convex unit-distance bounds separate from the variable-radius problem.[^syn]

--- a/docs/canonical-synthesis.md
+++ b/docs/canonical-synthesis.md
@@ -14,7 +14,7 @@ current finite-case status.
 
 Relative to `erdos97_final_consolidated.md`:
 
-1. **Corrected the uniform-radius reduction (§5.5).** The prior synthesis claimed the uniform-radius subcase of #97 was "folklore-resolved by Füredi's $2n-7$ bound for all $n \ge 7$." This was a direction-of-bound error: $2n-7$ is a lower-bound *construction* (Edelsbrunner–Hajnal 1991, Füredi 1990), not an upper bound. The needed $< 2n$ upper bound is the open Erdős–Fishburn conjecture. The uniform-radius subcase is therefore **open**, conditional on Erdős–Fishburn. The correction propagates to §1.5, §10, the TL;DR table, and Appendix A.
+1. **Corrected the uniform-radius reduction (§5.5).** The prior synthesis claimed the uniform-radius subcase of #97 was "folklore-resolved by Füredi's $2n-7$ bound for all $n \ge 7$." This was a direction-of-bound error: $2n-7$ is an Edelsbrunner--Hajnal lower-bound *construction*, not an upper bound. Füredi's separate convex-`n`-gon unit-distance work belongs to the upper-bound side. The needed $< 2n$ upper bound is the open Erdős–Fishburn conjecture. The uniform-radius subcase is therefore **open**, conditional on Erdős–Fishburn. The correction propagates to §1.5, §10, the TL;DR table, and Appendix A.
 2. **Added external citation anchors** as footnotes to all background literature claims (Aggarwal 2010, Edelsbrunner–Hajnal 1991, Fishburn–Reeds 1992, Nivasch et al. 2013, the erdosproblems.com #97 entry, the DeepMind `formal-conjectures` Lean file). Background numbers no longer rely on archive-internal cross-talk.
 3. **Added a claim taxonomy** (Appendix C) tagging top-level claims as `VERIFIED`, `CONDITIONAL`, `EVIDENCE`, `REJECTED`, or `PROVENANCE-WARNING`.
 4. **Added SHA-256 source inventory** (Appendix D) from the four-stage consolidation, for reproducibility.
@@ -118,7 +118,7 @@ A 4-bad $n$-gon imposes $3n$ scalar equality constraints on $2n$ coordinates. Af
 - $k = 3$ analogue is FALSE: Danzer (1963) — convex 9-gon with $M(i) = 3$ everywhere (variable radii); Fishburn–Reeds (1992) — convex 20-gon with $M(i) = 3$ at one global radius.[^fishburn-reeds]
 - Erdős's 1975 statement asks whether every convex $n$-gon, $n \ge n_0$, has a vertex with at most $k$ others at any single distance, *for every $k$*. The boundary now known is $k = 4$: this is #97. (The "every $k$" framing is recorded on erdosproblems.com[^erdos97-page] as likely mistaken — Erdős did not repeat it later. `PROVENANCE-WARNING`.)
 - Distinct-distance bounds from a vertex of a convex polygon: Nivasch–Pach–Pinchasi–Zerbib (2013) give $\ge (13/36 + \varepsilon)n - O(1)$.[^nivasch]
-- **Unit-distance bounds in convex position.** *Upper:* $n \log_2 n + O(n)$ (Aggarwal 2010, improving Füredi's earlier $2\pi n \log_2 n + O(n)$).[^aggarwal] *Lower:* there exist convex $n$-gons achieving $\ge 2n - 7$ unit distances (Edelsbrunner–Hajnal 1991, Füredi 1990).[^edels-hajnal] **Direction-of-bound note:** $2n-7$ is a lower-bound *construction*; it does **not** upper-bound the unit distances in a convex polygon. The Erdős–Fishburn conjecture posits an upper bound of $< 2n$; it is open. (See §5.5 for why this matters to #97.)
+- **Unit-distance bounds in convex position.** *Upper:* $n \log_2 n + O(n)$ (Aggarwal 2010, improving Füredi's earlier $2\pi n \log_2 n + O(n)$).[^aggarwal] *Lower:* there exist convex $n$-gons achieving $\ge 2n - 7$ unit distances (Edelsbrunner--Hajnal 1991).[^edels-hajnal] **Direction-of-bound note:** $2n-7$ is a lower-bound *construction*; it does **not** upper-bound the unit distances in a convex polygon. The Erdős–Fishburn conjecture posits an upper bound of $< 2n$; it is open. (See §5.5 for why this matters to #97.)
 
 ---
 
@@ -315,7 +315,7 @@ This is a global "outside-of-$A$" control statement. Three sub-questions:
 
 **Best known bounds (verified externally; see §1.5 footnotes).**
 - *Upper:* $n \log_2 n + O(n)$ (Aggarwal 2010), improving Füredi's earlier $2\pi n \log_2 n + O(n)$.[^aggarwal]
-- *Lower:* there exist convex $n$-gons with $\ge 2n - 7$ unit distances (Edelsbrunner–Hajnal 1991, Füredi 1990).[^edels-hajnal]
+- *Lower:* there exist convex $n$-gons with $\ge 2n - 7$ unit distances (Edelsbrunner--Hajnal 1991).[^edels-hajnal]
 
 **Uniform-radius subcase of #97.** If a 4-bad polygon has all $r_i$ equal to a common $r$, then the distance-$r$ graph has $\ge 2n$ edges (each vertex has 4 neighbors at distance $r$, divide by 2). To rule this out via distance bounds, one would need an *upper* bound of the form "convex $n$-gon has $< 2n$ pairs at any single distance" — which is exactly the Erdős–Fishburn conjecture.
 
@@ -942,7 +942,7 @@ What the prior synthesis documents disagreed about, and what this document adopt
 | "Erdős Problem #97" name provenance | Various | Numbering from erdosproblems.com; the 4-equidistant problem appears under that label there (last edited 2025-10-27). |
 | $n = 6$ status under uniform-radius framing | `erdos97_useful_findings.md` §A.11 appears to suggest $n = 6$ remains open in the variable-radius case | **Closed.** The clean proof in §3.2 uses only L5 directly and works regardless of radius pattern. The useful-findings phrasing is misleading; it conflates the uniform-radius proof method with the actual case status. |
 | $k = 3$ "solved" framing | Some sources call it "solved" | More precisely: $k = 3$ has explicit counterexamples (Danzer; Fishburn–Reeds), so the natural conjecture is *false* there. Erdős #97 ($k = 4$) is the boundary and is open. |
-| **Uniform-radius case "folklore-resolved by Füredi $2n-7$"** (NEW in canonical merge) | `erdos97_final_consolidated.md` §5.5; `erdos97_useful_findings.md` §A.11; `zip/source_notes/17_uniform_radius_related_case.md` | **Open, not resolved.** The cited $2n-7$ is a lower-bound *construction* (Edelsbrunner–Hajnal 1991, Füredi 1990), not an upper bound; saying $\ge 2n$ unit edges is *consistent* with $\ge 2n-7$, not in conflict with it. The needed $< 2n$ upper bound is the Erdős–Fishburn conjecture, still open. Verified externally via Aggarwal arXiv:1009.2216.[^aggarwal][^edels-hajnal] (§5.5.) |
+| **Uniform-radius case "folklore-resolved by Füredi $2n-7$"** (NEW in canonical merge) | `erdos97_final_consolidated.md` §5.5; `erdos97_useful_findings.md` §A.11; `zip/source_notes/17_uniform_radius_related_case.md` | **Open, not resolved.** The cited $2n-7$ is an Edelsbrunner--Hajnal lower-bound *construction*, not an upper bound; Füredi's separate convex-`n`-gon unit-distance work belongs to the upper-bound side. Saying $\ge 2n$ unit edges is *consistent* with $\ge 2n-7$, not in conflict with it. The needed $< 2n$ upper bound is the Erdős–Fishburn conjecture, still open. Verified externally via Aggarwal arXiv:1009.2216.[^aggarwal][^edels-hajnal] (§5.5.) |
 
 ---
 
@@ -1168,6 +1168,6 @@ Imported from `erdos97_four_stage_consolidation.md` for traceability. Hashes are
 
 [^aggarwal]: A. Aggarwal, "On Unit Distances in a Convex Polygon," arXiv:1009.2216 (2010). The abstract states Füredi's earlier upper bound of $2\pi n \log_2 n + O(n)$ and Aggarwal's improvement to $n \log_2 n + O(n)$. **This is the relevant external check that the prior synthesis's "Füredi $2n-7$" claim was a direction-of-bound error.** <https://arxiv.org/abs/1009.2216>
 
-[^edels-hajnal]: H. Edelsbrunner and P. Hajnal, "A lower bound on the number of unit distances between the points of a convex polygon," *JCTA* 56 (1991), 312–316. Provides the lower-bound *construction* with $\ge 2n - 7$ unit-distance pairs in some convex $n$-gons. **Not an upper bound.** <https://pub.ista.ac.at/~edels/Papers/1991-03-UnitDistancesConvexPolygon.pdf>
+[^edels-hajnal]: H. Edelsbrunner and P. Hajnal, "A lower bound on the number of unit distances between the points of a convex polygon," *JCTA* 56 (1991), 312–316. Provides the lower-bound *construction* with $\ge 2n - 7$ unit-distance pairs in some convex $n$-gons. **Not an upper bound.** Füredi's separate convex-`n`-gon unit-distance work is cited under [^aggarwal] on the upper-bound side. <https://pub.ista.ac.at/~edels/Papers/1991-03-UnitDistancesConvexPolygon.pdf>
 
 [^nivasch]: G. Nivasch, J. Pach, R. Pinchasi, and S. Zerbib, "The number of distinct distances from a vertex of a convex polygon," *Journal of Computational Geometry* 4(1):1–12, 2013 / arXiv:1207.1266. Lower bound $\ge (13/36 + \varepsilon)n - O(1)$ on the number of distinct distances from a vertex of a convex polygon. <https://arxiv.org/abs/1207.1266>

--- a/docs/failed-ideas.md
+++ b/docs/failed-ideas.md
@@ -97,10 +97,12 @@ Failure mode: requiring one global radius solves only a stricter subcase. The
 actual problem allows each center to choose its own radius, so common-radius
 or unit-distance bounds must stay in a separate literature-risk lane.[^syn]
 
-A related rejected shortcut claimed that Furedi's `2n-7` unit-distance result
+A related rejected shortcut claimed that the `2n-7` unit-distance construction
 settles the uniform-radius subcase. The canonical synthesis records this as a
-direction-of-bound error: `2n-7` is a lower-bound construction, not the needed
-`< 2n` upper bound.[^canon]
+direction-of-bound error: `2n-7` is an Edelsbrunner--Hajnal lower-bound
+construction, not the needed `< 2n` upper bound. Furedi's separate
+convex-`n`-gon unit-distance work belongs to the upper-bound side of the
+common-radius problem.[^canon]
 
 ## 16. Metric-linear rank obstruction without convexity
 

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -17,7 +17,7 @@ are claimed here.
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound
   construction, not an upper bound resolving the subcase. Furedi's separate
   convex-`n`-gon unit-distance work belongs to the upper-bound side of the
-  common-radius problem.[^canon]
+  common-radius problem.[^edels-hajnal][^aggarwal][^canon]
 
 ## Checked external anchors, 2026-04-30
 
@@ -68,3 +68,5 @@ are claimed here.
 [^erdos1975]: P. Erdos, "On some problems of elementary and combinatorial geometry," Annali di Matematica Pura ed Applicata 103, 99--108, 1975. <https://www.renyi.hu/~p_erdos/1975-25.pdf>
 [^fishburn-reeds]: P. C. Fishburn and J. A. Reeds, "Unit distances between vertices of a convex polygon," Computational Geometry 2(2), 81--91, 1992. DOI: `10.1016/0925-7721(92)90026-O`.
 [^formal97]: `google-deepmind/formal-conjectures`, `FormalConjectures/ErdosProblems/97.lean`, accessed 2026-04-30. <https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/97.lean>
+[^edels-hajnal]: H. Edelsbrunner and P. Hajnal, "A lower bound on the number of unit distances between the points of a convex polygon," Journal of Combinatorial Theory, Series A 56(2), 312--316, 1991. DOI: `10.1016/0097-3165(91)90042-F`.
+[^aggarwal]: A. Aggarwal, "On Unit Distances in a Convex Polygon," Discrete Mathematics 338(3), 88--92, 2015; arXiv:1009.2216. DOI: `10.1016/j.disc.2014.10.009`.

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -13,9 +13,32 @@ are claimed here.
 - Common-radius or unit-distance reductions belong to a stricter subcase.
   Convex unit-distance bounds may settle that subcase without touching the
   full variable-radius problem.[^syn]
-- The canonical synthesis corrects a prior uniform-radius shortcut: Furedi's
-  `2n-7` result is a lower-bound construction, not an upper bound resolving
-  the subcase.[^canon]
+- The canonical synthesis corrects a prior uniform-radius shortcut:
+  Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound
+  construction, not an upper bound resolving the subcase. Furedi's separate
+  convex-`n`-gon unit-distance work belongs to the upper-bound side of the
+  common-radius problem.[^canon]
+
+## Checked external anchors, 2026-04-30
+
+- Official Erdos Problem #97 page: status `FALSIFIABLE/Open`, prize `$100`,
+  no comment-claimed partial or complete solution, and page last edited
+  `2025-10-27`.[^erdos97]
+- Danzer's 9-point construction is a `k=3` variable-radius construction. It is
+  not a `k=4` counterexample. The official page points to Erdos 1987 for the
+  construction explanation.[^erdos97][^erdos1987]
+- Erdos 1975 reports an unpublished stronger Danzer claim for every `k`, but
+  the official page says this was not repeated in later papers and was
+  presumably mistaken. Treat that all-`k` statement as `UNVERIFIED` and do not
+  cite it as a `k=4` counterexample unless an exact primary construction or
+  certificate is recovered.[^erdos97][^erdos1975]
+- Fishburn--Reeds 1992 is a `k=3` common-radius/unit-distance construction on
+  20 points, with a cut-minimality statement in the accessible abstract. It is
+  not a variable-radius `k=4` result.[^fishburn-reeds]
+- The Google DeepMind Formal Conjectures entry is a formal statement/alignment
+  source, not a proof certificate: `erdos_97` is marked `research open` and the
+  theorem body uses `sorry`; nearby Danzer and Fishburn--Reeds variants also
+  use `sorry`.[^formal97]
 
 ## Current risks
 
@@ -40,3 +63,8 @@ are claimed here.
 [^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
 [^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
 [^canon]: Source file: `docs/canonical-synthesis.md`.
+[^erdos97]: T. F. Bloom, "Erdos Problem #97," Erdos Problems, accessed 2026-04-30. <https://www.erdosproblems.com/97>
+[^erdos1987]: P. Erdos, "Some combinatorial and metric problems in geometry," Intuitive Geometry, Colloquia Mathematica Societatis Janos Bolyai 48, 167--177, 1987. <https://www.renyi.hu/~p_erdos/1987-27.pdf>
+[^erdos1975]: P. Erdos, "On some problems of elementary and combinatorial geometry," Annali di Matematica Pura ed Applicata 103, 99--108, 1975. <https://www.renyi.hu/~p_erdos/1975-25.pdf>
+[^fishburn-reeds]: P. C. Fishburn and J. A. Reeds, "Unit distances between vertices of a convex polygon," Computational Geometry 2(2), 81--91, 1992. DOI: `10.1016/0925-7721(92)90026-O`.
+[^formal97]: `google-deepmind/formal-conjectures`, `FormalConjectures/ErdosProblems/97.lean`, accessed 2026-04-30. <https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/97.lean>

--- a/docs/upstream-alignment.md
+++ b/docs/upstream-alignment.md
@@ -9,9 +9,21 @@ Problem #97. It is not a replacement for the public Erdos problem database.
 
 - Official page: <https://www.erdosproblems.com/97>
 - Status: falsifiable/open
+- Status checked: 2026-04-30
+- Page last edited: 2025-10-27
+- Comment solution claims: none partial or complete
 - Prize: $100
 - Tags: geometry, distances, convex
-- Formalised statement: yes
+- Formalised statement: yes, but not a formal proof
+
+## Formalization note
+
+The Google DeepMind Formal Conjectures entry
+`FormalConjectures/ErdosProblems/97.lean` is useful for statement alignment:
+it encodes the variable-radius `HasNEquidistantProperty 4` statement and marks
+`erdos_97` as `research open`. The theorem body uses `sorry`, and the nearby
+Danzer and Fishburn--Reeds `k=3` variants also use `sorry`; do not cite those
+Lean entries as proof certificates.
 
 ## Local repository status
 

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -24,6 +24,34 @@ formalization:
   lean_status: "research open"
   local_alignment_note: "Compare strict-convex-polygon language with ConvexIndep A in the Lean statement."
 
+nearby_literature:
+  last_swept: "2026-04-30"
+  entries:
+    - key: "danzer_9_point_k3"
+      title: "Danzer 9-point construction"
+      status: "nearby k=3 variable-radius construction; not a k=4 counterexample"
+      source: "P. Erdos, Some combinatorial and metric problems in geometry, 1987"
+      url: "https://www.renyi.hu/~p_erdos/1987-27.pdf"
+    - key: "erdos_1975_all_k_danzer_report"
+      title: "Unpublished all-k Danzer report"
+      status: "unverified literature risk; official #97 page says presumably mistaken"
+      source: "P. Erdos, On some problems of elementary and combinatorial geometry, 1975"
+      url: "https://www.renyi.hu/~p_erdos/1975-25.pdf"
+    - key: "fishburn_reeds_20_point_k3_unit"
+      title: "Unit distances between vertices of a convex polygon"
+      status: "nearby k=3 common-radius/unit-distance construction; not a k=4 result"
+      authors:
+        - "P. C. Fishburn"
+        - "J. A. Reeds"
+      year: 1992
+      doi: "10.1016/0925-7721(92)90026-O"
+    - key: "unit_distance_common_radius_caveat"
+      title: "Convex polygon unit-distance literature"
+      status: "common-radius/global pair-count literature; not interchangeable with variable-radius selected witnesses"
+      notes:
+        - "Edelsbrunner--Hajnal 2n-7 is a lower-bound construction."
+        - "Furedi's convex n-gon unit-distance work belongs to the upper-bound side."
+
 local_repo:
   repository: "https://github.com/davidiach/erdos97"
   overall_claim: "No general proof and no counterexample are claimed."

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -30,24 +30,43 @@ nearby_literature:
     - key: "danzer_9_point_k3"
       title: "Danzer 9-point construction"
       status: "nearby k=3 variable-radius construction; not a k=4 counterexample"
-      source: "P. Erdos, Some combinatorial and metric problems in geometry, 1987"
-      url: "https://www.renyi.hu/~p_erdos/1987-27.pdf"
+      citation:
+        authors:
+          - "P. Erdos"
+        year: 1987
+        source: "Some combinatorial and metric problems in geometry"
+        url: "https://www.renyi.hu/~p_erdos/1987-27.pdf"
     - key: "erdos_1975_all_k_danzer_report"
       title: "Unpublished all-k Danzer report"
       status: "unverified literature risk; official #97 page says presumably mistaken"
-      source: "P. Erdos, On some problems of elementary and combinatorial geometry, 1975"
-      url: "https://www.renyi.hu/~p_erdos/1975-25.pdf"
+      citation:
+        authors:
+          - "P. Erdos"
+        year: 1975
+        source: "On some problems of elementary and combinatorial geometry"
+        url: "https://www.renyi.hu/~p_erdos/1975-25.pdf"
     - key: "fishburn_reeds_20_point_k3_unit"
       title: "Unit distances between vertices of a convex polygon"
       status: "nearby k=3 common-radius/unit-distance construction; not a k=4 result"
-      authors:
-        - "P. C. Fishburn"
-        - "J. A. Reeds"
-      year: 1992
-      doi: "10.1016/0925-7721(92)90026-O"
+      citation:
+        authors:
+          - "P. C. Fishburn"
+          - "J. A. Reeds"
+        year: 1992
+        source: "Unit distances between vertices of a convex polygon"
+        doi: "10.1016/0925-7721(92)90026-O"
+        url: "https://doi.org/10.1016/0925-7721(92)90026-O"
     - key: "unit_distance_common_radius_caveat"
       title: "Convex polygon unit-distance literature"
       status: "common-radius/global pair-count literature; not interchangeable with variable-radius selected witnesses"
+      citation:
+        authors:
+          - "H. Edelsbrunner"
+          - "P. Hajnal"
+          - "Z. Furedi"
+          - "A. Aggarwal"
+        source: "Convex polygon unit-distance lower- and upper-bound literature"
+        url: "docs/canonical-synthesis.md"
       notes:
         - "Edelsbrunner--Hajnal 2n-7 is a lower-bound construction."
         - "Furedi's convex n-gon unit-distance work belongs to the upper-bound side."

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -53,6 +53,7 @@ METADATA_EXPECTED_TRUE = (
     "exact_certificates_required_for_counterexamples",
     "independent_review_required_for_public_theorem_claims",
 )
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
 
 
 def fail(msg: str) -> None:
@@ -83,6 +84,15 @@ def metadata_value(metadata: dict[str, object], path: tuple[str, ...]) -> object
             fail(f"metadata/erdos97.yaml is missing {'.'.join(path)}")
         current = current[key]
     return current
+
+
+def require_string_field(mapping: object, key: str, label: str) -> str:
+    if not isinstance(mapping, dict):
+        fail(f"{label} should be a mapping")
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        fail(f"{label}.{key} should be a non-empty string")
+    return value
 
 
 def require_pattern(label: str, text: str, pattern: re.Pattern[str], detail: str) -> None:
@@ -136,6 +146,37 @@ def validate_metadata() -> None:
     for key in METADATA_EXPECTED_TRUE:
         if metadata_value(metadata, ("trust_policy", key)) is not True:
             fail(f"metadata trust_policy.{key} should be true")
+
+    validate_nearby_literature(metadata)
+
+
+def validate_nearby_literature(metadata: dict[str, object]) -> None:
+    nearby = metadata_value(metadata, ("nearby_literature",))
+    if not isinstance(nearby, dict):
+        fail("metadata nearby_literature should be a mapping")
+
+    last_swept = require_string_field(nearby, "last_swept", "metadata nearby_literature")
+    if not DATE_RE.fullmatch(last_swept):
+        fail("metadata nearby_literature.last_swept should be YYYY-MM-DD")
+
+    entries = nearby.get("entries")
+    if not isinstance(entries, list) or not entries:
+        fail("metadata nearby_literature.entries should be a non-empty list")
+
+    for index, entry in enumerate(entries):
+        label = f"metadata nearby_literature.entries[{index}]"
+        require_string_field(entry, "key", label)
+        require_string_field(entry, "title", label)
+        require_string_field(entry, "status", label)
+        if not isinstance(entry, dict) or not isinstance(entry.get("citation"), dict):
+            fail(f"{label}.citation should be a mapping")
+        citation = entry["citation"]
+        has_reference = any(
+            isinstance(citation.get(field), str) and citation.get(field).strip()
+            for field in ("source", "doi", "url")
+        )
+        if not has_reference:
+            fail(f"{label}.citation should include a non-empty source, doi, or url")
 
 
 def validate_top_level_status() -> None:


### PR DESCRIPTION
## Summary

- records the 2026-04-30 official #97 status check and FormalConjectures caveat
- quarantines the Erdos 1975 unpublished all-k Danzer report as unverified literature risk
- pins nearby Danzer/Fishburn-Reeds/unit-distance context in docs and metadata without changing the repo claim posture

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `pytest -q` was unavailable on PATH, so ran `python -m pytest -q` (`66 passed, 7 deselected`)

No finite-case artifacts were changed.