### PR TITLE
[codex] Sample radius propagation over cyclic orders

### DIFF
--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -34,6 +34,19 @@ python scripts/analyze_sparse_frontier.py \
 Sampling is not exhaustive; it is a smoke test for whether the natural-order
 empty-gap escape is robust under order changes.
 
+To additionally run the full radius-propagation filter on each sampled order:
+
+```bash
+python scripts/analyze_sparse_frontier.py \
+  --frontier \
+  --sample-orders 200 \
+  --sample-seed 0 \
+  --sample-radius-propagation
+```
+
+This distinguishes orders with an all-empty short-gap choice from orders that
+still admit an acyclic strict-radius inequality choice.
+
 ## Snapshot
 
 | Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | empty radius choice |
@@ -63,6 +76,20 @@ This separates `C13` from the larger sparse frontier. The natural order of
 `C13_sidon_1_2_4_10` has an empty radius choice, but many sampled orders do
 not. In contrast, all sampled orders for `C19`, `C25`, and `C29` kept the empty
 choice. This is still sampling only, not an abstract-order theorem.
+
+With the same order sample and `--sample-radius-propagation`:
+
+| Pattern | radius status histogram | no-empty-choice radius status histogram | maximum explored nodes |
+|---|---|---|---:|
+| `C19_skew` | `{PASS_ACYCLIC_CHOICE: 201}` | `{}` | 20 |
+| `C13_sidon_1_2_4_10` | `{PASS_ACYCLIC_CHOICE: 201}` | `{PASS_ACYCLIC_CHOICE: 176}` | 14 |
+| `C25_sidon_2_5_9_14` | `{PASS_ACYCLIC_CHOICE: 201}` | `{}` | 26 |
+| `C29_sidon_1_3_7_15` | `{PASS_ACYCLIC_CHOICE: 201}` | `{}` | 30 |
+
+Thus this sampled run found no strict radius-cycle obstruction. In particular,
+the 176 sampled `C13` orders without an all-empty choice still passed by an
+acyclic radius-inequality assignment. This is negative evidence about the
+current radius-propagation filter, not evidence for geometric realizability.
 
 ## Interpretation
 

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -16,6 +16,7 @@ if str(SRC) not in sys.path:
 from erdos97.search import built_in_patterns  # noqa: E402
 from erdos97.sparse_frontier import (  # noqa: E402
     sample_empty_gap_orders,
+    sample_radius_propagation_orders,
     sparse_frontier_summary,
 )
 
@@ -53,10 +54,18 @@ def print_summary(rows: list[dict[str, object]]) -> None:
 
 
 def print_sample_summary(rows: list[dict[str, object]]) -> None:
-    print(
-        "pattern  n  orders  empty-choice  min-uncovered-rows  "
-        "row-count-histogram  natural-empty-choice"
-    )
+    has_radius = bool(rows and "radius_status_histogram" in rows[0])
+    if has_radius:
+        print(
+            "pattern  n  orders  empty-choice  min-uncovered-rows  "
+            "row-count-histogram  radius-status  no-empty-radius-status  "
+            "natural-empty-choice  natural-radius-status"
+        )
+    else:
+        print(
+            "pattern  n  orders  empty-choice  min-uncovered-rows  "
+            "row-count-histogram  natural-empty-choice"
+        )
     for row in rows:
         natural = row["natural_order"]
         natural_empty = (
@@ -64,13 +73,29 @@ def print_sample_summary(rows: list[dict[str, object]]) -> None:
             if isinstance(natural, dict)
             else None
         )
-        print(
-            f"{row['pattern']}  {row['n']}  {row['orders_checked']}  "
-            f"{row['empty_choice_orders']}  "
-            f"{row['min_rows_with_uncovered_consecutive_pair']}  "
-            f"{row['rows_with_uncovered_consecutive_histogram']}  "
-            f"{natural_empty}"
-        )
+        if has_radius:
+            natural_radius = (
+                natural["radius_propagation"]["status"]
+                if isinstance(natural, dict)
+                else None
+            )
+            print(
+                f"{row['pattern']}  {row['n']}  {row['orders_checked']}  "
+                f"{row['empty_choice_orders']}  "
+                f"{row['min_rows_with_uncovered_consecutive_pair']}  "
+                f"{row['rows_with_uncovered_consecutive_histogram']}  "
+                f"{row['radius_status_histogram']}  "
+                f"{row['no_empty_choice_radius_status_histogram']}  "
+                f"{natural_empty}  {natural_radius}"
+            )
+        else:
+            print(
+                f"{row['pattern']}  {row['n']}  {row['orders_checked']}  "
+                f"{row['empty_choice_orders']}  "
+                f"{row['min_rows_with_uncovered_consecutive_pair']}  "
+                f"{row['rows_with_uncovered_consecutive_histogram']}  "
+                f"{natural_empty}"
+            )
 
 
 def main() -> int:
@@ -106,6 +131,17 @@ def main() -> int:
         help="sample this many random cyclic orders in addition to natural order",
     )
     parser.add_argument("--sample-seed", type=int, default=0)
+    parser.add_argument(
+        "--sample-radius-propagation",
+        action="store_true",
+        help="with --sample-orders, run the full radius-propagation filter per order",
+    )
+    parser.add_argument(
+        "--radius-node-limit",
+        type=int,
+        default=100_000,
+        help="node limit for the sampled radius-propagation filter",
+    )
     args = parser.parse_args()
 
     patterns = built_in_patterns()
@@ -120,6 +156,8 @@ def main() -> int:
 
     if args.sample_orders is not None and args.order is not None:
         raise SystemExit("--sample-orders cannot be combined with --order")
+    if args.sample_radius_propagation and args.sample_orders is None:
+        raise SystemExit("--sample-radius-propagation requires --sample-orders")
 
     if args.sample_orders is None:
         rows = [
@@ -128,6 +166,19 @@ def main() -> int:
                 patterns[name].S,
                 order=args.order,
                 max_row_examples=args.max_row_examples,
+            )
+            for name in names
+        ]
+    elif args.sample_radius_propagation:
+        rows = [
+            sample_radius_propagation_orders(
+                name,
+                patterns[name].S,
+                random_samples=args.sample_orders,
+                seed=args.sample_seed,
+                include_natural=True,
+                max_examples=args.max_row_examples,
+                node_limit=args.radius_node_limit,
             )
             for name in names
         ]

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -19,7 +19,11 @@ from erdos97.min_radius_filter import (
     row_is_order_free_blocked,
     selected_pair_sources,
 )
-from erdos97.stuck_sets import validate_selected_pattern
+from erdos97.stuck_sets import (
+    RadiusPropagationResult,
+    radius_propagation_obstruction,
+    validate_selected_pattern,
+)
 
 Pair = tuple[int, int]
 Pattern = Sequence[Sequence[int]]
@@ -53,6 +57,39 @@ def _source_profile(S: Pattern, pair: Pair) -> PairSourceProfile:
 
 def _histogram(values: Sequence[int]) -> dict[str, int]:
     return {str(key): count for key, count in sorted(Counter(values).items())}
+
+
+def _sample_cyclic_orders(
+    n: int,
+    random_samples: int,
+    seed: int,
+    include_natural: bool,
+) -> list[list[int]]:
+    if random_samples < 0:
+        raise ValueError("random_samples must be nonnegative")
+    rng = random.Random(seed)
+    orders: list[list[int]] = []
+    seen: set[tuple[int, ...]] = set()
+
+    def add_order(order: Sequence[int]) -> None:
+        normalized = tuple(normalize_cyclic_order(order))
+        if normalized not in seen:
+            seen.add(normalized)
+            orders.append(list(normalized))
+
+    if include_natural:
+        add_order(list(range(n)))
+    attempts = 0
+    max_attempts = max(100, random_samples * 20)
+    while (
+        len(orders) < random_samples + int(include_natural)
+        and attempts < max_attempts
+    ):
+        attempts += 1
+        order = list(range(n))
+        rng.shuffle(order)
+        add_order(order)
+    return orders
 
 
 def normalize_cyclic_order(order: Sequence[int]) -> list[int]:
@@ -217,28 +254,7 @@ def sample_empty_gap_orders(
         raise ValueError("max_examples must be nonnegative")
     validate_selected_pattern(S)
     n = len(S)
-    rng = random.Random(seed)
-    orders: list[list[int]] = []
-    seen: set[tuple[int, ...]] = set()
-
-    def add_order(order: Sequence[int]) -> None:
-        normalized = tuple(normalize_cyclic_order(order))
-        if normalized not in seen:
-            seen.add(normalized)
-            orders.append(list(normalized))
-
-    if include_natural:
-        add_order(list(range(n)))
-    attempts = 0
-    max_attempts = max(100, random_samples * 20)
-    while (
-        len(orders) < random_samples + int(include_natural)
-        and attempts < max_attempts
-    ):
-        attempts += 1
-        order = list(range(n))
-        rng.shuffle(order)
-        add_order(order)
+    orders = _sample_cyclic_orders(n, random_samples, seed, include_natural)
 
     row_counts: list[int] = []
     empty_choice_orders = 0
@@ -297,5 +313,133 @@ def sample_empty_gap_orders(
             "Random cyclic-order sampling only, quotienting rotation and "
             "reversal for reporting. Failing to find an order without the "
             "empty-gap escape is not an exhaustive abstract-order theorem."
+        ),
+    }
+
+
+def _radius_summary(order_result: RadiusPropagationResult) -> dict[str, object]:
+    acyclic_choice = order_result.acyclic_choice
+    return {
+        "status": order_result.status,
+        "obstructed": order_result.obstructed,
+        "explored_nodes": order_result.explored_nodes,
+        "acyclic_edge_count": (
+            None
+            if acyclic_choice is None
+            else sum(len(choice.smaller_centers) for choice in acyclic_choice)
+        ),
+    }
+
+
+def sample_radius_propagation_orders(
+    pattern_name: str,
+    S: Pattern,
+    random_samples: int = 100,
+    seed: int = 0,
+    include_natural: bool = True,
+    max_examples: int = 3,
+    node_limit: int = 100_000,
+) -> dict[str, object]:
+    """Sample cyclic orders and run the full radius-propagation filter."""
+
+    if random_samples < 0:
+        raise ValueError("random_samples must be nonnegative")
+    if max_examples < 0:
+        raise ValueError("max_examples must be nonnegative")
+    if node_limit <= 0:
+        raise ValueError("node_limit must be positive")
+    validate_selected_pattern(S)
+    n = len(S)
+    orders = _sample_cyclic_orders(n, random_samples, seed, include_natural)
+
+    row_counts: list[int] = []
+    empty_choice_orders = 0
+    status_counts: Counter[str] = Counter()
+    empty_choice_status_counts: Counter[str] = Counter()
+    no_empty_choice_status_counts: Counter[str] = Counter()
+    explored_nodes: list[int] = []
+    natural_order_result: dict[str, object] | None = None
+    examples_without_empty_choice: list[dict[str, object]] = []
+    examples_obstructed_or_unknown: list[dict[str, object]] = []
+
+    for order in orders:
+        summary = sparse_frontier_summary(
+            pattern_name,
+            S,
+            order=order,
+            max_row_examples=0,
+        )
+        rows = list(summary["rows_with_uncovered_consecutive_pair"])
+        row_count = len(rows)
+        row_counts.append(row_count)
+        missing = [center for center in range(n) if center not in rows]
+        has_empty_choice = row_count == n
+        radius = radius_propagation_obstruction(
+            S,
+            order=order,
+            node_limit=node_limit,
+        )
+        status_counts[radius.status] += 1
+        if has_empty_choice:
+            empty_choice_orders += 1
+            empty_choice_status_counts[radius.status] += 1
+        else:
+            no_empty_choice_status_counts[radius.status] += 1
+        explored_nodes.append(radius.explored_nodes)
+        item = {
+            "order": order,
+            "rows_with_uncovered_consecutive_pair": rows,
+            "rows_without_uncovered_consecutive_pair": missing,
+            "trivial_empty_radius_choice_exists": has_empty_choice,
+            "radius_propagation": _radius_summary(radius),
+        }
+        if order == list(range(n)):
+            natural_order_result = item
+        if (
+            not has_empty_choice
+            and len(examples_without_empty_choice) < max_examples
+        ):
+            examples_without_empty_choice.append(item)
+        if (
+            radius.obstructed is not False
+            and len(examples_obstructed_or_unknown) < max_examples
+        ):
+            examples_obstructed_or_unknown.append(item)
+
+    return {
+        "type": "sparse_frontier_radius_order_sample",
+        "pattern": pattern_name,
+        "n": n,
+        "random_samples_requested": random_samples,
+        "seed": seed,
+        "include_natural": include_natural,
+        "orders_checked": len(orders),
+        "unique_orders_generated": len(orders),
+        "node_limit": node_limit,
+        "empty_choice_orders": empty_choice_orders,
+        "empty_choice_fraction": (
+            empty_choice_orders / len(orders) if orders else None
+        ),
+        "rows_with_uncovered_consecutive_histogram": _histogram(row_counts),
+        "min_rows_with_uncovered_consecutive_pair": (
+            min(row_counts) if row_counts else None
+        ),
+        "radius_status_histogram": dict(sorted(status_counts.items())),
+        "empty_choice_radius_status_histogram": dict(
+            sorted(empty_choice_status_counts.items())
+        ),
+        "no_empty_choice_radius_status_histogram": dict(
+            sorted(no_empty_choice_status_counts.items())
+        ),
+        "max_explored_nodes": max(explored_nodes) if explored_nodes else None,
+        "natural_order": natural_order_result,
+        "examples_without_empty_choice": examples_without_empty_choice,
+        "examples_obstructed_or_unknown": examples_obstructed_or_unknown,
+        "semantics": (
+            "Random cyclic-order sampling only. The radius-propagation status "
+            "is an exact fixed-order necessary filter for each sampled order. "
+            "PASS_ACYCLIC_CHOICE is not evidence of geometric realizability; "
+            "it only means that this radius-cycle filter did not obstruct "
+            "that order."
         ),
     }

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -4,6 +4,7 @@ from erdos97.search import built_in_patterns
 from erdos97.sparse_frontier import (
     normalize_cyclic_order,
     sample_empty_gap_orders,
+    sample_radius_propagation_orders,
     sparse_frontier_summary,
     sparse_row_profiles,
 )
@@ -84,6 +85,28 @@ def test_sample_empty_gap_orders_records_counterexamples() -> None:
     assert sample["orders_checked"] == 21
     assert sample["empty_choice_orders"] < sample["orders_checked"]
     assert sample["examples_without_empty_choice"]
+
+
+def test_sample_radius_propagation_orders_distinguishes_empty_gap_failures() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    sample = sample_radius_propagation_orders(
+        pattern.name,
+        pattern.S,
+        random_samples=20,
+        seed=0,
+    )
+
+    assert sample["orders_checked"] == 21
+    assert sample["empty_choice_orders"] == 3
+    assert sample["radius_status_histogram"] == {"PASS_ACYCLIC_CHOICE": 21}
+    assert sample["no_empty_choice_radius_status_histogram"] == {
+        "PASS_ACYCLIC_CHOICE": 18
+    }
+    assert sample["examples_without_empty_choice"]
+    example = sample["examples_without_empty_choice"][0]
+    assert example["trivial_empty_radius_choice_exists"] is False
+    assert example["radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
 
 
 def test_normalize_cyclic_order_quotients_rotation_and_reversal() -> None:


### PR DESCRIPTION
## Summary

- add sampled cyclic-order radius-propagation diagnostics alongside the existing empty-gap sampler
- report radius status histograms, no-empty-choice status histograms, natural-order status, explored-node maxima, and representative no-empty-choice examples
- document the deterministic frontier snapshot showing sampled C13 no-empty orders still pass the strict radius-cycle filter

## Validation

- `python scripts/analyze_sparse_frontier.py --frontier --sample-orders 200 --sample-seed 0 --sample-radius-propagation`
- `python -m pytest tests/test_sparse_frontier.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Status

Diagnostic only. This does not claim a general proof, a counterexample, or geometric realizability.