### PR TITLE
Add exact Altman linear certificates

### DIFF
--- a/docs/altman-diagonal-sums.md
+++ b/docs/altman-diagonal-sums.md
@@ -147,3 +147,34 @@ signature obstruction above. For the known abstract `C19_skew` order, the
 optimum is `0.08333333333333333`, so this broader relaxation still does not
 kill that order. This is useful negative information, not evidence of
 geometric realizability.
+
+## Exact Linear Certificates
+
+The same adjacent-gap bookkeeping can emit an exact rational certificate:
+
+```bash
+python scripts/check_altman_diagonal_sums.py \
+  --pattern C19_skew \
+  --order 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 \
+  --rational-certificate \
+  --assert-natural-killed
+```
+
+A certificate is a nonnegative rational combination of adjacent Altman gaps
+`U_{k+1} - U_k` whose selected-distance-class coefficients are all
+nonpositive. If all adjacent Altman gaps were strictly positive, every
+nonzero nonnegative combination would be positive. The verified nonpositive
+coefficient vector is therefore an exact fixed-order obstruction.
+
+For natural-order `C19_skew`, the shortest certificate found uses the single
+adjacent gap
+
+```text
+U_9-U_8.
+```
+
+The selected rows force the formal coefficient vector to be identically zero,
+so Altman's strict inequality `U_8 < U_9` is impossible. The known abstract
+`C19_skew` order has no such rational certificate with denominator at most
+`1000` under the current search. That is only a certificate-search miss, not a
+realizability claim.

--- a/scripts/check_altman_diagonal_sums.py
+++ b/scripts/check_altman_diagonal_sums.py
@@ -15,6 +15,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.altman_diagonal_sums import (  # noqa: E402
+    altman_order_linear_certificate,
     altman_order_lp_diagnostic,
     altman_order_obstruction,
     check_altman,
@@ -126,6 +127,17 @@ def main() -> int:
         help="with --order, run the numerical Altman-chain LP relaxation",
     )
     parser.add_argument(
+        "--rational-certificate",
+        action="store_true",
+        help="with --order, search for an exact rational Altman-chain certificate",
+    )
+    parser.add_argument(
+        "--max-denominator",
+        type=int,
+        default=1000,
+        help="maximum denominator for rationalized LP-dual certificate weights",
+    )
+    parser.add_argument(
         "--assert-expected",
         action="store_true",
         help="assert every registered expected output is selected and correct",
@@ -136,6 +148,10 @@ def main() -> int:
         help="assert every selected pattern has an Altman contradiction",
     )
     args = parser.parse_args()
+    if args.lp_diagnostic and args.rational_certificate:
+        raise SystemExit(
+            "--lp-diagnostic and --rational-certificate are mutually exclusive"
+        )
 
     patterns = built_in_patterns()
     if args.pattern:
@@ -149,7 +165,16 @@ def main() -> int:
         if len(selected) != 1:
             raise SystemExit("--order requires exactly one --pattern")
         pattern = selected[0]
-        if args.lp_diagnostic:
+        if args.rational_certificate:
+            row = dataclasses.asdict(
+                altman_order_linear_certificate(
+                    pattern.S,
+                    args.order,
+                    pattern.name,
+                    max_denominator=args.max_denominator,
+                )
+            )
+        elif args.lp_diagnostic:
             row = dataclasses.asdict(
                 altman_order_lp_diagnostic(pattern.S, args.order, pattern.name)
             )
@@ -160,7 +185,7 @@ def main() -> int:
         if args.assert_natural_killed:
             obstructed = (
                 bool(row.get("obstructed"))
-                if args.lp_diagnostic
+                if args.lp_diagnostic or args.rational_certificate
                 else bool(row["altman_contradiction"])
             )
             if not obstructed:
@@ -170,7 +195,13 @@ def main() -> int:
         if args.json:
             print(json.dumps(row, indent=2, sort_keys=True))
         else:
-            if args.lp_diagnostic:
+            if args.rational_certificate:
+                print("pattern  n  status                            nonzero gaps")
+                print(
+                    f"{row['pattern']}  {row['n']}  {row['status']}  "
+                    f"{row['nonzero_gap_orders']}"
+                )
+            elif args.lp_diagnostic:
                 print("pattern  n  status                           max margin")
                 print(
                     f"{row['pattern']}  {row['n']}  {row['status']}  "

--- a/src/erdos97/altman_diagonal_sums.py
+++ b/src/erdos97/altman_diagonal_sums.py
@@ -7,6 +7,7 @@ coordinates or floating point.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from fractions import Fraction
 from typing import Sequence
 
 from erdos97.search import PatternInfo
@@ -50,6 +51,27 @@ class AltmanLPResult:
     inequality_count: int
     max_margin: float | None
     tolerance: float
+    message: str
+
+
+@dataclass(frozen=True)
+class AltmanLinearCertificateResult:
+    pattern: str
+    n: int
+    order: list[int]
+    trust_label: str
+    status: str
+    obstructed: bool
+    distance_class_count: int
+    inequality_count: int
+    gap_orders: list[int]
+    nonzero_gap_orders: list[int]
+    weights: list[str]
+    combined_nonzero_coefficients: list[tuple[Pair, str]]
+    positive_coefficient_count: int
+    negative_coefficient_count: int
+    zero_coefficient_count: int
+    certificate_method: str
     message: str
 
 
@@ -302,6 +324,104 @@ def altman_order_lp_diagnostic(
         tolerance=float(tolerance),
         message=str(result.message),
     )
+
+
+def altman_order_linear_certificate(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+    pattern: str = "",
+    max_denominator: int = 1000,
+    tolerance: float = 1e-9,
+) -> AltmanLinearCertificateResult:
+    """Search for an exact rational Altman-chain certificate.
+
+    The certificate is a nonzero nonnegative rational combination of adjacent
+    Altman gaps ``U_{k+1}-U_k`` whose selected-distance-class coefficients are
+    all nonpositive.  If every Altman gap were strictly positive, the weighted
+    combination would be strictly positive; the nonpositive coefficient vector
+    contradicts that for nonnegative distance classes.
+    """
+
+    if max_denominator <= 0:
+        raise ValueError("max_denominator must be positive")
+    if tolerance < 0:
+        raise ValueError("tolerance must be nonnegative")
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    _validate_order(order, n)
+    class_reps, coefficient_rows = _diagonal_integer_rows(S, order)
+    inequality_count = max(0, len(coefficient_rows) - 1)
+    if inequality_count == 0:
+        return _linear_certificate_result(
+            pattern=pattern,
+            n=n,
+            order=order,
+            class_reps=class_reps,
+            gap_rows=[],
+            weights=[],
+            certificate_method="none",
+            message="fewer than two diagonal orders",
+        )
+
+    gap_rows = [
+        [right[idx] - left[idx] for idx in range(len(class_reps))]
+        for left, right in zip(coefficient_rows, coefficient_rows[1:])
+    ]
+    interval = _interval_dominance_certificate(coefficient_rows)
+    if interval is not None:
+        start, end = interval
+        weights = [Fraction(0) for _ in gap_rows]
+        weight = Fraction(1, end - start)
+        for idx in range(start, end):
+            weights[idx] = weight
+        return _linear_certificate_result(
+            pattern=pattern,
+            n=n,
+            order=order,
+            class_reps=class_reps,
+            gap_rows=gap_rows,
+            weights=weights,
+            certificate_method="interval_dominance",
+            message=(
+                f"averaged gaps from U_{start + 1} to U_{end + 1} "
+                "have nonpositive coefficients"
+            ),
+        )
+
+    weights = _rationalized_dual_certificate(
+        gap_rows,
+        max_denominator=max_denominator,
+        tolerance=tolerance,
+    )
+    if weights is not None:
+        return _linear_certificate_result(
+            pattern=pattern,
+            n=n,
+            order=order,
+            class_reps=class_reps,
+            gap_rows=gap_rows,
+            weights=weights,
+            certificate_method="rationalized_lp_dual",
+            message="rationalized LP-dual certificate verified exactly",
+        )
+
+    return _linear_certificate_result(
+        pattern=pattern,
+        n=n,
+        order=order,
+        class_reps=class_reps,
+        gap_rows=gap_rows,
+        weights=[],
+        certificate_method="none",
+        message=(
+            "no exact rational Altman-chain certificate found with "
+            f"denominator <= {max_denominator}"
+        ),
+    )
+
+
 def _validate_order(order: Sequence[int], n: int) -> None:
     seen = set(order)
     if len(order) != n or seen != set(range(n)):
@@ -356,6 +476,15 @@ def _diagonal_coefficient_rows(
     order: Sequence[int],
 ):
     np, _ = _linear_programming()
+    class_reps, integer_rows = _diagonal_integer_rows(S, order)
+    rows = [np.array(row, dtype=float) for row in integer_rows]
+    return class_reps, rows
+
+
+def _diagonal_integer_rows(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int],
+) -> tuple[list[Pair], list[list[int]]]:
     uf = _distance_class_union_find(S)
     class_reps = sorted(
         {uf.find(pair(u, v)) for u in range(len(S)) for v in range(u + 1, len(S))}
@@ -363,13 +492,150 @@ def _diagonal_coefficient_rows(
     class_index = {distance_class: idx for idx, distance_class in enumerate(class_reps)}
     rows = []
     for diagonal_order in range(1, len(S) // 2 + 1):
-        row = np.zeros(len(class_reps))
+        row = [0] * len(class_reps)
         for idx, source in enumerate(order):
             target = order[(idx + diagonal_order) % len(order)]
             distance_class = uf.find(pair(source, target))
-            row[class_index[distance_class]] += 1.0
+            row[class_index[distance_class]] += 1
         rows.append(row)
     return class_reps, rows
+
+
+def _interval_dominance_certificate(
+    coefficient_rows: Sequence[Sequence[int]],
+) -> tuple[int, int] | None:
+    """Return row indices start < end with U_end - U_start coefficientwise <= 0."""
+
+    for width in range(1, len(coefficient_rows)):
+        for start in range(0, len(coefficient_rows) - width):
+            end = start + width
+            diff = [
+                coefficient_rows[end][idx] - coefficient_rows[start][idx]
+                for idx in range(len(coefficient_rows[start]))
+            ]
+            if all(value <= 0 for value in diff):
+                return start, end
+    return None
+
+
+def _rationalized_dual_certificate(
+    gap_rows: Sequence[Sequence[int]],
+    max_denominator: int,
+    tolerance: float,
+) -> list[Fraction] | None:
+    if not gap_rows:
+        return None
+    np, linprog = _linear_programming()
+    gap_matrix = np.array(gap_rows, dtype=float)
+    result = linprog(
+        c=np.zeros(len(gap_rows)),
+        A_ub=gap_matrix.T,
+        b_ub=np.zeros(len(gap_rows[0])),
+        A_eq=np.array([[1.0] * len(gap_rows)]),
+        b_eq=np.array([1.0]),
+        bounds=[(0.0, None)] * len(gap_rows),
+        method="highs",
+    )
+    if not result.success:
+        return None
+    weights = [
+        Fraction(0)
+        if abs(float(value)) <= tolerance
+        else Fraction(float(value)).limit_denominator(max_denominator)
+        for value in result.x
+    ]
+    if _combined_certificate_coefficients(gap_rows, weights) is None:
+        return None
+    return weights
+
+
+def _linear_certificate_result(
+    pattern: str,
+    n: int,
+    order: Sequence[int],
+    class_reps: Sequence[Pair],
+    gap_rows: Sequence[Sequence[int]],
+    weights: Sequence[Fraction],
+    certificate_method: str,
+    message: str,
+) -> AltmanLinearCertificateResult:
+    combined = _combined_certificate_coefficients(gap_rows, weights)
+    obstructed = combined is not None
+    if combined is None:
+        combined = []
+        positive_count = 0
+        negative_count = 0
+        zero_count = 0
+    else:
+        positive_count = sum(1 for value in combined if value > 0)
+        negative_count = sum(1 for value in combined if value < 0)
+        zero_count = len(class_reps) - positive_count - negative_count
+    return AltmanLinearCertificateResult(
+        pattern=pattern,
+        n=n,
+        order=list(order),
+        trust_label=(
+            "EXACT_LINEAR_CERTIFICATE"
+            if obstructed
+            else "NO_EXACT_LINEAR_CERTIFICATE"
+        ),
+        status=(
+            "EXACT_ALTMAN_LINEAR_OBSTRUCTION"
+            if obstructed
+            else "NO_EXACT_ALTMAN_LINEAR_CERTIFICATE_FOUND"
+        ),
+        obstructed=obstructed,
+        distance_class_count=len(class_reps),
+        inequality_count=len(gap_rows),
+        gap_orders=list(range(1, len(gap_rows) + 1)),
+        nonzero_gap_orders=[
+            idx + 1 for idx, weight in enumerate(weights) if weight != 0
+        ],
+        weights=[_fraction_string(weight) for weight in weights],
+        combined_nonzero_coefficients=[
+            (distance_class, _fraction_string(value))
+            for distance_class, value in zip(class_reps, combined)
+            if value != 0
+        ],
+        positive_coefficient_count=positive_count,
+        negative_coefficient_count=negative_count,
+        zero_coefficient_count=zero_count,
+        certificate_method=certificate_method,
+        message=message,
+    )
+
+
+def _combined_certificate_coefficients(
+    gap_rows: Sequence[Sequence[int]],
+    weights: Sequence[Fraction],
+) -> list[Fraction] | None:
+    if not gap_rows or not weights:
+        return None
+    if len(gap_rows) != len(weights):
+        return None
+    if any(weight < 0 for weight in weights):
+        return None
+    if sum(weights, Fraction(0)) != 1:
+        return None
+    if not any(weight > 0 for weight in weights):
+        return None
+    combined = []
+    for idx in range(len(gap_rows[0])):
+        combined.append(
+            sum(
+                weights[gap_idx] * gap_rows[gap_idx][idx]
+                for gap_idx in range(len(gap_rows))
+            )
+        )
+    if any(value > 0 for value in combined):
+        return None
+    return combined
+
+
+def _fraction_string(value: Fraction) -> str:
+    if value.denominator == 1:
+        return str(value.numerator)
+    return f"{value.numerator}/{value.denominator}"
 
 
 def _linear_programming():

--- a/tests/test_altman_diagonal_sums.py
+++ b/tests/test_altman_diagonal_sums.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from erdos97.altman_diagonal_sums import (
+    altman_order_linear_certificate,
     altman_order_lp_diagnostic,
     altman_order_obstruction,
     check_altman,
@@ -69,6 +70,22 @@ def test_c19_natural_order_fails_altman_lp_relaxation() -> None:
     assert result.max_margin <= result.tolerance
 
 
+def test_c19_natural_order_has_exact_altman_linear_certificate() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    result = altman_order_linear_certificate(
+        pattern.S, list(range(pattern.n)), pattern.name
+    )
+
+    assert result.status == "EXACT_ALTMAN_LINEAR_OBSTRUCTION"
+    assert result.trust_label == "EXACT_LINEAR_CERTIFICATE"
+    assert result.obstructed is True
+    assert result.certificate_method == "interval_dominance"
+    assert result.nonzero_gap_orders == [8]
+    assert result.positive_coefficient_count == 0
+    assert result.combined_nonzero_coefficients == []
+    assert result.weights == ["0", "0", "0", "0", "0", "0", "0", "1"]
+
+
 def test_c19_known_abstract_order_passes_altman_lp_relaxation() -> None:
     pattern = built_in_patterns()["C19_skew"]
     order = [18, 10, 7, 17, 6, 3, 5, 9, 14, 11, 2, 13, 4, 16, 12, 15, 0, 8, 1]
@@ -78,3 +95,13 @@ def test_c19_known_abstract_order_passes_altman_lp_relaxation() -> None:
     assert result.obstructed is False
     assert result.max_margin is not None
     assert result.max_margin > result.tolerance
+
+
+def test_c19_known_abstract_order_has_no_altman_linear_certificate() -> None:
+    pattern = built_in_patterns()["C19_skew"]
+    order = [18, 10, 7, 17, 6, 3, 5, 9, 14, 11, 2, 13, 4, 16, 12, 15, 0, 8, 1]
+    result = altman_order_linear_certificate(pattern.S, order, pattern.name)
+
+    assert result.status == "NO_EXACT_ALTMAN_LINEAR_CERTIFICATE_FOUND"
+    assert result.obstructed is False
+    assert result.weights == []


### PR DESCRIPTION
## Summary
- add exact rational Altman-chain certificate search over selected-distance classes
- expose it through `check_altman_diagonal_sums.py --order --rational-certificate`
- certify natural-order `C19_skew` with the one-gap obstruction `U_9 - U_8`
- keep the known abstract `C19_skew` order as a certificate-search miss, not a realizability claim

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest tests/test_altman_diagonal_sums.py -q`
- `python -m pytest -q`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --order 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 --rational-certificate --assert-natural-killed --json`
- `python scripts/check_altman_diagonal_sums.py --pattern C19_skew --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1 --rational-certificate --json`

No general proof or counterexample is claimed; this is fixed-order exact certificate infrastructure.