### PR TITLE
Add order-dependent Altman signature filter

### DIFF
--- a/docs/altman-diagonal-sums.md
+++ b/docs/altman-diagonal-sums.md
@@ -76,7 +76,44 @@ Thus `C19_skew` is exactly obstructed in natural cyclic order.
 
 ## Caveats
 
-- Altman's diagonal-order obstruction is natural-cyclic-order only.
-- It does not kill abstract-incidence versions with arbitrary cyclic relabeling.
+- The constant-offset application above is natural-cyclic-order only.
+- The order-dependent signature extension below can check any supplied cyclic
+  order, but it is not a complete abstract-order search.
 - `C19_skew` remains an abstract-incidence sparse survivor of the current
   `phi`, midpoint, forced-perpendicularity, and vertex-circle filters.
+
+## Order-Dependent Signature Filter
+
+The script also has a fixed-order extension:
+
+```bash
+python scripts/check_altman_diagonal_sums.py \
+  --pattern C19_skew \
+  --order 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 \
+  --assert-natural-killed
+```
+
+For a supplied cyclic order, the checker unions the distance classes forced by
+the selected rows. It then writes every Altman diagonal sum `U_k` as a formal
+multiset of those distance classes. If two distinct diagonal orders have the
+same formal multiset, the selected equalities force the corresponding `U_k`
+values to be equal, contradicting Altman's strict chain.
+
+This recovers the natural-order `C19_skew` obstruction as an exact fixed-order
+signature contradiction:
+
+```text
+equal diagonal groups: [[3, 5, 8, 9]]
+```
+
+The known abstract `C19_skew` cyclic order that passes the crossing plus
+vertex-circle filter also passes this signature filter:
+
+```bash
+python scripts/check_altman_diagonal_sums.py \
+  --pattern C19_skew \
+  --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1
+```
+
+So the order-dependent signature filter is useful bookkeeping but does not
+close the `C19_skew` abstract-order gap.

--- a/scripts/check_altman_diagonal_sums.py
+++ b/scripts/check_altman_diagonal_sums.py
@@ -14,7 +14,10 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from erdos97.altman_diagonal_sums import check_altman  # noqa: E402
+from erdos97.altman_diagonal_sums import (  # noqa: E402
+    altman_order_obstruction,
+    check_altman,
+)
 from erdos97.search import built_in_patterns  # noqa: E402
 
 PATTERN_LEDGER = ROOT / "data" / "patterns" / "candidate_patterns.json"
@@ -49,6 +52,13 @@ def abstract_status_from_ledger(pattern_name: str) -> str:
     if normalized.startswith("killed"):
         return "EXACT_OBSTRUCTION"
     return abstract_status or "UNTOUCHED"
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
 
 
 def decorate_row(row: dict[str, object]) -> dict[str, object]:
@@ -105,6 +115,11 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="print JSON instead of a table")
     parser.add_argument("--pattern", help="limit checks to one built-in pattern")
     parser.add_argument(
+        "--order",
+        type=parse_order,
+        help="comma-separated cyclic order for the order-dependent signature filter",
+    )
+    parser.add_argument(
         "--assert-expected",
         action="store_true",
         help="assert every registered expected output is selected and correct",
@@ -123,6 +138,29 @@ def main() -> int:
         selected = [patterns[args.pattern]]
     else:
         selected = list(patterns.values())
+
+    if args.order is not None:
+        if len(selected) != 1:
+            raise SystemExit("--order requires exactly one --pattern")
+        pattern = selected[0]
+        row = dataclasses.asdict(
+            altman_order_obstruction(pattern.S, args.order, pattern.name)
+        )
+        if args.assert_natural_killed and not row["altman_contradiction"]:
+            raise AssertionError(f"{pattern.name}: expected an Altman contradiction")
+        if args.assert_expected:
+            assert_expected([decorate_row(dataclasses.asdict(check_altman(pattern)))])
+        if args.json:
+            print(json.dumps(row, indent=2, sort_keys=True))
+        else:
+            print("pattern  n  status                    equal diagonal groups")
+            print(
+                f"{row['pattern']}  {row['n']}  {row['status']}  "
+                f"{row['equal_diagonal_order_groups']}"
+            )
+            if args.assert_expected or args.assert_natural_killed:
+                print("OK: Altman order expectation verified")
+        return 0
 
     rows = [decorate_row(dataclasses.asdict(check_altman(pattern))) for pattern in selected]
     if args.assert_expected:

--- a/src/erdos97/altman_diagonal_sums.py
+++ b/src/erdos97/altman_diagonal_sums.py
@@ -11,6 +11,8 @@ from typing import Sequence
 
 from erdos97.search import PatternInfo
 
+Pair = tuple[int, int]
+
 
 @dataclass(frozen=True)
 class AltmanDiagonalSumResult:
@@ -24,12 +26,56 @@ class AltmanDiagonalSumResult:
     status: str
 
 
+@dataclass(frozen=True)
+class AltmanOrderResult:
+    pattern: str
+    n: int
+    order: list[int]
+    diagonal_orders: list[int]
+    distance_class_count: int
+    equal_diagonal_order_groups: list[list[int]]
+    altman_contradiction: bool
+    status: str
+
+
+class UnionFind:
+    """Small deterministic union-find over unordered vertex pairs."""
+
+    def __init__(self, items: Sequence[Pair]) -> None:
+        self.parent = {item: item for item in items}
+
+    def find(self, item: Pair) -> Pair:
+        if item not in self.parent:
+            self.parent[item] = item
+        while self.parent[item] != item:
+            self.parent[item] = self.parent[self.parent[item]]
+            item = self.parent[item]
+        return item
+
+    def union(self, a: Pair, b: Pair) -> None:
+        root_a = self.find(a)
+        root_b = self.find(b)
+        if root_a == root_b:
+            return
+        if root_b < root_a:
+            root_a, root_b = root_b, root_a
+        self.parent[root_b] = root_a
+
+
 def chord_order(n: int, offset: int) -> int:
     """Return the cyclic chord order of an offset modulo n."""
     if n <= 0:
         raise ValueError(f"n must be positive, got {n}")
     t = offset % n
     return min(t, n - t)
+
+
+def pair(u: int, v: int) -> Pair:
+    """Return a normalized unordered pair. Reject loops."""
+
+    if u == v:
+        raise ValueError(f"loop pair is not allowed: ({u}, {v})")
+    return (u, v) if u < v else (v, u)
 
 
 def signed_offset(n: int, residue: int) -> int:
@@ -96,3 +142,102 @@ def check_altman(pattern: PatternInfo) -> AltmanDiagonalSumResult:
             else "NO_NATURAL_ORDER_ALTMAN_OBSTRUCTION"
         ),
     )
+
+
+def altman_order_obstruction(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+    pattern: str = "",
+) -> AltmanOrderResult:
+    """Check the Altman diagonal-sum signature obstruction for one order.
+
+    Selected rows force equal distance classes. For a fixed cyclic order, each
+    Altman diagonal sum ``U_k`` is then a formal sum of those classes. If two
+    distinct ``U_k`` have the same formal signature, the selected equalities
+    force them equal, contradicting Altman's strict chain.
+    """
+
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    _validate_order(order, n)
+
+    uf = _distance_class_union_find(S)
+    representatives = {uf.find(pair(u, v)) for u in range(n) for v in range(u + 1, n)}
+    signatures = {
+        diagonal_order: _diagonal_signature(uf, order, diagonal_order)
+        for diagonal_order in range(1, n // 2 + 1)
+    }
+    grouped: dict[tuple[tuple[Pair, int], ...], list[int]] = {}
+    for diagonal_order, signature in signatures.items():
+        grouped.setdefault(signature, []).append(diagonal_order)
+    equal_groups = sorted(
+        sorted(group)
+        for group in grouped.values()
+        if len(group) >= 2
+    )
+    contradiction = bool(equal_groups)
+    return AltmanOrderResult(
+        pattern=pattern,
+        n=n,
+        order=order,
+        diagonal_orders=list(range(1, n // 2 + 1)),
+        distance_class_count=len(representatives),
+        equal_diagonal_order_groups=equal_groups,
+        altman_contradiction=contradiction,
+        status=(
+            "ORDER_EXACT_OBSTRUCTION"
+            if contradiction
+            else "NO_ORDER_ALTMAN_SIGNATURE_OBSTRUCTION"
+        ),
+    )
+
+
+def _validate_order(order: Sequence[int], n: int) -> None:
+    seen = set(order)
+    if len(order) != n or seen != set(range(n)):
+        missing = sorted(set(range(n)) - seen)
+        extra = sorted(seen - set(range(n)))
+        raise ValueError(
+            f"cyclic order is not a permutation; missing={missing}, extra={extra}"
+        )
+
+
+def _all_pairs(n: int) -> list[Pair]:
+    return [(u, v) for u in range(n) for v in range(u + 1, n)]
+
+
+def _distance_class_union_find(S: Sequence[Sequence[int]]) -> UnionFind:
+    n = len(S)
+    uf = UnionFind(_all_pairs(n))
+    for center, row in enumerate(S):
+        if len(row) != 4:
+            raise ValueError(f"row {center} has length {len(row)}, expected 4")
+        if len(set(row)) != 4:
+            raise ValueError(f"row {center} has repeated witnesses: {list(row)}")
+        if center in row:
+            raise ValueError(f"row {center} contains its own center")
+        for witness in row:
+            if witness < 0 or witness >= n:
+                raise ValueError(
+                    f"row {center} contains out-of-range label {witness}"
+                )
+        base = pair(center, int(row[0]))
+        for witness in row[1:]:
+            uf.union(base, pair(center, int(witness)))
+    return uf
+
+
+def _diagonal_signature(
+    uf: UnionFind,
+    order: Sequence[int],
+    diagonal_order: int,
+) -> tuple[tuple[Pair, int], ...]:
+    counts: dict[Pair, int] = {}
+    n = len(order)
+    for idx, source in enumerate(order):
+        target = order[(idx + diagonal_order) % n]
+        distance_class = uf.find(pair(source, target))
+        counts[distance_class] = counts.get(distance_class, 0) + 1
+    return tuple(sorted(counts.items()))

--- a/tests/test_altman_diagonal_sums.py
+++ b/tests/test_altman_diagonal_sums.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from erdos97.altman_diagonal_sums import check_altman, chord_order
+from erdos97.altman_diagonal_sums import (
+    altman_order_obstruction,
+    check_altman,
+    chord_order,
+)
 from erdos97.search import built_in_patterns
 
 
@@ -32,3 +36,22 @@ def test_parity_patterns_are_not_automatically_altman_checked() -> None:
 
     assert not result.altman_contradiction
     assert result.status == "NOT_APPLIED_NONCONSTANT_OFFSETS"
+
+
+def test_c19_natural_order_signature_filter_recovers_altman_kill() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    result = altman_order_obstruction(pattern.S, list(range(pattern.n)), pattern.name)
+
+    assert result.status == "ORDER_EXACT_OBSTRUCTION"
+    assert result.altman_contradiction
+    assert result.equal_diagonal_order_groups == [[3, 5, 8, 9]]
+
+
+def test_c19_known_abstract_order_passes_signature_filter() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    order = [18, 10, 7, 17, 6, 3, 5, 9, 14, 11, 2, 13, 4, 16, 12, 15, 0, 8, 1]
+    result = altman_order_obstruction(pattern.S, order, pattern.name)
+
+    assert result.status == "NO_ORDER_ALTMAN_SIGNATURE_OBSTRUCTION"
+    assert not result.altman_contradiction
+    assert result.equal_diagonal_order_groups == []


### PR DESCRIPTION
## Summary
- add a fixed-cyclic-order Altman diagonal-sum signature filter
- expose it through `check_altman_diagonal_sums.py --order`
- recover the natural-order `C19_skew` obstruction as equal formal signatures for `U_3`, `U_5`, `U_8`, and `U_9`
- document that the known abstract `C19_skew` order still passes this filter, so the abstract-order gap remains open

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --order 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 --assert-natural-killed`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1`

No proof or counterexample is claimed; this is an exact fixed-order necessary filter and a negative update for the C19 abstract-order route.