### PR TITLE
[codex] Add sparse frontier radius diagnostic

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`minimum-radius-filter.md`](minimum-radius-filter.md): weak exact
   minimum-radius short-chord filter; records why it does not kill `C19_skew`
   by itself.
+- [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
+  fixed-order witness-pair source diagnostic explaining the sparse/Sidon
+  radius-propagation blind spot.
 - [`stuck-set-miner.md`](stuck-set-miner.md): fixed-selection stuck-set mining
   for the bridge/peeling program.
 - [`stuck-frontier-snapshot.md`](stuck-frontier-snapshot.md): first stuck-set,

--- a/docs/minimum-radius-filter.md
+++ b/docs/minimum-radius-filter.md
@@ -78,6 +78,11 @@ Thus the minimum-radius idea does not by itself kill `C19_skew`. It should be
 recorded as a weak exact filter, not promoted as a central route unless it is
 combined with additional cyclic-order or radius-inequality propagation.
 
+For the sparse/Sidon frontier, the issue is sharper: in the natural order every
+frontier row has at least one uncovered consecutive witness pair, so the current
+radius-propagation filter can choose an all-empty set of short gaps and force no
+strict radius inequalities. See `docs/sparse-frontier-diagnostic.md`.
+
 ## Reproducible check
 
 ```bash

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -1,0 +1,66 @@
+# Sparse-Frontier Diagnostic
+
+Status: exact fixed-order incidence diagnostic. No general proof and no
+counterexample are claimed.
+
+This note explains why the current minimum-radius and radius-propagation
+filters do not see the live sparse/Sidon frontier in natural cyclic order.
+
+For a row `i` and a witness pair `{a,b}` inside `S_i`, call the pair
+**covered** if `b in S_a` or `a in S_b`. A covered short witness gap would force
+a strict radius inequality. An uncovered short gap forces no such inequality.
+
+The diagnostic counts covered and uncovered witness pairs, with special focus
+on the three consecutive witness pairs in the supplied cyclic order.
+
+## Reproducible command
+
+```bash
+python scripts/analyze_sparse_frontier.py --frontier --assert-empty-choice
+```
+
+This prints a compact table and asserts that every live frontier row has at
+least one uncovered consecutive witness pair in the natural order.
+
+## Snapshot
+
+| Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | empty radius choice |
+|---|---:|---|---|---:|---:|---|
+| `C19_skew` | 19 | `{0: 76, 1: 38}` | `{0: 38, 1: 19}` | 19/19 | 0 | yes |
+| `C13_sidon_1_2_4_10` | 13 | `{0: 26, 1: 52}` | `{0: 13, 1: 26}` | 13/13 | 0 | yes |
+| `C25_sidon_2_5_9_14` | 25 | `{0: 100, 1: 50}` | `{0: 50, 1: 25}` | 25/25 | 0 | yes |
+| `C29_sidon_1_3_7_15` | 29 | `{0: 145, 1: 29}` | `{0: 87}` | 29/29 | 0 | yes |
+
+Here `{0: 76, 1: 38}` means 76 row-local witness pairs have no endpoint source,
+and 38 have exactly one endpoint source. No pair in this table has two endpoint
+sources.
+
+## Interpretation
+
+The radius-propagation filter chooses one possible short consecutive witness
+pair per row. If every row has an uncovered consecutive pair, it can choose
+those pairs and force no strict radius inequalities at all. That is the
+`empty radius choice` column.
+
+Thus the natural-order pass is not merely a subtle acyclic inequality graph.
+For these frontier patterns, the current filter can pass vacuously: it has a
+choice with no radius edges.
+
+This is useful negative information. A sparse-overlap proof route needs a new
+mechanism that does not rely on two-overlap `phi` edges or on short gaps whose
+endpoints select each other.
+
+## Example
+
+For `C19_skew`, row `0` has:
+
+```text
+S_0 = {5, 9, 11, 16}
+consecutive witness pairs in natural order:
+  {5,9}:  uncovered
+  {9,11}: uncovered
+  {11,16}: covered by source 11
+```
+
+So row `0` alone already survives the minimum-radius row test. The diagnostic
+checks that every row has the same kind of escape.

--- a/docs/stuck-frontier-snapshot.md
+++ b/docs/stuck-frontier-snapshot.md
@@ -76,7 +76,10 @@ forces a different witness choice.
 The current radius-propagation filter does not kill any of the four patterns.
 In these sparse-overlap cases there are many consecutive witness pairs whose
 selected-pair source list is empty, so the disjunctive strict-radius graph can
-choose acyclic local gaps.
+choose acyclic local gaps. The sharper witness-pair source diagnostic in
+`docs/sparse-frontier-diagnostic.md` records that, in natural order, every
+frontier row has an uncovered consecutive pair and the radius-propagation
+filter admits an all-empty radius choice.
 
 The fragile-cover snapshot is also not decisive. `C13` and `C19` have complete
 incidence-level covers of sizes `4` and `7`, respectively. `C25` and `C29` have

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Analyze sparse witness-pair sources for selected-witness patterns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.search import built_in_patterns  # noqa: E402
+from erdos97.sparse_frontier import sparse_frontier_summary  # noqa: E402
+
+FRONTIER_PATTERNS = (
+    "C19_skew",
+    "C13_sidon_1_2_4_10",
+    "C25_sidon_2_5_9_14",
+    "C29_sidon_1_3_7_15",
+)
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
+
+
+def print_summary(rows: list[dict[str, object]]) -> None:
+    print(
+        "pattern  n  all-pair-sources  consecutive-sources  "
+        "uncovered-consecutive-rows  order-free-blocked  empty-radius-choice"
+    )
+    for row in rows:
+        n = int(row["n"])
+        uncovered = len(row["rows_with_uncovered_consecutive_pair"])
+        blocked = len(row["order_free_blocked_rows"])
+        print(
+            f"{row['pattern']}  {n}  "
+            f"{row['all_pair_source_count_histogram']}  "
+            f"{row['consecutive_pair_source_count_histogram']}  "
+            f"{uncovered}/{n}  {blocked}  "
+            f"{row['trivial_empty_radius_choice_exists']}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pattern", help="built-in pattern name")
+    target.add_argument(
+        "--frontier",
+        action="store_true",
+        help="analyze C19 plus the Sidon frontier patterns",
+    )
+    target.add_argument(
+        "--all-built-ins",
+        action="store_true",
+        help="analyze every built-in pattern",
+    )
+    parser.add_argument(
+        "--order",
+        type=parse_order,
+        help="comma-separated cyclic order; defaults to natural order",
+    )
+    parser.add_argument(
+        "--max-row-examples",
+        type=int,
+        default=4,
+        help="number of row examples to include in JSON",
+    )
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-empty-choice", action="store_true")
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern:
+        if args.pattern not in patterns:
+            raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+        names = [args.pattern]
+    elif args.frontier:
+        names = list(FRONTIER_PATTERNS)
+    else:
+        names = list(patterns)
+
+    rows = [
+        sparse_frontier_summary(
+            name,
+            patterns[name].S,
+            order=args.order,
+            max_row_examples=args.max_row_examples,
+        )
+        for name in names
+    ]
+
+    if args.assert_empty_choice:
+        for row in rows:
+            if not row["trivial_empty_radius_choice_exists"]:
+                raise AssertionError(f"{row['pattern']}: expected empty radius choice")
+
+    payload: dict[str, object] | list[dict[str, object]]
+    payload = rows[0] if len(rows) == 1 else rows
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(rows)
+        if args.assert_empty_choice:
+            print("OK: empty radius choice verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -1,0 +1,181 @@
+"""Sparse-overlap diagnostics for selected-witness patterns.
+
+These routines explain when the minimum-radius and radius-propagation filters
+have no leverage because each row has an uncovered consecutive witness pair in
+the supplied cyclic order.  They are exact incidence/order diagnostics, not
+geometric realization tests.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Sequence
+
+from erdos97.min_radius_filter import (
+    consecutive_witness_pairs,
+    row_is_order_free_blocked,
+    selected_pair_sources,
+)
+from erdos97.stuck_sets import validate_selected_pattern
+
+Pair = tuple[int, int]
+Pattern = Sequence[Sequence[int]]
+
+
+@dataclass(frozen=True)
+class PairSourceProfile:
+    pair: Pair
+    sources: list[int]
+
+
+@dataclass(frozen=True)
+class SparseRowProfile:
+    center: int
+    all_pairs: list[PairSourceProfile]
+    consecutive_pairs: list[PairSourceProfile]
+    order_free_blocked: bool
+
+    @property
+    def uncovered_pairs(self) -> list[PairSourceProfile]:
+        return [item for item in self.all_pairs if not item.sources]
+
+    @property
+    def uncovered_consecutive_pairs(self) -> list[PairSourceProfile]:
+        return [item for item in self.consecutive_pairs if not item.sources]
+
+
+def _source_profile(S: Pattern, pair: Pair) -> PairSourceProfile:
+    return PairSourceProfile(pair=pair, sources=selected_pair_sources(S, *pair))
+
+
+def _histogram(values: Sequence[int]) -> dict[str, int]:
+    return {str(key): count for key, count in sorted(Counter(values).items())}
+
+
+def sparse_row_profiles(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+) -> list[SparseRowProfile]:
+    """Return source-count diagnostics for all witness pairs in every row."""
+
+    validate_selected_pattern(S)
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    profiles: list[SparseRowProfile] = []
+    for center, row in enumerate(S):
+        all_pairs = [
+            _source_profile(S, (min(a, b), max(a, b)))
+            for a, b in combinations(row, 2)
+        ]
+        consecutive = [
+            _source_profile(S, pair)
+            for pair in consecutive_witness_pairs(order, center, row)
+        ]
+        profiles.append(
+            SparseRowProfile(
+                center=center,
+                all_pairs=all_pairs,
+                consecutive_pairs=consecutive,
+                order_free_blocked=row_is_order_free_blocked(S, center),
+            )
+        )
+    return profiles
+
+
+def _pair_json(profile: PairSourceProfile) -> dict[str, object]:
+    return {
+        "pair": [profile.pair[0], profile.pair[1]],
+        "sources": profile.sources,
+        "source_count": len(profile.sources),
+    }
+
+
+def sparse_frontier_summary(
+    pattern_name: str,
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    max_row_examples: int = 4,
+) -> dict[str, object]:
+    """Return a JSON-ready sparse-frontier diagnostic summary."""
+
+    if max_row_examples < 0:
+        raise ValueError("max_row_examples must be nonnegative")
+    validate_selected_pattern(S)
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    profiles = sparse_row_profiles(S, order=order)
+    all_source_counts = [
+        len(pair.sources) for row in profiles for pair in row.all_pairs
+    ]
+    consecutive_source_counts = [
+        len(pair.sources) for row in profiles for pair in row.consecutive_pairs
+    ]
+    rows_with_uncovered_pair = [
+        row.center for row in profiles if row.uncovered_pairs
+    ]
+    rows_with_uncovered_consecutive = [
+        row.center for row in profiles if row.uncovered_consecutive_pairs
+    ]
+    order_free_blocked = [
+        row.center for row in profiles if row.order_free_blocked
+    ]
+    empty_choice = [
+        _pair_json(row.uncovered_consecutive_pairs[0])
+        for row in profiles
+        if row.uncovered_consecutive_pairs
+    ]
+    row_examples = []
+    for row in profiles[:max_row_examples]:
+        row_examples.append(
+            {
+                "center": row.center,
+                "all_pairs": [_pair_json(pair) for pair in row.all_pairs],
+                "consecutive_pairs": [
+                    _pair_json(pair) for pair in row.consecutive_pairs
+                ],
+                "uncovered_pair_count": len(row.uncovered_pairs),
+                "uncovered_consecutive_pair_count": len(
+                    row.uncovered_consecutive_pairs
+                ),
+                "order_free_blocked": row.order_free_blocked,
+            }
+        )
+
+    all_rows_have_empty_consecutive_choice = (
+        len(rows_with_uncovered_consecutive) == n
+    )
+    return {
+        "type": "sparse_frontier_pair_source_diagnostic",
+        "pattern": pattern_name,
+        "n": n,
+        "order": order,
+        "all_pair_source_count_histogram": _histogram(all_source_counts),
+        "consecutive_pair_source_count_histogram": _histogram(
+            consecutive_source_counts
+        ),
+        "rows_with_uncovered_pair": rows_with_uncovered_pair,
+        "rows_with_uncovered_consecutive_pair": rows_with_uncovered_consecutive,
+        "order_free_blocked_rows": order_free_blocked,
+        "all_rows_have_uncovered_consecutive_pair": (
+            all_rows_have_empty_consecutive_choice
+        ),
+        "trivial_empty_radius_choice_exists": (
+            all_rows_have_empty_consecutive_choice
+        ),
+        "empty_radius_choice": (
+            empty_choice if all_rows_have_empty_consecutive_choice else None
+        ),
+        "row_examples": row_examples,
+        "semantics": (
+            "Exact fixed-order incidence diagnostic. If every row has an "
+            "uncovered consecutive witness pair, the radius-propagation filter "
+            "can choose those pairs and force no strict radius inequalities. "
+            "This is a blindness certificate for that filter, not evidence of "
+            "geometric realizability."
+        ),
+    }

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from erdos97.search import built_in_patterns
+from erdos97.sparse_frontier import sparse_frontier_summary, sparse_row_profiles
+
+
+FRONTIER_PATTERNS = (
+    "C19_skew",
+    "C13_sidon_1_2_4_10",
+    "C25_sidon_2_5_9_14",
+    "C29_sidon_1_3_7_15",
+)
+
+
+def test_frontier_patterns_have_trivial_empty_radius_choice() -> None:
+    patterns = built_in_patterns()
+
+    for name in FRONTIER_PATTERNS:
+        summary = sparse_frontier_summary(name, patterns[name].S)
+        assert summary["trivial_empty_radius_choice_exists"] is True
+        assert summary["all_rows_have_uncovered_consecutive_pair"] is True
+        assert summary["order_free_blocked_rows"] == []
+
+
+def test_c13_sidon_all_witness_pairs_have_at_most_one_source() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    summary = sparse_frontier_summary(pattern.name, pattern.S)
+
+    assert summary["all_pair_source_count_histogram"] == {"0": 26, "1": 52}
+    assert summary["consecutive_pair_source_count_histogram"] == {"0": 13, "1": 26}
+
+
+def test_sparse_row_profile_records_uncovered_consecutive_pairs() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+
+    row0 = sparse_row_profiles(pattern.S)[0]
+
+    assert row0.center == 0
+    assert [item.pair for item in row0.consecutive_pairs] == [(5, 9), (9, 11), (11, 16)]
+    assert [item.pair for item in row0.uncovered_consecutive_pairs] == [(5, 9), (9, 11)]


### PR DESCRIPTION
## Summary
- add an exact fixed-order sparse witness-pair source diagnostic for selected-witness patterns
- add `scripts/analyze_sparse_frontier.py` to show when radius propagation has an all-empty short-gap choice
- document why the live sparse/Sidon frontier passes the current radius-propagation filter vacuously in natural order

## Verification
- `python scripts/analyze_sparse_frontier.py --frontier --assert-empty-choice`
- `python scripts/analyze_sparse_frontier.py --all-built-ins`
- `python -m pytest tests/test_sparse_frontier.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Research Status
No general proof and no counterexample are claimed. This is a filter-blindness diagnostic, not a geometric realizability test or obstruction.