### PR TITLE
[codex] Search adversarial sparse frontier orders

### DIFF
--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -91,6 +91,38 @@ the 176 sampled `C13` orders without an all-empty choice still passed by an
 acyclic radius-inequality assignment. This is negative evidence about the
 current radius-propagation filter, not evidence for geometric realizability.
 
+## Adversarial Order Search
+
+The random sampler can also seed a heuristic swap hill-climb that looks for
+cyclic orders with fewer rows admitting uncovered consecutive witness pairs:
+
+```bash
+python scripts/analyze_sparse_frontier.py \
+  --frontier \
+  --adversarial-orders 50 \
+  --sample-seed 0 \
+  --adversarial-restarts 6 \
+  --adversarial-steps 80
+```
+
+This is not exhaustive. It is a way to produce better stress tests for the
+same fixed-order necessary filter.
+
+With that deterministic run:
+
+| Pattern | orders evaluated | minimum rows with an uncovered consecutive pair | radius status histogram | best acyclic edge count |
+|---|---:|---:|---|---:|
+| `C19_skew` | 529 | 19 | `{PASS_ACYCLIC_CHOICE: 529}` | 0 |
+| `C13_sidon_1_2_4_10` | 496 | 5 | `{PASS_ACYCLIC_CHOICE: 496}` | 8 |
+| `C25_sidon_2_5_9_14` | 530 | 25 | `{PASS_ACYCLIC_CHOICE: 530}` | 0 |
+| `C29_sidon_1_3_7_15` | 531 | 29 | `{PASS_ACYCLIC_CHOICE: 531}` | 0 |
+
+For `C13`, this produces much more adversarial cyclic orders than passive
+sampling: only 5 of 13 rows retain an uncovered consecutive pair in the best
+found orders. Even then, the radius-propagation filter still finds an acyclic
+choice. For `C19`, `C25`, and `C29`, the same heuristic did not break the
+all-empty escape.
+
 ## Interpretation
 
 The radius-propagation filter chooses one possible short consecutive witness

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -17,6 +17,7 @@ from erdos97.search import built_in_patterns  # noqa: E402
 from erdos97.sparse_frontier import (  # noqa: E402
     sample_empty_gap_orders,
     sample_radius_propagation_orders,
+    search_adversarial_orders,
     sparse_frontier_summary,
 )
 
@@ -98,6 +99,30 @@ def print_sample_summary(rows: list[dict[str, object]]) -> None:
             )
 
 
+def print_adversarial_summary(rows: list[dict[str, object]]) -> None:
+    print(
+        "pattern  n  evaluated  min-uncovered-rows  "
+        "row-count-histogram  radius-status  best-radius-status  "
+        "best-edges  best-explored"
+    )
+    for row in rows:
+        examples = row["best_examples"]
+        best = examples[0] if isinstance(examples, list) and examples else None
+        radius = (
+            best["radius_propagation"]
+            if isinstance(best, dict)
+            else {"status": None, "acyclic_edge_count": None, "explored_nodes": None}
+        )
+        print(
+            f"{row['pattern']}  {row['n']}  {row['orders_evaluated']}  "
+            f"{row['min_rows_with_uncovered_consecutive_pair']}  "
+            f"{row['rows_with_uncovered_consecutive_histogram']}  "
+            f"{row['radius_status_histogram']}  "
+            f"{radius['status']}  {radius['acyclic_edge_count']}  "
+            f"{radius['explored_nodes']}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     target = parser.add_mutually_exclusive_group(required=True)
@@ -130,6 +155,11 @@ def main() -> int:
         type=int,
         help="sample this many random cyclic orders in addition to natural order",
     )
+    parser.add_argument(
+        "--adversarial-orders",
+        type=int,
+        help="sample this many random starts and hill-climb adversarial cyclic orders",
+    )
     parser.add_argument("--sample-seed", type=int, default=0)
     parser.add_argument(
         "--sample-radius-propagation",
@@ -142,6 +172,8 @@ def main() -> int:
         default=100_000,
         help="node limit for the sampled radius-propagation filter",
     )
+    parser.add_argument("--adversarial-restarts", type=int, default=8)
+    parser.add_argument("--adversarial-steps", type=int, default=200)
     args = parser.parse_args()
 
     patterns = built_in_patterns()
@@ -156,19 +188,39 @@ def main() -> int:
 
     if args.sample_orders is not None and args.order is not None:
         raise SystemExit("--sample-orders cannot be combined with --order")
+    if args.adversarial_orders is not None and args.order is not None:
+        raise SystemExit("--adversarial-orders cannot be combined with --order")
+    if args.sample_orders is not None and args.adversarial_orders is not None:
+        raise SystemExit("--sample-orders cannot be combined with --adversarial-orders")
     if args.sample_radius_propagation and args.sample_orders is None:
         raise SystemExit("--sample-radius-propagation requires --sample-orders")
 
     if args.sample_orders is None:
-        rows = [
-            sparse_frontier_summary(
-                name,
-                patterns[name].S,
-                order=args.order,
-                max_row_examples=args.max_row_examples,
-            )
-            for name in names
-        ]
+        if args.adversarial_orders is None:
+            rows = [
+                sparse_frontier_summary(
+                    name,
+                    patterns[name].S,
+                    order=args.order,
+                    max_row_examples=args.max_row_examples,
+                )
+                for name in names
+            ]
+        else:
+            rows = [
+                search_adversarial_orders(
+                    name,
+                    patterns[name].S,
+                    random_samples=args.adversarial_orders,
+                    seed=args.sample_seed,
+                    include_natural=True,
+                    restarts=args.adversarial_restarts,
+                    local_steps=args.adversarial_steps,
+                    max_examples=args.max_row_examples,
+                    node_limit=args.radius_node_limit,
+                )
+                for name in names
+            ]
     elif args.sample_radius_propagation:
         rows = [
             sample_radius_propagation_orders(
@@ -209,7 +261,9 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        if args.sample_orders is None:
+        if args.adversarial_orders is not None:
+            print_adversarial_summary(rows)
+        elif args.sample_orders is None:
             print_summary(rows)
         else:
             print_sample_summary(rows)

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -331,6 +331,57 @@ def _radius_summary(order_result: RadiusPropagationResult) -> dict[str, object]:
     }
 
 
+def _order_radius_item(
+    pattern_name: str,
+    S: Pattern,
+    order: Sequence[int],
+    node_limit: int,
+) -> dict[str, object]:
+    n = len(S)
+    summary = sparse_frontier_summary(
+        pattern_name,
+        S,
+        order=order,
+        max_row_examples=0,
+    )
+    rows = list(summary["rows_with_uncovered_consecutive_pair"])
+    missing = [center for center in range(n) if center not in rows]
+    radius = radius_propagation_obstruction(
+        S,
+        order=order,
+        node_limit=node_limit,
+    )
+    return {
+        "order": list(order),
+        "rows_with_uncovered_consecutive_pair": rows,
+        "rows_without_uncovered_consecutive_pair": missing,
+        "trivial_empty_radius_choice_exists": len(rows) == n,
+        "radius_propagation": _radius_summary(radius),
+    }
+
+
+def _adversarial_score(item: dict[str, object]) -> tuple[int, int, int, int]:
+    rows = item["rows_with_uncovered_consecutive_pair"]
+    radius = item["radius_propagation"]
+    if not isinstance(rows, list) or not isinstance(radius, dict):
+        raise TypeError("invalid adversarial item")
+    status = radius["status"]
+    if status == "RADIUS_CYCLE_OBSTRUCTED":
+        status_rank = 0
+    elif status == "UNKNOWN_NODE_LIMIT":
+        status_rank = 1
+    else:
+        status_rank = 2
+    edge_count = radius["acyclic_edge_count"]
+    explored = radius["explored_nodes"]
+    return (
+        len(rows),
+        status_rank,
+        -(int(edge_count) if edge_count is not None else -1),
+        -int(explored),
+    )
+
+
 def sample_radius_propagation_orders(
     pattern_name: str,
     S: Pattern,
@@ -441,5 +492,130 @@ def sample_radius_propagation_orders(
             "PASS_ACYCLIC_CHOICE is not evidence of geometric realizability; "
             "it only means that this radius-cycle filter did not obstruct "
             "that order."
+        ),
+    }
+
+
+def search_adversarial_orders(
+    pattern_name: str,
+    S: Pattern,
+    random_samples: int = 100,
+    seed: int = 0,
+    include_natural: bool = True,
+    restarts: int = 8,
+    local_steps: int = 200,
+    max_examples: int = 5,
+    node_limit: int = 100_000,
+) -> dict[str, object]:
+    """Heuristically search for cyclic orders stressing radius propagation."""
+
+    if random_samples < 0:
+        raise ValueError("random_samples must be nonnegative")
+    if restarts < 0:
+        raise ValueError("restarts must be nonnegative")
+    if local_steps < 0:
+        raise ValueError("local_steps must be nonnegative")
+    if max_examples < 0:
+        raise ValueError("max_examples must be nonnegative")
+    if node_limit <= 0:
+        raise ValueError("node_limit must be positive")
+    validate_selected_pattern(S)
+    n = len(S)
+    rng = random.Random(seed)
+    initial_orders = _sample_cyclic_orders(n, random_samples, seed, include_natural)
+
+    cache: dict[tuple[int, ...], dict[str, object]] = {}
+    evaluated: list[dict[str, object]] = []
+
+    def evaluate(order: Sequence[int]) -> dict[str, object]:
+        normalized = tuple(normalize_cyclic_order(order))
+        if normalized in cache:
+            return cache[normalized]
+        item = _order_radius_item(pattern_name, S, normalized, node_limit)
+        cache[normalized] = item
+        evaluated.append(item)
+        return item
+
+    for order in initial_orders:
+        evaluate(order)
+
+    if not evaluated:
+        return {
+            "type": "sparse_frontier_adversarial_order_search",
+            "pattern": pattern_name,
+            "n": n,
+            "random_samples_requested": random_samples,
+            "seed": seed,
+            "include_natural": include_natural,
+            "restarts": restarts,
+            "local_steps": local_steps,
+            "node_limit": node_limit,
+            "orders_evaluated": 0,
+            "best_examples": [],
+            "semantics": (
+                "Heuristic cyclic-order search only. No exhaustive abstract-order "
+                "claim is made."
+            ),
+        }
+
+    starts = sorted(evaluated, key=lambda item: (_adversarial_score(item), item["order"]))
+    for restart in range(restarts):
+        current = starts[restart % len(starts)]
+        current_order = list(current["order"])
+        current_score = _adversarial_score(current)
+        for _ in range(local_steps):
+            trial = list(current_order)
+            left, right = rng.sample(range(n), 2)
+            trial[left], trial[right] = trial[right], trial[left]
+            trial_item = evaluate(trial)
+            trial_score = _adversarial_score(trial_item)
+            if trial_score <= current_score:
+                current = trial_item
+                current_order = list(current["order"])
+                current_score = trial_score
+
+    row_counts = [
+        len(item["rows_with_uncovered_consecutive_pair"]) for item in evaluated
+    ]
+    status_counts: Counter[str] = Counter(
+        str(item["radius_propagation"]["status"]) for item in evaluated
+    )
+    best = sorted(evaluated, key=lambda item: (_adversarial_score(item), item["order"]))
+    best_examples = best[:max_examples]
+    best_score = _adversarial_score(best[0]) if best else None
+
+    return {
+        "type": "sparse_frontier_adversarial_order_search",
+        "pattern": pattern_name,
+        "n": n,
+        "random_samples_requested": random_samples,
+        "seed": seed,
+        "include_natural": include_natural,
+        "restarts": restarts,
+        "local_steps": local_steps,
+        "node_limit": node_limit,
+        "orders_evaluated": len(evaluated),
+        "rows_with_uncovered_consecutive_histogram": _histogram(row_counts),
+        "min_rows_with_uncovered_consecutive_pair": (
+            min(row_counts) if row_counts else None
+        ),
+        "radius_status_histogram": dict(sorted(status_counts.items())),
+        "best_score": (
+            None
+            if best_score is None
+            else {
+                "rows_with_uncovered_consecutive_pair": best_score[0],
+                "radius_status_rank": best_score[1],
+                "negative_acyclic_edge_count": best_score[2],
+                "negative_explored_nodes": best_score[3],
+            }
+        ),
+        "best_examples": best_examples,
+        "semantics": (
+            "Heuristic cyclic-order search only, using random starts plus "
+            "swap hill-climbing. It looks for orders with fewer rows admitting "
+            "uncovered consecutive witness pairs, then for stronger "
+            "radius-propagation stress. Failure to find an obstruction is not "
+            "an exhaustive abstract-order theorem."
         ),
     }

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -5,6 +5,7 @@ from erdos97.sparse_frontier import (
     normalize_cyclic_order,
     sample_empty_gap_orders,
     sample_radius_propagation_orders,
+    search_adversarial_orders,
     sparse_frontier_summary,
     sparse_row_profiles,
 )
@@ -107,6 +108,26 @@ def test_sample_radius_propagation_orders_distinguishes_empty_gap_failures() -> 
     example = sample["examples_without_empty_choice"][0]
     assert example["trivial_empty_radius_choice_exists"] is False
     assert example["radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
+
+
+def test_adversarial_order_search_finds_stronger_c13_order() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    result = search_adversarial_orders(
+        pattern.name,
+        pattern.S,
+        random_samples=20,
+        seed=0,
+        restarts=4,
+        local_steps=40,
+    )
+
+    assert result["orders_evaluated"] == 170
+    assert result["min_rows_with_uncovered_consecutive_pair"] == 5
+    assert result["radius_status_histogram"] == {"PASS_ACYCLIC_CHOICE": 170}
+    best = result["best_examples"][0]
+    assert len(best["rows_with_uncovered_consecutive_pair"]) == 5
+    assert best["radius_propagation"]["acyclic_edge_count"] == 8
 
 
 def test_normalize_cyclic_order_quotients_rotation_and_reversal() -> None:


### PR DESCRIPTION
## Summary

- add a heuristic adversarial cyclic-order search for sparse frontier patterns
- seed from random cyclic orders, then use swap hill-climbing to minimize rows with uncovered consecutive witness pairs and stress radius propagation
- document the deterministic frontier snapshot: C13 reaches 5/13 uncovered-row escapes but still passes by an 8-edge acyclic radius choice; C19/C25/C29 keep the all-empty escape in this run

## Validation

- `python scripts/analyze_sparse_frontier.py --frontier --adversarial-orders 50 --sample-seed 0 --adversarial-restarts 6 --adversarial-steps 80`
- `python -m pytest tests/test_sparse_frontier.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Status

Heuristic diagnostic only. This does not claim exhaustive abstract-order coverage, geometric realizability, a counterexample, or a general proof.