### PR TITLE
[codex] Certify order-free sparse empty gaps

### DIFF
--- a/docs/minimum-radius-filter.md
+++ b/docs/minimum-radius-filter.md
@@ -58,6 +58,16 @@ for every possible cyclic order. If every center is order-free blocked, the
 fixed selected pattern is impossible. The complete `n=5` all-other-vertices
 pattern is a toy example killed this way.
 
+There is also an order-free escape certificate in the other direction. Build
+the covered-pair graph on the four witnesses of row `i`, joining two witnesses
+when at least one endpoint selects the other. The row can be blocked in some
+local witness order exactly when this covered-pair graph has a Hamiltonian path.
+If it has no such path, every possible local witness order has an uncovered
+consecutive pair, so that row always survives the minimum-radius short-chord
+test. If every row has this property, then every cyclic order admits the
+all-empty radius-propagation choice. This certifies a blind spot of the filter,
+not geometric realizability.
+
 ## Current impact on built-in patterns
 
 The current built-in candidate patterns all pass the natural-order version of
@@ -81,7 +91,11 @@ combined with additional cyclic-order or radius-inequality propagation.
 For the sparse/Sidon frontier, the issue is sharper: in the natural order every
 frontier row has at least one uncovered consecutive witness pair, so the current
 radius-propagation filter can choose an all-empty set of short gaps and force no
-strict radius inequalities. See `docs/sparse-frontier-diagnostic.md`.
+strict radius inequalities. For `C19_skew`, `C25_sidon_2_5_9_14`, and
+`C29_sidon_1_3_7_15`, the new covered-path test certifies that this all-empty
+escape persists for every cyclic order. The `C13_sidon_1_2_4_10` pattern does
+not have this order-free escape certificate, which is why adversarial cyclic
+orders remain useful for it. See `docs/sparse-frontier-diagnostic.md`.
 
 ## Reproducible check
 

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -49,16 +49,24 @@ still admit an acyclic strict-radius inequality choice.
 
 ## Snapshot
 
-| Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | empty radius choice |
-|---|---:|---|---|---:|---:|---|
-| `C19_skew` | 19 | `{0: 76, 1: 38}` | `{0: 38, 1: 19}` | 19/19 | 0 | yes |
-| `C13_sidon_1_2_4_10` | 13 | `{0: 26, 1: 52}` | `{0: 13, 1: 26}` | 13/13 | 0 | yes |
-| `C25_sidon_2_5_9_14` | 25 | `{0: 100, 1: 50}` | `{0: 50, 1: 25}` | 25/25 | 0 | yes |
-| `C29_sidon_1_3_7_15` | 29 | `{0: 145, 1: 29}` | `{0: 87}` | 29/29 | 0 | yes |
+| Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | order-free empty-gap rows | empty radius choice |
+|---|---:|---|---|---:|---:|---:|---|
+| `C19_skew` | 19 | `{0: 76, 1: 38}` | `{0: 38, 1: 19}` | 19/19 | 0 | 19/19 | yes |
+| `C13_sidon_1_2_4_10` | 13 | `{0: 26, 1: 52}` | `{0: 13, 1: 26}` | 13/13 | 0 | 0/13 | yes |
+| `C25_sidon_2_5_9_14` | 25 | `{0: 100, 1: 50}` | `{0: 50, 1: 25}` | 25/25 | 0 | 25/25 | yes |
+| `C29_sidon_1_3_7_15` | 29 | `{0: 145, 1: 29}` | `{0: 87}` | 29/29 | 0 | 29/29 | yes |
 
 Here `{0: 76, 1: 38}` means 76 row-local witness pairs have no endpoint source,
 and 38 have exactly one endpoint source. No pair in this table has two endpoint
 sources.
+
+The order-free empty-gap column is an exact row-local certificate. For a row,
+form the covered-pair graph on its four witnesses. If that graph has no
+Hamiltonian path, then every possible local witness order has at least one
+uncovered consecutive pair. Thus the `C19`, `C25`, and `C29` entries certify
+that the all-empty radius choice exists for every cyclic order. The `C13` entry
+does not have this certificate: every `C13` row has covered witness paths, so
+some cyclic orders can block its empty-gap escape in selected rows.
 
 ## Order Sampling
 
@@ -75,7 +83,9 @@ checked orders:
 This separates `C13` from the larger sparse frontier. The natural order of
 `C13_sidon_1_2_4_10` has an empty radius choice, but many sampled orders do
 not. In contrast, all sampled orders for `C19`, `C25`, and `C29` kept the empty
-choice. This is still sampling only, not an abstract-order theorem.
+choice; the order-free empty-gap certificate above upgrades that observation
+for those three patterns to an exact abstract-order statement about the
+current radius-propagation filter.
 
 With the same order sample and `--sample-radius-propagation`:
 
@@ -122,7 +132,8 @@ sampling: only 5 of 13 rows retain an uncovered consecutive pair in the best
 found orders. The minimum acyclic radius choice is certified at 8 strict
 radius edges, matching the 8 rows without an uncovered consecutive pair. Even
 then, the radius-propagation filter still finds an acyclic choice. For `C19`,
-`C25`, and `C29`, the same heuristic did not break the all-empty escape.
+`C25`, and `C29`, the exact order-free empty-gap certificate explains why this
+heuristic cannot break the all-empty escape.
 
 ## Interpretation
 

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -39,17 +39,20 @@ def parse_order(raw: str) -> list[int]:
 def print_summary(rows: list[dict[str, object]]) -> None:
     print(
         "pattern  n  all-pair-sources  consecutive-sources  "
-        "uncovered-consecutive-rows  order-free-blocked  empty-radius-choice"
+        "uncovered-consecutive-rows  order-free-blocked  "
+        "order-free-empty-gap  empty-radius-choice"
     )
     for row in rows:
         n = int(row["n"])
         uncovered = len(row["rows_with_uncovered_consecutive_pair"])
         blocked = len(row["order_free_blocked_rows"])
+        empty_gap = len(row["order_free_empty_gap_rows"])
         print(
             f"{row['pattern']}  {n}  "
             f"{row['all_pair_source_count_histogram']}  "
             f"{row['consecutive_pair_source_count_histogram']}  "
             f"{uncovered}/{n}  {blocked}  "
+            f"{empty_gap}/{n}  "
             f"{row['trivial_empty_radius_choice_exists']}"
         )
 

--- a/scripts/check_min_radius_filter.py
+++ b/scripts/check_min_radius_filter.py
@@ -41,13 +41,14 @@ def print_summary(row: dict[str, object]) -> None:
     result = "OBSTRUCTED" if row["obstructed"] else "PASS"
     print(
         "pattern  n  result      blocked centers  possible minimum centers  "
-        "order-free blocked"
+        "order-free blocked  order-free empty-gap"
     )
     print(
         f"{row['pattern']}  {row['n']}  {result:<10}  "
         f"{len(row['blocked_centers'])}  "
         f"{len(row['possible_min_centers'])}  "
-        f"{len(row['order_free_blocked_centers'])}"
+        f"{len(row['order_free_blocked_centers'])}  "
+        f"{len(row['order_free_empty_gap_centers'])}"
     )
 
 

--- a/src/erdos97/min_radius_filter.py
+++ b/src/erdos97/min_radius_filter.py
@@ -18,7 +18,7 @@ It is useful mainly as a cheap way to record and test the minimum-radius idea.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from itertools import combinations
+from itertools import combinations, permutations
 from typing import Sequence
 
 Pair = tuple[int, int]
@@ -48,6 +48,7 @@ class MinRadiusOrderResult:
     blocked_centers: list[int]
     possible_min_centers: list[int]
     order_free_blocked_centers: list[int]
+    order_free_empty_gap_centers: list[int]
     obstructed: bool
 
 
@@ -227,6 +228,53 @@ def _row_is_order_free_blocked(S: Pattern, center: int) -> bool:
     return all(_selected_pair_sources(S, a, b) for a, b in combinations(S[center], 2))
 
 
+def covered_witness_path_orders(S: Pattern, center: int) -> list[list[int]]:
+    """Return witness orders whose three consecutive pairs are all covered.
+
+    Equivalently, these are Hamiltonian paths in the covered-pair graph on the
+    four witnesses of ``center``.  Reversed paths are identified.
+    """
+
+    _validate_pattern(S)
+    if center < 0 or center >= len(S):
+        raise ValueError(f"center out of range: {center}")
+    return _covered_witness_path_orders(S, center)
+
+
+def _covered_witness_path_orders(S: Pattern, center: int) -> list[list[int]]:
+    """Return all-covered local witness orders for a validated pattern."""
+
+    paths: set[tuple[int, ...]] = set()
+    for raw in permutations(sorted(S[center])):
+        if all(
+            _selected_pair_sources(S, a, b)
+            for a, b in zip(raw, raw[1:])
+        ):
+            path = tuple(int(label) for label in raw)
+            paths.add(min(path, tuple(reversed(path))))
+    return [list(path) for path in sorted(paths)]
+
+
+def row_has_order_free_empty_gap(S: Pattern, center: int) -> bool:
+    """Return True iff every local witness order has an uncovered short gap.
+
+    This is the exact row-level complement of having an all-covered witness
+    path.  It certifies that the row can never be blocked by the minimum-radius
+    short-chord test, whatever the ambient cyclic order is.
+    """
+
+    _validate_pattern(S)
+    if center < 0 or center >= len(S):
+        raise ValueError(f"center out of range: {center}")
+    return _row_has_order_free_empty_gap(S, center)
+
+
+def _row_has_order_free_empty_gap(S: Pattern, center: int) -> bool:
+    """Return order-free empty-gap status for a validated pattern."""
+
+    return not _covered_witness_path_orders(S, center)
+
+
 def minimum_radius_order_obstruction(
     S: Pattern,
     order: Sequence[int] | None = None,
@@ -244,6 +292,9 @@ def minimum_radius_order_obstruction(
     blocked = [row.center for row in rows if row.blocked]
     possible = [row.center for row in rows if not row.blocked]
     order_free = [center for center in range(n) if _row_is_order_free_blocked(S, center)]
+    order_free_empty_gap = [
+        center for center in range(n) if _row_has_order_free_empty_gap(S, center)
+    ]
     return MinRadiusOrderResult(
         pattern=pattern,
         n=n,
@@ -252,6 +303,7 @@ def minimum_radius_order_obstruction(
         blocked_centers=blocked,
         possible_min_centers=possible,
         order_free_blocked_centers=order_free,
+        order_free_empty_gap_centers=order_free_empty_gap,
         obstructed=not possible,
     )
 
@@ -284,5 +336,8 @@ def result_to_json(result: MinRadiusOrderResult) -> dict[str, object]:
         "blocked_centers": [int(center) for center in result.blocked_centers],
         "possible_min_centers": [int(center) for center in result.possible_min_centers],
         "order_free_blocked_centers": [int(center) for center in result.order_free_blocked_centers],
+        "order_free_empty_gap_centers": [
+            int(center) for center in result.order_free_empty_gap_centers
+        ],
         "rows": [_json_row(row) for row in result.rows],
     }

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -16,7 +16,9 @@ from typing import Sequence
 
 from erdos97.min_radius_filter import (
     consecutive_witness_pairs,
+    covered_witness_path_orders,
     row_is_order_free_blocked,
+    row_has_order_free_empty_gap,
     selected_pair_sources,
 )
 from erdos97.stuck_sets import (
@@ -44,6 +46,12 @@ class SparseRowProfile:
     all_pairs: list[PairSourceProfile]
     consecutive_pairs: list[PairSourceProfile]
     order_free_blocked: bool
+    order_free_empty_gap: bool
+    covered_witness_path_orders: list[list[int]]
+
+    @property
+    def covered_pairs(self) -> list[PairSourceProfile]:
+        return [item for item in self.all_pairs if item.sources]
 
     @property
     def uncovered_pairs(self) -> list[PairSourceProfile]:
@@ -140,6 +148,8 @@ def sparse_row_profiles(
                 all_pairs=all_pairs,
                 consecutive_pairs=consecutive,
                 order_free_blocked=row_is_order_free_blocked(S, center),
+                order_free_empty_gap=row_has_order_free_empty_gap(S, center),
+                covered_witness_path_orders=covered_witness_path_orders(S, center),
             )
         )
     return profiles
@@ -184,6 +194,9 @@ def sparse_frontier_summary(
     order_free_blocked = [
         row.center for row in profiles if row.order_free_blocked
     ]
+    order_free_empty_gap = [
+        row.center for row in profiles if row.order_free_empty_gap
+    ]
     empty_choice = [
         _pair_json(row.uncovered_consecutive_pairs[0])
         for row in profiles
@@ -199,10 +212,14 @@ def sparse_frontier_summary(
                     _pair_json(pair) for pair in row.consecutive_pairs
                 ],
                 "uncovered_pair_count": len(row.uncovered_pairs),
+                "covered_pair_count": len(row.covered_pairs),
                 "uncovered_consecutive_pair_count": len(
                     row.uncovered_consecutive_pairs
                 ),
                 "order_free_blocked": row.order_free_blocked,
+                "order_free_empty_gap": row.order_free_empty_gap,
+                "covered_witness_path_count": len(row.covered_witness_path_orders),
+                "covered_witness_path_examples": row.covered_witness_path_orders[:3],
             }
         )
 
@@ -221,12 +238,15 @@ def sparse_frontier_summary(
         "rows_with_uncovered_pair": rows_with_uncovered_pair,
         "rows_with_uncovered_consecutive_pair": rows_with_uncovered_consecutive,
         "order_free_blocked_rows": order_free_blocked,
+        "order_free_empty_gap_rows": order_free_empty_gap,
         "all_rows_have_uncovered_consecutive_pair": (
             all_rows_have_empty_consecutive_choice
         ),
+        "all_rows_order_free_empty_gap": len(order_free_empty_gap) == n,
         "trivial_empty_radius_choice_exists": (
             all_rows_have_empty_consecutive_choice
         ),
+        "trivial_empty_radius_choice_all_orders": len(order_free_empty_gap) == n,
         "empty_radius_choice": (
             empty_choice if all_rows_have_empty_consecutive_choice else None
         ),
@@ -235,6 +255,9 @@ def sparse_frontier_summary(
             "Exact fixed-order incidence diagnostic. If every row has an "
             "uncovered consecutive witness pair, the radius-propagation filter "
             "can choose those pairs and force no strict radius inequalities. "
+            "If all_rows_order_free_empty_gap is true, the same empty-choice "
+            "escape holds for every cyclic order by a row-local covered-path "
+            "certificate. "
             "This is a blindness certificate for that filter, not evidence of "
             "geometric realizability."
         ),

--- a/src/erdos97/stuck_sets.py
+++ b/src/erdos97/stuck_sets.py
@@ -887,6 +887,12 @@ def pattern_filter_snapshot(
         ],
         "minimum_radius_obstructed_in_order": min_radius.obstructed,
         "minimum_radius_possible_centers": min_radius.possible_min_centers,
+        "minimum_radius_order_free_blocked_centers": (
+            min_radius.order_free_blocked_centers
+        ),
+        "minimum_radius_order_free_empty_gap_centers": (
+            min_radius.order_free_empty_gap_centers
+        ),
         "radius_propagation": radius_result_to_json(radius),
         "fragile_cover": fragile_cover_snapshot(
             S,

--- a/tests/test_min_radius_filter.py
+++ b/tests/test_min_radius_filter.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from erdos97.min_radius_filter import (
+    covered_witness_path_orders,
     minimum_radius_order_obstruction,
     row_is_order_free_blocked,
+    row_has_order_free_empty_gap,
     selected_pair_sources,
 )
 from erdos97.search import built_in_patterns
@@ -18,6 +20,7 @@ def test_min_radius_filter_kills_all_other_pentagon_pattern() -> None:
     assert result.blocked_centers == list(range(5))
     assert all(row.blocked for row in result.rows)
     assert all(row_is_order_free_blocked(S, center) for center in range(5))
+    assert result.order_free_empty_gap_centers == []
 
 
 def test_min_radius_filter_c19_survives_natural_order() -> None:
@@ -31,3 +34,16 @@ def test_min_radius_filter_c19_survives_natural_order() -> None:
     assert result.rows[0].witness_order == [5, 9, 11, 16]
     assert result.rows[0].uncovered_consecutive_pairs == [(5, 9), (9, 11)]
     assert selected_pair_sources(pattern.S, 11, 16) == [11]
+    assert row_has_order_free_empty_gap(pattern.S, 0)
+    assert covered_witness_path_orders(pattern.S, 0) == []
+
+
+def test_c13_sidon_has_local_covered_witness_paths() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    result = minimum_radius_order_obstruction(pattern.S, pattern=pattern.name)
+    paths = covered_witness_path_orders(pattern.S, 0)
+
+    assert not row_has_order_free_empty_gap(pattern.S, 0)
+    assert result.order_free_empty_gap_centers == []
+    assert [4, 2, 1, 10] in paths

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -29,6 +29,17 @@ def test_frontier_patterns_have_trivial_empty_radius_choice() -> None:
         assert summary["order_free_blocked_rows"] == []
 
 
+def test_larger_sparse_frontier_has_order_free_empty_gap_certificate() -> None:
+    patterns = built_in_patterns()
+
+    for name in ("C19_skew", "C25_sidon_2_5_9_14", "C29_sidon_1_3_7_15"):
+        summary = sparse_frontier_summary(name, patterns[name].S)
+
+        assert summary["all_rows_order_free_empty_gap"] is True
+        assert summary["trivial_empty_radius_choice_all_orders"] is True
+        assert len(summary["order_free_empty_gap_rows"]) == patterns[name].n
+
+
 def test_c13_sidon_all_witness_pairs_have_at_most_one_source() -> None:
     pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
 
@@ -36,6 +47,8 @@ def test_c13_sidon_all_witness_pairs_have_at_most_one_source() -> None:
 
     assert summary["all_pair_source_count_histogram"] == {"0": 26, "1": 52}
     assert summary["consecutive_pair_source_count_histogram"] == {"0": 13, "1": 26}
+    assert summary["all_rows_order_free_empty_gap"] is False
+    assert summary["order_free_empty_gap_rows"] == []
 
 
 def test_sparse_row_profile_records_uncovered_consecutive_pairs() -> None:
@@ -53,6 +66,8 @@ def test_sparse_row_profile_records_uncovered_consecutive_pairs() -> None:
         (5, 9),
         (9, 11),
     ]
+    assert row0.order_free_empty_gap is True
+    assert row0.covered_witness_path_orders == []
 
 
 def test_c13_has_sampled_order_without_empty_choice() -> None:

--- a/tests/test_stuck_sets.py
+++ b/tests/test_stuck_sets.py
@@ -89,6 +89,8 @@ def test_c19_skew_snapshot_records_sparse_filter_wall() -> None:
     assert filters["phi_edges"] == 0
     assert filters["odd_forced_perpendicular_cycle_length"] is None
     assert filters["minimum_radius_obstructed_in_order"] is False
+    assert filters["minimum_radius_order_free_blocked_centers"] == []
+    assert filters["minimum_radius_order_free_empty_gap_centers"] == list(range(19))
     assert filters["radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
     assert filters["fragile_cover"]["cover_stats"]["cover_exists"] is True
     assert stuck.minimal_size == 8


### PR DESCRIPTION
## Summary
- add an exact row-level covered-witness-path test for order-free empty-gap certificates
- expose the certificate through minimum-radius JSON, sparse-frontier summaries, and fixed-pattern filter snapshots
- document that C19/C25/C29 have all-order empty-gap escapes while C13 does not

## Validation
- `python -m pytest tests/test_min_radius_filter.py tests/test_sparse_frontier.py tests/test_stuck_sets.py -q`
- `python scripts/analyze_sparse_frontier.py --frontier --assert-empty-choice`
- `python scripts/check_min_radius_filter.py --pattern C19_skew --assert-pass`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Status
This is an exact incidence/order diagnostic for the current minimum-radius and radius-propagation filters. It does not claim a proof of Erdos Problem #97, geometric realizability, or a counterexample.