### PR TITLE
Add radius propagation filter

### DIFF
--- a/docs/minimum-radius-filter.md
+++ b/docs/minimum-radius-filter.md
@@ -97,11 +97,44 @@ escape persists for every cyclic order. The `C13_sidon_1_2_4_10` pattern does
 not have this order-free escape certificate, which is why adversarial cyclic
 orders remain useful for it. See `docs/sparse-frontier-diagnostic.md`.
 
+## Radius-Propagation Search
+
+The strengthened fixed-order diagnostic searches all choices of one
+consecutive witness pair per row. Choosing pair `{a,b}` for center `i` means
+that pair is allowed to be the short chord guaranteed by the lemma. If `b in
+S_a`, the choice forces `r_a < r_i`; if `a in S_b`, it forces `r_b < r_i`.
+A directed cycle of strict radius inequalities is impossible.
+
+The search is exact finite combinatorics for the supplied order:
+
+- `EXACT_RADIUS_PROPAGATION_OBSTRUCTION` means every short-gap choice forces a
+  directed strict-radius cycle.
+- `PASS_RADIUS_PROPAGATION` returns one acyclic short-gap assignment. This is
+  only an escape from this filter, not evidence for realizability.
+- `UNKNOWN_RADIUS_PROPAGATION_NODE_LIMIT` is reported only when an explicit
+  node cap stops the search.
+
+Reproduction:
+
+```bash
+python scripts/check_min_radius_filter.py \
+  --pattern C13_sidon_1_2_4_10 \
+  --radius-propagation \
+  --assert-pass
+```
+
+For natural-order `C13_sidon_1_2_4_10`, the propagation search passes quickly:
+it chooses an uncovered short gap for every row and therefore forces no strict
+radius inequalities. Natural-order `C19_skew` also passes. The toy `n=5`
+all-other-vertices pattern is obstructed by the propagation search, matching
+the original minimum-radius filter.
+
 ## Reproducible check
 
 ```bash
 python scripts/check_min_radius_filter.py --pattern C19_skew --assert-pass
 python scripts/check_min_radius_filter.py --pattern C19_skew --json
+python scripts/check_min_radius_filter.py --pattern C19_skew --radius-propagation --assert-pass
 ```
 
 The first command should report `PASS`, with all 19 centers still possible as

--- a/scripts/check_min_radius_filter.py
+++ b/scripts/check_min_radius_filter.py
@@ -15,6 +15,8 @@ if str(SRC) not in sys.path:
 
 from erdos97.min_radius_filter import (  # noqa: E402
     minimum_radius_order_obstruction,
+    radius_propagation_order_obstruction,
+    radius_result_to_json,
     result_to_json,
 )
 from erdos97.search import built_in_patterns  # noqa: E402
@@ -28,16 +30,29 @@ def parse_order(raw: str) -> list[int]:
 
 
 def assert_obstructed(row: dict[str, object]) -> None:
-    if not row["obstructed"]:
+    if row["obstructed"] is not True:
         raise AssertionError(f"{row['pattern']}: expected obstruction")
 
 
 def assert_pass(row: dict[str, object]) -> None:
-    if row["obstructed"]:
+    if row["obstructed"] is not False:
         raise AssertionError(f"{row['pattern']}: expected pass")
 
 
 def print_summary(row: dict[str, object]) -> None:
+    if row["type"] == "radius_propagation_order_result":
+        print(
+            "pattern  n  result                         nodes  max depth  "
+            "choice count  acyclic choice"
+        )
+        print(
+            f"{row['pattern']}  {row['n']}  {row['status']}  "
+            f"{row['nodes_visited']}  {row['max_depth']}  "
+            f"{row['short_gap_choice_count']}  "
+            f"{row['acyclic_choice'] is not None}"
+        )
+        return
+
     result = "OBSTRUCTED" if row["obstructed"] else "PASS"
     print(
         "pattern  n  result      blocked centers  possible minimum centers  "
@@ -63,6 +78,16 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="print JSON instead of a summary")
     parser.add_argument("--assert-obstructed", action="store_true", help="assert obstruction")
     parser.add_argument("--assert-pass", action="store_true", help="assert no obstruction")
+    parser.add_argument(
+        "--radius-propagation",
+        action="store_true",
+        help="run the stronger fixed-order radius-propagation cycle search",
+    )
+    parser.add_argument(
+        "--max-nodes",
+        type=int,
+        help="optional node cap for the radius-propagation search",
+    )
     parser.add_argument("--write-certificate", help="write JSON result to this path")
     args = parser.parse_args()
 
@@ -71,12 +96,21 @@ def main() -> int:
         raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
     pattern = patterns[args.pattern]
 
-    result = minimum_radius_order_obstruction(
-        pattern.S,
-        order=args.order,
-        pattern=pattern.name,
-    )
-    row = result_to_json(result)
+    if args.radius_propagation:
+        result = radius_propagation_order_obstruction(
+            pattern.S,
+            order=args.order,
+            pattern=pattern.name,
+            max_nodes=args.max_nodes,
+        )
+        row = radius_result_to_json(result)
+    else:
+        result = minimum_radius_order_obstruction(
+            pattern.S,
+            order=args.order,
+            pattern=pattern.name,
+        )
+        row = result_to_json(result)
 
     if args.assert_obstructed:
         assert_obstructed(row)

--- a/src/erdos97/min_radius_filter.py
+++ b/src/erdos97/min_radius_filter.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import combinations, permutations
+from math import prod
 from typing import Sequence
 
 Pair = tuple[int, int]
+DirectedEdge = tuple[int, int]
 Pattern = Sequence[Sequence[int]]
 
 
@@ -50,6 +52,32 @@ class MinRadiusOrderResult:
     order_free_blocked_centers: list[int]
     order_free_empty_gap_centers: list[int]
     obstructed: bool
+
+
+@dataclass(frozen=True)
+class RadiusPropagationChoice:
+    """One selected short-gap choice and its forced radius inequalities."""
+
+    center: int
+    consecutive_pair: Pair
+    selected_sources: list[int]
+    inequality_edges: list[DirectedEdge]
+
+
+@dataclass(frozen=True)
+class RadiusPropagationResult:
+    """Exact fixed-order radius-propagation search result."""
+
+    pattern: str
+    n: int
+    order: list[int]
+    status: str
+    obstructed: bool | None
+    short_gap_choice_count: int
+    nodes_visited: int
+    max_depth: int
+    search_truncated: bool
+    acyclic_choice: list[RadiusPropagationChoice] | None
 
 
 def pair(a: int, b: int) -> Pair:
@@ -308,6 +336,134 @@ def minimum_radius_order_obstruction(
     )
 
 
+def radius_propagation_order_obstruction(
+    S: Pattern,
+    order: Sequence[int] | None = None,
+    pattern: str = "",
+    max_nodes: int | None = None,
+) -> RadiusPropagationResult:
+    """Search fixed-order short-gap choices for unavoidable radius cycles.
+
+    For each row, the minimum-radius lemma guarantees at least one consecutive
+    witness pair is a short chord. If that pair is selected by one or both
+    endpoints, it forces a strict inequality ``r_source < r_center``. A strict
+    directed cycle in these inequalities is impossible. This routine searches
+    all choices of one consecutive pair per row, pruning whenever a cycle is
+    already forced.
+
+    A returned acyclic choice is only an escape from this filter, not evidence
+    for geometric realizability.
+    """
+
+    _validate_pattern(S)
+    if max_nodes is not None and max_nodes <= 0:
+        raise ValueError("max_nodes must be positive or None")
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    order = list(order)
+    pos = _positions(order, n, require_full=True)
+    rows = [_minimum_radius_row_result(S, pos, center) for center in range(n)]
+    row_choices = [
+        [
+            (short_pair, _selected_pair_sources(S, *short_pair))
+            for short_pair in row.consecutive_pairs
+        ]
+        for row in rows
+    ]
+    choice_count = prod(len(choices) for choices in row_choices)
+    nodes_visited = 0
+    max_depth = 0
+    search_truncated = False
+    edges: list[DirectedEdge] = []
+    choice_stack: list[RadiusPropagationChoice] = []
+
+    def search(row_idx: int) -> list[RadiusPropagationChoice] | None:
+        nonlocal nodes_visited, max_depth, search_truncated
+        if max_nodes is not None and nodes_visited >= max_nodes:
+            search_truncated = True
+            return None
+        nodes_visited += 1
+        max_depth = max(max_depth, row_idx)
+        if row_idx == len(rows):
+            return list(choice_stack)
+
+        center = rows[row_idx].center
+        # Try uncovered gaps first; they are the most direct escape from the
+        # propagation filter and make surviving orders cheap to certify.
+        choices = sorted(
+            row_choices[row_idx],
+            key=lambda item: (len(item[1]), item[0]),
+        )
+        for short_pair, sources in choices:
+            new_edges = [(source, center) for source in sources]
+            old_edge_count = len(edges)
+            edges.extend(new_edges)
+            if not _directed_cycle_exists(n, edges):
+                choice_stack.append(
+                    RadiusPropagationChoice(
+                        center=center,
+                        consecutive_pair=short_pair,
+                        selected_sources=list(sources),
+                        inequality_edges=list(new_edges),
+                    )
+                )
+                found = search(row_idx + 1)
+                if found is not None:
+                    return found
+                choice_stack.pop()
+            del edges[old_edge_count:]
+            if search_truncated:
+                return None
+        return None
+
+    acyclic_choice = search(0)
+    if acyclic_choice is not None:
+        status = "PASS_RADIUS_PROPAGATION"
+        obstructed: bool | None = False
+    elif search_truncated:
+        status = "UNKNOWN_RADIUS_PROPAGATION_NODE_LIMIT"
+        obstructed = None
+    else:
+        status = "EXACT_RADIUS_PROPAGATION_OBSTRUCTION"
+        obstructed = True
+
+    return RadiusPropagationResult(
+        pattern=pattern,
+        n=n,
+        order=order,
+        status=status,
+        obstructed=obstructed,
+        short_gap_choice_count=choice_count,
+        nodes_visited=nodes_visited,
+        max_depth=max_depth,
+        search_truncated=search_truncated,
+        acyclic_choice=acyclic_choice,
+    )
+
+
+def _directed_cycle_exists(n: int, edges: Sequence[DirectedEdge]) -> bool:
+    graph: list[list[int]] = [[] for _ in range(n)]
+    for source, target in edges:
+        graph[source].append(target)
+    color = [0] * n
+
+    def visit(node: int) -> bool:
+        color[node] = 1
+        for target in graph[node]:
+            if color[target] == 1:
+                return True
+            if color[target] == 0 and visit(target):
+                return True
+        color[node] = 2
+        return False
+
+    for node in range(n):
+        if color[node] == 0 and visit(node):
+            return True
+    return False
+
+
 def _json_pair(item: Pair) -> list[int]:
     return [int(item[0]), int(item[1])]
 
@@ -320,6 +476,18 @@ def _json_row(row: MinRadiusRowResult) -> dict[str, object]:
         "covered_consecutive_pairs": [_json_pair(item) for item in row.covered_consecutive_pairs],
         "uncovered_consecutive_pairs": [_json_pair(item) for item in row.uncovered_consecutive_pairs],
         "blocked": row.blocked,
+    }
+
+
+def _json_choice(choice: RadiusPropagationChoice) -> dict[str, object]:
+    return {
+        "center": int(choice.center),
+        "consecutive_pair": _json_pair(choice.consecutive_pair),
+        "selected_sources": [int(source) for source in choice.selected_sources],
+        "inequality_edges": [
+            {"source": int(source), "target": int(target)}
+            for source, target in choice.inequality_edges
+        ],
     }
 
 
@@ -340,4 +508,27 @@ def result_to_json(result: MinRadiusOrderResult) -> dict[str, object]:
             int(center) for center in result.order_free_empty_gap_centers
         ],
         "rows": [_json_row(row) for row in result.rows],
+    }
+
+
+def radius_result_to_json(result: RadiusPropagationResult) -> dict[str, object]:
+    """Return a JSON-serializable form of a radius-propagation result."""
+
+    return {
+        "type": "radius_propagation_order_result",
+        "pattern": result.pattern,
+        "n": int(result.n),
+        "order": [int(label) for label in result.order],
+        "status": result.status,
+        "result": result.status,
+        "obstructed": result.obstructed,
+        "short_gap_choice_count": int(result.short_gap_choice_count),
+        "nodes_visited": int(result.nodes_visited),
+        "max_depth": int(result.max_depth),
+        "search_truncated": result.search_truncated,
+        "acyclic_choice": (
+            None
+            if result.acyclic_choice is None
+            else [_json_choice(choice) for choice in result.acyclic_choice]
+        ),
     }

--- a/tests/test_min_radius_filter.py
+++ b/tests/test_min_radius_filter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from erdos97.min_radius_filter import (
     covered_witness_path_orders,
     minimum_radius_order_obstruction,
+    radius_propagation_order_obstruction,
     row_is_order_free_blocked,
     row_has_order_free_empty_gap,
     selected_pair_sources,
@@ -21,6 +22,11 @@ def test_min_radius_filter_kills_all_other_pentagon_pattern() -> None:
     assert all(row.blocked for row in result.rows)
     assert all(row_is_order_free_blocked(S, center) for center in range(5))
     assert result.order_free_empty_gap_centers == []
+
+    propagation = radius_propagation_order_obstruction(S, list(range(5)), "K5_all_other")
+    assert propagation.status == "EXACT_RADIUS_PROPAGATION_OBSTRUCTION"
+    assert propagation.obstructed is True
+    assert propagation.acyclic_choice is None
 
 
 def test_min_radius_filter_c19_survives_natural_order() -> None:
@@ -47,3 +53,28 @@ def test_c13_sidon_has_local_covered_witness_paths() -> None:
     assert not row_has_order_free_empty_gap(pattern.S, 0)
     assert result.order_free_empty_gap_centers == []
     assert [4, 2, 1, 10] in paths
+
+
+def test_c13_sidon_passes_natural_order_radius_propagation() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    result = radius_propagation_order_obstruction(pattern.S, pattern=pattern.name)
+
+    assert result.status == "PASS_RADIUS_PROPAGATION"
+    assert result.obstructed is False
+    assert result.acyclic_choice is not None
+    assert len(result.acyclic_choice) == pattern.n
+
+
+def test_radius_propagation_node_limit_reports_unknown() -> None:
+    pattern = built_in_patterns()["C13_sidon_1_2_4_10"]
+
+    result = radius_propagation_order_obstruction(
+        pattern.S,
+        pattern=pattern.name,
+        max_nodes=1,
+    )
+
+    assert result.status == "UNKNOWN_RADIUS_PROPAGATION_NODE_LIMIT"
+    assert result.obstructed is None
+    assert result.search_truncated


### PR DESCRIPTION
## Summary
- add an exact fixed-order radius-propagation search over short-gap choices
- expose it via `check_min_radius_filter.py --radius-propagation`
- return explicit acyclic short-gap assignments when the filter passes, and reserve exact obstruction for exhaustive cycle forcing
- record that natural-order `C13_sidon_1_2_4_10` and `C19_skew` pass this stronger filter, while the toy all-other pentagon is obstructed

## Validation
- `python -m pytest tests/test_min_radius_filter.py -q`
- `python scripts/check_min_radius_filter.py --pattern C13_sidon_1_2_4_10 --radius-propagation --assert-pass --json`
- `python scripts/check_min_radius_filter.py --pattern C19_skew --radius-propagation --assert-pass`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `git diff --cached --check`
- `python -m pytest -q`

No general proof or counterexample is claimed; a passing acyclic assignment is only an escape from this radius filter.