### PR TITLE
Add two-orbit linearized escape diagnostic

### DIFF
--- a/docs/two-orbit-radius-propagation.md
+++ b/docs/two-orbit-radius-propagation.md
@@ -162,3 +162,44 @@ If this first-order obstruction exists, it becomes a reusable
 radius-propagation-versus-convexity filter. If it fails, the escaping tangent
 direction gives a much better perturbative ansatz than another symmetric
 guess.
+
+## Linearized escape diagnostic
+
+The first-order Farkas obstruction does not appear in the checked small
+two-orbit cases. The command
+
+```bash
+python scripts/check_two_orbit_radius_propagation.py \
+  --linearized-escape \
+  --t 1 \
+  --t-max 5 \
+  --assert-linearized-escape
+```
+
+solves the numerical LP
+
+```text
+J v = 0,
+d(turn_q)(v) >= 1 for every currently concave alternating turn q,
+minimize ||v||_1.
+```
+
+Here `J` is the selected squared-distance equality Jacobian at the exact
+symmetric ansatz. The reproducible snapshot is:
+
+```text
+t  n   status                   rank  kernel  concave turns
+1  8   LINEARIZED_ESCAPE_FOUND  12    4       4
+2  16  LINEARIZED_ESCAPE_FOUND  26    6       8
+3  24  LINEARIZED_ESCAPE_FOUND  40    8       12
+4  32  LINEARIZED_ESCAPE_FOUND  54    10      16
+5  40  LINEARIZED_ESCAPE_FOUND  68    12      20
+```
+
+This is a `NUMERICAL_LINEARIZED_DIAGNOSTIC`, not an exact proof certificate and
+not a counterexample. Its useful interpretation is negative: the symmetric
+two-orbit ansatz is not blocked by a first-order tangent-cone certificate of
+the simplest kind. Any proof route based on this ansatz needs second-order
+information, a stronger convexity cone, or an exact nonlinear obstruction. Any
+counterexample route should treat the LP direction as a targeted perturbative
+seed rather than as evidence of realizability.

--- a/scripts/check_two_orbit_radius_propagation.py
+++ b/scripts/check_two_orbit_radius_propagation.py
@@ -15,6 +15,8 @@ if str(SRC) not in sys.path:
 
 from erdos97.two_orbit_radius_propagation import (  # noqa: E402
     alternating_turns,
+    linearized_escape_summary,
+    linearized_escape_to_json,
     selected_distance_residuals,
     summary_to_json,
     two_orbit_summary,
@@ -67,6 +69,20 @@ def assert_expected(t: int, *, verify_all_rows: bool) -> None:
             raise AssertionError("expected at least one negative alternating turn")
 
 
+def assert_linearized_escape(t: int) -> None:
+    summary = linearized_escape_summary(t)
+    if summary.status != "LINEARIZED_ESCAPE_FOUND":
+        raise AssertionError(f"expected a linearized escape for t={t}")
+    if summary.min_concave_turn_derivative is None:
+        raise AssertionError("missing turn derivative")
+    if summary.min_concave_turn_derivative < summary.derivative_floor - 1e-8:
+        raise AssertionError("linearized escape does not meet derivative floor")
+    if summary.max_abs_equality_jacobian_residual is None:
+        raise AssertionError("missing equality residual")
+    if summary.max_abs_equality_jacobian_residual > 1e-8:
+        raise AssertionError("linearized escape does not preserve equalities")
+
+
 def print_summary(t: int) -> None:
     summary = two_orbit_summary(t)
     print("t  m  n  distance_eq  A_gap  B_gap  turn_B<0  turn_A>0  forced_concave")
@@ -80,17 +96,92 @@ def print_summary(t: int) -> None:
     print(f"cos(h) - S/R = {summary.cos_minus_ratio}")
 
 
+def print_linearized_escape_summary(t: int, *, t_max: int | None) -> None:
+    rows = [
+        linearized_escape_summary(current_t)
+        for current_t in range(t, (t_max or t) + 1)
+    ]
+    print(
+        "t  n  status                   rank  kernel  concave turns  min dturn  max |Jv|  l1"
+    )
+    for row in rows:
+        min_derivative = (
+            "-"
+            if row.min_concave_turn_derivative is None
+            else f"{row.min_concave_turn_derivative:.6g}"
+        )
+        residual = (
+            "-"
+            if row.max_abs_equality_jacobian_residual is None
+            else f"{row.max_abs_equality_jacobian_residual:.3g}"
+        )
+        l1_norm = "-" if row.l1_norm is None else f"{row.l1_norm:.6g}"
+        print(
+            f"{row.t}  {row.n}  {row.status:<24}  "
+            f"{row.equality_rank}  {row.kernel_dimension}  "
+            f"{row.concave_turn_count}  {min_derivative}  {residual}  {l1_norm}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--t", type=int, default=2, help="positive integer with m=4t")
     parser.add_argument("--json", action="store_true", help="print JSON")
     parser.add_argument("--assert-expected", action="store_true")
     parser.add_argument(
+        "--linearized-escape",
+        action="store_true",
+        help="run the numerical first-order escape LP instead of the exact ansatz summary",
+    )
+    parser.add_argument(
+        "--t-max",
+        type=int,
+        help="with --linearized-escape, scan every t from --t through --t-max",
+    )
+    parser.add_argument(
+        "--include-direction",
+        action="store_true",
+        help="include the LP direction in --linearized-escape JSON output",
+    )
+    parser.add_argument(
+        "--assert-linearized-escape",
+        action="store_true",
+        help="assert that the selected t values have a linearized escape",
+    )
+    parser.add_argument(
         "--verify-all-rows",
         action="store_true",
         help="also verify all selected row distances and alternating turns",
     )
     args = parser.parse_args()
+
+    if args.t_max is not None and args.t_max < args.t:
+        raise SystemExit("--t-max must be at least --t")
+    if args.assert_linearized_escape and not args.linearized_escape:
+        raise SystemExit("--assert-linearized-escape requires --linearized-escape")
+
+    if args.linearized_escape:
+        t_values = range(args.t, (args.t_max or args.t) + 1)
+        rows = [
+            linearized_escape_to_json(
+                linearized_escape_summary(
+                    current_t,
+                    include_direction=args.include_direction,
+                )
+            )
+            for current_t in t_values
+        ]
+        if args.assert_linearized_escape:
+            for current_t in t_values:
+                assert_linearized_escape(current_t)
+        if args.json:
+            output: object = rows[0] if args.t_max is None else rows
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            print_linearized_escape_summary(args.t, t_max=args.t_max)
+            if args.assert_linearized_escape:
+                print("OK: linearized escape expectation verified")
+        return 0
 
     if args.assert_expected:
         assert_expected(args.t, verify_all_rows=args.verify_all_rows)

--- a/src/erdos97/two_orbit_radius_propagation.py
+++ b/src/erdos97/two_orbit_radius_propagation.py
@@ -47,6 +47,26 @@ class TwoOrbitSummary:
     forced_concave: bool
 
 
+@dataclass(frozen=True)
+class TwoOrbitLinearizedEscapeSummary:
+    """Numerical first-order deformation diagnostic for the two-orbit ansatz."""
+
+    t: int
+    m: int
+    n: int
+    status: str
+    trust_label: str
+    equality_equation_count: int
+    equality_rank: int
+    kernel_dimension: int
+    concave_turn_count: int
+    derivative_floor: float
+    min_concave_turn_derivative: float | None
+    max_abs_equality_jacobian_residual: float | None
+    l1_norm: float | None
+    direction: list[list[float]] | None
+
+
 def _check_t(t: int) -> None:
     if not isinstance(t, int) or t < 1:
         raise ValueError("t must be a positive integer")
@@ -172,6 +192,125 @@ def alternating_turns(t: int) -> list[object]:
     return turns
 
 
+def linearized_escape_summary(
+    t: int,
+    derivative_floor: float = 1.0,
+    include_direction: bool = False,
+) -> TwoOrbitLinearizedEscapeSummary:
+    """Search for a first-order escape from the concave two-orbit ansatz.
+
+    The linearized system keeps the selected squared-distance equalities fixed
+    to first order and asks for every currently concave alternating turn to
+    increase at rate at least ``derivative_floor``. This is a numerical LP
+    diagnostic around the exact ansatz, not an exact proof certificate.
+    """
+
+    _check_t(t)
+    if derivative_floor <= 0:
+        raise ValueError("derivative_floor must be positive")
+
+    np, linprog = _numeric_lp()
+    points = _numeric_points(t)
+    cohorts = two_orbit_cohorts(t)
+    n = len(points)
+    equality_jacobian = _selected_equality_jacobian(points, cohorts)
+    turn_jacobian, base_turns = _turn_jacobian(points)
+    concave_rows = [
+        idx
+        for idx, value in enumerate(base_turns)
+        if float(value) < -1e-12
+    ]
+    concave_jacobian = turn_jacobian[concave_rows, :]
+
+    equality_rank = int(np.linalg.matrix_rank(equality_jacobian, tol=1e-9))
+    kernel_dimension = int(2 * n - equality_rank)
+    if not concave_rows:
+        return TwoOrbitLinearizedEscapeSummary(
+            t=t,
+            m=4 * t,
+            n=n,
+            status="NO_CONCAVE_TURNS",
+            trust_label="NUMERICAL_LINEARIZED_DIAGNOSTIC",
+            equality_equation_count=int(equality_jacobian.shape[0]),
+            equality_rank=equality_rank,
+            kernel_dimension=kernel_dimension,
+            concave_turn_count=0,
+            derivative_floor=float(derivative_floor),
+            min_concave_turn_derivative=None,
+            max_abs_equality_jacobian_residual=None,
+            l1_norm=None,
+            direction=None,
+        )
+
+    dim = 2 * n
+    # Minimize ||v||_1 subject to Jv=0 and every concave turn derivative >= floor.
+    c = np.concatenate([np.zeros(dim), np.ones(dim)])
+    inequalities = []
+    rhs = []
+
+    inequalities.append(np.hstack([-concave_jacobian, np.zeros((len(concave_rows), dim))]))
+    rhs.extend([-float(derivative_floor)] * len(concave_rows))
+
+    identity = np.eye(dim)
+    inequalities.append(np.hstack([identity, -identity]))
+    rhs.extend([0.0] * dim)
+    inequalities.append(np.hstack([-identity, -identity]))
+    rhs.extend([0.0] * dim)
+
+    bounds = [(None, None)] * dim + [(0.0, None)] * dim
+    result = linprog(
+        c=c,
+        A_ub=np.vstack(inequalities),
+        b_ub=np.array(rhs, dtype=float),
+        A_eq=np.hstack([equality_jacobian, np.zeros((equality_jacobian.shape[0], dim))]),
+        b_eq=np.zeros(equality_jacobian.shape[0]),
+        bounds=bounds,
+        method="highs",
+    )
+    if not result.success:
+        return TwoOrbitLinearizedEscapeSummary(
+            t=t,
+            m=4 * t,
+            n=n,
+            status="NO_LINEARIZED_ESCAPE_FOUND",
+            trust_label="NUMERICAL_LINEARIZED_DIAGNOSTIC",
+            equality_equation_count=int(equality_jacobian.shape[0]),
+            equality_rank=equality_rank,
+            kernel_dimension=kernel_dimension,
+            concave_turn_count=len(concave_rows),
+            derivative_floor=float(derivative_floor),
+            min_concave_turn_derivative=None,
+            max_abs_equality_jacobian_residual=None,
+            l1_norm=None,
+            direction=None,
+        )
+
+    direction_vector = result.x[:dim]
+    equality_residual = equality_jacobian @ direction_vector
+    turn_derivatives = concave_jacobian @ direction_vector
+    direction = direction_vector.reshape((n, 2))
+    return TwoOrbitLinearizedEscapeSummary(
+        t=t,
+        m=4 * t,
+        n=n,
+        status="LINEARIZED_ESCAPE_FOUND",
+        trust_label="NUMERICAL_LINEARIZED_DIAGNOSTIC",
+        equality_equation_count=int(equality_jacobian.shape[0]),
+        equality_rank=equality_rank,
+        kernel_dimension=kernel_dimension,
+        concave_turn_count=len(concave_rows),
+        derivative_floor=float(derivative_floor),
+        min_concave_turn_derivative=float(np.min(turn_derivatives)),
+        max_abs_equality_jacobian_residual=float(np.max(np.abs(equality_residual))),
+        l1_norm=float(np.sum(np.abs(direction_vector))),
+        direction=(
+            [[float(x), float(y)] for x, y in direction]
+            if include_direction
+            else None
+        ),
+    )
+
+
 def summary_to_json(summary: TwoOrbitSummary) -> dict[str, object]:
     """Return a JSON-friendly exact summary."""
     return {
@@ -198,9 +337,113 @@ def summary_to_json(summary: TwoOrbitSummary) -> dict[str, object]:
     }
 
 
+def linearized_escape_to_json(
+    summary: TwoOrbitLinearizedEscapeSummary,
+) -> dict[str, object]:
+    """Return a JSON-friendly linearized escape diagnostic."""
+
+    return {
+        "type": "two_orbit_linearized_escape",
+        "status": summary.status,
+        "trust_label": summary.trust_label,
+        "t": summary.t,
+        "m": summary.m,
+        "n": summary.n,
+        "equality_equation_count": summary.equality_equation_count,
+        "equality_rank": summary.equality_rank,
+        "kernel_dimension": summary.kernel_dimension,
+        "concave_turn_count": summary.concave_turn_count,
+        "derivative_floor": summary.derivative_floor,
+        "min_concave_turn_derivative": summary.min_concave_turn_derivative,
+        "max_abs_equality_jacobian_residual": (
+            summary.max_abs_equality_jacobian_residual
+        ),
+        "l1_norm": summary.l1_norm,
+        "direction": summary.direction,
+        "interpretation": (
+            "A LINEARIZED_ESCAPE_FOUND result means the equality Jacobian has "
+            "a first-order tangent direction that increases every concave "
+            "alternating turn. This rules out the hoped-for first-order "
+            "Farkas obstruction for this ansatz, but it is not a counterexample."
+        ),
+    }
+
+
 def _squared_distance(p: Sequence[object], q: Sequence[object]):
     sp = _sympy()
     return sp.simplify((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2)
+
+
+def _numeric_lp():
+    try:
+        import numpy as np  # type: ignore
+        from scipy.optimize import linprog  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depends on dev deps
+        raise RuntimeError(
+            "NumPy and SciPy are required for linearized escape diagnostics"
+        ) from exc
+    return np, linprog
+
+
+def _numeric_points(t: int):
+    sp = _sympy()
+    np, _ = _numeric_lp()
+    return np.array(
+        [
+            [float(sp.N(x, 80)), float(sp.N(y, 80))]
+            for x, y in two_orbit_points(t)
+        ],
+        dtype=float,
+    )
+
+
+def _selected_equality_jacobian(points, cohorts: Sequence[Sequence[int]]):
+    np, _ = _numeric_lp()
+    n = len(points)
+    rows = []
+    for center, row in enumerate(cohorts):
+        base = row[0]
+        for target in row[1:]:
+            gradient = np.zeros(2 * n)
+            target_delta = points[center] - points[target]
+            base_delta = points[center] - points[base]
+            gradient[2 * center : 2 * center + 2] += 2 * (
+                target_delta - base_delta
+            )
+            gradient[2 * target : 2 * target + 2] += -2 * target_delta
+            gradient[2 * base : 2 * base + 2] += 2 * base_delta
+            rows.append(gradient)
+    return np.vstack(rows)
+
+
+def _turn_jacobian(points):
+    np, _ = _numeric_lp()
+    n = len(points)
+    rows = []
+    values = []
+    for idx in range(n):
+        p = points[idx]
+        q = points[(idx + 1) % n]
+        r = points[(idx + 2) % n]
+        e = q - p
+        f = r - q
+        values.append(_det2(e, f))
+
+        gradient = np.zeros(2 * n)
+        p_grad = np.array([-f[1], f[0]])
+        r_grad = np.array([-e[1], e[0]])
+        q_grad = -(p_grad + r_grad)
+        gradient[2 * idx : 2 * idx + 2] = p_grad
+        q_idx = (idx + 1) % n
+        r_idx = (idx + 2) % n
+        gradient[2 * q_idx : 2 * q_idx + 2] = q_grad
+        gradient[2 * r_idx : 2 * r_idx + 2] = r_grad
+        rows.append(gradient)
+    return np.vstack(rows), np.array(values, dtype=float)
+
+
+def _det2(u: Sequence[float], v: Sequence[float]) -> float:
+    return float(u[0] * v[1] - u[1] * v[0])
 
 
 def _sub(p: Sequence[object], q: Sequence[object]) -> tuple[object, object]:

--- a/tests/test_two_orbit_radius_propagation.py
+++ b/tests/test_two_orbit_radius_propagation.py
@@ -4,6 +4,8 @@ import sympy as sp
 
 from erdos97.two_orbit_radius_propagation import (
     alternating_turns,
+    linearized_escape_summary,
+    linearized_escape_to_json,
     selected_distance_residuals,
     summary_to_json,
     two_orbit_summary,
@@ -54,3 +56,26 @@ def test_json_summary_keeps_claim_boundary_explicit() -> None:
 
     assert row["status"] == "exact_ansatz_obstruction_not_general_proof"
     assert row["forced_concave"] is True
+
+
+def test_linearized_escape_exists_for_small_two_orbit_cases() -> None:
+    for t in (1, 2, 3):
+        summary = linearized_escape_summary(t)
+
+        assert summary.status == "LINEARIZED_ESCAPE_FOUND"
+        assert summary.trust_label == "NUMERICAL_LINEARIZED_DIAGNOSTIC"
+        assert summary.concave_turn_count == 4 * t
+        assert summary.kernel_dimension == 2 * t + 2
+        assert summary.min_concave_turn_derivative is not None
+        assert summary.min_concave_turn_derivative >= 1 - 1e-8
+        assert summary.max_abs_equality_jacobian_residual is not None
+        assert summary.max_abs_equality_jacobian_residual <= 1e-8
+
+
+def test_linearized_escape_json_keeps_claim_boundary_explicit() -> None:
+    row = linearized_escape_to_json(linearized_escape_summary(2))
+
+    assert row["type"] == "two_orbit_linearized_escape"
+    assert row["status"] == "LINEARIZED_ESCAPE_FOUND"
+    assert row["trust_label"] == "NUMERICAL_LINEARIZED_DIAGNOSTIC"
+    assert "not a counterexample" in str(row["interpretation"])


### PR DESCRIPTION
## Summary
- add a numerical first-order LP diagnostic for the half-step two-orbit ansatz
- expose the scan through `check_two_orbit_radius_propagation.py --linearized-escape`
- document that small checked cases have equality-preserving tangent directions increasing all concave turns, so the simplest first-order Farkas obstruction route fails

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/check_two_orbit_radius_propagation.py --linearized-escape --t 1 --t-max 5 --assert-linearized-escape`

No proof or counterexample is claimed; the new result is labeled `NUMERICAL_LINEARIZED_DIAGNOSTIC`.