### PR TITLE
Add Altman LP chain diagnostic

### DIFF
--- a/docs/altman-diagonal-sums.md
+++ b/docs/altman-diagonal-sums.md
@@ -117,3 +117,33 @@ python scripts/check_altman_diagonal_sums.py \
 
 So the order-dependent signature filter is useful bookkeeping but does not
 close the `C19_skew` abstract-order gap.
+
+## Altman LP Relaxation
+
+There is also a numerical linear diagnostic:
+
+```bash
+python scripts/check_altman_diagonal_sums.py \
+  --pattern C19_skew \
+  --order 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 \
+  --lp-diagnostic \
+  --assert-natural-killed
+```
+
+It assigns one nonnegative variable to each selected-distance class, normalizes
+their sum to `1`, and maximizes `gamma` subject to
+
+```text
+U_{k+1} - U_k >= gamma
+```
+
+for every adjacent diagonal order. A positive optimum means the selected
+distance classes can satisfy Altman's strict chain at this relaxation level. A
+nonpositive optimum is a `NUMERICAL_LINEAR_DIAGNOSTIC` obstruction for the
+fixed order.
+
+For natural-order `C19_skew`, the optimum is `-0.0`, matching the exact
+signature obstruction above. For the known abstract `C19_skew` order, the
+optimum is `0.08333333333333333`, so this broader relaxation still does not
+kill that order. This is useful negative information, not evidence of
+geometric realizability.

--- a/scripts/check_altman_diagonal_sums.py
+++ b/scripts/check_altman_diagonal_sums.py
@@ -15,6 +15,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.altman_diagonal_sums import (  # noqa: E402
+    altman_order_lp_diagnostic,
     altman_order_obstruction,
     check_altman,
 )
@@ -120,6 +121,11 @@ def main() -> int:
         help="comma-separated cyclic order for the order-dependent signature filter",
     )
     parser.add_argument(
+        "--lp-diagnostic",
+        action="store_true",
+        help="with --order, run the numerical Altman-chain LP relaxation",
+    )
+    parser.add_argument(
         "--assert-expected",
         action="store_true",
         help="assert every registered expected output is selected and correct",
@@ -143,21 +149,39 @@ def main() -> int:
         if len(selected) != 1:
             raise SystemExit("--order requires exactly one --pattern")
         pattern = selected[0]
-        row = dataclasses.asdict(
-            altman_order_obstruction(pattern.S, args.order, pattern.name)
-        )
-        if args.assert_natural_killed and not row["altman_contradiction"]:
-            raise AssertionError(f"{pattern.name}: expected an Altman contradiction")
+        if args.lp_diagnostic:
+            row = dataclasses.asdict(
+                altman_order_lp_diagnostic(pattern.S, args.order, pattern.name)
+            )
+        else:
+            row = dataclasses.asdict(
+                altman_order_obstruction(pattern.S, args.order, pattern.name)
+            )
+        if args.assert_natural_killed:
+            obstructed = (
+                bool(row.get("obstructed"))
+                if args.lp_diagnostic
+                else bool(row["altman_contradiction"])
+            )
+            if not obstructed:
+                raise AssertionError(f"{pattern.name}: expected an Altman obstruction")
         if args.assert_expected:
             assert_expected([decorate_row(dataclasses.asdict(check_altman(pattern)))])
         if args.json:
             print(json.dumps(row, indent=2, sort_keys=True))
         else:
-            print("pattern  n  status                    equal diagonal groups")
-            print(
-                f"{row['pattern']}  {row['n']}  {row['status']}  "
-                f"{row['equal_diagonal_order_groups']}"
-            )
+            if args.lp_diagnostic:
+                print("pattern  n  status                           max margin")
+                print(
+                    f"{row['pattern']}  {row['n']}  {row['status']}  "
+                    f"{row['max_margin']}"
+                )
+            else:
+                print("pattern  n  status                    equal diagonal groups")
+                print(
+                    f"{row['pattern']}  {row['n']}  {row['status']}  "
+                    f"{row['equal_diagonal_order_groups']}"
+                )
             if args.assert_expected or args.assert_natural_killed:
                 print("OK: Altman order expectation verified")
         return 0

--- a/src/erdos97/altman_diagonal_sums.py
+++ b/src/erdos97/altman_diagonal_sums.py
@@ -38,6 +38,21 @@ class AltmanOrderResult:
     status: str
 
 
+@dataclass(frozen=True)
+class AltmanLPResult:
+    pattern: str
+    n: int
+    order: list[int]
+    trust_label: str
+    status: str
+    obstructed: bool | None
+    distance_class_count: int
+    inequality_count: int
+    max_margin: float | None
+    tolerance: float
+    message: str
+
+
 class UnionFind:
     """Small deterministic union-find over unordered vertex pairs."""
 
@@ -194,6 +209,99 @@ def altman_order_obstruction(
     )
 
 
+def altman_order_lp_diagnostic(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+    pattern: str = "",
+    tolerance: float = 1e-9,
+) -> AltmanLPResult:
+    """Numerically test Altman's strict chain over distance classes.
+
+    This maximizes ``gamma`` subject to ``sum(x)=1``, ``x >= 0``, and
+    ``U_{k+1}(x)-U_k(x) >= gamma`` for every adjacent diagonal order.  A
+    positive optimum means the selected-distance classes can pass this
+    necessary Altman-chain relaxation.  A nonpositive optimum is a numerical
+    obstruction for the supplied order.
+    """
+
+    if tolerance < 0:
+        raise ValueError("tolerance must be nonnegative")
+    np, linprog = _linear_programming()
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    _validate_order(order, n)
+    class_reps, coefficient_rows = _diagonal_coefficient_rows(S, order)
+    inequality_count = max(0, len(coefficient_rows) - 1)
+    if inequality_count == 0:
+        return AltmanLPResult(
+            pattern=pattern,
+            n=n,
+            order=order,
+            trust_label="NUMERICAL_LINEAR_DIAGNOSTIC",
+            status="NO_ALTMAN_INEQUALITIES",
+            obstructed=False,
+            distance_class_count=len(class_reps),
+            inequality_count=0,
+            max_margin=None,
+            tolerance=float(tolerance),
+            message="fewer than two diagonal orders",
+        )
+
+    class_count = len(class_reps)
+    objective = np.zeros(class_count + 1)
+    objective[-1] = -1.0
+    constraints = []
+    for left, right in zip(coefficient_rows, coefficient_rows[1:]):
+        gap = right - left
+        row = np.zeros(class_count + 1)
+        row[:class_count] = -gap
+        row[-1] = 1.0
+        constraints.append(row)
+    result = linprog(
+        c=objective,
+        A_ub=np.vstack(constraints),
+        b_ub=np.zeros(inequality_count),
+        A_eq=np.array([[*([1.0] * class_count), 0.0]]),
+        b_eq=np.array([1.0]),
+        bounds=[(0.0, None)] * class_count + [(None, None)],
+        method="highs",
+    )
+    if not result.success:
+        return AltmanLPResult(
+            pattern=pattern,
+            n=n,
+            order=order,
+            trust_label="NUMERICAL_LINEAR_DIAGNOSTIC",
+            status="UNKNOWN_LP_FAILURE",
+            obstructed=None,
+            distance_class_count=class_count,
+            inequality_count=inequality_count,
+            max_margin=None,
+            tolerance=float(tolerance),
+            message=str(result.message),
+        )
+
+    max_margin = float(result.x[-1])
+    obstructed = max_margin <= tolerance
+    return AltmanLPResult(
+        pattern=pattern,
+        n=n,
+        order=order,
+        trust_label="NUMERICAL_LINEAR_DIAGNOSTIC",
+        status=(
+            "NUMERICAL_ALTMAN_LP_OBSTRUCTION"
+            if obstructed
+            else "PASS_ALTMAN_LP_RELAXATION"
+        ),
+        obstructed=obstructed,
+        distance_class_count=class_count,
+        inequality_count=inequality_count,
+        max_margin=max_margin,
+        tolerance=float(tolerance),
+        message=str(result.message),
+    )
 def _validate_order(order: Sequence[int], n: int) -> None:
     seen = set(order)
     if len(order) != n or seen != set(range(n)):
@@ -241,3 +349,35 @@ def _diagonal_signature(
         distance_class = uf.find(pair(source, target))
         counts[distance_class] = counts.get(distance_class, 0) + 1
     return tuple(sorted(counts.items()))
+
+
+def _diagonal_coefficient_rows(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int],
+):
+    np, _ = _linear_programming()
+    uf = _distance_class_union_find(S)
+    class_reps = sorted(
+        {uf.find(pair(u, v)) for u in range(len(S)) for v in range(u + 1, len(S))}
+    )
+    class_index = {distance_class: idx for idx, distance_class in enumerate(class_reps)}
+    rows = []
+    for diagonal_order in range(1, len(S) // 2 + 1):
+        row = np.zeros(len(class_reps))
+        for idx, source in enumerate(order):
+            target = order[(idx + diagonal_order) % len(order)]
+            distance_class = uf.find(pair(source, target))
+            row[class_index[distance_class]] += 1.0
+        rows.append(row)
+    return class_reps, rows
+
+
+def _linear_programming():
+    try:
+        import numpy as np  # type: ignore
+        from scipy.optimize import linprog  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depends on dev deps
+        raise RuntimeError(
+            "NumPy and SciPy are required for Altman LP diagnostics"
+        ) from exc
+    return np, linprog

--- a/tests/test_altman_diagonal_sums.py
+++ b/tests/test_altman_diagonal_sums.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from erdos97.altman_diagonal_sums import (
+    altman_order_lp_diagnostic,
     altman_order_obstruction,
     check_altman,
     chord_order,
@@ -55,3 +56,25 @@ def test_c19_known_abstract_order_passes_signature_filter() -> None:
     assert result.status == "NO_ORDER_ALTMAN_SIGNATURE_OBSTRUCTION"
     assert not result.altman_contradiction
     assert result.equal_diagonal_order_groups == []
+
+
+def test_c19_natural_order_fails_altman_lp_relaxation() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    result = altman_order_lp_diagnostic(pattern.S, list(range(pattern.n)), pattern.name)
+
+    assert result.status == "NUMERICAL_ALTMAN_LP_OBSTRUCTION"
+    assert result.trust_label == "NUMERICAL_LINEAR_DIAGNOSTIC"
+    assert result.obstructed is True
+    assert result.max_margin is not None
+    assert result.max_margin <= result.tolerance
+
+
+def test_c19_known_abstract_order_passes_altman_lp_relaxation() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    order = [18, 10, 7, 17, 6, 3, 5, 9, 14, 11, 2, 13, 4, 16, 12, 15, 0, 8, 1]
+    result = altman_order_lp_diagnostic(pattern.S, order, pattern.name)
+
+    assert result.status == "PASS_ALTMAN_LP_RELAXATION"
+    assert result.obstructed is False
+    assert result.max_margin is not None
+    assert result.max_margin > result.tolerance


### PR DESCRIPTION
## Summary
- add a numerical Altman-chain LP diagnostic over selected-distance classes
- expose it through `check_altman_diagonal_sums.py --order --lp-diagnostic`
- record that natural-order `C19_skew` has nonpositive LP margin, while the known abstract `C19_skew` order passes with margin `0.08333333333333333`
- keep the LP result labeled `NUMERICAL_LINEAR_DIAGNOSTIC`

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --order 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 --lp-diagnostic --assert-natural-killed`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1 --lp-diagnostic`

No proof or counterexample is claimed; this is a numerical fixed-order relaxation and negative evidence for the C19 abstract-order route.