### PR TITLE
[codex] Record stuck frontier snapshot

### DIFF
--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -19,6 +19,8 @@ separately.[^comp] The Sidon entries are incidence-pattern leads, not
 geometric realizability claims. The minimum-radius short-chord filter is also
 recorded as a weak exact necessary test, but it does not kill `C19_skew` in
 natural order or as currently implemented; see `docs/minimum-radius-filter.md`.
+For the first fixed-selection stuck-set/radius/fragile-cover pass over this
+frontier, see `docs/stuck-frontier-snapshot.md`.
 
 ## Natural-order killed / abstract-order status patterns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ put detailed reconciliation in the canonical synthesis.
   by itself.
 - [`stuck-set-miner.md`](stuck-set-miner.md): fixed-selection stuck-set mining
   for the bridge/peeling program.
+- [`stuck-frontier-snapshot.md`](stuck-frontier-snapshot.md): first stuck-set,
+  radius-propagation, and fragile-cover pass over the live sparse frontier.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible

--- a/docs/stuck-frontier-snapshot.md
+++ b/docs/stuck-frontier-snapshot.md
@@ -1,0 +1,88 @@
+# Stuck-Frontier Snapshot
+
+Status: exact fixed-selection diagnostics plus bounded search windows. No
+general proof and no counterexample are claimed.
+
+This note records the first pass of the fixed-selection stuck-set miner on the
+currently live sparse frontier:
+
+- `C19_skew`
+- `C13_sidon_1_2_4_10`
+- `C25_sidon_2_5_9_14`
+- `C29_sidon_1_3_7_15`
+
+The results are for the fixed selected rows in the natural label order. They do
+not settle abstract cyclic-order realizability, and they do not certify any
+Euclidean geometry.
+
+## Commands
+
+The compact table below is reproducible from:
+
+```bash
+python scripts/find_minimal_stuck_sets.py \
+  --pattern C19_skew \
+  --min-set-size 4 \
+  --max-set-size 12 \
+  --max-examples 2 \
+  --json
+
+python scripts/find_minimal_stuck_sets.py \
+  --pattern C13_sidon_1_2_4_10 \
+  --min-set-size 4 \
+  --max-set-size 12 \
+  --max-examples 2 \
+  --json
+
+python scripts/find_minimal_stuck_sets.py \
+  --pattern C25_sidon_2_5_9_14 \
+  --min-set-size 4 \
+  --max-set-size 4 \
+  --max-examples 1 \
+  --fragile-cover-max-size 7 \
+  --json
+
+python scripts/find_minimal_stuck_sets.py \
+  --pattern C29_sidon_1_3_7_15 \
+  --min-set-size 4 \
+  --max-set-size 4 \
+  --max-examples 1 \
+  --fragile-cover-max-size 8 \
+  --json
+```
+
+The `C25` and `C29` fragile-cover searches stop at the first nontrivial window:
+size `7` for `n=25`, and size `8` for `n=29`. These windows are incomplete
+cover searches; `NONE<=k` means no incidence cover was found through size `k`,
+not that no cover exists.
+
+## Snapshot
+
+| Pattern | n | max row overlap | `phi` edges | forward ear order | minimal fixed-row stuck size | stuck sets at min size | greedy terminal size | radius propagation | fragile-cover window |
+|---|---:|---:|---:|---|---:|---:|---:|---|---|
+| `C19_skew` | 19 | 1 | 0 | no | 4 | 3800 | 9 | `PASS_ACYCLIC_CHOICE` | min cover size 7, complete |
+| `C13_sidon_1_2_4_10` | 13 | 1 | 0 | no | 4 | 663 | 7 | `PASS_ACYCLIC_CHOICE` | min cover size 4, complete |
+| `C25_sidon_2_5_9_14` | 25 | 1 | 0 | no | 4 | 12550 | 9 | `PASS_ACYCLIC_CHOICE` | `NONE<=7`, incomplete |
+| `C29_sidon_1_3_7_15` | 29 | 1 | 0 | no | 4 | 23635 | 7 | `PASS_ACYCLIC_CHOICE` | `NONE<=8`, incomplete |
+
+## Reading
+
+The frontier patterns are already adversarial to a naive fixed-row bridge:
+none admits a forward ear order from a three-vertex seed, and all have many
+size-4 stuck subsets. This is not by itself geometric evidence; it says these
+selected rows are poor candidates for a simple peeling proof unless geometry
+forces a different witness choice.
+
+The current radius-propagation filter does not kill any of the four patterns.
+In these sparse-overlap cases there are many consecutive witness pairs whose
+selected-pair source list is empty, so the disjunctive strict-radius graph can
+choose acyclic local gaps.
+
+The fragile-cover snapshot is also not decisive. `C13` and `C19` have complete
+incidence-level covers of sizes `4` and `7`, respectively. `C25` and `C29` have
+no cover through the first nontrivial windows checked, but those are bounded
+negative results only.
+
+The useful conclusion is narrower: the live sparse/Sidon patterns remain a
+good target for a new sparse-overlap exact filter. The current two-overlap,
+minimum-radius, and radius-propagation filters do not see them.

--- a/docs/stuck-set-miner.md
+++ b/docs/stuck-set-miner.md
@@ -32,6 +32,9 @@ The tool separately reports:
 If the search starts above size `4`, or stops before `n` without finding a
 stuck set, the status is `UNKNOWN_TRUNCATED_SEARCH`.
 
+For the first run on the current live sparse/Sidon frontier, see
+`docs/stuck-frontier-snapshot.md`.
+
 ## Usage
 
 Analyze one built-in pattern:
@@ -210,4 +213,7 @@ vertices. Actual fragility requires metric uniqueness of an exact four-cohort,
 which this tool does not certify.
 
 For `n > 20`, exact cover-subset enumeration is skipped by default. Use
-`--fragile-cover-max-size` to search a bounded cover-size window.
+`--fragile-cover-max-size` to search a bounded cover-size window. A CLI summary
+label such as `NONE<=7` means no incidence cover was found through size `7`;
+it is not a complete no-cover certificate unless the JSON field
+`search_complete` is true.

--- a/scripts/find_minimal_stuck_sets.py
+++ b/scripts/find_minimal_stuck_sets.py
@@ -90,6 +90,22 @@ def assert_expectations(rows: list[dict[str, object]], assert_stuck: bool, asser
             raise AssertionError(f"{row['pattern']}: expected no stuck sets, got {status}")
 
 
+def fragile_cover_label(fragile_stats: dict[str, object]) -> str:
+    """Return a compact cover label without overstating truncated searches."""
+
+    if fragile_stats["status"] == "SKIPPED_LARGE_N":
+        return "SKIP"
+    if fragile_stats["cover_exists"]:
+        min_size = fragile_stats["min_cover_size"]
+        return f"YES({min_size})" if min_size is not None else "YES"
+    if fragile_stats.get("search_complete"):
+        return "NO"
+    searched = fragile_stats.get("searched_up_to_size")
+    if searched is not None:
+        return f"NONE<={searched}"
+    return "UNKNOWN"
+
+
 def print_summary(rows: list[dict[str, object]]) -> None:
     print(
         "pattern  n  forward-ear  greedy-terminal  key-peeling  radius  "
@@ -102,10 +118,7 @@ def print_summary(rows: list[dict[str, object]]) -> None:
         filters = row["filters"]
         radius = filters["radius_propagation"]["status"]
         fragile_stats = filters["fragile_cover"]["cover_stats"]
-        if fragile_stats["status"] == "SKIPPED_LARGE_N":
-            fragile = "SKIP"
-        else:
-            fragile = "YES" if fragile_stats["cover_exists"] else "NO"
+        fragile = fragile_cover_label(fragile_stats)
         search = row["stuck_search"]
         min_size = search["minimal_size"]
         min_text = "-" if min_size is None else str(min_size)

--- a/src/erdos97/stuck_motif_search.py
+++ b/src/erdos97/stuck_motif_search.py
@@ -128,8 +128,10 @@ def _candidate_rejection(
     if config.require_fragile_cover:
         if fragile["status"] != "SEARCHED":
             return "fragile_cover_not_searched"
-        if not fragile["cover_exists"]:
+        if not fragile["cover_exists"] and fragile.get("search_complete"):
             return "fragile_cover"
+        if not fragile["cover_exists"]:
+            return "fragile_cover_not_found_in_window"
 
     if config.require_no_forward_ear_order and forward_ear_order(rows).exists:
         return "forward_ear_order"

--- a/tests/test_find_minimal_stuck_sets_cli.py
+++ b/tests/test_find_minimal_stuck_sets_cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from scripts.find_minimal_stuck_sets import fragile_cover_label
+
+
+def test_fragile_cover_label_marks_truncated_empty_window() -> None:
+    assert (
+        fragile_cover_label(
+            {
+                "status": "SEARCHED",
+                "cover_exists": False,
+                "search_complete": False,
+                "searched_up_to_size": 7,
+                "min_cover_size": None,
+            }
+        )
+        == "NONE<=7"
+    )
+
+
+def test_fragile_cover_label_marks_complete_empty_search() -> None:
+    assert (
+        fragile_cover_label(
+            {
+                "status": "SEARCHED",
+                "cover_exists": False,
+                "search_complete": True,
+                "searched_up_to_size": 8,
+                "min_cover_size": None,
+            }
+        )
+        == "NO"
+    )

--- a/tests/test_stuck_sets.py
+++ b/tests/test_stuck_sets.py
@@ -93,3 +93,15 @@ def test_c19_skew_snapshot_records_sparse_filter_wall() -> None:
     assert stuck.examples[0].vertices == list(range(8))
     assert not greedy.success
     assert len(greedy.terminal_vertices) >= 4
+
+
+def test_large_sidon_fragile_cover_window_is_truncated() -> None:
+    pattern = built_in_patterns()["C25_sidon_2_5_9_14"]
+
+    fragile = fragile_cover_snapshot(pattern.S, max_cover_size=7)
+    stats = fragile["cover_stats"]
+
+    assert stats["status"] == "SEARCHED"
+    assert stats["cover_exists"] is False
+    assert stats["search_complete"] is False
+    assert stats["searched_up_to_size"] == 7


### PR DESCRIPTION
## Summary
- record the first fixed-selection stuck/radius/fragile-cover pass over `C19_skew` and the Sidon frontier patterns
- make the stuck-set CLI distinguish truncated fragile-cover windows (`NONE<=k`) from complete no-cover results
- label bounded fragile-cover window rejections separately in motif mining diagnostics

## Verification
- `python scripts/find_minimal_stuck_sets.py --pattern C25_sidon_2_5_9_14 --min-set-size 4 --max-set-size 4 --max-examples 1 --fragile-cover-max-size 7`
- `python scripts/find_minimal_stuck_sets.py --pattern C29_sidon_1_3_7_15 --min-set-size 4 --max-set-size 4 --max-examples 1 --fragile-cover-max-size 8`
- `python -m pytest tests/test_find_minimal_stuck_sets_cli.py tests/test_stuck_sets.py tests/test_stuck_motif_search.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Research Status
No general proof and no counterexample are claimed. The snapshot is fixed-selection diagnostic evidence only; bounded fragile-cover windows are explicitly incomplete unless `search_complete` is true.