### PR TITLE
[codex] Add stuck motif mining tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   and [`docs/vertex-circle-order-filter.md`](docs/vertex-circle-order-filter.md).
 - For the weak exact minimum-radius short-chord filter, read
   [`docs/minimum-radius-filter.md`](docs/minimum-radius-filter.md).
+- For fixed-selection stuck-set mining around the bridge/peeling program, read
+  [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).
 - For known bad proof routes, read [`docs/failed-ideas.md`](docs/failed-ideas.md).
 - For the verification standard, read [`docs/verification-contract.md`](docs/verification-contract.md).
@@ -168,6 +170,10 @@ Use these labels consistently:
 ├── pyproject.toml
 ├── src/erdos97/search.py              # main search/verification engine
 ├── src/erdos97/incidence_filters.py   # exact incidence obstruction filters
+├── src/erdos97/stuck_sets.py          # fixed-selection stuck-set miner core
+├── src/erdos97/motif_fingerprint.py   # cyclic/dihedral motif fingerprints
+├── src/erdos97/stuck_motif_search.py  # bounded SMT stuck-motif search
+├── src/erdos97/stuck_motif_sweep.py   # motif sweep and geometry smoke tests
 ├── src/erdos97/n7_fano.py             # exact n=7 Fano enumeration
 ├── scripts/                           # thin CLI helpers
 ├── tests/                             # smoke tests and incidence checks
@@ -182,6 +188,7 @@ Use these labels consistently:
 │   ├── candidate-patterns.md          # ranked incidence patterns
 │   ├── failed-ideas.md                # failed arguments to avoid repeating
 │   ├── exactification-plan.md         # numerical-to-exact certificate route
+│   ├── stuck-set-miner.md             # bridge/peeling obstruction tooling
 │   ├── n8-incidence-enumeration.md    # n=8 incidence-completeness proof
 │   ├── n8-exact-survivors.md          # n=8 exact survivor obstructions
 │   ├── mutual-rhombus-filter.md       # exact fixed-pattern filters

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`minimum-radius-filter.md`](minimum-radius-filter.md): weak exact
   minimum-radius short-chord filter; records why it does not kill `C19_skew`
   by itself.
+- [`stuck-set-miner.md`](stuck-set-miner.md): fixed-selection stuck-set mining
+  for the bridge/peeling program.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible

--- a/docs/stuck-set-miner.md
+++ b/docs/stuck-set-miner.md
@@ -1,0 +1,213 @@
+# Fixed-selection stuck-set miner
+
+Status: research tooling. No general proof and no counterexample are claimed.
+
+The stuck-set miner analyzes a fixed selected-witness system `S_i`. It is meant
+to expose obstructions to the bridge/peeling program without promoting them to
+geometric claims.
+
+## Semantics
+
+For a selected pattern, a subset `U` is stuck if `|U| >= 4` and every center
+`v in U` has at most two selected witnesses inside `U`.
+
+This obstructs the strong fixed-row Key Peeling property. It does not prove that
+the underlying abstract pattern is geometrically realizable or unrealizable,
+because a real bad polygon could have other rich-radius choices not represented
+by the fixed rows.
+
+The tool separately reports:
+
+- `forward_ear_order`: whether some three-vertex seed can grow by adding
+  vertices with three selected witnesses already present.
+- `greedy_reverse_peeling`: one deterministic peeling run from the full set.
+  A failure gives a concrete stuck motif, but a success is not a no-stuck proof.
+- `key_peeling_status`: the exhaustive stuck-search status over the requested
+  subset-size window.
+- `filters.fragile_cover`: an incidence-level fragile-cover snapshot assuming
+  any selected row may be declared fragile.
+- `filters.radius_propagation`: a fixed-order, disjunctive short-chord
+  radius-inequality check.
+
+If the search starts above size `4`, or stops before `n` without finding a
+stuck set, the status is `UNKNOWN_TRUNCATED_SEARCH`.
+
+## Usage
+
+Analyze one built-in pattern:
+
+```bash
+python scripts/find_minimal_stuck_sets.py --pattern C19_skew
+```
+
+Search only larger motifs:
+
+```bash
+python scripts/find_minimal_stuck_sets.py --pattern C19_skew --min-set-size 8 --json
+```
+
+Analyze all built-in patterns:
+
+```bash
+python scripts/find_minimal_stuck_sets.py --all-built-ins
+```
+
+Analyze the reconstructed `n=8` survivor classes:
+
+```bash
+python scripts/find_minimal_stuck_sets.py \
+  --n8-survivors data/incidence/n8_reconstructed_15_survivors.json
+```
+
+Write a certificate:
+
+```bash
+python scripts/find_minimal_stuck_sets.py \
+  --pattern C19_skew \
+  --write-certificate data/certificates/c19_stuck_sets.json \
+  --json
+```
+
+The JSON output includes cheap exact filter diagnostics for the full fixed
+pattern: row-pair cap, column-pair cap, `phi` edge count, odd forced
+perpendicularity cycles, natural-order crossing violations, and the current
+minimum-radius short-chord filter result.
+
+## Mining New Motifs
+
+`scripts/mine_stuck_motifs.py` uses the optional `z3-solver` dev dependency to
+ask for a full selected-witness system with a prescribed stuck subset. It then
+runs the same exact filters used by `find_minimal_stuck_sets.py`.
+
+Example:
+
+```bash
+python scripts/mine_stuck_motifs.py --n 9 --stuck-size 4 --max-models 100
+```
+
+By default, the solver enforces:
+
+- row size `4` and no self-selection;
+- row-pair intersection cap;
+- column-pair cap;
+- all labels are selected by at least one row;
+- adjacent-row overlap at most `1` in natural order;
+- two-overlap crossing compatibility in natural order.
+
+The post-solver filters also require no odd forced-perpendicularity cycle,
+radius-propagation survival, and incidence-level fragile-cover compatibility.
+Each of these can be relaxed with a named `--allow-*` flag.
+
+For motifs that are genuinely adversarial to the ear-orderable rank program,
+add:
+
+```bash
+python scripts/mine_stuck_motifs.py \
+  --n 10 \
+  --stuck-size 4 \
+  --max-models 500 \
+  --require-no-forward-ear-order
+```
+
+This rejects models admitting any forward ear order from a three-vertex seed.
+The solver also adds a cheap necessary seed screen, but the final check is done
+by the exact `forward_ear_order` routine.
+
+The stuck subset is fixed to labels `0..stuck_size-1`, so this is a bounded
+motif search, not an isomorphism-complete enumeration.
+
+Every stuck-analysis or motif payload includes a `fingerprint` block. The
+`cyclic_dihedral_sha256` value is canonical under cyclic rotation and reversal
+of the fixed order. It is intentionally not canonical under arbitrary
+relabeling, because these tools are tracking fixed cyclic-order filters.
+
+Current smoke-test behavior under the natural-order filters and
+`--require-no-forward-ear-order`:
+
+```text
+n=9,  stuck_size=4: exhausted in the bounded search used by tests
+n=10, stuck_size=4: found a surviving no-forward fixed-selection motif
+n=11, stuck_size=4: found a surviving no-forward fixed-selection motif
+n=12, stuck_size=4: found a surviving no-forward fixed-selection motif
+```
+
+These are search diagnostics, not finite-case theorems.
+
+## Geometry Smoke Search
+
+Mined motifs include `selected_rows`, so they can be passed directly into the
+existing numerical search stack:
+
+```bash
+python scripts/mine_stuck_motifs.py \
+  --n 10 \
+  --stuck-size 4 \
+  --max-models 80 \
+  --require-no-forward-ear-order \
+  --write-certificate data/runs/scratch/mined_n10_stuck4_no_forward.json
+
+python scripts/search_pattern_json.py \
+  --input data/runs/scratch/mined_n10_stuck4_no_forward.json \
+  --optimizer slsqp \
+  --restarts 20 \
+  --max-nfev 3000
+```
+
+The search result is numerical evidence only. Optimizer failure is reported as
+a failed numerical run, not as an obstruction. A low residual would still need
+exact coordinates, interval certificates, SMT certificates, or a formal proof
+before it could support an exact claim.
+
+## Sweeps
+
+Use `scripts/sweep_stuck_motifs.py` to reproduce a small parameter grid without
+leaving per-motif artifacts behind:
+
+```bash
+python scripts/sweep_stuck_motifs.py \
+  --n-range 9 12 \
+  --stuck-sizes 4 \
+  --max-models 220 \
+  --solver-seed 0 \
+  --require-no-forward-ear-order
+```
+
+Add `--run-geometry` for a lightweight numerical smoke search on every found
+motif:
+
+```bash
+python scripts/sweep_stuck_motifs.py \
+  --n 11 \
+  --stuck-sizes 4 \
+  --max-models 80 \
+  --solver-seed 0 \
+  --require-no-forward-ear-order \
+  --run-geometry \
+  --geometry-optimizer trf \
+  --geometry-restarts 3 \
+  --geometry-max-nfev 300
+```
+
+Model counts are solver diagnostics. They are useful for reproducibility with a
+fixed seed, but they should not be read as mathematical thresholds.
+
+## Radius Propagation
+
+For each row `i`, the four selected witnesses have at least one consecutive
+angular gap smaller than `pi/3`. If the short pair is `{a,b}` and `b in S_a`,
+then `r_a < r_i`; if `a in S_b`, then `r_b < r_i`.
+
+The implementation therefore searches over the disjunction of possible short
+pairs, one per row. The status `RADIUS_CYCLE_OBSTRUCTED` means every such
+choice forces a strict radius cycle. The status `PASS_ACYCLIC_CHOICE` means the
+pattern survives this necessary filter; it is not evidence of realizability.
+
+## Fragile Cover
+
+The fragile-cover snapshot is incidence-only. It treats every selected row as
+eligible to be a fragile row and asks whether selected cohorts can cover all
+vertices. Actual fragility requires metric uniqueness of an exact four-cohort,
+which this tool does not certify.
+
+For `n > 20`, exact cover-subset enumeration is skipped by default. Use
+`--fragile-cover-max-size` to search a bounded cover-size window.

--- a/scripts/find_minimal_stuck_sets.py
+++ b/scripts/find_minimal_stuck_sets.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Find fixed-selection stuck sets for selected-witness systems."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.search import built_in_patterns  # noqa: E402
+from erdos97.stuck_sets import (  # noqa: E402
+    find_minimal_stuck_sets,
+    forward_ear_order,
+    greedy_peeling_run,
+    pattern_filter_snapshot,
+    result_to_json,
+)
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
+
+
+def matrix_to_rows(matrix: Sequence[Sequence[int]]) -> list[list[int]]:
+    return [
+        [int(label) for label, value in enumerate(row) if int(value)]
+        for row in matrix
+    ]
+
+
+def load_n8_survivors(path: Path) -> list[tuple[str, list[list[int]]]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[tuple[str, list[list[int]]]] = []
+    for entry in data:
+        out.append((f"n8_class_{entry['id']}", matrix_to_rows(entry["rows"])))
+    return out
+
+
+def default_max_size(n: int, requested: int | None) -> int:
+    if requested is not None:
+        return requested
+    return n if n <= 20 else 12
+
+
+def analyze_one(
+    name: str,
+    rows: list[list[int]],
+    order: list[int] | None,
+    requested_min_size: int | None,
+    requested_max_size: int | None,
+    max_examples: int,
+    radius_node_limit: int,
+    fragile_cover_max_size: int | None,
+) -> dict[str, object]:
+    max_size = default_max_size(len(rows), requested_max_size)
+    stuck = find_minimal_stuck_sets(
+        rows,
+        min_size=requested_min_size,
+        max_size=max_size,
+        max_examples=max_examples,
+    )
+    forward = forward_ear_order(rows)
+    greedy = greedy_peeling_run(rows)
+    filters = pattern_filter_snapshot(
+        rows,
+        order=order,
+        radius_node_limit=radius_node_limit,
+        fragile_cover_max_size=fragile_cover_max_size,
+        fragile_cover_max_examples=max_examples,
+    )
+    return result_to_json(name, rows, stuck, forward, greedy_result=greedy, filters=filters)
+
+
+def assert_expectations(rows: list[dict[str, object]], assert_stuck: bool, assert_no_stuck: bool) -> None:
+    for row in rows:
+        status = row["key_peeling_status"]
+        if assert_stuck and status != "STUCK_SET_FOUND":
+            raise AssertionError(f"{row['pattern']}: expected a stuck set, got {status}")
+        if assert_no_stuck and status != "NO_STUCK_SETS":
+            raise AssertionError(f"{row['pattern']}: expected no stuck sets, got {status}")
+
+
+def print_summary(rows: list[dict[str, object]]) -> None:
+    print(
+        "pattern  n  forward-ear  greedy-terminal  key-peeling  radius  "
+        "fragile-cover  searched  min-size  examples"
+    )
+    for row in rows:
+        forward = "YES" if row["forward_ear_order"]["exists"] else "NO"
+        greedy = row["greedy_reverse_peeling"]
+        terminal_size = "-" if greedy is None else str(len(greedy["terminal_vertices"]))
+        filters = row["filters"]
+        radius = filters["radius_propagation"]["status"]
+        fragile_stats = filters["fragile_cover"]["cover_stats"]
+        if fragile_stats["status"] == "SKIPPED_LARGE_N":
+            fragile = "SKIP"
+        else:
+            fragile = "YES" if fragile_stats["cover_exists"] else "NO"
+        search = row["stuck_search"]
+        min_size = search["minimal_size"]
+        min_text = "-" if min_size is None else str(min_size)
+        print(
+            f"{row['pattern']}  {row['n']}  {forward:<11}  "
+            f"{terminal_size:<15}  "
+            f"{row['key_peeling_status']:<24}  "
+            f"{radius:<24}  "
+            f"{fragile:<13}  "
+            f"{search['searched_up_to_size']}  {min_text:<8}  "
+            f"{len(search['examples'])}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pattern", help="built-in pattern name")
+    target.add_argument("--all-built-ins", action="store_true", help="analyze all built-in patterns")
+    target.add_argument(
+        "--n8-survivors",
+        type=Path,
+        help="analyze rows from an n=8 survivor JSON file",
+    )
+    parser.add_argument(
+        "--order",
+        type=parse_order,
+        help="comma-separated cyclic order for order-sensitive filters",
+    )
+    parser.add_argument(
+        "--min-set-size",
+        type=int,
+        help="smallest subset size to search; defaults to 4",
+    )
+    parser.add_argument(
+        "--max-set-size",
+        type=int,
+        help="largest subset size to search; defaults to n for n<=20, else 12",
+    )
+    parser.add_argument("--max-examples", type=int, default=8, help="stored examples at minimal size")
+    parser.add_argument(
+        "--radius-node-limit",
+        type=int,
+        default=100_000,
+        help="backtracking node limit for the radius propagation filter",
+    )
+    parser.add_argument(
+        "--fragile-cover-max-size",
+        type=int,
+        help="maximum fragile-center subset size to enumerate for cover stats",
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a compact summary")
+    parser.add_argument("--write-certificate", type=Path, help="write JSON result to this path")
+    parser.add_argument("--assert-stuck", action="store_true", help="assert every target has a stuck set")
+    parser.add_argument(
+        "--assert-no-stuck",
+        action="store_true",
+        help="assert every target has a complete no-stuck certificate",
+    )
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    targets: list[tuple[str, list[list[int]]]]
+    if args.pattern:
+        if args.pattern not in patterns:
+            raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+        pat = patterns[args.pattern]
+        targets = [(pat.name, pat.S)]
+    elif args.all_built_ins:
+        targets = [(pat.name, pat.S) for pat in patterns.values()]
+    else:
+        if not args.n8_survivors.exists():
+            raise SystemExit(f"n8 survivor file does not exist: {args.n8_survivors}")
+        targets = load_n8_survivors(args.n8_survivors)
+
+    rows = [
+        analyze_one(
+            name,
+            selected_rows,
+            order=args.order,
+            requested_min_size=args.min_set_size,
+            requested_max_size=args.max_set_size,
+            max_examples=args.max_examples,
+            radius_node_limit=args.radius_node_limit,
+            fragile_cover_max_size=args.fragile_cover_max_size,
+        )
+        for name, selected_rows in targets
+    ]
+
+    assert_expectations(rows, args.assert_stuck, args.assert_no_stuck)
+
+    payload: dict[str, object] | list[dict[str, object]]
+    payload = rows[0] if len(rows) == 1 else rows
+
+    if args.write_certificate:
+        args.write_certificate.parent.mkdir(parents=True, exist_ok=True)
+        args.write_certificate.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(rows)
+        if args.assert_stuck or args.assert_no_stuck:
+            print("OK: stuck-set expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mine_stuck_motifs.py
+++ b/scripts/mine_stuck_motifs.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Mine bounded fixed-selection stuck motifs with SMT plus exact filters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.stuck_motif_search import (  # noqa: E402
+    MotifSearchConfig,
+    mine_stuck_motif,
+    search_result_to_json,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, required=True, help="number of vertices")
+    parser.add_argument("--stuck-size", type=int, required=True, help="forced stuck subset size")
+    parser.add_argument("--max-models", type=int, default=100, help="maximum SMT models to inspect")
+    parser.add_argument("--solver-seed", type=int, default=0, help="Z3 random seed")
+    parser.add_argument(
+        "--radius-node-limit",
+        type=int,
+        default=100_000,
+        help="node limit for radius propagation filter",
+    )
+    parser.add_argument(
+        "--fragile-cover-max-size",
+        type=int,
+        help="maximum fragile-cover subset size to enumerate",
+    )
+    parser.add_argument("--allow-uncovered", action="store_true", help="do not require all labels to appear in selected rows")
+    parser.add_argument("--allow-adjacent-two-overlap", action="store_true", help="do not reject adjacent source rows with two overlaps")
+    parser.add_argument("--allow-crossing-violations", action="store_true", help="do not reject two-overlap crossing violations")
+    parser.add_argument("--allow-odd-cycle", action="store_true", help="do not reject odd forced-perpendicularity cycles")
+    parser.add_argument("--allow-radius-obstruction", action="store_true", help="do not reject radius-cycle obstructions")
+    parser.add_argument("--allow-no-fragile-cover", action="store_true", help="do not require incidence-level fragile cover")
+    parser.add_argument(
+        "--require-no-forward-ear-order",
+        action="store_true",
+        help="reject models that admit a forward ear order from some three-vertex seed",
+    )
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument("--write-certificate", type=Path, help="write JSON result to this path")
+    parser.add_argument("--assert-found", action="store_true", help="assert a motif is found")
+    args = parser.parse_args()
+
+    config = MotifSearchConfig(
+        n=args.n,
+        stuck_size=args.stuck_size,
+        max_models=args.max_models,
+        solver_seed=args.solver_seed,
+        radius_node_limit=args.radius_node_limit,
+        require_all_rows_cover=not args.allow_uncovered,
+        require_adjacent_overlap=not args.allow_adjacent_two_overlap,
+        require_crossing=not args.allow_crossing_violations,
+        require_no_odd_cycle=not args.allow_odd_cycle,
+        require_radius_pass=not args.allow_radius_obstruction,
+        require_fragile_cover=not args.allow_no_fragile_cover,
+        require_no_forward_ear_order=args.require_no_forward_ear_order,
+        fragile_cover_max_size=args.fragile_cover_max_size,
+    )
+    result = mine_stuck_motif(config)
+    payload = search_result_to_json(result)
+
+    if args.assert_found and result.status != "FOUND":
+        raise AssertionError(f"expected FOUND, got {result.status}")
+
+    if args.write_certificate:
+        args.write_certificate.parent.mkdir(parents=True, exist_ok=True)
+        args.write_certificate.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("n  stuck-size  status  models-checked  rejection-counts")
+        print(
+            f"{args.n}  {args.stuck_size}  {result.status}  "
+            f"{result.models_checked}  {result.rejection_counts}"
+        )
+        if result.status == "FOUND" and result.motif is not None:
+            motif = result.motif
+            search = motif["stuck_search"]
+            print(
+                "motif:",
+                motif["pattern"],
+                "minimal stuck size",
+                search["minimal_size"],
+                "forward-ear",
+                motif["forward_ear_order"]["exists"],
+                "radius",
+                motif["filters"]["radius_propagation"]["status"],
+                "fingerprint",
+                motif["fingerprint"]["cyclic_dihedral_sha256"][:12],
+            )
+        if args.assert_found:
+            print("OK: stuck motif found")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/search_pattern_json.py
+++ b/scripts/search_pattern_json.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Run the numerical geometry search on a selected-witness JSON pattern."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.pattern_io import load_pattern_json  # noqa: E402
+from erdos97.search import (  # noqa: E402
+    PatternInfo,
+    result_to_json,
+    search_pattern,
+    write_certificate_template,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="JSON pattern or mined motif artifact")
+    parser.add_argument("--name", help="override pattern name")
+    parser.add_argument("--mode", choices=["polar", "direct", "support"], default="polar")
+    parser.add_argument("--optimizer", choices=["trf", "slsqp"], default="slsqp")
+    parser.add_argument("--restarts", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max-nfev", type=int, default=3000)
+    parser.add_argument("--margin", type=float, default=1e-3)
+    parser.add_argument("--out", type=Path, help="write full numerical result JSON")
+    parser.add_argument("--certificate", type=Path, help="write exactification certificate template")
+    parser.add_argument("--json", action="store_true", help="print compact JSON summary")
+    args = parser.parse_args()
+
+    name, rows = load_pattern_json(args.input)
+    if args.name:
+        name = args.name
+    pattern = PatternInfo(
+        name=name,
+        n=len(rows),
+        S=rows,
+        family="json",
+        formula=str(args.input),
+        notes="loaded from selected-witness JSON; numerical evidence only",
+    )
+    try:
+        result = search_pattern(
+            pattern,
+            mode=args.mode,
+            restarts=args.restarts,
+            seed=args.seed,
+            max_nfev=args.max_nfev,
+            optimizer=args.optimizer,
+            margin=args.margin,
+        )
+    except RuntimeError as exc:
+        summary = {
+            "pattern_name": name,
+            "n": len(rows),
+            "mode": f"{args.mode}_{args.optimizer}",
+            "success": False,
+            "message": str(exc),
+            "interpretation": (
+                "The numerical optimizer did not return a usable run. This is not "
+                "an exact obstruction or a counterexample."
+            ),
+        }
+        if args.json:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            print("pattern  n  mode  success  message")
+            print(f"{name}  {len(rows)}  {args.mode}_{args.optimizer}  False  {exc}")
+        return 2
+    data = result_to_json(result)
+    summary = {
+        key: data[key]
+        for key in [
+            "pattern_name",
+            "n",
+            "mode",
+            "loss",
+            "eq_rms",
+            "max_spread",
+            "max_rel_spread",
+            "convexity_margin",
+            "min_edge_length",
+            "min_pair_distance",
+            "success",
+            "elapsed_sec",
+        ]
+    }
+    summary["interpretation"] = (
+        "NUMERICAL_EVIDENCE only. A positive residual is not an exact obstruction; "
+        "a low residual is not a counterexample without exact or interval certificates."
+    )
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.certificate:
+        args.certificate.parent.mkdir(parents=True, exist_ok=True)
+        write_certificate_template(str(args.certificate), result)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("pattern  n  mode  eq_rms  max_spread  convexity  min_edge  success")
+        print(
+            f"{summary['pattern_name']}  {summary['n']}  {summary['mode']}  "
+            f"{summary['eq_rms']:.6g}  {summary['max_spread']:.6g}  "
+            f"{summary['convexity_margin']:.6g}  "
+            f"{summary['min_edge_length']:.6g}  {summary['success']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sweep_stuck_motifs.py
+++ b/scripts/sweep_stuck_motifs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Sweep bounded stuck-motif mining over n and stuck-size ranges."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.stuck_motif_sweep import SweepConfig, sweep_stuck_motifs  # noqa: E402
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    try:
+        values = [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid integer list: {raw}") from exc
+    if not values:
+        raise argparse.ArgumentTypeError("list must not be empty")
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    n_group = parser.add_mutually_exclusive_group(required=True)
+    n_group.add_argument("--n", type=parse_csv_ints, help="comma-separated n values")
+    n_group.add_argument("--n-range", nargs=2, type=int, metavar=("MIN", "MAX"), help="inclusive n range")
+    parser.add_argument("--stuck-sizes", type=parse_csv_ints, default=[4], help="comma-separated stuck sizes")
+    parser.add_argument("--max-models", type=int, default=100)
+    parser.add_argument("--solver-seed", type=int, default=0)
+    parser.add_argument("--require-no-forward-ear-order", action="store_true")
+    parser.add_argument("--fragile-cover-max-size", type=int)
+    parser.add_argument("--radius-node-limit", type=int, default=100_000)
+    parser.add_argument("--run-geometry", action="store_true")
+    parser.add_argument("--geometry-optimizer", choices=["trf", "slsqp"], default="trf")
+    parser.add_argument("--geometry-mode", choices=["polar", "direct", "support"], default="polar")
+    parser.add_argument("--geometry-restarts", type=int, default=3)
+    parser.add_argument("--geometry-max-nfev", type=int, default=300)
+    parser.add_argument("--geometry-margin", type=float, default=1e-3)
+    parser.add_argument("--geometry-seed", type=int, default=0)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--write-artifact", type=Path)
+    args = parser.parse_args()
+
+    if args.n is not None:
+        n_values = args.n
+    else:
+        start, end = args.n_range
+        if end < start:
+            raise SystemExit("--n-range MAX must be >= MIN")
+        n_values = list(range(start, end + 1))
+
+    payload = sweep_stuck_motifs(
+        SweepConfig(
+            n_values=n_values,
+            stuck_sizes=args.stuck_sizes,
+            max_models=args.max_models,
+            solver_seed=args.solver_seed,
+            require_no_forward_ear_order=args.require_no_forward_ear_order,
+            radius_node_limit=args.radius_node_limit,
+            fragile_cover_max_size=args.fragile_cover_max_size,
+            run_geometry=args.run_geometry,
+            geometry_optimizer=args.geometry_optimizer,
+            geometry_mode=args.geometry_mode,
+            geometry_restarts=args.geometry_restarts,
+            geometry_max_nfev=args.geometry_max_nfev,
+            geometry_margin=args.geometry_margin,
+            geometry_seed=args.geometry_seed,
+        )
+    )
+
+    if args.write_artifact:
+        args.write_artifact.parent.mkdir(parents=True, exist_ok=True)
+        args.write_artifact.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("n  stuck-size  status  models  forward-ear  radius  fingerprint  geometry-eq-rms")
+        for item in payload["items"]:
+            geometry = item["geometry"]
+            eq_rms = "-"
+            if isinstance(geometry, dict) and geometry.get("status") == "RAN":
+                eq_rms = f"{geometry['eq_rms']:.6g}"
+            motif = item["motif"]
+            fingerprint = "-"
+            if isinstance(motif, dict):
+                fingerprint = motif["fingerprint"]["cyclic_dihedral_sha256"][:12]
+            print(
+                f"{item['n']}  {item['stuck_size']}  {item['status']}  "
+                f"{item['models_checked']}  {item['motif_forward_ear_order']}  "
+                f"{item['radius_status']}  {fingerprint}  {eq_rms}"
+            )
+        print("summary:", payload["summary"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/fragile_hypergraph.py
+++ b/src/erdos97/fragile_hypergraph.py
@@ -247,6 +247,7 @@ def covering_subsets(
     n: int,
     rows: Mapping[int, Sequence[int]],
     max_examples: int = 8,
+    max_size: int | None = None,
 ) -> dict[str, object]:
     """Return small-n cover statistics for possible fragile centers.
 
@@ -257,6 +258,10 @@ def covering_subsets(
     _validate_labels(n, rows)
     if max_examples < 0:
         raise ValueError("max_examples must be nonnegative")
+    if max_size is None:
+        max_size = len(rows)
+    if max_size < 0:
+        raise ValueError("max_size must be nonnegative")
 
     centers = sorted(rows)
     row_sets = {center: set(row) for center, row in rows.items()}
@@ -265,7 +270,7 @@ def covering_subsets(
     min_size: int | None = None
     total = 0
 
-    for size in range(len(centers) + 1):
+    for size in range(min(max_size, len(centers)) + 1):
         for subset in combinations(centers, size):
             covered: set[int] = set()
             for center in subset:
@@ -282,6 +287,8 @@ def covering_subsets(
 
     return {
         "cover_exists": total > 0,
+        "searched_up_to_size": min(max_size, len(centers)),
+        "search_complete": max_size >= len(centers),
         "min_cover_size": min_size,
         "total_cover_subsets": total,
         "cover_counts_by_size": {

--- a/src/erdos97/motif_fingerprint.py
+++ b/src/erdos97/motif_fingerprint.py
@@ -1,0 +1,131 @@
+"""Cyclic-order fingerprints for fixed selected-witness patterns."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from itertools import combinations
+from typing import Sequence
+
+Pattern = Sequence[Sequence[int]]
+
+
+def _validate_pattern(S: Pattern) -> None:
+    n = len(S)
+    if n < 4:
+        raise ValueError(f"pattern must have at least four rows, got {n}")
+    for center, row in enumerate(S):
+        if len(row) != 4:
+            raise ValueError(f"row {center} has length {len(row)}, expected 4")
+        if len(set(row)) != 4:
+            raise ValueError(f"row {center} has repeated witnesses: {list(row)}")
+        if center in row:
+            raise ValueError(f"row {center} contains its own center")
+        for label in row:
+            if label < 0 or label >= n:
+                raise ValueError(f"row {center} contains out-of-range label {label}")
+
+
+def row_masks(S: Pattern) -> tuple[int, ...]:
+    """Return bit-mask rows for a validated selected-witness pattern."""
+
+    _validate_pattern(S)
+    masks: list[int] = []
+    for row in S:
+        mask = 0
+        for label in row:
+            mask |= 1 << int(label)
+        masks.append(mask)
+    return tuple(masks)
+
+
+def row_strings_from_masks(masks: Sequence[int], n: int) -> list[str]:
+    return [
+        "".join("1" if (mask >> label) & 1 else "0" for label in range(n))
+        for mask in masks
+    ]
+
+
+def transform_cyclic_dihedral(S: Pattern, shift: int = 0, reverse: bool = False) -> list[list[int]]:
+    """Relabel a pattern by a cyclic shift, optionally followed by reversal."""
+
+    _validate_pattern(S)
+    n = len(S)
+
+    def map_label(label: int) -> int:
+        if reverse:
+            return (shift - label) % n
+        return (label + shift) % n
+
+    out: list[list[int]] = [[] for _ in range(n)]
+    for old_center, row in enumerate(S):
+        new_center = map_label(old_center)
+        out[new_center] = sorted(map_label(label) for label in row)
+    return out
+
+
+def cyclic_dihedral_key(S: Pattern) -> tuple[int, ...]:
+    """Return the lexicographically least row-mask key under D_n relabeling."""
+
+    _validate_pattern(S)
+    n = len(S)
+    keys = []
+    for shift in range(n):
+        for reverse in (False, True):
+            keys.append(row_masks(transform_cyclic_dihedral(S, shift=shift, reverse=reverse)))
+    return min(keys)
+
+
+def _histogram(values: Sequence[int]) -> dict[str, int]:
+    return {str(key): count for key, count in sorted(Counter(values).items())}
+
+
+def pattern_profile(S: Pattern) -> dict[str, object]:
+    """Return a JSON-ready fixed-order profile and cyclic-dihedral fingerprint."""
+
+    _validate_pattern(S)
+    n = len(S)
+    masks = row_masks(S)
+    key = cyclic_dihedral_key(S)
+    key_strings = row_strings_from_masks(key, n)
+    key_blob = "|".join(key_strings).encode("ascii")
+    orbit_keys = {
+        row_masks(transform_cyclic_dihedral(S, shift=shift, reverse=reverse))
+        for shift in range(n)
+        for reverse in (False, True)
+    }
+
+    indegrees = [0] * n
+    for row in S:
+        for label in row:
+            indegrees[label] += 1
+
+    row_intersections = [
+        (masks[left] & masks[right]).bit_count()
+        for left, right in combinations(range(n), 2)
+    ]
+    column_pair_codegrees = []
+    for a, b in combinations(range(n), 2):
+        count = sum(1 for row in S if a in row and b in row)
+        column_pair_codegrees.append(count)
+
+    reciprocal_pairs = 0
+    for a, b in combinations(range(n), 2):
+        if b in S[a] and a in S[b]:
+            reciprocal_pairs += 1
+
+    return {
+        "type": "fixed_order_cyclic_dihedral_fingerprint",
+        "n": n,
+        "cyclic_dihedral_sha256": hashlib.sha256(key_blob).hexdigest(),
+        "cyclic_dihedral_key_rows": key_strings,
+        "cyclic_dihedral_orbit_size": len(orbit_keys),
+        "indegree_histogram": _histogram(indegrees),
+        "row_intersection_histogram": _histogram(row_intersections),
+        "column_pair_codegree_histogram": _histogram(column_pair_codegrees),
+        "reciprocal_edge_pairs": reciprocal_pairs,
+        "semantics": (
+            "Fingerprint is canonical only under cyclic rotations and reversal "
+            "of the fixed order, not under arbitrary relabeling."
+        ),
+    }

--- a/src/erdos97/pattern_io.py
+++ b/src/erdos97/pattern_io.py
@@ -1,0 +1,62 @@
+"""Load fixed selected-witness patterns from JSON artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from erdos97.fragile_hypergraph import rows_from_zero_one_matrix
+from erdos97.stuck_sets import validate_selected_pattern
+
+Pattern = list[list[int]]
+
+
+def _rows_from_candidate(raw: Any) -> Pattern | None:
+    if not isinstance(raw, list):
+        return None
+    if not raw:
+        return None
+    if not all(isinstance(row, list) for row in raw):
+        return None
+
+    try:
+        if all(len(row) == 4 for row in raw):
+            rows = [[int(label) for label in row] for row in raw]
+        elif all(all(value in (0, 1, False, True) for value in row) for row in raw):
+            rows = rows_from_zero_one_matrix(raw)
+            rows = [rows[center] for center in range(len(rows))]
+        else:
+            return None
+        validate_selected_pattern(rows)
+        return rows
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_pattern_payload(payload: Any) -> tuple[str, Pattern]:
+    """Extract ``(name, selected_rows)`` from a known repo JSON shape."""
+
+    if isinstance(payload, dict):
+        name = str(payload.get("pattern") or payload.get("pattern_name") or payload.get("name") or "json_pattern")
+        for key in ("selected_rows", "S", "rows"):
+            rows = _rows_from_candidate(payload.get(key))
+            if rows is not None:
+                return name, rows
+        if "motif" in payload:
+            motif_name, rows = extract_pattern_payload(payload["motif"])
+            if name != "json_pattern":
+                return f"{name}:{motif_name}", rows
+            return motif_name, rows
+
+    rows = _rows_from_candidate(payload)
+    if rows is not None:
+        return "json_pattern", rows
+
+    raise ValueError("could not find a selected-witness pattern in JSON payload")
+
+
+def load_pattern_json(path: Path) -> tuple[str, Pattern]:
+    """Load selected rows from a JSON file."""
+
+    return extract_pattern_payload(json.loads(path.read_text(encoding="utf-8")))

--- a/src/erdos97/stuck_motif_search.py
+++ b/src/erdos97/stuck_motif_search.py
@@ -1,0 +1,314 @@
+"""Bounded adversarial stuck-motif search.
+
+This module asks an SMT solver for fixed selected-witness systems with a
+prescribed stuck subset, then runs the repo's exact necessary filters on each
+model.  A found motif is an incidence/search object only; it is not a geometric
+realization certificate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Sequence
+
+from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
+from erdos97.stuck_sets import (
+    find_minimal_stuck_sets,
+    forward_ear_order,
+    greedy_peeling_run,
+    pattern_filter_snapshot,
+    result_to_json,
+    validate_selected_pattern,
+)
+
+Pattern = list[list[int]]
+
+
+@dataclass(frozen=True)
+class MotifSearchConfig:
+    n: int
+    stuck_size: int
+    max_models: int = 100
+    solver_seed: int = 0
+    variable_prefix: str = "x"
+    radius_node_limit: int = 100_000
+    require_all_rows_cover: bool = True
+    require_adjacent_overlap: bool = True
+    require_crossing: bool = True
+    require_no_odd_cycle: bool = True
+    require_radius_pass: bool = True
+    require_fragile_cover: bool = True
+    require_no_forward_ear_order: bool = False
+    fragile_cover_max_size: int | None = None
+
+
+@dataclass(frozen=True)
+class MotifSearchResult:
+    config: MotifSearchConfig
+    status: str
+    models_checked: int
+    rejection_counts: dict[str, int]
+    motif: dict[str, object] | None
+    rejected_examples: list[dict[str, object]]
+
+
+def _z3():
+    try:
+        import z3  # type: ignore
+    except Exception as exc:  # pragma: no cover - depends on optional dev dep
+        raise RuntimeError("z3-solver is required for stuck motif search") from exc
+    return z3
+
+
+def _validate_config(config: MotifSearchConfig) -> None:
+    if config.n < 5:
+        raise ValueError(f"n must be at least 5, got {config.n}")
+    if config.stuck_size < 4:
+        raise ValueError(f"stuck_size must be at least 4, got {config.stuck_size}")
+    if config.stuck_size > config.n:
+        raise ValueError("stuck_size cannot exceed n")
+    if config.max_models <= 0:
+        raise ValueError("max_models must be positive")
+    if config.radius_node_limit <= 0:
+        raise ValueError("radius_node_limit must be positive")
+
+
+def _model_to_rows(model, variables: Sequence[Sequence[object]]) -> Pattern:
+    z3 = _z3()
+    rows: Pattern = []
+    for row in variables:
+        rows.append(
+            [
+                int(label)
+                for label, variable in enumerate(row)
+                if z3.is_true(model.evaluate(variable, model_completion=True))
+            ]
+        )
+    return rows
+
+
+def _block_model(solver, variables: Sequence[Sequence[object]], rows: Pattern) -> None:
+    z3 = _z3()
+    differences = []
+    row_sets = [set(row) for row in rows]
+    for center, row in enumerate(variables):
+        for label, variable in enumerate(row):
+            value = label in row_sets[center]
+            differences.append(variable != z3.BoolVal(value))
+    solver.add(z3.Or(differences))
+
+
+def _candidate_rejection(
+    rows: Pattern,
+    snapshot: dict[str, object],
+    config: MotifSearchConfig,
+) -> str | None:
+    if not snapshot["row_pair_cap_ok"]:
+        return "row_pair_cap"
+    if not snapshot["column_pair_cap_ok"]:
+        return "column_pair_cap"
+    if config.require_all_rows_cover and not snapshot["all_rows_cover_vertices"]:
+        return "all_rows_cover"
+    if config.require_adjacent_overlap and snapshot["adjacent_two_overlap_violations"]:
+        return "adjacent_two_overlap"
+    if config.require_crossing and snapshot["crossing_bisector_violations"]:
+        return "crossing_bisector"
+    if (
+        config.require_no_odd_cycle
+        and snapshot["odd_forced_perpendicular_cycle_length"] is not None
+    ):
+        return "odd_forced_perpendicular_cycle"
+
+    radius = snapshot["radius_propagation"]
+    if config.require_radius_pass and radius["obstructed"] is not False:
+        return "radius_propagation"
+
+    fragile = snapshot["fragile_cover"]["cover_stats"]
+    if config.require_fragile_cover:
+        if fragile["status"] != "SEARCHED":
+            return "fragile_cover_not_searched"
+        if not fragile["cover_exists"]:
+            return "fragile_cover"
+
+    if config.require_no_forward_ear_order and forward_ear_order(rows).exists:
+        return "forward_ear_order"
+
+    validate_selected_pattern(rows)
+    return None
+
+
+def _analysis_payload(
+    name: str,
+    rows: Pattern,
+    snapshot: dict[str, object],
+) -> dict[str, object]:
+    stuck = find_minimal_stuck_sets(rows, max_examples=4)
+    forward = forward_ear_order(rows)
+    greedy = greedy_peeling_run(rows)
+    return result_to_json(name, rows, stuck, forward, greedy_result=greedy, filters=snapshot)
+
+
+def mine_stuck_motif(config: MotifSearchConfig) -> MotifSearchResult:
+    """Return the first solver model surviving the configured filters."""
+
+    _validate_config(config)
+    z3 = _z3()
+    n = config.n
+    stuck_vertices = list(range(config.stuck_size))
+    prefix = config.variable_prefix
+    X = [[z3.Bool(f"{prefix}_{i}_{j}") for j in range(n)] for i in range(n)]
+    solver = z3.Solver()
+    solver.set("random_seed", int(config.solver_seed))
+
+    for i in range(n):
+        solver.add(z3.Not(X[i][i]))
+        solver.add(z3.PbEq([(X[i][j], 1) for j in range(n)], 4))
+
+    for a in range(n):
+        for b in range(a + 1, n):
+            solver.add(z3.PbLe([(z3.And(X[a][j], X[b][j]), 1) for j in range(n)], 2))
+            solver.add(z3.PbLe([(z3.And(X[i][a], X[i][b]), 1) for i in range(n)], 2))
+
+    if config.require_all_rows_cover:
+        for target in range(n):
+            solver.add(z3.PbGe([(X[i][target], 1) for i in range(n)], 1))
+
+    natural_order = list(range(n))
+    if config.require_adjacent_overlap:
+        for i in range(n):
+            j = (i + 1) % n
+            solver.add(z3.PbLe([(z3.And(X[i][a], X[j][a]), 1) for a in range(n)], 1))
+
+    if config.require_crossing:
+        for i in range(n):
+            for j in range(i + 1, n):
+                source = normalize_chord(i, j)
+                possible_targets = [a for a in range(n) if a not in source]
+                for a_idx, a in enumerate(possible_targets):
+                    for b in possible_targets[a_idx + 1 :]:
+                        target = normalize_chord(a, b)
+                        if not chords_cross_in_order(source, target, natural_order):
+                            solver.add(
+                                z3.Not(
+                                    z3.And(
+                                        X[i][a],
+                                        X[j][a],
+                                        X[i][b],
+                                        X[j][b],
+                                    )
+                                )
+                            )
+
+    if config.require_no_forward_ear_order:
+        for seed in combinations(range(n), 3):
+            outside = [vertex for vertex in range(n) if vertex not in seed]
+            solver.add(
+                z3.Or(
+                    [
+                        z3.PbLe([(X[vertex][target], 1) for target in seed], 2)
+                        for vertex in outside
+                    ]
+                )
+            )
+
+    for center in stuck_vertices:
+        solver.add(z3.PbLe([(X[center][j], 1) for j in stuck_vertices], 2))
+
+    checked = 0
+    rejection_counts: dict[str, int] = {}
+    rejected_examples: list[dict[str, object]] = []
+    while checked < config.max_models:
+        check = solver.check()
+        if check != z3.sat:
+            status = "UNSAT" if checked == 0 else "EXHAUSTED"
+            return MotifSearchResult(
+                config=config,
+                status=status,
+                models_checked=checked,
+                rejection_counts=rejection_counts,
+                motif=None,
+                rejected_examples=rejected_examples,
+            )
+
+        rows = _model_to_rows(solver.model(), X)
+        checked += 1
+        snapshot = pattern_filter_snapshot(
+            rows,
+            radius_node_limit=config.radius_node_limit,
+            fragile_cover_max_size=config.fragile_cover_max_size,
+            fragile_cover_max_examples=0,
+        )
+        reason = _candidate_rejection(rows, snapshot, config)
+        if reason is None:
+            motif = _analysis_payload(f"mined_n{n}_stuck{config.stuck_size}", rows, snapshot)
+            motif["motif_search"] = {
+                "stuck_vertices_forced": stuck_vertices,
+                "models_checked": checked,
+                "filters_required": filters_required_to_json(config),
+            }
+            return MotifSearchResult(
+                config=config,
+                status="FOUND",
+                models_checked=checked,
+                rejection_counts=rejection_counts,
+                motif=motif,
+                rejected_examples=rejected_examples,
+            )
+
+        rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
+        if len(rejected_examples) < 5:
+            rejected_examples.append(
+                {
+                    "reason": reason,
+                    "rows": rows,
+                }
+            )
+        _block_model(solver, X, rows)
+
+    return MotifSearchResult(
+        config=config,
+        status="MODEL_LIMIT",
+        models_checked=checked,
+        rejection_counts=rejection_counts,
+        motif=None,
+        rejected_examples=rejected_examples,
+    )
+
+
+def filters_required_to_json(config: MotifSearchConfig) -> dict[str, object]:
+    return {
+        "require_all_rows_cover": config.require_all_rows_cover,
+        "require_adjacent_overlap": config.require_adjacent_overlap,
+        "require_crossing": config.require_crossing,
+        "require_no_odd_cycle": config.require_no_odd_cycle,
+        "require_radius_pass": config.require_radius_pass,
+        "require_fragile_cover": config.require_fragile_cover,
+        "require_no_forward_ear_order": config.require_no_forward_ear_order,
+        "fragile_cover_max_size": config.fragile_cover_max_size,
+        "solver_seed": config.solver_seed,
+    }
+
+
+def search_result_to_json(result: MotifSearchResult) -> dict[str, object]:
+    config = result.config
+    return {
+        "type": "bounded_stuck_motif_search",
+        "status": result.status,
+        "n": config.n,
+        "stuck_size": config.stuck_size,
+        "fixed_stuck_vertices": list(range(config.stuck_size)),
+        "models_checked": result.models_checked,
+        "max_models": config.max_models,
+        "solver_seed": config.solver_seed,
+        "rejection_counts": result.rejection_counts,
+        "rejected_examples": result.rejected_examples,
+        "filters_required": filters_required_to_json(config),
+        "motif": result.motif,
+        "semantics": (
+            "Bounded SMT search with the stuck subset fixed to labels "
+            "0..stuck_size-1. FOUND gives an incidence motif surviving the "
+            "configured necessary filters; it is not a Euclidean realization "
+            "certificate and does not settle Erdos Problem #97."
+        ),
+    }

--- a/src/erdos97/stuck_motif_sweep.py
+++ b/src/erdos97/stuck_motif_sweep.py
@@ -1,0 +1,176 @@
+"""Sweep bounded stuck-motif searches over small parameter grids."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+from erdos97.search import PatternInfo, result_to_json as geometry_result_to_json, search_pattern
+from erdos97.stuck_motif_search import (
+    MotifSearchConfig,
+    mine_stuck_motif,
+    search_result_to_json as motif_result_to_json,
+)
+
+
+@dataclass(frozen=True)
+class SweepConfig:
+    n_values: Sequence[int]
+    stuck_sizes: Sequence[int]
+    max_models: int = 100
+    solver_seed: int = 0
+    require_no_forward_ear_order: bool = False
+    radius_node_limit: int = 100_000
+    fragile_cover_max_size: int | None = None
+    run_geometry: bool = False
+    geometry_optimizer: Literal["trf", "slsqp"] = "trf"
+    geometry_mode: Literal["polar", "direct", "support"] = "polar"
+    geometry_restarts: int = 3
+    geometry_max_nfev: int = 300
+    geometry_margin: float = 1e-3
+    geometry_seed: int = 0
+
+
+def _geometry_summary(
+    motif: dict[str, object],
+    config: SweepConfig,
+) -> dict[str, object]:
+    rows = motif.get("selected_rows")
+    if not isinstance(rows, list):
+        return {
+            "status": "SKIPPED_NO_SELECTED_ROWS",
+            "success": False,
+        }
+
+    pattern = PatternInfo(
+        name=str(motif["pattern"]),
+        n=int(motif["n"]),
+        S=[[int(label) for label in row] for row in rows],
+        family="mined",
+        formula="stuck motif sweep",
+        notes="numerical smoke search only",
+    )
+    try:
+        result = search_pattern(
+            pattern,
+            mode=config.geometry_mode,
+            restarts=config.geometry_restarts,
+            seed=config.geometry_seed,
+            max_nfev=config.geometry_max_nfev,
+            optimizer=config.geometry_optimizer,
+            margin=config.geometry_margin,
+        )
+    except RuntimeError as exc:
+        return {
+            "status": "OPTIMIZER_FAILED",
+            "success": False,
+            "message": str(exc),
+            "interpretation": (
+                "Numerical optimizer failure is not an exact obstruction or a "
+                "counterexample."
+            ),
+        }
+
+    data = geometry_result_to_json(result)
+    return {
+        "status": "RAN",
+        "success": bool(data["success"]),
+        "mode": data["mode"],
+        "loss": data["loss"],
+        "eq_rms": data["eq_rms"],
+        "max_spread": data["max_spread"],
+        "convexity_margin": data["convexity_margin"],
+        "min_edge_length": data["min_edge_length"],
+        "min_pair_distance": data["min_pair_distance"],
+        "elapsed_sec": data["elapsed_sec"],
+        "interpretation": "NUMERICAL_EVIDENCE only.",
+    }
+
+
+def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
+    """Run a bounded stuck-motif sweep and return JSON-ready data."""
+
+    items: list[dict[str, object]] = []
+    for item_index, (n, stuck_size) in enumerate(
+        (int(n), int(stuck_size))
+        for n in config.n_values
+        for stuck_size in config.stuck_sizes
+    ):
+        result = mine_stuck_motif(
+            MotifSearchConfig(
+                n=n,
+                stuck_size=stuck_size,
+                max_models=config.max_models,
+                solver_seed=config.solver_seed,
+                variable_prefix=f"sweep_{item_index}_{n}_{stuck_size}_{config.solver_seed}",
+                radius_node_limit=config.radius_node_limit,
+                require_no_forward_ear_order=config.require_no_forward_ear_order,
+                fragile_cover_max_size=config.fragile_cover_max_size,
+            )
+        )
+        payload = motif_result_to_json(result)
+        motif = payload.get("motif")
+        geometry = None
+        if config.run_geometry and isinstance(motif, dict):
+            geometry = _geometry_summary(motif, config)
+        items.append(
+            {
+                "n": int(n),
+                "stuck_size": int(stuck_size),
+                "status": payload["status"],
+                "models_checked": payload["models_checked"],
+                "rejection_counts": payload["rejection_counts"],
+                "motif_pattern": motif.get("pattern") if isinstance(motif, dict) else None,
+                "motif_forward_ear_order": (
+                    motif["forward_ear_order"]["exists"] if isinstance(motif, dict) else None
+                ),
+                "motif_minimal_stuck_size": (
+                    motif["stuck_search"]["minimal_size"] if isinstance(motif, dict) else None
+                ),
+                "radius_status": (
+                    motif["filters"]["radius_propagation"]["status"]
+                    if isinstance(motif, dict)
+                    else None
+                ),
+                "geometry": geometry,
+                "motif": motif,
+            }
+        )
+
+    return {
+        "type": "bounded_stuck_motif_sweep",
+        "config": {
+            "n_values": [int(n) for n in config.n_values],
+            "stuck_sizes": [int(size) for size in config.stuck_sizes],
+            "max_models": config.max_models,
+            "solver_seed": config.solver_seed,
+            "require_no_forward_ear_order": config.require_no_forward_ear_order,
+            "run_geometry": config.run_geometry,
+            "geometry_optimizer": config.geometry_optimizer,
+            "geometry_mode": config.geometry_mode,
+            "geometry_restarts": config.geometry_restarts,
+            "geometry_max_nfev": config.geometry_max_nfev,
+            "geometry_margin": config.geometry_margin,
+            "geometry_seed": config.geometry_seed,
+        },
+        "items": items,
+        "summary": {
+            "total": len(items),
+            "found": sum(1 for item in items if item["status"] == "FOUND"),
+            "unique_found_cyclic_dihedral_fingerprints": len(
+                {
+                    item["motif"]["fingerprint"]["cyclic_dihedral_sha256"]
+                    for item in items
+                    if isinstance(item.get("motif"), dict)
+                }
+            ),
+            "exhausted": sum(1 for item in items if item["status"] == "EXHAUSTED"),
+            "model_limit": sum(1 for item in items if item["status"] == "MODEL_LIMIT"),
+            "unsat": sum(1 for item in items if item["status"] == "UNSAT"),
+        },
+        "semantics": (
+            "Bounded search diagnostics only. FOUND motifs are fixed-selection "
+            "incidence targets surviving configured necessary filters, not "
+            "Euclidean realization certificates."
+        ),
+    }

--- a/src/erdos97/stuck_sets.py
+++ b/src/erdos97/stuck_sets.py
@@ -1,0 +1,753 @@
+"""Fixed-selection stuck-set analysis for the bridge/peeling program.
+
+The checks here are combinatorial.  They analyze a chosen selected-witness
+system ``S_i`` and do not claim geometric realizability, a general proof, or a
+counterexample to Erdos Problem #97.
+
+Two notions are intentionally kept separate:
+
+* a forward ear order from a three-vertex seed, where each added vertex has
+  three selected witnesses already present;
+* the stronger fixed-row Key Peeling property, whose obstruction is a subset
+  ``U`` with no vertex of ``U`` seeing three selected witnesses inside ``U``.
+
+The second notion is the stuck-set miner's target.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable, Sequence
+
+from erdos97.fragile_hypergraph import (
+    check_fragile_hypergraph,
+    check_to_json,
+    covering_subsets,
+)
+from erdos97.incidence_filters import (
+    adjacent_two_overlap_violations,
+    crossing_bisector_violations,
+    odd_forced_perpendicular_cycle,
+    phi_map,
+)
+from erdos97.min_radius_filter import (
+    consecutive_witness_pairs,
+    minimum_radius_order_obstruction,
+    selected_pair_sources,
+)
+from erdos97.motif_fingerprint import pattern_profile
+
+Pattern = Sequence[Sequence[int]]
+
+
+@dataclass(frozen=True)
+class StuckRow:
+    center: int
+    internal_witnesses: list[int]
+    outside_witnesses: list[int]
+    internal_count: int
+
+
+@dataclass(frozen=True)
+class StuckSet:
+    vertices: list[int]
+    rows: list[StuckRow]
+
+
+@dataclass(frozen=True)
+class StuckSearchResult:
+    n: int
+    threshold: int
+    searched_from_size: int
+    searched_up_to_size: int
+    search_complete: bool
+    minimal_size: int | None
+    total_at_minimal_size: int
+    examples: list[StuckSet]
+
+    @property
+    def found(self) -> bool:
+        return self.minimal_size is not None
+
+    @property
+    def key_peeling_ok(self) -> bool | None:
+        if self.found:
+            return False
+        if self.search_complete and self.searched_from_size <= self.threshold + 1:
+            return True
+        return None
+
+
+@dataclass(frozen=True)
+class ForwardEarOrderResult:
+    exists: bool
+    seed: list[int] | None
+    order: list[int] | None
+    largest_closure_size: int
+    largest_closure_seed: list[int] | None
+    largest_closure: list[int]
+
+
+@dataclass(frozen=True)
+class GreedyPeelingResult:
+    """One deterministic reverse-peeling run from the full vertex set."""
+
+    success: bool
+    removed_order: list[int]
+    terminal_vertices: list[int]
+    terminal_stuck_set: StuckSet | None
+
+
+@dataclass(frozen=True)
+class RadiusChoice:
+    center: int
+    consecutive_pair: tuple[int, int]
+    smaller_centers: list[int]
+
+
+@dataclass(frozen=True)
+class RadiusPropagationResult:
+    n: int
+    order: list[int]
+    status: str
+    obstructed: bool | None
+    explored_nodes: int
+    node_limit: int
+    acyclic_choice: list[RadiusChoice] | None
+    choices_by_center: list[list[RadiusChoice]]
+
+
+def validate_selected_pattern(S: Pattern) -> None:
+    """Validate the fixed selected-witness contract."""
+
+    n = len(S)
+    if n < 4:
+        raise ValueError(f"pattern must have at least four rows, got {n}")
+    for center, row in enumerate(S):
+        if len(row) != 4:
+            raise ValueError(f"row {center} has length {len(row)}, expected 4")
+        if len(set(row)) != 4:
+            raise ValueError(f"row {center} has repeated witnesses: {list(row)}")
+        if center in row:
+            raise ValueError(f"row {center} contains its own center")
+        for label in row:
+            if label < 0 or label >= n:
+                raise ValueError(f"row {center} contains out-of-range label {label}")
+
+
+def rows_to_masks(S: Pattern) -> list[int]:
+    """Return one bit mask of selected witnesses per row."""
+
+    validate_selected_pattern(S)
+    masks: list[int] = []
+    for row in S:
+        mask = 0
+        for label in row:
+            mask |= 1 << int(label)
+        masks.append(mask)
+    return masks
+
+
+def mask_from_vertices(vertices: Iterable[int]) -> int:
+    mask = 0
+    for vertex in vertices:
+        mask |= 1 << int(vertex)
+    return mask
+
+
+def vertices_from_mask(mask: int, n: int) -> list[int]:
+    return [vertex for vertex in range(n) if mask & (1 << vertex)]
+
+
+def internal_witness_count(S: Pattern, subset: Iterable[int], center: int) -> int:
+    """Return ``|S_center cap subset|`` for a fixed selected row."""
+
+    masks = rows_to_masks(S)
+    return (masks[center] & mask_from_vertices(subset)).bit_count()
+
+
+def peelable_vertices(S: Pattern, subset: Iterable[int], threshold: int = 3) -> list[int]:
+    """Return vertices in ``subset`` with at least ``threshold`` internal witnesses."""
+
+    if threshold < 0:
+        raise ValueError("threshold must be nonnegative")
+    masks = rows_to_masks(S)
+    subset_mask = mask_from_vertices(subset)
+    n = len(S)
+    return [
+        vertex
+        for vertex in range(n)
+        if subset_mask & (1 << vertex)
+        and (masks[vertex] & subset_mask).bit_count() >= threshold
+    ]
+
+
+def is_stuck_subset(S: Pattern, subset: Iterable[int], threshold: int = 3) -> bool:
+    """Return True iff ``subset`` is a fixed-row stuck set."""
+
+    subset_vertices = list(subset)
+    if len(subset_vertices) < threshold + 1:
+        return False
+    return not peelable_vertices(S, subset_vertices, threshold=threshold)
+
+
+def describe_stuck_set(S: Pattern, subset: Iterable[int]) -> StuckSet:
+    """Return row-level diagnostics for a stuck subset."""
+
+    validate_selected_pattern(S)
+    subset_vertices = sorted(int(v) for v in subset)
+    subset_mask = mask_from_vertices(subset_vertices)
+    rows: list[StuckRow] = []
+    for center in subset_vertices:
+        internal = sorted(label for label in S[center] if subset_mask & (1 << label))
+        outside = sorted(label for label in S[center] if not subset_mask & (1 << label))
+        rows.append(
+            StuckRow(
+                center=int(center),
+                internal_witnesses=[int(label) for label in internal],
+                outside_witnesses=[int(label) for label in outside],
+                internal_count=len(internal),
+            )
+        )
+    return StuckSet(vertices=subset_vertices, rows=rows)
+
+
+def find_minimal_stuck_sets(
+    S: Pattern,
+    min_size: int | None = None,
+    max_size: int | None = None,
+    max_examples: int = 8,
+    threshold: int = 3,
+) -> StuckSearchResult:
+    """Find cardinality-minimal fixed-row stuck sets.
+
+    The search is exhaustive through ``max_size``.  If ``max_size`` is at least
+    ``n``, a no-stuck result certifies the fixed-row Key Peeling property for
+    this selected-witness system.
+    """
+
+    validate_selected_pattern(S)
+    if max_examples < 0:
+        raise ValueError("max_examples must be nonnegative")
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+
+    n = len(S)
+    if min_size is None:
+        min_size = threshold + 1
+    if max_size is None:
+        max_size = n
+    min_size = max(min_size, threshold + 1)
+    max_size = min(max_size, n)
+    if max_size < min_size:
+        raise ValueError(f"max_size must be at least min_size={min_size}, got {max_size}")
+
+    masks = rows_to_masks(S)
+    all_vertices = range(n)
+    for size in range(min_size, max_size + 1):
+        examples: list[StuckSet] = []
+        total = 0
+        for subset in combinations(all_vertices, size):
+            subset_mask = mask_from_vertices(subset)
+            if all((masks[center] & subset_mask).bit_count() < threshold for center in subset):
+                total += 1
+                if len(examples) < max_examples:
+                    examples.append(describe_stuck_set(S, subset))
+        if total:
+            return StuckSearchResult(
+                n=n,
+                threshold=threshold,
+                searched_from_size=min_size,
+                searched_up_to_size=size,
+                search_complete=size == n,
+                minimal_size=size,
+                total_at_minimal_size=total,
+                examples=examples,
+            )
+
+    return StuckSearchResult(
+        n=n,
+        threshold=threshold,
+        searched_from_size=min_size,
+        searched_up_to_size=max_size,
+        search_complete=max_size == n,
+        minimal_size=None,
+        total_at_minimal_size=0,
+        examples=[],
+    )
+
+
+def forward_ear_order(S: Pattern, threshold: int = 3) -> ForwardEarOrderResult:
+    """Search for a forward ear order from a three-vertex seed."""
+
+    validate_selected_pattern(S)
+    n = len(S)
+    masks = rows_to_masks(S)
+    best_seed: tuple[int, ...] | None = None
+    best_closure_mask = 0
+    best_order: list[int] = []
+
+    for seed in combinations(range(n), threshold):
+        closure_mask = mask_from_vertices(seed)
+        order = list(seed)
+        changed = True
+        while changed:
+            changed = False
+            for vertex in range(n):
+                if closure_mask & (1 << vertex):
+                    continue
+                if (masks[vertex] & closure_mask).bit_count() >= threshold:
+                    closure_mask |= 1 << vertex
+                    order.append(vertex)
+                    changed = True
+        if closure_mask.bit_count() > best_closure_mask.bit_count():
+            best_seed = seed
+            best_closure_mask = closure_mask
+            best_order = order
+        if closure_mask.bit_count() == n:
+            return ForwardEarOrderResult(
+                exists=True,
+                seed=list(seed),
+                order=order,
+                largest_closure_size=n,
+                largest_closure_seed=list(seed),
+                largest_closure=vertices_from_mask(closure_mask, n),
+            )
+
+    return ForwardEarOrderResult(
+        exists=False,
+        seed=None,
+        order=None,
+        largest_closure_size=best_closure_mask.bit_count(),
+        largest_closure_seed=list(best_seed) if best_seed is not None else None,
+        largest_closure=vertices_from_mask(best_closure_mask, n),
+    )
+
+
+def greedy_peeling_run(S: Pattern, threshold: int = 3) -> GreedyPeelingResult:
+    """Run a deterministic reverse-peeling pass from the full set.
+
+    At each step, remove a currently peelable vertex with largest internal
+    selected-witness count, breaking ties by smallest label.  The result is a
+    diagnostic motif, not a completeness proof over all possible peel orders.
+    """
+
+    validate_selected_pattern(S)
+    n = len(S)
+    masks = rows_to_masks(S)
+    remaining_mask = (1 << n) - 1
+    removed: list[int] = []
+
+    while remaining_mask.bit_count() > threshold:
+        candidates: list[tuple[int, int]] = []
+        for vertex in range(n):
+            if remaining_mask & (1 << vertex):
+                internal_count = (masks[vertex] & remaining_mask).bit_count()
+                if internal_count >= threshold:
+                    candidates.append((vertex, internal_count))
+        if not candidates:
+            break
+        vertex, _ = min(candidates, key=lambda item: (-item[1], item[0]))
+        remaining_mask &= ~(1 << vertex)
+        removed.append(vertex)
+
+    terminal = vertices_from_mask(remaining_mask, n)
+    success = len(terminal) <= threshold
+    return GreedyPeelingResult(
+        success=success,
+        removed_order=removed,
+        terminal_vertices=terminal,
+        terminal_stuck_set=None if success else describe_stuck_set(S, terminal),
+    )
+
+
+def short_chord_radius_choices(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+) -> list[list[RadiusChoice]]:
+    """Return all possible short-chord inequality choices for each row.
+
+    If the consecutive witness pair ``{a,b}`` is the short pair for center
+    ``i`` and one endpoint selects the other, then that endpoint's selected
+    radius is strictly smaller than ``r_i``.
+    """
+
+    validate_selected_pattern(S)
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    choices_by_center: list[list[RadiusChoice]] = []
+    for center in range(n):
+        choices: list[RadiusChoice] = []
+        for pair in consecutive_witness_pairs(order, center, S[center]):
+            sources = selected_pair_sources(S, *pair)
+            choices.append(
+                RadiusChoice(
+                    center=center,
+                    consecutive_pair=pair,
+                    smaller_centers=[int(source) for source in sources],
+                )
+            )
+        choices_by_center.append(choices)
+    return choices_by_center
+
+
+def _reaches(adjacency: list[set[int]], start: int, target: int) -> bool:
+    if start == target:
+        return True
+    seen = {start}
+    stack = [start]
+    while stack:
+        cur = stack.pop()
+        for nxt in adjacency[cur]:
+            if nxt == target:
+                return True
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return False
+
+
+def _choice_json(choice: RadiusChoice) -> dict[str, object]:
+    return {
+        "center": choice.center,
+        "consecutive_pair": [choice.consecutive_pair[0], choice.consecutive_pair[1]],
+        "smaller_centers": choice.smaller_centers,
+    }
+
+
+def radius_propagation_obstruction(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    node_limit: int = 100_000,
+) -> RadiusPropagationResult:
+    """Search for an acyclic assignment of short-chord radius inequalities.
+
+    A strict directed cycle among selected radii is impossible.  The filter is
+    obstructed only if every possible choice of one short consecutive pair per
+    row forces such a cycle.  If an acyclic choice is found, the pattern merely
+    passes this necessary filter.
+    """
+
+    validate_selected_pattern(S)
+    if node_limit <= 0:
+        raise ValueError("node_limit must be positive")
+
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    choices_by_center = short_chord_radius_choices(S, order=order)
+    row_order = sorted(
+        range(n),
+        key=lambda center: (
+            min(len(choice.smaller_centers) for choice in choices_by_center[center]),
+            len(choices_by_center[center]),
+            center,
+        ),
+    )
+    sorted_choices = {
+        center: sorted(
+            choices_by_center[center],
+            key=lambda choice: (len(choice.smaller_centers), choice.consecutive_pair),
+        )
+        for center in range(n)
+    }
+
+    adjacency: list[set[int]] = [set() for _ in range(n)]
+    selected: list[RadiusChoice] = []
+    explored = 0
+    hit_limit = False
+
+    def search(depth: int) -> bool:
+        nonlocal explored, hit_limit
+        explored += 1
+        if explored > node_limit:
+            hit_limit = True
+            return False
+        if depth == len(row_order):
+            return True
+
+        center = row_order[depth]
+        for choice in sorted_choices[center]:
+            added: list[tuple[int, int]] = []
+            creates_cycle = False
+            for smaller in choice.smaller_centers:
+                if smaller == center or _reaches(adjacency, smaller, center):
+                    creates_cycle = True
+                    break
+                if smaller not in adjacency[center]:
+                    adjacency[center].add(smaller)
+                    added.append((center, smaller))
+            if creates_cycle:
+                for source, target in added:
+                    adjacency[source].remove(target)
+                continue
+            selected.append(choice)
+            if search(depth + 1):
+                return True
+            selected.pop()
+            for source, target in added:
+                adjacency[source].remove(target)
+        return False
+
+    found_acyclic = search(0)
+    if found_acyclic:
+        status = "PASS_ACYCLIC_CHOICE"
+        obstructed: bool | None = False
+        acyclic_choice: list[RadiusChoice] | None = list(selected)
+    elif hit_limit:
+        status = "UNKNOWN_NODE_LIMIT"
+        obstructed = None
+        acyclic_choice = None
+    else:
+        status = "RADIUS_CYCLE_OBSTRUCTED"
+        obstructed = True
+        acyclic_choice = None
+
+    return RadiusPropagationResult(
+        n=n,
+        order=order,
+        status=status,
+        obstructed=obstructed,
+        explored_nodes=explored,
+        node_limit=node_limit,
+        acyclic_choice=acyclic_choice,
+        choices_by_center=choices_by_center,
+    )
+
+
+def radius_result_to_json(result: RadiusPropagationResult) -> dict[str, object]:
+    """Return a JSON-serializable radius propagation result."""
+
+    return {
+        "type": "radius_propagation_short_chord_result",
+        "n": result.n,
+        "order": result.order,
+        "status": result.status,
+        "obstructed": result.obstructed,
+        "explored_nodes": result.explored_nodes,
+        "node_limit": result.node_limit,
+        "acyclic_choice": (
+            None
+            if result.acyclic_choice is None
+            else [_choice_json(choice) for choice in result.acyclic_choice]
+        ),
+        "choices_by_center": [
+            [_choice_json(choice) for choice in choices]
+            for choices in result.choices_by_center
+        ],
+        "interpretation": (
+            "Exact fixed-order necessary filter. PASS means there exists a "
+            "choice of short witness gaps whose implied strict radius "
+            "inequalities are acyclic; it is not evidence of realizability."
+        ),
+    }
+
+
+def fragile_cover_snapshot(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    max_cover_size: int | None = None,
+    max_examples: int = 8,
+    exhaustive_n_limit: int = 20,
+) -> dict[str, object]:
+    """Return incidence-level fragile-cover compatibility diagnostics."""
+
+    validate_selected_pattern(S)
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    rows = {center: list(row) for center, row in enumerate(S)}
+    full_check = check_fragile_hypergraph(n, rows, order=order)
+
+    if max_cover_size is None and n > exhaustive_n_limit:
+        cover_stats: dict[str, object] = {
+            "status": "SKIPPED_LARGE_N",
+            "reason": (
+                "exact subset-cover enumeration is skipped by default for "
+                f"n>{exhaustive_n_limit}; pass a max cover size to search a window"
+            ),
+        }
+    else:
+        cover_stats = {
+            "status": "SEARCHED",
+            **covering_subsets(
+                n,
+                rows,
+                max_examples=max_examples,
+                max_size=max_cover_size,
+            ),
+        }
+
+    return {
+        "type": "fragile_cover_incidence_snapshot",
+        "semantics": (
+            "Incidence-level only, assuming any selected row may be declared "
+            "fragile. This does not certify unique exact four-cohorts."
+        ),
+        "all_rows_fragile_hypergraph_check": check_to_json(full_check),
+        "cover_stats": cover_stats,
+    }
+
+
+def column_pair_cap_violations(S: Pattern) -> list[dict[str, object]]:
+    """Return witness-pair codegree violations of the at-most-two cap."""
+
+    validate_selected_pattern(S)
+    n = len(S)
+    violations: list[dict[str, object]] = []
+    for a, b in combinations(range(n), 2):
+        centers = [center for center, row in enumerate(S) if a in row and b in row]
+        if len(centers) > 2:
+            violations.append({"pair": [a, b], "centers": centers, "count": len(centers)})
+    return violations
+
+
+def pattern_filter_snapshot(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    radius_node_limit: int = 100_000,
+    fragile_cover_max_size: int | None = None,
+    fragile_cover_max_examples: int = 2,
+) -> dict[str, object]:
+    """Return cheap exact-filter diagnostics for the full fixed pattern."""
+
+    validate_selected_pattern(S)
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+
+    row_pair_violations: list[dict[str, object]] = []
+    max_row_intersection = 0
+    for left, right in combinations(range(n), 2):
+        inter = sorted(set(S[left]) & set(S[right]))
+        max_row_intersection = max(max_row_intersection, len(inter))
+        if len(inter) > 2:
+            row_pair_violations.append(
+                {"centers": [left, right], "intersection": inter, "count": len(inter)}
+            )
+
+    column_violations = column_pair_cap_violations(S)
+    odd_cycle = odd_forced_perpendicular_cycle(S)
+    adjacent = adjacent_two_overlap_violations(S, order)
+    crossing = crossing_bisector_violations(S, order)
+    min_radius = minimum_radius_order_obstruction(S, order=order)
+    radius = radius_propagation_obstruction(S, order=order, node_limit=radius_node_limit)
+    covered = sorted({label for row in S for label in row})
+
+    return {
+        "row_size_ok": all(len(row) == 4 and len(set(row)) == 4 for row in S),
+        "self_exclusion_ok": all(center not in row for center, row in enumerate(S)),
+        "row_pair_cap_ok": not row_pair_violations,
+        "max_row_intersection": max_row_intersection,
+        "row_pair_cap_violations": row_pair_violations,
+        "column_pair_cap_ok": not column_violations,
+        "column_pair_cap_violations": column_violations,
+        "phi_edges": len(phi_map(S)),
+        "odd_forced_perpendicular_cycle_length": len(odd_cycle) if odd_cycle else None,
+        "adjacent_two_overlap_violations": [
+            [[int(a), int(b)] for a, b in pair] for pair in adjacent
+        ],
+        "crossing_bisector_violations": [
+            [[int(a), int(b)] for a, b in pair] for pair in crossing
+        ],
+        "minimum_radius_obstructed_in_order": min_radius.obstructed,
+        "minimum_radius_possible_centers": min_radius.possible_min_centers,
+        "radius_propagation": radius_result_to_json(radius),
+        "fragile_cover": fragile_cover_snapshot(
+            S,
+            order=order,
+            max_cover_size=fragile_cover_max_size,
+            max_examples=fragile_cover_max_examples,
+        ),
+        "all_rows_cover_vertices": covered == list(range(n)),
+        "uncovered_by_all_rows": [vertex for vertex in range(n) if vertex not in covered],
+    }
+
+
+def _json_stuck_row(row: StuckRow) -> dict[str, object]:
+    return {
+        "center": row.center,
+        "internal_witnesses": row.internal_witnesses,
+        "outside_witnesses": row.outside_witnesses,
+        "internal_count": row.internal_count,
+    }
+
+
+def _json_stuck_set(stuck_set: StuckSet) -> dict[str, object]:
+    return {
+        "vertices": stuck_set.vertices,
+        "rows": [_json_stuck_row(row) for row in stuck_set.rows],
+    }
+
+
+def result_to_json(
+    pattern_name: str,
+    S: Pattern,
+    stuck_result: StuckSearchResult,
+    forward_result: ForwardEarOrderResult,
+    greedy_result: GreedyPeelingResult | None = None,
+    filters: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Return a JSON-serializable stuck-set analysis payload."""
+
+    key_status: str
+    if stuck_result.key_peeling_ok is True:
+        key_status = "NO_STUCK_SETS"
+    elif stuck_result.key_peeling_ok is False:
+        key_status = "STUCK_SET_FOUND"
+    else:
+        key_status = "UNKNOWN_TRUNCATED_SEARCH"
+
+    return {
+        "type": "fixed_selection_stuck_set_analysis",
+        "pattern": pattern_name,
+        "n": stuck_result.n,
+        "selected_rows": [[int(label) for label in row] for row in S],
+        "fingerprint": pattern_profile(S),
+        "semantics": (
+            "Fixed selected-witness system only. Stuck sets obstruct the "
+            "strong fixed-row Key Peeling property; they are not geometric "
+            "realization certificates and do not settle Erdos Problem #97."
+        ),
+        "forward_ear_order": {
+            "exists": forward_result.exists,
+            "seed": forward_result.seed,
+            "order": forward_result.order,
+            "largest_closure_size": forward_result.largest_closure_size,
+            "largest_closure_seed": forward_result.largest_closure_seed,
+            "largest_closure": forward_result.largest_closure,
+        },
+        "greedy_reverse_peeling": (
+            None
+            if greedy_result is None
+            else {
+                "success": greedy_result.success,
+                "removed_order": greedy_result.removed_order,
+                "terminal_vertices": greedy_result.terminal_vertices,
+                "terminal_stuck_set": (
+                    None
+                    if greedy_result.terminal_stuck_set is None
+                    else _json_stuck_set(greedy_result.terminal_stuck_set)
+                ),
+                "interpretation": (
+                    "One deterministic peeling run only; failure gives a concrete "
+                    "fixed-selection stuck motif, while success is not a complete "
+                    "no-stuck certificate."
+                ),
+            }
+        ),
+        "key_peeling_status": key_status,
+        "stuck_search": {
+            "searched_from_size": stuck_result.searched_from_size,
+            "searched_up_to_size": stuck_result.searched_up_to_size,
+            "threshold": stuck_result.threshold,
+            "search_complete": stuck_result.search_complete,
+            "minimal_size": stuck_result.minimal_size,
+            "total_at_minimal_size": stuck_result.total_at_minimal_size,
+            "examples": [_json_stuck_set(item) for item in stuck_result.examples],
+        },
+        "filters": filters if filters is not None else pattern_filter_snapshot(S),
+    }

--- a/tests/test_motif_fingerprint.py
+++ b/tests/test_motif_fingerprint.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from erdos97.motif_fingerprint import (
+    cyclic_dihedral_key,
+    pattern_profile,
+    transform_cyclic_dihedral,
+)
+
+
+ROWS = [
+    [1, 2, 4, 5],
+    [0, 2, 4, 5],
+    [0, 1, 4, 5],
+    [0, 1, 4, 5],
+    [0, 1, 2, 3],
+    [0, 1, 2, 3],
+]
+
+
+def test_cyclic_dihedral_key_is_invariant_under_shift_and_reversal() -> None:
+    shifted = transform_cyclic_dihedral(ROWS, shift=2)
+    reversed_rows = transform_cyclic_dihedral(ROWS, shift=1, reverse=True)
+
+    assert cyclic_dihedral_key(shifted) == cyclic_dihedral_key(ROWS)
+    assert cyclic_dihedral_key(reversed_rows) == cyclic_dihedral_key(ROWS)
+
+
+def test_pattern_profile_contains_expected_histograms() -> None:
+    profile = pattern_profile(ROWS)
+
+    assert profile["n"] == 6
+    assert len(profile["cyclic_dihedral_sha256"]) == 64
+    assert profile["cyclic_dihedral_orbit_size"] <= 12
+    assert profile["indegree_histogram"] == {"2": 1, "4": 3, "5": 2}
+    assert profile["reciprocal_edge_pairs"] == 11

--- a/tests/test_pattern_io.py
+++ b/tests/test_pattern_io.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.pattern_io import extract_pattern_payload
+from erdos97.stuck_sets import find_minimal_stuck_sets, forward_ear_order, result_to_json
+
+
+TOY_ROWS = [
+    [1, 2, 4, 5],
+    [0, 2, 4, 5],
+    [0, 1, 4, 5],
+    [0, 1, 4, 5],
+    [0, 1, 2, 3],
+    [0, 1, 2, 3],
+]
+
+
+def test_extract_selected_rows_from_stuck_payload() -> None:
+    payload = result_to_json(
+        "toy",
+        TOY_ROWS,
+        find_minimal_stuck_sets(TOY_ROWS),
+        forward_ear_order(TOY_ROWS),
+    )
+
+    name, rows = extract_pattern_payload(payload)
+
+    assert name == "toy"
+    assert rows == TOY_ROWS
+
+
+def test_extract_selected_rows_from_nested_motif_payload() -> None:
+    payload = {
+        "type": "bounded_stuck_motif_search",
+        "motif": {
+            "pattern": "nested",
+            "selected_rows": TOY_ROWS,
+        },
+    }
+
+    name, rows = extract_pattern_payload(payload)
+
+    assert name == "nested"
+    assert rows == TOY_ROWS
+
+
+def test_extract_selected_rows_from_zero_one_matrix() -> None:
+    matrix = [
+        [1 if label in row else 0 for label in range(len(TOY_ROWS))]
+        for row in TOY_ROWS
+    ]
+
+    name, rows = extract_pattern_payload({"name": "matrix", "rows": matrix})
+
+    assert name == "matrix"
+    assert rows == TOY_ROWS
+
+
+def test_extract_pattern_payload_rejects_missing_rows() -> None:
+    with pytest.raises(ValueError, match="selected-witness pattern"):
+        extract_pattern_payload({"pattern": "empty"})

--- a/tests/test_stuck_motif_search.py
+++ b/tests/test_stuck_motif_search.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.stuck_motif_search import (
+    MotifSearchConfig,
+    mine_stuck_motif,
+    search_result_to_json,
+)
+
+
+def test_mine_stuck_motif_finds_strict_small_model() -> None:
+    result = mine_stuck_motif(MotifSearchConfig(n=9, stuck_size=4, max_models=5))
+    payload = search_result_to_json(result)
+
+    assert result.status == "FOUND"
+    assert result.models_checked == 1
+    assert payload["motif"]["key_peeling_status"] == "STUCK_SET_FOUND"
+    assert payload["motif"]["filters"]["adjacent_two_overlap_violations"] == []
+    assert payload["motif"]["filters"]["crossing_bisector_violations"] == []
+    assert payload["motif"]["filters"]["radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
+    assert payload["motif"]["filters"]["fragile_cover"]["cover_stats"]["cover_exists"] is True
+
+
+def test_mine_stuck_motif_relaxed_model_records_search_contract() -> None:
+    config = MotifSearchConfig(
+        n=8,
+        stuck_size=4,
+        max_models=5,
+        require_adjacent_overlap=False,
+        require_crossing=False,
+        require_no_odd_cycle=False,
+        require_radius_pass=False,
+        require_fragile_cover=False,
+    )
+
+    payload = search_result_to_json(mine_stuck_motif(config))
+
+    assert payload["status"] == "FOUND"
+    assert payload["fixed_stuck_vertices"] == [0, 1, 2, 3]
+    assert payload["filters_required"]["require_crossing"] is False
+    assert payload["motif"]["motif_search"]["stuck_vertices_forced"] == [0, 1, 2, 3]
+
+
+def test_mine_stuck_motif_can_require_no_forward_ear_order() -> None:
+    result = mine_stuck_motif(
+        MotifSearchConfig(
+            n=11,
+            stuck_size=4,
+            max_models=160,
+            variable_prefix="test_no_forward_11",
+            require_no_forward_ear_order=True,
+        )
+    )
+    payload = search_result_to_json(result)
+
+    assert result.status == "FOUND"
+    assert payload["filters_required"]["require_no_forward_ear_order"] is True
+    assert payload["motif"]["forward_ear_order"]["exists"] is False
+
+
+def test_motif_search_rejects_invalid_stuck_size() -> None:
+    with pytest.raises(ValueError, match="stuck_size"):
+        mine_stuck_motif(MotifSearchConfig(n=9, stuck_size=3))

--- a/tests/test_stuck_motif_sweep.py
+++ b/tests/test_stuck_motif_sweep.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from erdos97.stuck_motif_sweep import SweepConfig, sweep_stuck_motifs
+
+
+def test_sweep_finds_motif_in_n9() -> None:
+    payload = sweep_stuck_motifs(
+        SweepConfig(
+            n_values=[9],
+            stuck_sizes=[4],
+            max_models=5,
+            solver_seed=0,
+        )
+    )
+
+    assert payload["summary"]["found"] == 1
+    item = payload["items"][0]
+    assert item["status"] == "FOUND"
+    assert item["radius_status"] == "PASS_ACYCLIC_CHOICE"
+
+
+def test_sweep_can_run_geometry_smoke() -> None:
+    payload = sweep_stuck_motifs(
+        SweepConfig(
+            n_values=[9],
+            stuck_sizes=[4],
+            max_models=5,
+            run_geometry=True,
+            geometry_restarts=1,
+            geometry_max_nfev=50,
+            geometry_optimizer="trf",
+        )
+    )
+
+    item = payload["items"][0]
+    assert item["status"] == "FOUND"
+    assert item["geometry"]["status"] == "RAN"
+    assert "eq_rms" in item["geometry"]

--- a/tests/test_stuck_sets.py
+++ b/tests/test_stuck_sets.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from erdos97.search import built_in_patterns
+from erdos97.stuck_sets import (
+    fragile_cover_snapshot,
+    find_minimal_stuck_sets,
+    forward_ear_order,
+    greedy_peeling_run,
+    is_stuck_subset,
+    pattern_filter_snapshot,
+    radius_propagation_obstruction,
+    result_to_json,
+)
+
+
+def test_detects_fixed_selection_stuck_subset() -> None:
+    S = [
+        [1, 2, 4, 5],
+        [0, 2, 4, 5],
+        [0, 1, 4, 5],
+        [0, 1, 4, 5],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+    ]
+
+    assert is_stuck_subset(S, [0, 1, 2, 3])
+
+    result = find_minimal_stuck_sets(S)
+
+    assert result.found
+    assert result.key_peeling_ok is False
+    assert result.minimal_size == 4
+    assert result.examples[0].vertices == [0, 1, 2, 3]
+    assert [row.internal_count for row in result.examples[0].rows] == [2, 2, 2, 2]
+
+
+def test_forward_ear_order_is_reported_separately_from_stuck_sets() -> None:
+    S = [
+        [1, 2, 4, 5],
+        [0, 2, 4, 5],
+        [0, 1, 4, 5],
+        [0, 1, 4, 5],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+    ]
+
+    forward = forward_ear_order(S)
+    stuck = find_minimal_stuck_sets(S)
+    greedy = greedy_peeling_run(S)
+    payload = result_to_json("toy", S, stuck, forward, greedy_result=greedy)
+
+    assert forward.exists
+    assert forward.seed == [0, 1, 2]
+    assert payload["forward_ear_order"]["exists"] is True
+    assert len(payload["fingerprint"]["cyclic_dihedral_sha256"]) == 64
+    assert payload["key_peeling_status"] == "STUCK_SET_FOUND"
+    assert payload["greedy_reverse_peeling"]["terminal_vertices"] == [2, 3, 4, 5]
+
+
+def test_all_other_pentagon_has_complete_no_stuck_certificate() -> None:
+    S = [[j for j in range(5) if j != i] for i in range(5)]
+
+    result = find_minimal_stuck_sets(S)
+    shifted = find_minimal_stuck_sets(S, min_size=5)
+    radius = radius_propagation_obstruction(S)
+    fragile = fragile_cover_snapshot(S)
+
+    assert not result.found
+    assert result.search_complete
+    assert result.key_peeling_ok is True
+    assert shifted.search_complete
+    assert shifted.key_peeling_ok is None
+    assert radius.obstructed is True
+    assert fragile["cover_stats"]["cover_exists"] is True
+    assert fragile["cover_stats"]["min_cover_size"] == 2
+
+
+def test_c19_skew_snapshot_records_sparse_filter_wall() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+
+    filters = pattern_filter_snapshot(pattern.S)
+    stuck = find_minimal_stuck_sets(pattern.S, min_size=8, max_size=8, max_examples=1)
+    greedy = greedy_peeling_run(pattern.S)
+
+    assert filters["row_pair_cap_ok"] is True
+    assert filters["column_pair_cap_ok"] is True
+    assert filters["phi_edges"] == 0
+    assert filters["odd_forced_perpendicular_cycle_length"] is None
+    assert filters["minimum_radius_obstructed_in_order"] is False
+    assert filters["radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
+    assert filters["fragile_cover"]["cover_stats"]["cover_exists"] is True
+    assert stuck.minimal_size == 8
+    assert stuck.examples[0].vertices == list(range(8))
+    assert not greedy.success
+    assert len(greedy.terminal_vertices) >= 4


### PR DESCRIPTION
## Summary
- add fixed-selection stuck-set analysis, radius propagation diagnostics, fragile-cover snapshots, and cyclic-dihedral motif fingerprints
- add bounded SMT motif mining, sweep, JSON-loader, and numerical smoke-search scripts for adversarial bridge/peeling targets
- document the stuck-set miner and link it from the README/docs index

## Verification
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python scripts/analyze_n8_fragile_covers.py --check`
- `python scripts/sweep_stuck_motifs.py --n-range 9 12 --stuck-sizes 4 --max-models 220 --solver-seed 0 --require-no-forward-ear-order --json`

## Research Status
No general proof and no counterexample are claimed. The new outputs are fixed-selection incidence diagnostics and numerical smoke tests only.