### PR TITLE
[codex] Certify sparse frontier radius pass

### DIFF
--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -59,6 +59,20 @@ This branch-and-bound search fixes label `0` to quotient cyclic rotations. It
 does not quotient reversal. The objective is still only the current
 minimum-radius/radius-propagation filter's empty-gap row count.
 
+To certify that the sparse single-target frontier always passes the current
+radius-propagation cycle filter:
+
+```bash
+python scripts/analyze_sparse_frontier.py \
+  --frontier \
+  --certify-single-target-radius-pass
+```
+
+This uses the fact that every covered row-local witness pair in these sparse
+patterns has at most one endpoint source. In that single-target setting, a
+fixed cyclic order is radius-cycle obstructed only if it realizes a nonempty
+closed target set.
+
 ## Snapshot
 
 | Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | order-free empty-gap rows | empty radius choice |
@@ -177,6 +191,28 @@ The three rows retaining an uncovered consecutive pair in that order are
 the radius-propagation optimizer still finds an acyclic choice with 10 strict
 radius edges. This is an exact benchmark for this filter, not a realization
 claim.
+
+## Single-Target Radius Pass
+
+With `--certify-single-target-radius-pass`:
+
+| Pattern | status | all orders pass radius filter | active rows | checked subsets | candidate closed subsets | compatibility nodes | compatible closed target set |
+|---|---|---|---:|---:|---:|---:|---|
+| `C19_skew` | `CERTIFIED_PASS_ALL_ORDERS` | yes | 0 | 0 | 0 | 0 | none |
+| `C13_sidon_1_2_4_10` | `CERTIFIED_PASS_ALL_ORDERS` | yes | 13 | 8191 | 1 | 429 | none |
+| `C25_sidon_2_5_9_14` | `CERTIFIED_PASS_ALL_ORDERS` | yes | 0 | 0 | 0 | 0 | none |
+| `C29_sidon_1_3_7_15` | `CERTIFIED_PASS_ALL_ORDERS` | yes | 0 | 0 | 0 | 0 | none |
+
+For `C19`, `C25`, and `C29`, no row has a covered local witness path, so the
+empty-radius escape already proves the pass. For `C13`, all 13 rows are active.
+The subset scan finds one row-local closed target candidate, the full vertex
+set, but a 429-node cyclic-order compatibility search proves that candidate is
+not realizable by any cyclic order. Therefore no cyclic order of `C13` can be
+obstructed by the current single-target radius-cycle filter.
+
+This closes the radius-propagation route for the sparse frontier as currently
+implemented. A proof or counterexample must use additional geometry or a
+strictly stronger sparse-overlap mechanism.
 
 ## Interpretation
 

--- a/scripts/analyze_sparse_frontier.py
+++ b/scripts/analyze_sparse_frontier.py
@@ -16,6 +16,7 @@ if str(SRC) not in sys.path:
 from erdos97.search import built_in_patterns  # noqa: E402
 from erdos97.sparse_frontier import (  # noqa: E402
     certify_min_uncovered_consecutive_rows,
+    certify_single_target_radius_pass,
     sample_empty_gap_orders,
     sample_radius_propagation_orders,
     search_adversarial_orders,
@@ -150,6 +151,24 @@ def print_bound_summary(rows: list[dict[str, object]]) -> None:
         )
 
 
+def print_single_target_radius_summary(rows: list[dict[str, object]]) -> None:
+    print(
+        "pattern  n  status  radius-pass-all-orders  active-rows  "
+        "checked-subsets  candidate-subsets  compatibility-nodes  "
+        "closed-target-set"
+    )
+    for row in rows:
+        print(
+            f"{row['pattern']}  {row['n']}  {row['status']}  "
+            f"{row['radius_pass_all_orders']}  "
+            f"{row.get('active_row_count')}  "
+            f"{row.get('checked_subsets')}  "
+            f"{row.get('candidate_closed_subsets')}  "
+            f"{row.get('compatibility_nodes')}  "
+            f"{row.get('closed_target_set')}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     target = parser.add_mutually_exclusive_group(required=True)
@@ -192,6 +211,11 @@ def main() -> int:
         action="store_true",
         help="exactly optimize the empty-gap row count over cyclic orders",
     )
+    parser.add_argument(
+        "--certify-single-target-radius-pass",
+        action="store_true",
+        help="certify all-order radius pass via the single-target closed-set test",
+    )
     parser.add_argument("--sample-seed", type=int, default=0)
     parser.add_argument(
         "--sample-radius-propagation",
@@ -209,6 +233,18 @@ def main() -> int:
         type=int,
         default=1_000_000,
         help="node limit for --certify-empty-gap-bound",
+    )
+    parser.add_argument(
+        "--single-target-max-active-rows",
+        type=int,
+        default=24,
+        help="active-row limit for --certify-single-target-radius-pass",
+    )
+    parser.add_argument(
+        "--single-target-compatibility-node-limit",
+        type=int,
+        default=100_000,
+        help="per-subset node limit for --certify-single-target-radius-pass",
     )
     parser.add_argument("--adversarial-restarts", type=int, default=8)
     parser.add_argument("--adversarial-steps", type=int, default=200)
@@ -230,19 +266,49 @@ def main() -> int:
         raise SystemExit("--adversarial-orders cannot be combined with --order")
     if args.certify_empty_gap_bound and args.order is not None:
         raise SystemExit("--certify-empty-gap-bound cannot be combined with --order")
+    if args.certify_single_target_radius_pass and args.order is not None:
+        raise SystemExit(
+            "--certify-single-target-radius-pass cannot be combined with --order"
+        )
     if args.sample_orders is not None and args.adversarial_orders is not None:
         raise SystemExit("--sample-orders cannot be combined with --adversarial-orders")
     if args.certify_empty_gap_bound and args.sample_orders is not None:
         raise SystemExit("--certify-empty-gap-bound cannot be combined with --sample-orders")
+    if args.certify_single_target_radius_pass and args.sample_orders is not None:
+        raise SystemExit(
+            "--certify-single-target-radius-pass cannot be combined with --sample-orders"
+        )
     if args.certify_empty_gap_bound and args.adversarial_orders is not None:
         raise SystemExit(
             "--certify-empty-gap-bound cannot be combined with --adversarial-orders"
+        )
+    if args.certify_single_target_radius_pass and args.adversarial_orders is not None:
+        raise SystemExit(
+            "--certify-single-target-radius-pass cannot be combined with "
+            "--adversarial-orders"
+        )
+    if args.certify_empty_gap_bound and args.certify_single_target_radius_pass:
+        raise SystemExit(
+            "--certify-empty-gap-bound cannot be combined with "
+            "--certify-single-target-radius-pass"
         )
     if args.sample_radius_propagation and args.sample_orders is None:
         raise SystemExit("--sample-radius-propagation requires --sample-orders")
 
     if args.sample_orders is None:
-        if args.certify_empty_gap_bound:
+        if args.certify_single_target_radius_pass:
+            rows = [
+                certify_single_target_radius_pass(
+                    name,
+                    patterns[name].S,
+                    max_active_rows=args.single_target_max_active_rows,
+                    compatibility_node_limit=(
+                        args.single_target_compatibility_node_limit
+                    ),
+                )
+                for name in names
+            ]
+        elif args.certify_empty_gap_bound:
             rows = [
                 certify_min_uncovered_consecutive_rows(
                     name,
@@ -304,7 +370,9 @@ def main() -> int:
 
     if args.assert_empty_choice:
         for row in rows:
-            if args.certify_empty_gap_bound:
+            if args.certify_single_target_radius_pass:
+                ok = row["radius_pass_all_orders"] is True
+            elif args.certify_empty_gap_bound:
                 ok = (
                     row["certified_min_rows_with_uncovered_consecutive_pair"]
                     == row["n"]
@@ -321,7 +389,9 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        if args.certify_empty_gap_bound:
+        if args.certify_single_target_radius_pass:
+            print_single_target_radius_summary(rows)
+        elif args.certify_empty_gap_bound:
             print_bound_summary(rows)
         elif args.adversarial_orders is not None:
             print_adversarial_summary(rows)

--- a/src/erdos97/sparse_frontier.py
+++ b/src/erdos97/sparse_frontier.py
@@ -89,6 +89,27 @@ def _blocked_rows_in_order(S: Pattern, order: Sequence[int]) -> list[int]:
     ]
 
 
+def _row_pair_source_histogram(S: Pattern) -> tuple[dict[str, int], list[dict[str, object]]]:
+    """Return source-count histogram for row-local witness pairs."""
+
+    counts: Counter[int] = Counter()
+    multi_source_pairs: list[dict[str, object]] = []
+    for center, row in enumerate(S):
+        for a, b in combinations(row, 2):
+            pair = (min(a, b), max(a, b))
+            sources = selected_pair_sources(S, *pair)
+            counts[len(sources)] += 1
+            if len(sources) > 1:
+                multi_source_pairs.append(
+                    {
+                        "center": center,
+                        "pair": [pair[0], pair[1]],
+                        "sources": sources,
+                    }
+                )
+    return _histogram(list(counts.elements())), multi_source_pairs
+
+
 def _covered_local_cycles(S: Pattern, center: int) -> list[tuple[int, ...]]:
     """Return local five-label cycles that make ``center`` row-blocked."""
 
@@ -100,6 +121,93 @@ def _covered_local_cycles(S: Pattern, center: int) -> list[tuple[int, ...]]:
         ):
             cycles.append((center, *witness_order))
     return cycles
+
+
+def _covered_local_target_sets(S: Pattern, center: int) -> list[tuple[int, ...]]:
+    """Return target sets for all-covered local witness orders."""
+
+    target_sets: set[tuple[int, ...]] = set()
+    for witness_order in permutations(S[center]):
+        targets = []
+        for a, b in zip(witness_order, witness_order[1:]):
+            sources = selected_pair_sources(S, a, b)
+            if len(sources) != 1:
+                break
+            targets.append(sources[0])
+        else:
+            target_sets.add(tuple(sorted(set(targets))))
+    return sorted(target_sets)
+
+
+def _closed_target_subset_order(
+    S: Pattern,
+    subset: set[int],
+    node_limit: int,
+) -> tuple[list[int] | None, int, bool]:
+    """Return a compatible cyclic order for a closed target subset, if any."""
+
+    constraints = []
+    for center in sorted(subset):
+        rotations = []
+        for witness_order in permutations(S[center]):
+            targets = []
+            for a, b in zip(witness_order, witness_order[1:]):
+                sources = selected_pair_sources(S, a, b)
+                if len(sources) != 1:
+                    break
+                targets.append(sources[0])
+            else:
+                if set(targets) <= subset:
+                    rotations.extend(_cycle_rotations((center, *witness_order)))
+        rotations = sorted(set(rotations))
+        if not rotations:
+            return None, 0, False
+        constraints.append((set(rotations[0]), rotations))
+
+    explored_nodes = 0
+    hit_limit = False
+
+    def compatible(
+        rotations: Sequence[tuple[int, ...]],
+        involved: set[int],
+        prefix: Sequence[int],
+    ) -> bool:
+        placed = tuple(label for label in prefix if label in involved)
+        return any(placed == rotation[: len(placed)] for rotation in rotations)
+
+    def search(prefix: list[int], remaining: set[int]) -> list[int] | None:
+        nonlocal explored_nodes, hit_limit
+        explored_nodes += 1
+        if explored_nodes > node_limit:
+            hit_limit = True
+            return None
+        if not all(
+            compatible(rotations, involved, prefix)
+            for involved, rotations in constraints
+        ):
+            return None
+        if not remaining:
+            return list(prefix)
+
+        candidates = []
+        for label in remaining:
+            next_prefix = [*prefix, label]
+            alive = sum(
+                compatible(rotations, involved, next_prefix)
+                for involved, rotations in constraints
+            )
+            candidates.append((-alive, label))
+        for _, label in sorted(candidates):
+            next_remaining = set(remaining)
+            next_remaining.remove(label)
+            result = search([*prefix, label], next_remaining)
+            if result is not None:
+                return result
+            if hit_limit:
+                return None
+        return None
+
+    return search([0], set(range(len(S))) - {0}), explored_nodes, hit_limit
 
 
 def _cycle_rotations(cycle: Sequence[int]) -> list[tuple[int, ...]]:
@@ -527,6 +635,142 @@ def certify_min_uncovered_consecutive_rows(
             "true. The objective is only the row-local empty-gap count for the "
             "minimum-radius/radius-propagation filter; it is not a geometric "
             "realizability test."
+        ),
+    }
+
+
+def certify_single_target_radius_pass(
+    pattern_name: str,
+    S: Pattern,
+    max_active_rows: int = 24,
+    compatibility_node_limit: int = 100_000,
+) -> dict[str, object]:
+    """Certify all-order radius-propagation pass in the single-target case.
+
+    When every covered row-local witness pair has exactly one endpoint source,
+    a fixed-order radius obstruction is equivalent to a nonempty closed target
+    set: every row in the set is blocked, and all of its possible radius targets
+    stay inside the set.  If no such target set exists even before imposing a
+    global cyclic order, every cyclic order passes this radius-cycle filter.
+    """
+
+    validate_selected_pattern(S)
+    if max_active_rows <= 0:
+        raise ValueError("max_active_rows must be positive")
+    if compatibility_node_limit <= 0:
+        raise ValueError("compatibility_node_limit must be positive")
+    n = len(S)
+    source_histogram, multi_source_pairs = _row_pair_source_histogram(S)
+    if multi_source_pairs:
+        return {
+            "type": "sparse_frontier_single_target_radius_pass_certificate",
+            "pattern": pattern_name,
+            "n": n,
+            "status": "UNSUPPORTED_MULTI_TARGET_PAIR",
+            "search_complete": False,
+            "radius_pass_all_orders": None,
+            "row_pair_source_count_histogram": source_histogram,
+            "multi_source_pair_examples": multi_source_pairs[:8],
+            "semantics": (
+                "This certificate only applies when every row-local covered "
+                "witness pair has at most one endpoint source."
+            ),
+        }
+
+    target_sets_by_center = [
+        _covered_local_target_sets(S, center) for center in range(n)
+    ]
+    active_rows = [
+        center for center, target_sets in enumerate(target_sets_by_center)
+        if target_sets
+    ]
+    if len(active_rows) > max_active_rows:
+        return {
+            "type": "sparse_frontier_single_target_radius_pass_certificate",
+            "pattern": pattern_name,
+            "n": n,
+            "status": "UNKNOWN_TOO_MANY_ACTIVE_ROWS",
+            "search_complete": False,
+            "radius_pass_all_orders": None,
+            "max_active_rows": max_active_rows,
+            "active_rows": active_rows,
+            "active_row_count": len(active_rows),
+            "row_pair_source_count_histogram": source_histogram,
+        }
+
+    checked_subsets = 0
+    candidate_closed_subsets = 0
+    compatibility_nodes = 0
+    closed_target_set: list[int] | None = None
+    closed_target_order: list[int] | None = None
+    hit_limit = False
+    active_count = len(active_rows)
+    for mask in range(1, 1 << active_count):
+        checked_subsets += 1
+        subset = {
+            active_rows[index]
+            for index in range(active_count)
+            if mask & (1 << index)
+        }
+        if all(
+            any(set(targets) <= subset for targets in target_sets_by_center[center])
+            for center in subset
+        ):
+            candidate_closed_subsets += 1
+            order, nodes, subset_hit_limit = _closed_target_subset_order(
+                S,
+                subset,
+                compatibility_node_limit,
+            )
+            compatibility_nodes += nodes
+            if subset_hit_limit:
+                hit_limit = True
+                break
+            if order is not None:
+                closed_target_set = sorted(subset)
+                closed_target_order = order
+                break
+
+    no_closed_set = closed_target_set is None and not hit_limit
+    return {
+        "type": "sparse_frontier_single_target_radius_pass_certificate",
+        "pattern": pattern_name,
+        "n": n,
+        "status": (
+            "CERTIFIED_PASS_ALL_ORDERS"
+            if no_closed_set
+            else (
+                "UNKNOWN_COMPATIBILITY_NODE_LIMIT"
+                if hit_limit
+                else "COMPATIBLE_CLOSED_TARGET_SET_FOUND"
+            )
+        ),
+        "search_complete": not hit_limit,
+        "radius_pass_all_orders": (
+            True if no_closed_set else False if closed_target_set is not None else None
+        ),
+        "row_pair_source_count_histogram": source_histogram,
+        "active_rows": active_rows,
+        "active_row_count": active_count,
+        "checked_subsets": checked_subsets,
+        "candidate_closed_subsets": candidate_closed_subsets,
+        "compatibility_node_limit": compatibility_node_limit,
+        "compatibility_nodes": compatibility_nodes,
+        "closed_target_set": closed_target_set,
+        "closed_target_order": closed_target_order,
+        "target_set_counts_by_center": [
+            len(target_sets) for target_sets in target_sets_by_center
+        ],
+        "target_set_examples_by_center": [
+            [list(targets) for targets in target_sets[:4]]
+            for target_sets in target_sets_by_center
+        ],
+        "semantics": (
+            "Exact row-local certificate for the single-target radius-choice "
+            "case, plus a cyclic-order compatibility check for any closed "
+            "target-set candidate. If radius_pass_all_orders is true, no "
+            "cyclic order can be obstructed by the current radius-propagation "
+            "cycle filter. This does not test geometric realizability."
         ),
     }
 

--- a/tests/test_sparse_frontier.py
+++ b/tests/test_sparse_frontier.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from erdos97.search import built_in_patterns
 from erdos97.sparse_frontier import (
     certify_min_uncovered_consecutive_rows,
+    certify_single_target_radius_pass,
     normalize_cyclic_order,
     sample_empty_gap_orders,
     sample_radius_propagation_orders,
@@ -89,6 +90,42 @@ def test_c13_empty_gap_order_bound_certifies_three_rows() -> None:
     assert result["best_radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
     assert result["best_radius_choice_minimization"]["edge_count"] == 10
     assert result["best_radius_choice_minimization"]["optimality_certified"] is True
+
+
+def test_sparse_frontier_single_target_radius_pass_certificate() -> None:
+    patterns = built_in_patterns()
+
+    for name in FRONTIER_PATTERNS:
+        result = certify_single_target_radius_pass(name, patterns[name].S)
+
+        assert result["status"] == "CERTIFIED_PASS_ALL_ORDERS"
+        assert result["search_complete"] is True
+        assert result["radius_pass_all_orders"] is True
+        assert result["closed_target_set"] is None
+
+
+def test_c13_single_target_radius_pass_checks_all_target_subsets() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    result = certify_single_target_radius_pass(pattern.name, pattern.S)
+
+    assert result["active_rows"] == list(range(13))
+    assert result["active_row_count"] == 13
+    assert result["checked_subsets"] == 8191
+    assert result["candidate_closed_subsets"] == 1
+    assert result["compatibility_nodes"] == 429
+    assert result["target_set_counts_by_center"] == [2] * 13
+
+
+def test_single_target_radius_certificate_rejects_multi_source_pairs() -> None:
+    S = [[j for j in range(5) if j != i] for i in range(5)]
+
+    result = certify_single_target_radius_pass("K5_all_other", S)
+
+    assert result["status"] == "UNSUPPORTED_MULTI_TARGET_PAIR"
+    assert result["search_complete"] is False
+    assert result["radius_pass_all_orders"] is None
+    assert result["multi_source_pair_examples"]
 
 
 def test_sparse_row_profile_records_uncovered_consecutive_pairs() -> None:


### PR DESCRIPTION
## Summary
- add a single-target closed-set certificate for all-order radius-propagation pass
- certify the sparse frontier, including C13, cannot be obstructed by the current single-target radius-cycle filter in any cyclic order
- expose the certificate through `analyze_sparse_frontier.py --certify-single-target-radius-pass` and document the frontier snapshot

## Validation
- `python -m pytest tests/test_sparse_frontier.py -q`
- `python scripts/analyze_sparse_frontier.py --frontier --certify-single-target-radius-pass`
- `python scripts/analyze_sparse_frontier.py --pattern C13_sidon_1_2_4_10 --certify-single-target-radius-pass --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`

## Status
This is an exact certificate for the current single-target radius-propagation diagnostic only. It does not claim geometric realizability, a counterexample, or a proof of Erdos Problem #97.