### PR TITLE
[codex] Certify C13 empty-gap order bound

### DIFF
--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -47,6 +47,18 @@ python scripts/analyze_sparse_frontier.py \
 This distinguishes orders with an all-empty short-gap choice from orders that
 still admit an acyclic strict-radius inequality choice.
 
+To exactly optimize the row-local empty-gap count over cyclic orders:
+
+```bash
+python scripts/analyze_sparse_frontier.py \
+  --frontier \
+  --certify-empty-gap-bound
+```
+
+This branch-and-bound search fixes label `0` to quotient cyclic rotations. It
+does not quotient reversal. The objective is still only the current
+minimum-radius/radius-propagation filter's empty-gap row count.
+
 ## Snapshot
 
 | Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | order-free empty-gap rows | empty radius choice |
@@ -134,6 +146,37 @@ radius edges, matching the 8 rows without an uncovered consecutive pair. Even
 then, the radius-propagation filter still finds an acyclic choice. For `C19`,
 `C25`, and `C29`, the exact order-free empty-gap certificate explains why this
 heuristic cannot break the all-empty escape.
+
+The exact empty-gap bound below supersedes this heuristic as the sharp
+row-local benchmark for `C13`; the heuristic remains useful as a cheap stress
+test.
+
+## Exact Empty-Gap Bound
+
+With `--certify-empty-gap-bound`:
+
+| Pattern | status | explored nodes | certified minimum rows with an uncovered consecutive pair | certified maximum blocked rows | best radius status | optimized minimum acyclic edge count |
+|---|---|---:|---:|---:|---|---:|
+| `C19_skew` | `CERTIFIED_OPTIMUM` | 1 | 19 | 0 | `PASS_ACYCLIC_CHOICE` | 0 |
+| `C13_sidon_1_2_4_10` | `CERTIFIED_OPTIMUM` | 39610 | 3 | 10 | `PASS_ACYCLIC_CHOICE` | 10 |
+| `C25_sidon_2_5_9_14` | `CERTIFIED_OPTIMUM` | 1 | 25 | 0 | `PASS_ACYCLIC_CHOICE` | 0 |
+| `C29_sidon_1_3_7_15` | `CERTIFIED_OPTIMUM` | 1 | 29 | 0 | `PASS_ACYCLIC_CHOICE` | 0 |
+
+For `C19`, `C25`, and `C29`, the one-node certificate comes from the
+order-free empty-gap row certificates above: no row can be blocked in any
+cyclic order. For `C13`, the exact search proves that at least 3 rows must
+retain an uncovered consecutive pair in every cyclic order, and gives this
+extremal order:
+
+```text
+0, 1, 3, 11, 7, 5, 8, 10, 12, 2, 6, 4, 9
+```
+
+The three rows retaining an uncovered consecutive pair in that order are
+`0, 1, 7`. The remaining 10 rows are blocked for the local empty-gap test, but
+the radius-propagation optimizer still finds an acyclic choice with 10 strict
+radius edges. This is an exact benchmark for this filter, not a realization
+claim.
 
 ## Interpretation
 

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -15,6 +15,7 @@ if str(SRC) not in sys.path:
 
 from erdos97.search import built_in_patterns  # noqa: E402
 from erdos97.sparse_frontier import (  # noqa: E402
+    certify_min_uncovered_consecutive_rows,
     sample_empty_gap_orders,
     sample_radius_propagation_orders,
     search_adversarial_orders,
@@ -132,6 +133,23 @@ def print_adversarial_summary(rows: list[dict[str, object]]) -> None:
         )
 
 
+def print_bound_summary(rows: list[dict[str, object]]) -> None:
+    print(
+        "pattern  n  status  explored  pruned  certified-min-uncovered  "
+        "certified-max-blocked  best-radius-status  optimized-min-edges"
+    )
+    for row in rows:
+        radius = row["best_radius_propagation"]
+        optimization = row["best_radius_choice_minimization"]
+        print(
+            f"{row['pattern']}  {row['n']}  {row['status']}  "
+            f"{row['explored_nodes']}  {row['pruned_nodes']}  "
+            f"{row['certified_min_rows_with_uncovered_consecutive_pair']}  "
+            f"{row['certified_max_blocked_rows']}  "
+            f"{radius['status']}  {optimization['edge_count']}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     target = parser.add_mutually_exclusive_group(required=True)
@@ -169,6 +187,11 @@ def main() -> int:
         type=int,
         help="sample this many random starts and hill-climb adversarial cyclic orders",
     )
+    parser.add_argument(
+        "--certify-empty-gap-bound",
+        action="store_true",
+        help="exactly optimize the empty-gap row count over cyclic orders",
+    )
     parser.add_argument("--sample-seed", type=int, default=0)
     parser.add_argument(
         "--sample-radius-propagation",
@@ -180,6 +203,12 @@ def main() -> int:
         type=int,
         default=100_000,
         help="node limit for the sampled radius-propagation filter",
+    )
+    parser.add_argument(
+        "--empty-gap-bound-node-limit",
+        type=int,
+        default=1_000_000,
+        help="node limit for --certify-empty-gap-bound",
     )
     parser.add_argument("--adversarial-restarts", type=int, default=8)
     parser.add_argument("--adversarial-steps", type=int, default=200)
@@ -199,13 +228,30 @@ def main() -> int:
         raise SystemExit("--sample-orders cannot be combined with --order")
     if args.adversarial_orders is not None and args.order is not None:
         raise SystemExit("--adversarial-orders cannot be combined with --order")
+    if args.certify_empty_gap_bound and args.order is not None:
+        raise SystemExit("--certify-empty-gap-bound cannot be combined with --order")
     if args.sample_orders is not None and args.adversarial_orders is not None:
         raise SystemExit("--sample-orders cannot be combined with --adversarial-orders")
+    if args.certify_empty_gap_bound and args.sample_orders is not None:
+        raise SystemExit("--certify-empty-gap-bound cannot be combined with --sample-orders")
+    if args.certify_empty_gap_bound and args.adversarial_orders is not None:
+        raise SystemExit(
+            "--certify-empty-gap-bound cannot be combined with --adversarial-orders"
+        )
     if args.sample_radius_propagation and args.sample_orders is None:
         raise SystemExit("--sample-radius-propagation requires --sample-orders")
 
     if args.sample_orders is None:
-        if args.adversarial_orders is None:
+        if args.certify_empty_gap_bound:
+            rows = [
+                certify_min_uncovered_consecutive_rows(
+                    name,
+                    patterns[name].S,
+                    node_limit=args.empty_gap_bound_node_limit,
+                )
+                for name in names
+            ]
+        elif args.adversarial_orders is None:
             rows = [
                 sparse_frontier_summary(
                     name,
@@ -258,7 +304,12 @@ def main() -> int:
 
     if args.assert_empty_choice:
         for row in rows:
-            if args.sample_orders is None:
+            if args.certify_empty_gap_bound:
+                ok = (
+                    row["certified_min_rows_with_uncovered_consecutive_pair"]
+                    == row["n"]
+                )
+            elif args.sample_orders is None:
                 ok = row["trivial_empty_radius_choice_exists"]
             else:
                 ok = row["empty_choice_orders"] == row["orders_checked"]
@@ -270,7 +321,9 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        if args.adversarial_orders is not None:
+        if args.certify_empty_gap_bound:
+            print_bound_summary(rows)
+        elif args.adversarial_orders is not None:
             print_adversarial_summary(rows)
         elif args.sample_orders is None:
             print_summary(rows)

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import random
 from collections import Counter
 from dataclasses import dataclass
-from itertools import combinations
+from itertools import combinations, permutations
 from typing import Sequence
 
 from erdos97.min_radius_filter import (
@@ -68,6 +68,58 @@ def _source_profile(S: Pattern, pair: Pair) -> PairSourceProfile:
 
 def _histogram(values: Sequence[int]) -> dict[str, int]:
     return {str(key): count for key, count in sorted(Counter(values).items())}
+
+
+def _row_blocked_in_order(S: Pattern, order: Sequence[int], center: int) -> bool:
+    """Return True iff every short witness gap for ``center`` is covered."""
+
+    return all(
+        selected_pair_sources(S, *pair)
+        for pair in consecutive_witness_pairs(order, center, S[center])
+    )
+
+
+def _blocked_rows_in_order(S: Pattern, order: Sequence[int]) -> list[int]:
+    """Return centers with no uncovered consecutive witness pair."""
+
+    return [
+        center
+        for center in range(len(S))
+        if _row_blocked_in_order(S, order, center)
+    ]
+
+
+def _covered_local_cycles(S: Pattern, center: int) -> list[tuple[int, ...]]:
+    """Return local five-label cycles that make ``center`` row-blocked."""
+
+    cycles: list[tuple[int, ...]] = []
+    for witness_order in permutations(S[center]):
+        if all(
+            selected_pair_sources(S, a, b)
+            for a, b in zip(witness_order, witness_order[1:])
+        ):
+            cycles.append((center, *witness_order))
+    return cycles
+
+
+def _cycle_rotations(cycle: Sequence[int]) -> list[tuple[int, ...]]:
+    return [
+        tuple(cycle[offset:]) + tuple(cycle[:offset])
+        for offset in range(len(cycle))
+    ]
+
+
+def _prefix_can_still_block(
+    rotations: Sequence[tuple[int, ...]],
+    involved: set[int],
+    prefix: Sequence[int],
+) -> bool:
+    """Return whether future appended labels could make one row blocked."""
+
+    if not rotations:
+        return False
+    placed = tuple(label for label in prefix if label in involved)
+    return any(placed == rotation[: len(placed)] for rotation in rotations)
 
 
 def _sample_cyclic_orders(
@@ -339,6 +391,142 @@ def sample_empty_gap_orders(
             "Random cyclic-order sampling only, quotienting rotation and "
             "reversal for reporting. Failing to find an order without the "
             "empty-gap escape is not an exhaustive abstract-order theorem."
+        ),
+    }
+
+
+def certify_min_uncovered_consecutive_rows(
+    pattern_name: str,
+    S: Pattern,
+    node_limit: int = 1_000_000,
+    initial_order: Sequence[int] | None = None,
+) -> dict[str, object]:
+    """Certify the best possible empty-gap row count over cyclic orders.
+
+    The objective is row-local: minimize the number of centers whose four
+    witnesses have at least one uncovered consecutive pair.  Equivalently, this
+    maximizes rows that are blocked by the minimum-radius short-chord test.
+    The search fixes label 0 first, which quotients cyclic rotations but not
+    reversal.
+    """
+
+    validate_selected_pattern(S)
+    if node_limit <= 0:
+        raise ValueError("node_limit must be positive")
+    n = len(S)
+    if initial_order is None:
+        initial_order = list(range(n))
+    initial_order = normalize_cyclic_order(initial_order)
+    if len(initial_order) != n:
+        raise ValueError("initial order has wrong length")
+
+    local_cycles = [_covered_local_cycles(S, center) for center in range(n)]
+    row_rotations = []
+    row_involved = []
+    for cycles in local_cycles:
+        rotations = sorted(
+            {
+                rotation
+                for cycle in cycles
+                for rotation in _cycle_rotations(cycle)
+            }
+        )
+        row_rotations.append(rotations)
+        row_involved.append(set(rotations[0]) if rotations else set())
+
+    def possible_blocked_rows(prefix: Sequence[int]) -> list[int]:
+        return [
+            center
+            for center in range(n)
+            if _prefix_can_still_block(
+                row_rotations[center],
+                row_involved[center],
+                prefix,
+            )
+        ]
+
+    best_order = list(initial_order)
+    best_blocked_rows = _blocked_rows_in_order(S, best_order)
+    best_blocked_count = len(best_blocked_rows)
+    explored_nodes = 0
+    pruned_nodes = 0
+    hit_limit = False
+
+    def search(prefix: list[int], remaining: set[int]) -> None:
+        nonlocal best_order, best_blocked_rows, best_blocked_count
+        nonlocal explored_nodes, pruned_nodes, hit_limit
+
+        if hit_limit:
+            return
+        explored_nodes += 1
+        if explored_nodes > node_limit:
+            hit_limit = True
+            return
+
+        possible = possible_blocked_rows(prefix)
+        if len(possible) <= best_blocked_count:
+            pruned_nodes += 1
+            return
+        if not remaining:
+            blocked = _blocked_rows_in_order(S, prefix)
+            if len(blocked) > best_blocked_count:
+                best_blocked_count = len(blocked)
+                best_blocked_rows = blocked
+                best_order = list(prefix)
+            return
+
+        candidates = []
+        for label in remaining:
+            next_prefix = [*prefix, label]
+            candidates.append((len(possible_blocked_rows(next_prefix)), label))
+        for _, label in sorted(candidates):
+            next_remaining = set(remaining)
+            next_remaining.remove(label)
+            search([*prefix, label], next_remaining)
+
+    search([0], set(range(1, n)))
+
+    search_complete = not hit_limit
+    rows_with_uncovered = [
+        center for center in range(n) if center not in set(best_blocked_rows)
+    ]
+    radius = radius_propagation_obstruction(S, order=best_order)
+    minimization = optimize_radius_choice_edges(S, order=best_order, objective="min")
+    status = "CERTIFIED_OPTIMUM" if search_complete else "UNKNOWN_NODE_LIMIT"
+    return {
+        "type": "sparse_frontier_empty_gap_order_bound",
+        "pattern": pattern_name,
+        "n": n,
+        "status": status,
+        "search_complete": search_complete,
+        "node_limit": node_limit,
+        "explored_nodes": explored_nodes,
+        "pruned_nodes": pruned_nodes,
+        "rotation_quotient_fixed_label": 0,
+        "reversal_quotiented": False,
+        "best_order": best_order,
+        "best_rows_with_uncovered_consecutive_pair": rows_with_uncovered,
+        "best_rows_without_uncovered_consecutive_pair": best_blocked_rows,
+        "best_rows_with_uncovered_consecutive_pair_count": len(rows_with_uncovered),
+        "max_blocked_rows_found": best_blocked_count,
+        "certified_min_rows_with_uncovered_consecutive_pair": (
+            len(rows_with_uncovered) if search_complete else None
+        ),
+        "certified_max_blocked_rows": (
+            best_blocked_count if search_complete else None
+        ),
+        "covered_local_cycle_counts": [
+            len(cycles) for cycles in local_cycles
+        ],
+        "best_radius_propagation": _radius_summary(radius),
+        "best_radius_choice_minimization": _radius_optimization_summary(
+            minimization
+        ),
+        "semantics": (
+            "Exact branch-and-bound over cyclic orders when search_complete is "
+            "true. The objective is only the row-local empty-gap count for the "
+            "minimum-radius/radius-propagation filter; it is not a geometric "
+            "realizability test."
         ),
     }
 

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from erdos97.search import built_in_patterns
 from erdos97.sparse_frontier import (
+    certify_min_uncovered_consecutive_rows,
     normalize_cyclic_order,
     sample_empty_gap_orders,
     sample_radius_propagation_orders,
@@ -40,6 +41,29 @@ def test_larger_sparse_frontier_has_order_free_empty_gap_certificate() -> None:
         assert len(summary["order_free_empty_gap_rows"]) == patterns[name].n
 
 
+def test_c19_empty_gap_order_bound_is_trivial_from_order_free_certificate() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+
+    result = certify_min_uncovered_consecutive_rows(pattern.name, pattern.S)
+
+    assert result["status"] == "CERTIFIED_OPTIMUM"
+    assert result["search_complete"] is True
+    assert result["certified_min_rows_with_uncovered_consecutive_pair"] == 19
+    assert result["certified_max_blocked_rows"] == 0
+    assert result["explored_nodes"] == 1
+
+
+def test_empty_gap_order_bound_matches_all_other_pentagon() -> None:
+    S = [[j for j in range(5) if j != i] for i in range(5)]
+
+    result = certify_min_uncovered_consecutive_rows("K5_all_other", S)
+
+    assert result["status"] == "CERTIFIED_OPTIMUM"
+    assert result["certified_min_rows_with_uncovered_consecutive_pair"] == 0
+    assert result["certified_max_blocked_rows"] == 5
+    assert result["best_rows_with_uncovered_consecutive_pair"] == []
+
+
 def test_c13_sidon_all_witness_pairs_have_at_most_one_source() -> None:
     pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
 
@@ -49,6 +73,22 @@ def test_c13_sidon_all_witness_pairs_have_at_most_one_source() -> None:
     assert summary["consecutive_pair_source_count_histogram"] == {"0": 13, "1": 26}
     assert summary["all_rows_order_free_empty_gap"] is False
     assert summary["order_free_empty_gap_rows"] == []
+
+
+def test_c13_empty_gap_order_bound_certifies_three_rows() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    result = certify_min_uncovered_consecutive_rows(pattern.name, pattern.S)
+
+    assert result["status"] == "CERTIFIED_OPTIMUM"
+    assert result["search_complete"] is True
+    assert result["certified_min_rows_with_uncovered_consecutive_pair"] == 3
+    assert result["certified_max_blocked_rows"] == 10
+    assert result["best_order"] == [0, 1, 3, 11, 7, 5, 8, 10, 12, 2, 6, 4, 9]
+    assert result["best_rows_with_uncovered_consecutive_pair"] == [0, 1, 7]
+    assert result["best_radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
+    assert result["best_radius_choice_minimization"]["edge_count"] == 10
+    assert result["best_radius_choice_minimization"]["optimality_certified"] is True
 
 
 def test_sparse_row_profile_records_uncovered_consecutive_pairs() -> None:


### PR DESCRIPTION
## Summary
- add an exact branch-and-bound optimizer for the row-local empty-gap count over cyclic orders
- certify `C13_sidon_1_2_4_10` has minimum 3 rows with uncovered consecutive pairs and maximum 10 blocked rows
- expose the benchmark through `analyze_sparse_frontier.py --certify-empty-gap-bound` and update the sparse-frontier note

## Validation
- `python -m pytest tests/test_sparse_frontier.py -q`
- `python scripts/analyze_sparse_frontier.py --frontier --certify-empty-gap-bound`
- `python scripts/analyze_sparse_frontier.py --pattern C13_sidon_1_2_4_10 --certify-empty-gap-bound --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Status
This is an exact finite cyclic-order certificate for the current empty-gap/radius-propagation diagnostic only. It does not claim geometric realizability, a counterexample, or a proof of Erdos Problem #97.