### PR TITLE
[codex] Optimize sparse frontier radius choices

### DIFF
--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -110,7 +110,7 @@ same fixed-order necessary filter.
 
 With that deterministic run:
 
-| Pattern | orders evaluated | minimum rows with an uncovered consecutive pair | radius status histogram | best acyclic edge count |
+| Pattern | orders evaluated | minimum rows with an uncovered consecutive pair | radius status histogram | certified minimum acyclic edge count |
 |---|---:|---:|---|---:|
 | `C19_skew` | 529 | 19 | `{PASS_ACYCLIC_CHOICE: 529}` | 0 |
 | `C13_sidon_1_2_4_10` | 496 | 5 | `{PASS_ACYCLIC_CHOICE: 496}` | 8 |
@@ -119,9 +119,10 @@ With that deterministic run:
 
 For `C13`, this produces much more adversarial cyclic orders than passive
 sampling: only 5 of 13 rows retain an uncovered consecutive pair in the best
-found orders. Even then, the radius-propagation filter still finds an acyclic
-choice. For `C19`, `C25`, and `C29`, the same heuristic did not break the
-all-empty escape.
+found orders. The minimum acyclic radius choice is certified at 8 strict
+radius edges, matching the 8 rows without an uncovered consecutive pair. Even
+then, the radius-propagation filter still finds an acyclic choice. For `C19`,
+`C25`, and `C29`, the same heuristic did not break the all-empty escape.
 
 ## Interpretation
 

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -103,7 +103,7 @@ def print_adversarial_summary(rows: list[dict[str, object]]) -> None:
     print(
         "pattern  n  evaluated  min-uncovered-rows  "
         "row-count-histogram  radius-status  best-radius-status  "
-        "best-edges  best-explored"
+        "best-edges  optimized-min-edges  best-explored"
     )
     for row in rows:
         examples = row["best_examples"]
@@ -113,12 +113,18 @@ def print_adversarial_summary(rows: list[dict[str, object]]) -> None:
             if isinstance(best, dict)
             else {"status": None, "acyclic_edge_count": None, "explored_nodes": None}
         )
+        optimized = (
+            best["radius_choice_minimization"]
+            if isinstance(best, dict) and "radius_choice_minimization" in best
+            else {"edge_count": None}
+        )
         print(
             f"{row['pattern']}  {row['n']}  {row['orders_evaluated']}  "
             f"{row['min_rows_with_uncovered_consecutive_pair']}  "
             f"{row['rows_with_uncovered_consecutive_histogram']}  "
             f"{row['radius_status_histogram']}  "
             f"{radius['status']}  {radius['acyclic_edge_count']}  "
+            f"{optimized['edge_count']}  "
             f"{radius['explored_nodes']}"
         )
 

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -20,7 +20,10 @@ from erdos97.min_radius_filter import (
     selected_pair_sources,
 )
 from erdos97.stuck_sets import (
+    RadiusChoice,
+    RadiusChoiceOptimizationResult,
     RadiusPropagationResult,
+    optimize_radius_choice_edges,
     radius_propagation_obstruction,
     validate_selected_pattern,
 )
@@ -331,6 +334,37 @@ def _radius_summary(order_result: RadiusPropagationResult) -> dict[str, object]:
     }
 
 
+def _choice_summary(choice: RadiusChoice) -> dict[str, object]:
+    return {
+        "center": choice.center,
+        "consecutive_pair": [
+            choice.consecutive_pair[0],
+            choice.consecutive_pair[1],
+        ],
+        "smaller_centers": choice.smaller_centers,
+    }
+
+
+def _radius_optimization_summary(
+    result: RadiusChoiceOptimizationResult,
+) -> dict[str, object]:
+    return {
+        "status": result.status,
+        "obstructed": result.obstructed,
+        "objective": result.objective,
+        "optimality_certified": result.optimality_certified,
+        "edge_count": result.edge_count,
+        "edge_lower_bound": result.edge_lower_bound,
+        "edge_upper_bound": result.edge_upper_bound,
+        "explored_nodes": result.explored_nodes,
+        "acyclic_choice": (
+            None
+            if result.acyclic_choice is None
+            else [_choice_summary(choice) for choice in result.acyclic_choice]
+        ),
+    }
+
+
 def _order_radius_item(
     pattern_name: str,
     S: Pattern,
@@ -581,7 +615,19 @@ def search_adversarial_orders(
         str(item["radius_propagation"]["status"]) for item in evaluated
     )
     best = sorted(evaluated, key=lambda item: (_adversarial_score(item), item["order"]))
-    best_examples = best[:max_examples]
+    best_examples: list[dict[str, object]] = []
+    for item in best[:max_examples]:
+        enriched = dict(item)
+        minimization = optimize_radius_choice_edges(
+            S,
+            order=list(item["order"]),
+            objective="min",
+            node_limit=node_limit,
+        )
+        enriched["radius_choice_minimization"] = _radius_optimization_summary(
+            minimization
+        )
+        best_examples.append(enriched)
     best_score = _adversarial_score(best[0]) if best else None
 
     return {

--- a/src/erdos97/stuck_sets.py
+++ b/src/erdos97/stuck_sets.py
@@ -118,6 +118,23 @@ class RadiusPropagationResult:
     choices_by_center: list[list[RadiusChoice]]
 
 
+@dataclass(frozen=True)
+class RadiusChoiceOptimizationResult:
+    n: int
+    order: list[int]
+    objective: str
+    status: str
+    obstructed: bool | None
+    optimality_certified: bool
+    edge_count: int | None
+    edge_lower_bound: int
+    edge_upper_bound: int
+    explored_nodes: int
+    node_limit: int
+    acyclic_choice: list[RadiusChoice] | None
+    choices_by_center: list[list[RadiusChoice]]
+
+
 def validate_selected_pattern(S: Pattern) -> None:
     """Validate the fixed selected-witness contract."""
 
@@ -542,6 +559,221 @@ def radius_result_to_json(result: RadiusPropagationResult) -> dict[str, object]:
             "Exact fixed-order necessary filter. PASS means there exists a "
             "choice of short witness gaps whose implied strict radius "
             "inequalities are acyclic; it is not evidence of realizability."
+        ),
+    }
+
+
+def optimize_radius_choice_edges(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    objective: str = "min",
+    node_limit: int = 100_000,
+) -> RadiusChoiceOptimizationResult:
+    """Optimize acyclic short-chord radius choices by edge count.
+
+    The objective is over choices that pass the fixed-order radius-propagation
+    necessary filter.  A certified optimum is still only a statement about this
+    incidence/order filter, not about geometric realizability.
+    """
+
+    validate_selected_pattern(S)
+    if objective not in {"min", "max"}:
+        raise ValueError("objective must be 'min' or 'max'")
+    if node_limit <= 0:
+        raise ValueError("node_limit must be positive")
+
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    choices_by_center = short_chord_radius_choices(S, order=order)
+    row_order = sorted(
+        range(n),
+        key=lambda center: (
+            min(len(choice.smaller_centers) for choice in choices_by_center[center]),
+            len(choices_by_center[center]),
+            center,
+        ),
+    )
+    if objective == "max":
+        row_order = sorted(
+            range(n),
+            key=lambda center: (
+                -max(
+                    len(choice.smaller_centers)
+                    for choice in choices_by_center[center]
+                ),
+                len(choices_by_center[center]),
+                center,
+            ),
+        )
+
+    def choice_sort_key(choice: RadiusChoice) -> tuple[int, tuple[int, int]]:
+        edge_count = len(choice.smaller_centers)
+        if objective == "min":
+            return (edge_count, choice.consecutive_pair)
+        return (-edge_count, choice.consecutive_pair)
+
+    sorted_choices = {
+        center: sorted(
+            choices_by_center[center],
+            key=choice_sort_key,
+        )
+        for center in range(n)
+    }
+    min_edges_by_center = [
+        min(len(choice.smaller_centers) for choice in choices_by_center[center])
+        for center in row_order
+    ]
+    max_edges_by_center = [
+        max(len(choice.smaller_centers) for choice in choices_by_center[center])
+        for center in row_order
+    ]
+    edge_lower_bound = sum(min_edges_by_center)
+    edge_upper_bound = sum(max_edges_by_center)
+    suffix_min = [0] * (len(row_order) + 1)
+    suffix_max = [0] * (len(row_order) + 1)
+    for idx in range(len(row_order) - 1, -1, -1):
+        suffix_min[idx] = suffix_min[idx + 1] + min_edges_by_center[idx]
+        suffix_max[idx] = suffix_max[idx + 1] + max_edges_by_center[idx]
+
+    adjacency: list[set[int]] = [set() for _ in range(n)]
+    selected: list[RadiusChoice] = []
+    best_choice: list[RadiusChoice] | None = None
+    best_edge_count: int | None = None
+    explored = 0
+    hit_limit = False
+    optimality_certified = False
+
+    def improves(edge_count: int) -> bool:
+        if best_edge_count is None:
+            return True
+        if objective == "min":
+            return edge_count < best_edge_count
+        return edge_count > best_edge_count
+
+    def best_possible(depth: int, edge_count: int) -> int:
+        if objective == "min":
+            return edge_count + suffix_min[depth]
+        return edge_count + suffix_max[depth]
+
+    def cannot_improve(depth: int, edge_count: int) -> bool:
+        if best_edge_count is None:
+            return False
+        possible = best_possible(depth, edge_count)
+        if objective == "min":
+            return possible >= best_edge_count
+        return possible <= best_edge_count
+
+    def search(depth: int, edge_count: int) -> None:
+        nonlocal best_choice, best_edge_count, explored, hit_limit, optimality_certified
+        if optimality_certified:
+            return
+        explored += 1
+        if explored > node_limit:
+            hit_limit = True
+            return
+        if cannot_improve(depth, edge_count):
+            return
+        if depth == len(row_order):
+            if improves(edge_count):
+                best_edge_count = edge_count
+                best_choice = list(selected)
+                if (
+                    (objective == "min" and edge_count == edge_lower_bound)
+                    or (objective == "max" and edge_count == edge_upper_bound)
+                ):
+                    optimality_certified = True
+            return
+
+        center = row_order[depth]
+        for choice in sorted_choices[center]:
+            added: list[tuple[int, int]] = []
+            creates_cycle = False
+            for smaller in choice.smaller_centers:
+                if smaller == center or _reaches(adjacency, smaller, center):
+                    creates_cycle = True
+                    break
+                if smaller not in adjacency[center]:
+                    adjacency[center].add(smaller)
+                    added.append((center, smaller))
+            if creates_cycle:
+                for source, target in added:
+                    adjacency[source].remove(target)
+                continue
+            selected.append(choice)
+            search(depth + 1, edge_count + len(choice.smaller_centers))
+            selected.pop()
+            for source, target in added:
+                adjacency[source].remove(target)
+            if optimality_certified or hit_limit:
+                break
+
+    search(0, 0)
+    if best_choice is not None:
+        if optimality_certified or not hit_limit:
+            status = "PASS_OPTIMAL_CHOICE"
+            obstructed: bool | None = False
+            optimality_certified = True
+        else:
+            status = "UNKNOWN_NODE_LIMIT"
+            obstructed = None
+    elif hit_limit:
+        status = "UNKNOWN_NODE_LIMIT"
+        obstructed = None
+    else:
+        status = "RADIUS_CYCLE_OBSTRUCTED"
+        obstructed = True
+        optimality_certified = True
+
+    return RadiusChoiceOptimizationResult(
+        n=n,
+        order=order,
+        objective=objective,
+        status=status,
+        obstructed=obstructed,
+        optimality_certified=optimality_certified,
+        edge_count=best_edge_count,
+        edge_lower_bound=edge_lower_bound,
+        edge_upper_bound=edge_upper_bound,
+        explored_nodes=explored,
+        node_limit=node_limit,
+        acyclic_choice=best_choice,
+        choices_by_center=choices_by_center,
+    )
+
+
+def radius_choice_optimization_to_json(
+    result: RadiusChoiceOptimizationResult,
+) -> dict[str, object]:
+    """Return a JSON-serializable radius choice optimization result."""
+
+    return {
+        "type": "radius_choice_edge_optimization_result",
+        "n": result.n,
+        "order": result.order,
+        "objective": result.objective,
+        "status": result.status,
+        "obstructed": result.obstructed,
+        "optimality_certified": result.optimality_certified,
+        "edge_count": result.edge_count,
+        "edge_lower_bound": result.edge_lower_bound,
+        "edge_upper_bound": result.edge_upper_bound,
+        "explored_nodes": result.explored_nodes,
+        "node_limit": result.node_limit,
+        "acyclic_choice": (
+            None
+            if result.acyclic_choice is None
+            else [_choice_json(choice) for choice in result.acyclic_choice]
+        ),
+        "choices_by_center": [
+            [_choice_json(choice) for choice in choices]
+            for choices in result.choices_by_center
+        ],
+        "interpretation": (
+            "Exact fixed-order optimization over this radius-propagation "
+            "necessary filter when optimality_certified is true. PASS is not "
+            "evidence of geometric realizability."
         ),
     }
 

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -128,6 +128,8 @@ def test_adversarial_order_search_finds_stronger_c13_order() -> None:
     best = result["best_examples"][0]
     assert len(best["rows_with_uncovered_consecutive_pair"]) == 5
     assert best["radius_propagation"]["acyclic_edge_count"] == 8
+    assert best["radius_choice_minimization"]["edge_count"] == 8
+    assert best["radius_choice_minimization"]["optimality_certified"] is True
 
 
 def test_normalize_cyclic_order_quotients_rotation_and_reversal() -> None:

--- a/tests/test_stuck_sets.py
+++ b/tests/test_stuck_sets.py
@@ -7,8 +7,10 @@ from erdos97.stuck_sets import (
     forward_ear_order,
     greedy_peeling_run,
     is_stuck_subset,
+    optimize_radius_choice_edges,
     pattern_filter_snapshot,
     radius_propagation_obstruction,
+    radius_choice_optimization_to_json,
     result_to_json,
 )
 
@@ -105,3 +107,19 @@ def test_large_sidon_fragile_cover_window_is_truncated() -> None:
     assert stats["cover_exists"] is False
     assert stats["search_complete"] is False
     assert stats["searched_up_to_size"] == 7
+
+
+def test_radius_choice_optimization_certifies_c13_adversarial_minimum() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+    order = [0, 1, 3, 7, 4, 10, 6, 2, 12, 8, 5, 9, 11]
+
+    result = optimize_radius_choice_edges(pattern.S, order=order)
+    payload = radius_choice_optimization_to_json(result)
+
+    assert result.status == "PASS_OPTIMAL_CHOICE"
+    assert result.obstructed is False
+    assert result.optimality_certified is True
+    assert result.edge_count == 8
+    assert result.edge_lower_bound == 8
+    assert result.edge_upper_bound == 13
+    assert payload["edge_count"] == 8


### PR DESCRIPTION
## Summary

- add an exact fixed-order optimizer for acyclic radius-propagation choices by strict-edge count
- attach compact certified minimum radius-choice summaries to sparse frontier adversarial best examples
- document that the best C13 adversarial orders have a certified minimum of 8 strict radius edges, while still passing the radius-cycle filter

## Validation

- `python scripts/analyze_sparse_frontier.py --frontier --adversarial-orders 50 --sample-seed 0 --adversarial-restarts 6 --adversarial-steps 80`
- `python -m pytest tests/test_sparse_frontier.py tests/test_stuck_sets.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Status

Exact fixed-order filter optimization only. This does not claim geometric realizability, a counterexample, exhaustive abstract-order coverage, or a general proof.