### PR TITLE
Add sparse order survivor sweep

### DIFF
--- a/data/certificates/sparse_order_survivors.json
+++ b/data/certificates/sparse_order_survivors.json
@@ -1,0 +1,169 @@
+{
+  "cases": [
+    {
+      "altman_linear_certificate": {
+        "certificate_method": "none",
+        "nonzero_gap_orders": [],
+        "obstructed": false,
+        "status": "NO_EXACT_ALTMAN_LINEAR_CERTIFICATE_FOUND"
+      },
+      "altman_signature": {
+        "equal_diagonal_order_groups": [],
+        "obstructed": false,
+        "status": "NO_ORDER_ALTMAN_SIGNATURE_OBSTRUCTION"
+      },
+      "case": "C13_sidon_1_2_4_10:sample_full_filter_survivor",
+      "crossing": {
+        "constraint_count": 0,
+        "passes": true
+      },
+      "minimum_radius": {
+        "blocked_center_count": 4,
+        "obstructed": false,
+        "possible_min_center_count": 9
+      },
+      "n": 13,
+      "order": [
+        5,
+        0,
+        10,
+        8,
+        9,
+        7,
+        4,
+        6,
+        2,
+        11,
+        12,
+        3,
+        1
+      ],
+      "order_label": "sample_full_filter_survivor",
+      "pattern": "C13_sidon_1_2_4_10",
+      "radius_propagation": {
+        "acyclic_choice_edge_count": 4,
+        "max_depth": 13,
+        "nodes_visited": 14,
+        "obstructed": false,
+        "status": "PASS_RADIUS_PROPAGATION"
+      },
+      "semantics": "Fixed-order exact-filter diagnostic only. Surviving all listed filters is not evidence of geometric realizability.",
+      "sparse_frontier": {
+        "rows_with_uncovered_consecutive_pair": [
+          0,
+          1,
+          3,
+          4,
+          6,
+          7,
+          8,
+          9,
+          11
+        ],
+        "rows_with_uncovered_consecutive_pair_count": 9,
+        "trivial_empty_radius_choice_exists": false
+      },
+      "survives_current_exact_filters": true,
+      "vertex_circle": {
+        "cycle": false,
+        "obstructed": false,
+        "self_edge_count": 0,
+        "strict_edge_count": 117
+      }
+    },
+    {
+      "altman_linear_certificate": {
+        "certificate_method": "none",
+        "nonzero_gap_orders": [],
+        "obstructed": false,
+        "status": "NO_EXACT_ALTMAN_LINEAR_CERTIFICATE_FOUND"
+      },
+      "altman_signature": {
+        "equal_diagonal_order_groups": [],
+        "obstructed": false,
+        "status": "NO_ORDER_ALTMAN_SIGNATURE_OBSTRUCTION"
+      },
+      "case": "C19_skew:vertex_circle_survivor",
+      "crossing": {
+        "constraint_count": 0,
+        "passes": true
+      },
+      "minimum_radius": {
+        "blocked_center_count": 0,
+        "obstructed": false,
+        "possible_min_center_count": 19
+      },
+      "n": 19,
+      "order": [
+        18,
+        10,
+        7,
+        17,
+        6,
+        3,
+        5,
+        9,
+        14,
+        11,
+        2,
+        13,
+        4,
+        16,
+        12,
+        15,
+        0,
+        8,
+        1
+      ],
+      "order_label": "vertex_circle_survivor",
+      "pattern": "C19_skew",
+      "radius_propagation": {
+        "acyclic_choice_edge_count": 0,
+        "max_depth": 19,
+        "nodes_visited": 20,
+        "obstructed": false,
+        "status": "PASS_RADIUS_PROPAGATION"
+      },
+      "semantics": "Fixed-order exact-filter diagnostic only. Surviving all listed filters is not evidence of geometric realizability.",
+      "sparse_frontier": {
+        "rows_with_uncovered_consecutive_pair": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18
+        ],
+        "rows_with_uncovered_consecutive_pair_count": 19,
+        "trivial_empty_radius_choice_exists": true
+      },
+      "survives_current_exact_filters": true,
+      "vertex_circle": {
+        "cycle": false,
+        "obstructed": false,
+        "self_edge_count": 0,
+        "strict_edge_count": 171
+      }
+    }
+  ],
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "Surviving all listed filters is not evidence of realizability."
+  ],
+  "trust": "FIXED_ORDER_EXACT_FILTER_DIAGNOSTIC",
+  "type": "sparse_order_survivor_filter_sweep_v1"
+}

--- a/data/patterns/candidate_patterns.json
+++ b/data/patterns/candidate_patterns.json
@@ -95,7 +95,7 @@
     "n": 13,
     "formula": "offsets {1,2,4,10} (Singer (13,4,1) planar difference set)",
     "type": "Sidon circulant",
-    "status": "natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as numerical evidence",
+    "status": "natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: registered non-natural order survives current fixed-order exact filters; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as numerical evidence",
     "trust": "INCIDENCE_PATTERN"
   },
   {

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -17,8 +17,10 @@ The live abstract-incidence patterns above pass the row-overlap filter
 realization is already exactly obstructed; its abstract-order status is tracked
 separately.[^comp] The Sidon natural orders are also exactly obstructed by
 Altman linear certificates, but their arbitrary abstract-order status remains
-separate. The Sidon entries are incidence-pattern leads, not geometric
-realizability claims. The minimum-radius short-chord filter is also
+separate. A registered non-natural `C13_sidon_1_2_4_10` order survives the
+current fixed-order exact filters; see `docs/sparse-frontier-diagnostic.md`.
+The Sidon entries are incidence-pattern leads, not geometric realizability
+claims. The minimum-radius short-chord filter is also
 recorded as a weak exact necessary test, but it does not kill `C19_skew` in
 natural order or as currently implemented; see `docs/minimum-radius-filter.md`.
 For the first fixed-selection stuck-set/radius/fragile-cover pass over this

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -73,6 +73,17 @@ patterns has at most one endpoint source. In that single-target setting, a
 fixed cyclic order is radius-cycle obstructed only if it realizes a nonempty
 closed target set.
 
+To check registered abstract-order survivors against the current exact
+fixed-order filters:
+
+```bash
+python scripts/check_sparse_order_survivors.py --assert-expected
+```
+
+This combines crossing constraints, Altman signature and linear-certificate
+filters, vertex-circle strict-cycle checks, minimum-radius checks, and
+radius-propagation checks for each registered order.
+
 ## Snapshot
 
 | Pattern | n | all witness-pair sources | consecutive-pair sources | rows with uncovered consecutive pair | order-free blocked rows | order-free empty-gap rows | empty radius choice |
@@ -213,6 +224,34 @@ obstructed by the current single-target radius-cycle filter.
 This closes the radius-propagation route for the sparse frontier as currently
 implemented. A proof or counterexample must use additional geometry or a
 strictly stronger sparse-overlap mechanism.
+
+## Registered Exact-Filter Survivors
+
+The combined exact-filter sweep is checked in at
+`data/certificates/sparse_order_survivors.json`. It currently records two
+non-natural cyclic orders that survive every listed fixed-order exact filter:
+
+| Pattern | Order label | n | Vertex-circle | Altman linear | Radius propagation | Empty radius choice |
+|---|---|---:|---|---|---|---|
+| `C13_sidon_1_2_4_10` | `sample_full_filter_survivor` | 13 | pass | no certificate found | pass with 4 strict edges | no |
+| `C19_skew` | `vertex_circle_survivor` | 19 | pass | no certificate found | pass with 0 strict edges | yes |
+
+The `C13` order is:
+
+```text
+5,0,10,8,9,7,4,6,2,11,12,3,1
+```
+
+The `C19` order is:
+
+```text
+18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1
+```
+
+These are adversarial objects for the current proof search, not
+counterexamples. In particular, the `C13` order only says the present exact
+filters miss this abstract order; numerical optimization remains separate and
+does not certify realizability.
 
 ## Interpretation
 

--- a/scripts/check_sparse_order_survivors.py
+++ b/scripts/check_sparse_order_survivors.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Check registered sparse abstract-order survivors against exact filters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.altman_diagonal_sums import (  # noqa: E402
+    altman_order_linear_certificate,
+    altman_order_obstruction,
+)
+from erdos97.cyclic_crossing_csp import (  # noqa: E402
+    all_constraints_cross,
+    crossing_constraints,
+)
+from erdos97.min_radius_filter import (  # noqa: E402
+    minimum_radius_order_obstruction,
+    radius_propagation_order_obstruction,
+)
+from erdos97.search import PatternInfo, built_in_patterns  # noqa: E402
+from erdos97.sparse_frontier import sparse_frontier_summary  # noqa: E402
+from erdos97.vertex_circle_order_filter import vertex_circle_order_obstruction  # noqa: E402
+
+REGISTERED_ORDERS: dict[str, dict[str, list[int]]] = {
+    "C13_sidon_1_2_4_10": {
+        "sample_full_filter_survivor": [5, 0, 10, 8, 9, 7, 4, 6, 2, 11, 12, 3, 1],
+    },
+    "C19_skew": {
+        "vertex_circle_survivor": [
+            18,
+            10,
+            7,
+            17,
+            6,
+            3,
+            5,
+            9,
+            14,
+            11,
+            2,
+            13,
+            4,
+            16,
+            12,
+            15,
+            0,
+            8,
+            1,
+        ],
+    },
+}
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
+
+
+def evaluate_order(
+    pattern: PatternInfo,
+    order: list[int],
+    order_label: str,
+) -> dict[str, object]:
+    constraints = crossing_constraints(pattern.S)
+    crossing_ok = all_constraints_cross(order, constraints)
+    altman_signature = altman_order_obstruction(pattern.S, order, pattern.name)
+    altman_linear = altman_order_linear_certificate(pattern.S, order, pattern.name)
+    vertex = vertex_circle_order_obstruction(pattern.S, order, pattern.name)
+    min_radius = minimum_radius_order_obstruction(pattern.S, order, pattern.name)
+    radius = radius_propagation_order_obstruction(pattern.S, order, pattern.name)
+    sparse = sparse_frontier_summary(
+        pattern.name,
+        pattern.S,
+        order=order,
+        max_row_examples=0,
+    )
+    survives = (
+        crossing_ok
+        and not altman_signature.altman_contradiction
+        and altman_linear.obstructed is False
+        and not vertex.obstructed
+        and not min_radius.obstructed
+        and radius.obstructed is False
+    )
+    return {
+        "case": f"{pattern.name}:{order_label}",
+        "pattern": pattern.name,
+        "n": pattern.n,
+        "order_label": order_label,
+        "order": order,
+        "survives_current_exact_filters": survives,
+        "crossing": {
+            "constraint_count": len(constraints),
+            "passes": crossing_ok,
+        },
+        "altman_signature": {
+            "status": altman_signature.status,
+            "obstructed": altman_signature.altman_contradiction,
+            "equal_diagonal_order_groups": (
+                altman_signature.equal_diagonal_order_groups
+            ),
+        },
+        "altman_linear_certificate": {
+            "status": altman_linear.status,
+            "obstructed": altman_linear.obstructed,
+            "certificate_method": altman_linear.certificate_method,
+            "nonzero_gap_orders": altman_linear.nonzero_gap_orders,
+        },
+        "vertex_circle": {
+            "obstructed": vertex.obstructed,
+            "strict_edge_count": vertex.strict_edge_count,
+            "self_edge_count": len(vertex.self_edge_conflicts),
+            "cycle": bool(vertex.cycle_edges),
+        },
+        "minimum_radius": {
+            "obstructed": min_radius.obstructed,
+            "blocked_center_count": len(min_radius.blocked_centers),
+            "possible_min_center_count": len(min_radius.possible_min_centers),
+        },
+        "radius_propagation": {
+            "status": radius.status,
+            "obstructed": radius.obstructed,
+            "nodes_visited": radius.nodes_visited,
+            "max_depth": radius.max_depth,
+            "acyclic_choice_edge_count": (
+                None
+                if radius.acyclic_choice is None
+                else sum(len(choice.inequality_edges) for choice in radius.acyclic_choice)
+            ),
+        },
+        "sparse_frontier": {
+            "rows_with_uncovered_consecutive_pair": (
+                sparse["rows_with_uncovered_consecutive_pair"]
+            ),
+            "rows_with_uncovered_consecutive_pair_count": len(
+                sparse["rows_with_uncovered_consecutive_pair"]
+            ),
+            "trivial_empty_radius_choice_exists": (
+                sparse["trivial_empty_radius_choice_exists"]
+            ),
+        },
+        "semantics": (
+            "Fixed-order exact-filter diagnostic only. Surviving all listed "
+            "filters is not evidence of geometric realizability."
+        ),
+    }
+
+
+def registered_rows(patterns: dict[str, PatternInfo]) -> list[dict[str, object]]:
+    rows = []
+    for pattern_name, orders in REGISTERED_ORDERS.items():
+        pattern = patterns[pattern_name]
+        for order_label, order in orders.items():
+            rows.append(evaluate_order(pattern, order, order_label))
+    return rows
+
+
+def assert_expected(rows: list[dict[str, object]]) -> None:
+    by_case = {str(row["case"]): row for row in rows}
+    expected = {
+        "C13_sidon_1_2_4_10:sample_full_filter_survivor",
+        "C19_skew:vertex_circle_survivor",
+    }
+    missing = sorted(expected - set(by_case))
+    if missing:
+        raise AssertionError(f"missing expected case(s): {', '.join(missing)}")
+    for case in sorted(expected):
+        if by_case[case]["survives_current_exact_filters"] is not True:
+            raise AssertionError(f"{case} did not survive current exact filters")
+
+
+def payload(rows: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "type": "sparse_order_survivor_filter_sweep_v1",
+        "trust": "FIXED_ORDER_EXACT_FILTER_DIAGNOSTIC",
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "Surviving all listed filters is not evidence of realizability.",
+        ],
+        "cases": rows,
+    }
+
+
+def print_table(rows: list[dict[str, object]]) -> None:
+    headers = [
+        "case",
+        "n",
+        "survives",
+        "vertex",
+        "altman",
+        "radius",
+        "empty rows",
+    ]
+    table = [
+        [
+            str(row["case"]),
+            str(row["n"]),
+            str(row["survives_current_exact_filters"]),
+            str(row["vertex_circle"]["obstructed"]),
+            str(row["altman_linear_certificate"]["status"]),
+            str(row["radius_propagation"]["status"]),
+            str(row["sparse_frontier"]["rows_with_uncovered_consecutive_pair_count"]),
+        ]
+        for row in rows
+    ]
+    widths = [
+        max(len(headers[col]), *(len(row[col]) for row in table))
+        for col in range(len(headers))
+    ]
+    print("  ".join(headers[col].ljust(widths[col]) for col in range(len(headers))))
+    print("  ".join("-" * widths[col] for col in range(len(headers))))
+    for row in table:
+        print("  ".join(row[col].ljust(widths[col]) for col in range(len(headers))))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON")
+    parser.add_argument("--out", help="write JSON payload to this path")
+    parser.add_argument("--pattern", help="built-in pattern name for a supplied --order")
+    parser.add_argument("--order", type=parse_order, help="comma-separated cyclic order")
+    parser.add_argument("--order-label", default="supplied", help="label for --order")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.order is not None:
+        if not args.pattern:
+            raise SystemExit("--pattern is required with --order")
+        if args.pattern not in patterns:
+            raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+        rows = [
+            evaluate_order(
+                patterns[args.pattern],
+                args.order,
+                args.order_label,
+            )
+        ]
+    else:
+        if args.pattern:
+            raise SystemExit("--pattern requires --order")
+        rows = registered_rows(patterns)
+
+    if args.assert_expected:
+        assert_expected(rows)
+    data = payload(rows)
+    if args.out:
+        with Path(args.out).open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        print_table(rows)
+        if args.assert_expected:
+            print("OK: sparse order survivor expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sparse_order_survivors.py
+++ b/tests/test_sparse_order_survivors.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_registered_sparse_order_survivors_match_artifact() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_sparse_order_survivors.py",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    artifact = json.loads(
+        (ROOT / "data" / "certificates" / "sparse_order_survivors.json")
+        .read_text(encoding="utf-8")
+    )
+
+    assert artifact == payload
+    by_case = {row["case"]: row for row in payload["cases"]}
+    c13 = by_case["C13_sidon_1_2_4_10:sample_full_filter_survivor"]
+    c19 = by_case["C19_skew:vertex_circle_survivor"]
+
+    assert c13["survives_current_exact_filters"] is True
+    assert c13["vertex_circle"]["obstructed"] is False
+    assert c13["radius_propagation"]["acyclic_choice_edge_count"] == 4
+    assert c19["survives_current_exact_filters"] is True
+    assert c19["sparse_frontier"]["trivial_empty_radius_choice_exists"] is True


### PR DESCRIPTION
## Summary
- add `scripts/check_sparse_order_survivors.py` to evaluate registered non-natural sparse orders against the current fixed-order exact filters
- check in `data/certificates/sparse_order_survivors.json` for the `C13_sidon_1_2_4_10` and `C19_skew` survivor orders
- record that both orders pass crossing, Altman signature/certificate, vertex-circle, minimum-radius, and radius-propagation filters
- update sparse-frontier and catalog docs to mark the C13 non-natural order as a current exact-filter survivor, not a realization claim

## Validation
- `python scripts/check_sparse_order_survivors.py --assert-expected --json`
- `python -m pytest tests/test_sparse_order_survivors.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `git diff --cached --check`
- `python -m pytest -q`

No general proof or counterexample is claimed; surviving all listed filters is not evidence of geometric realizability.