### PR TITLE
[codex] Sample empty-gap cyclic orders

### DIFF
--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -22,6 +22,18 @@ python scripts/analyze_sparse_frontier.py --frontier --assert-empty-choice
 This prints a compact table and asserts that every live frontier row has at
 least one uncovered consecutive witness pair in the natural order.
 
+To sample other cyclic orders:
+
+```bash
+python scripts/analyze_sparse_frontier.py \
+  --frontier \
+  --sample-orders 200 \
+  --sample-seed 0
+```
+
+Sampling is not exhaustive; it is a smoke test for whether the natural-order
+empty-gap escape is robust under order changes.
+
 ## Snapshot
 
 | Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | empty radius choice |
@@ -34,6 +46,23 @@ least one uncovered consecutive witness pair in the natural order.
 Here `{0: 76, 1: 38}` means 76 row-local witness pairs have no endpoint source,
 and 38 have exactly one endpoint source. No pair in this table has two endpoint
 sources.
+
+## Order Sampling
+
+With `--sample-orders 200 --sample-seed 0`, including natural order for 201
+checked orders:
+
+| Pattern | orders checked | empty-choice orders | minimum rows with an uncovered consecutive pair | row-count histogram |
+|---|---:|---:|---:|---|
+| `C19_skew` | 201 | 201 | 19 | `{19: 201}` |
+| `C13_sidon_1_2_4_10` | 201 | 25 | 7 | `{7: 4, 8: 6, 9: 23, 10: 52, 11: 52, 12: 39, 13: 25}` |
+| `C25_sidon_2_5_9_14` | 201 | 201 | 25 | `{25: 201}` |
+| `C29_sidon_1_3_7_15` | 201 | 201 | 29 | `{29: 201}` |
+
+This separates `C13` from the larger sparse frontier. The natural order of
+`C13_sidon_1_2_4_10` has an empty radius choice, but many sampled orders do
+not. In contrast, all sampled orders for `C19`, `C25`, and `C29` kept the empty
+choice. This is still sampling only, not an abstract-order theorem.
 
 ## Interpretation
 

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -14,7 +14,10 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.search import built_in_patterns  # noqa: E402
-from erdos97.sparse_frontier import sparse_frontier_summary  # noqa: E402
+from erdos97.sparse_frontier import (  # noqa: E402
+    sample_empty_gap_orders,
+    sparse_frontier_summary,
+)
 
 FRONTIER_PATTERNS = (
     "C19_skew",
@@ -49,6 +52,27 @@ def print_summary(rows: list[dict[str, object]]) -> None:
         )
 
 
+def print_sample_summary(rows: list[dict[str, object]]) -> None:
+    print(
+        "pattern  n  orders  empty-choice  min-uncovered-rows  "
+        "row-count-histogram  natural-empty-choice"
+    )
+    for row in rows:
+        natural = row["natural_order"]
+        natural_empty = (
+            natural["trivial_empty_radius_choice_exists"]
+            if isinstance(natural, dict)
+            else None
+        )
+        print(
+            f"{row['pattern']}  {row['n']}  {row['orders_checked']}  "
+            f"{row['empty_choice_orders']}  "
+            f"{row['min_rows_with_uncovered_consecutive_pair']}  "
+            f"{row['rows_with_uncovered_consecutive_histogram']}  "
+            f"{natural_empty}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     target = parser.add_mutually_exclusive_group(required=True)
@@ -76,6 +100,12 @@ def main() -> int:
     )
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--assert-empty-choice", action="store_true")
+    parser.add_argument(
+        "--sample-orders",
+        type=int,
+        help="sample this many random cyclic orders in addition to natural order",
+    )
+    parser.add_argument("--sample-seed", type=int, default=0)
     args = parser.parse_args()
 
     patterns = built_in_patterns()
@@ -88,19 +118,39 @@ def main() -> int:
     else:
         names = list(patterns)
 
-    rows = [
-        sparse_frontier_summary(
-            name,
-            patterns[name].S,
-            order=args.order,
-            max_row_examples=args.max_row_examples,
-        )
-        for name in names
-    ]
+    if args.sample_orders is not None and args.order is not None:
+        raise SystemExit("--sample-orders cannot be combined with --order")
+
+    if args.sample_orders is None:
+        rows = [
+            sparse_frontier_summary(
+                name,
+                patterns[name].S,
+                order=args.order,
+                max_row_examples=args.max_row_examples,
+            )
+            for name in names
+        ]
+    else:
+        rows = [
+            sample_empty_gap_orders(
+                name,
+                patterns[name].S,
+                random_samples=args.sample_orders,
+                seed=args.sample_seed,
+                include_natural=True,
+                max_examples=args.max_row_examples,
+            )
+            for name in names
+        ]
 
     if args.assert_empty_choice:
         for row in rows:
-            if not row["trivial_empty_radius_choice_exists"]:
+            if args.sample_orders is None:
+                ok = row["trivial_empty_radius_choice_exists"]
+            else:
+                ok = row["empty_choice_orders"] == row["orders_checked"]
+            if not ok:
                 raise AssertionError(f"{row['pattern']}: expected empty radius choice")
 
     payload: dict[str, object] | list[dict[str, object]]
@@ -108,7 +158,10 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print_summary(rows)
+        if args.sample_orders is None:
+            print_summary(rows)
+        else:
+            print_sample_summary(rows)
         if args.assert_empty_choice:
             print("OK: empty radius choice verified")
     return 0

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -8,6 +8,7 @@ geometric realization tests.
 
 from __future__ import annotations
 
+import random
 from collections import Counter
 from dataclasses import dataclass
 from itertools import combinations
@@ -52,6 +53,25 @@ def _source_profile(S: Pattern, pair: Pair) -> PairSourceProfile:
 
 def _histogram(values: Sequence[int]) -> dict[str, int]:
     return {str(key): count for key, count in sorted(Counter(values).items())}
+
+
+def normalize_cyclic_order(order: Sequence[int]) -> list[int]:
+    """Return a rotation/reversal canonical representative of a cyclic order."""
+
+    if not order:
+        raise ValueError("cyclic order must be nonempty")
+    n = len(order)
+    seen = set(order)
+    if seen != set(range(n)):
+        missing = sorted(set(range(n)) - seen)
+        extra = sorted(seen - set(range(n)))
+        raise ValueError(
+            f"cyclic order is not a permutation; missing={missing}, extra={extra}"
+        )
+    pos0 = list(order).index(0)
+    rotated = list(order[pos0:]) + list(order[:pos0])
+    reversed_order = [rotated[0], *reversed(rotated[1:])]
+    return min(rotated, reversed_order)
 
 
 def sparse_row_profiles(
@@ -177,5 +197,105 @@ def sparse_frontier_summary(
             "can choose those pairs and force no strict radius inequalities. "
             "This is a blindness certificate for that filter, not evidence of "
             "geometric realizability."
+        ),
+    }
+
+
+def sample_empty_gap_orders(
+    pattern_name: str,
+    S: Pattern,
+    random_samples: int = 100,
+    seed: int = 0,
+    include_natural: bool = True,
+    max_examples: int = 3,
+) -> dict[str, object]:
+    """Sample cyclic orders and test for all-row uncovered short-gap choices."""
+
+    if random_samples < 0:
+        raise ValueError("random_samples must be nonnegative")
+    if max_examples < 0:
+        raise ValueError("max_examples must be nonnegative")
+    validate_selected_pattern(S)
+    n = len(S)
+    rng = random.Random(seed)
+    orders: list[list[int]] = []
+    seen: set[tuple[int, ...]] = set()
+
+    def add_order(order: Sequence[int]) -> None:
+        normalized = tuple(normalize_cyclic_order(order))
+        if normalized not in seen:
+            seen.add(normalized)
+            orders.append(list(normalized))
+
+    if include_natural:
+        add_order(list(range(n)))
+    attempts = 0
+    max_attempts = max(100, random_samples * 20)
+    while (
+        len(orders) < random_samples + int(include_natural)
+        and attempts < max_attempts
+    ):
+        attempts += 1
+        order = list(range(n))
+        rng.shuffle(order)
+        add_order(order)
+
+    row_counts: list[int] = []
+    empty_choice_orders = 0
+    natural_order_result: dict[str, object] | None = None
+    examples_without_empty_choice: list[dict[str, object]] = []
+    examples_with_empty_choice: list[dict[str, object]] = []
+
+    for order in orders:
+        summary = sparse_frontier_summary(
+            pattern_name,
+            S,
+            order=order,
+            max_row_examples=0,
+        )
+        rows = list(summary["rows_with_uncovered_consecutive_pair"])
+        row_count = len(rows)
+        row_counts.append(row_count)
+        missing = [center for center in range(n) if center not in rows]
+        has_empty_choice = row_count == n
+        if has_empty_choice:
+            empty_choice_orders += 1
+        item = {
+            "order": order,
+            "rows_with_uncovered_consecutive_pair": rows,
+            "rows_without_uncovered_consecutive_pair": missing,
+            "trivial_empty_radius_choice_exists": has_empty_choice,
+        }
+        if order == list(range(n)):
+            natural_order_result = item
+        if has_empty_choice and len(examples_with_empty_choice) < max_examples:
+            examples_with_empty_choice.append(item)
+        if not has_empty_choice and len(examples_without_empty_choice) < max_examples:
+            examples_without_empty_choice.append(item)
+
+    return {
+        "type": "sparse_frontier_empty_gap_order_sample",
+        "pattern": pattern_name,
+        "n": n,
+        "random_samples_requested": random_samples,
+        "seed": seed,
+        "include_natural": include_natural,
+        "orders_checked": len(orders),
+        "unique_orders_generated": len(orders),
+        "empty_choice_orders": empty_choice_orders,
+        "empty_choice_fraction": (
+            empty_choice_orders / len(orders) if orders else None
+        ),
+        "rows_with_uncovered_consecutive_histogram": _histogram(row_counts),
+        "min_rows_with_uncovered_consecutive_pair": (
+            min(row_counts) if row_counts else None
+        ),
+        "natural_order": natural_order_result,
+        "examples_with_empty_choice": examples_with_empty_choice,
+        "examples_without_empty_choice": examples_without_empty_choice,
+        "semantics": (
+            "Random cyclic-order sampling only, quotienting rotation and "
+            "reversal for reporting. Failing to find an order without the "
+            "empty-gap escape is not an exhaustive abstract-order theorem."
         ),
     }

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from erdos97.search import built_in_patterns
-from erdos97.sparse_frontier import sparse_frontier_summary, sparse_row_profiles
+from erdos97.sparse_frontier import (
+    normalize_cyclic_order,
+    sample_empty_gap_orders,
+    sparse_frontier_summary,
+    sparse_row_profiles,
+)
 
 
 FRONTIER_PATTERNS = (
@@ -37,5 +42,50 @@ def test_sparse_row_profile_records_uncovered_consecutive_pairs() -> None:
     row0 = sparse_row_profiles(pattern.S)[0]
 
     assert row0.center == 0
-    assert [item.pair for item in row0.consecutive_pairs] == [(5, 9), (9, 11), (11, 16)]
-    assert [item.pair for item in row0.uncovered_consecutive_pairs] == [(5, 9), (9, 11)]
+    assert [item.pair for item in row0.consecutive_pairs] == [
+        (5, 9),
+        (9, 11),
+        (11, 16),
+    ]
+    assert [item.pair for item in row0.uncovered_consecutive_pairs] == [
+        (5, 9),
+        (9, 11),
+    ]
+
+
+def test_c13_has_sampled_order_without_empty_choice() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+    order = [1, 10, 9, 5, 11, 2, 3, 7, 8, 4, 0, 12, 6]
+
+    summary = sparse_frontier_summary(pattern.name, pattern.S, order=order)
+
+    assert summary["trivial_empty_radius_choice_exists"] is False
+    assert summary["rows_with_uncovered_consecutive_pair"] == [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10,
+        11,
+        12,
+    ]
+
+
+def test_sample_empty_gap_orders_records_counterexamples() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    sample = sample_empty_gap_orders(pattern.name, pattern.S, random_samples=20, seed=0)
+
+    assert sample["orders_checked"] == 21
+    assert sample["empty_choice_orders"] < sample["orders_checked"]
+    assert sample["examples_without_empty_choice"]
+
+
+def test_normalize_cyclic_order_quotients_rotation_and_reversal() -> None:
+    assert normalize_cyclic_order([2, 3, 0, 1]) == [0, 1, 2, 3]
+    assert normalize_cyclic_order([2, 1, 0, 3]) == [0, 1, 2, 3]


### PR DESCRIPTION
## Summary
- extend the sparse-frontier diagnostic with deterministic random cyclic-order sampling
- record that C13's natural-order empty-gap escape is not robust in sampled orders, while C19/C25/C29 kept it for the sampled seed/window
- add tests for cyclic-order normalization, sampled C13 counterorders, and sampler JSON summaries

## Verification
- `python scripts/analyze_sparse_frontier.py --frontier --sample-orders 200 --sample-seed 0`
- `python scripts/analyze_sparse_frontier.py --pattern C13_sidon_1_2_4_10 --sample-orders 20 --sample-seed 0 --json`
- `python -m pytest tests/test_sparse_frontier.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Research Status
No general proof and no counterexample are claimed. The cyclic-order results are random sampling diagnostics only, not abstract-order theorems.