### PR TITLE
Stabilize stuck motif sweep searches

### DIFF
--- a/docs/stuck-set-miner.md
+++ b/docs/stuck-set-miner.md
@@ -192,7 +192,12 @@ python scripts/sweep_stuck_motifs.py \
 ```
 
 Model counts are solver diagnostics. They are useful for reproducibility with a
-fixed seed, but they should not be read as mathematical thresholds.
+fixed seed, but they should not be read as mathematical thresholds. Sweep runs
+use a stable SMT variable prefix derived from the base prefix, `n`, stuck size,
+and solver seed. This keeps a parameter item independent of its position in a
+larger sweep while avoiding symbol reuse between different items. Each motif
+search also uses a fresh Z3 context. Use `--variable-prefix` when a
+pytest/regression context needs a distinct symbol namespace.
 
 ## Radius Propagation
 

--- a/scripts/sweep_stuck_motifs.py
+++ b/scripts/sweep_stuck_motifs.py
@@ -34,6 +34,11 @@ def main() -> int:
     parser.add_argument("--stuck-sizes", type=parse_csv_ints, default=[4], help="comma-separated stuck sizes")
     parser.add_argument("--max-models", type=int, default=100)
     parser.add_argument("--solver-seed", type=int, default=0)
+    parser.add_argument(
+        "--variable-prefix",
+        default="sweep",
+        help="base prefix; n, stuck size, and seed are appended for each item",
+    )
     parser.add_argument("--require-no-forward-ear-order", action="store_true")
     parser.add_argument("--fragile-cover-max-size", type=int)
     parser.add_argument("--radius-node-limit", type=int, default=100_000)
@@ -62,6 +67,7 @@ def main() -> int:
             stuck_sizes=args.stuck_sizes,
             max_models=args.max_models,
             solver_seed=args.solver_seed,
+            variable_prefix=args.variable_prefix,
             require_no_forward_ear_order=args.require_no_forward_ear_order,
             radius_node_limit=args.radius_node_limit,
             fragile_cover_max_size=args.fragile_cover_max_size,

--- a/src/erdos97/stuck_motif_search.py
+++ b/src/erdos97/stuck_motif_search.py
@@ -90,12 +90,13 @@ def _model_to_rows(model, variables: Sequence[Sequence[object]]) -> Pattern:
 
 def _block_model(solver, variables: Sequence[Sequence[object]], rows: Pattern) -> None:
     z3 = _z3()
+    ctx = variables[0][0].ctx
     differences = []
     row_sets = [set(row) for row in rows]
     for center, row in enumerate(variables):
         for label, variable in enumerate(row):
             value = label in row_sets[center]
-            differences.append(variable != z3.BoolVal(value))
+            differences.append(variable != z3.BoolVal(value, ctx=ctx))
     solver.add(z3.Or(differences))
 
 
@@ -159,8 +160,12 @@ def mine_stuck_motif(config: MotifSearchConfig) -> MotifSearchResult:
     n = config.n
     stuck_vertices = list(range(config.stuck_size))
     prefix = config.variable_prefix
-    X = [[z3.Bool(f"{prefix}_{i}_{j}") for j in range(n)] for i in range(n)]
-    solver = z3.Solver()
+    ctx = z3.Context()
+    X = [
+        [z3.Bool(f"{prefix}_{i}_{j}", ctx=ctx) for j in range(n)]
+        for i in range(n)
+    ]
+    solver = z3.Solver(ctx=ctx)
     solver.set("random_seed", int(config.solver_seed))
 
     for i in range(n):

--- a/src/erdos97/stuck_motif_sweep.py
+++ b/src/erdos97/stuck_motif_sweep.py
@@ -19,6 +19,7 @@ class SweepConfig:
     stuck_sizes: Sequence[int]
     max_models: int = 100
     solver_seed: int = 0
+    variable_prefix: str = "sweep"
     require_no_forward_ear_order: bool = False
     radius_node_limit: int = 100_000
     fragile_cover_max_size: int | None = None
@@ -91,18 +92,19 @@ def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
     """Run a bounded stuck-motif sweep and return JSON-ready data."""
 
     items: list[dict[str, object]] = []
-    for item_index, (n, stuck_size) in enumerate(
+    for n, stuck_size in (
         (int(n), int(stuck_size))
         for n in config.n_values
         for stuck_size in config.stuck_sizes
     ):
+        resolved_prefix = f"{config.variable_prefix}_{n}_{stuck_size}_{config.solver_seed}"
         result = mine_stuck_motif(
             MotifSearchConfig(
                 n=n,
                 stuck_size=stuck_size,
                 max_models=config.max_models,
                 solver_seed=config.solver_seed,
-                variable_prefix=f"sweep_{item_index}_{n}_{stuck_size}_{config.solver_seed}",
+                variable_prefix=resolved_prefix,
                 radius_node_limit=config.radius_node_limit,
                 require_no_forward_ear_order=config.require_no_forward_ear_order,
                 fragile_cover_max_size=config.fragile_cover_max_size,
@@ -127,6 +129,7 @@ def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
                 "motif_minimal_stuck_size": (
                     motif["stuck_search"]["minimal_size"] if isinstance(motif, dict) else None
                 ),
+                "variable_prefix": resolved_prefix,
                 "radius_status": (
                     motif["filters"]["radius_propagation"]["status"]
                     if isinstance(motif, dict)
@@ -144,6 +147,7 @@ def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
             "stuck_sizes": [int(size) for size in config.stuck_sizes],
             "max_models": config.max_models,
             "solver_seed": config.solver_seed,
+            "variable_prefix": config.variable_prefix,
             "require_no_forward_ear_order": config.require_no_forward_ear_order,
             "run_geometry": config.run_geometry,
             "geometry_optimizer": config.geometry_optimizer,

--- a/tests/test_stuck_motif_search.py
+++ b/tests/test_stuck_motif_search.py
@@ -14,7 +14,7 @@ def test_mine_stuck_motif_finds_strict_small_model() -> None:
     payload = search_result_to_json(result)
 
     assert result.status == "FOUND"
-    assert result.models_checked == 1
+    assert 1 <= result.models_checked <= 5
     assert payload["motif"]["key_peeling_status"] == "STUCK_SET_FOUND"
     assert payload["motif"]["filters"]["adjacent_two_overlap_violations"] == []
     assert payload["motif"]["filters"]["crossing_bisector_violations"] == []

--- a/tests/test_stuck_motif_sweep.py
+++ b/tests/test_stuck_motif_sweep.py
@@ -36,3 +36,19 @@ def test_sweep_can_run_geometry_smoke() -> None:
     assert item["status"] == "FOUND"
     assert item["geometry"]["status"] == "RAN"
     assert "eq_rms" in item["geometry"]
+
+
+def test_sweep_records_stable_item_variable_prefix() -> None:
+    sweep = sweep_stuck_motifs(
+        SweepConfig(
+            n_values=[9],
+            stuck_sizes=[4],
+            max_models=5,
+            solver_seed=0,
+            variable_prefix="sweep_contract",
+        )
+    )
+
+    assert sweep["config"]["variable_prefix"] == "sweep_contract"
+    assert sweep["items"][0]["variable_prefix"] == "sweep_contract_9_4_0"
+    assert sweep["items"][0]["status"] == "FOUND"


### PR DESCRIPTION
## Summary
- run each stuck-motif SMT search in a fresh Z3 context
- give sweep items stable parameter-derived variable prefixes instead of item-index-derived names
- expose `--variable-prefix` for sweep runs and record resolved item prefixes in JSON
- relax brittle exact model-count expectations in tests

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/sweep_stuck_motifs.py --n 10 --stuck-sizes 4 --max-models 220 --solver-seed 0 --require-no-forward-ear-order`
- `python scripts/sweep_stuck_motifs.py --n-range 9 12 --stuck-sizes 4 --max-models 220 --solver-seed 0 --require-no-forward-ear-order`

No proof or counterexample is claimed; this is search reproducibility hygiene for the stuck-motif pipeline.