### PR TITLE
Add phi 4-cycle rectangle-trap filter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,5 @@ jobs:
       - run: python scripts/check_text_clean.py
       - run: python scripts/check_status_consistency.py
       - run: git diff --check
+      - run: ruff check .
       - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ This repository is a public research log and reproducibility workspace for Erdő
   read [`docs/n8-geometric-proof.md`](docs/n8-geometric-proof.md).
 - For an interactive visualization of that proof idea, open
   [`docs/octagon-trap.html`](docs/octagon-trap.html).
-- For the crossing-bisector, mutual-rhombus, and vertex-circle fixed-pattern
-  filters, read [`docs/mutual-rhombus-filter.md`](docs/mutual-rhombus-filter.md)
-  and [`docs/vertex-circle-order-filter.md`](docs/vertex-circle-order-filter.md).
+- For the crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, and
+  vertex-circle fixed-pattern filters, read
+  [`docs/mutual-rhombus-filter.md`](docs/mutual-rhombus-filter.md),
+  [`docs/phi4-rectangle-trap.md`](docs/phi4-rectangle-trap.md), and
+  [`docs/vertex-circle-order-filter.md`](docs/vertex-circle-order-filter.md).
 - For the weak exact minimum-radius short-chord filter, read
   [`docs/minimum-radius-filter.md`](docs/minimum-radius-filter.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
@@ -103,13 +105,15 @@ strictly convex realization for those classes. See
 theorem claims should still get independent review of the computer-assisted
 artifacts.
 
-The crossing-bisector, mutual-rhombus, cyclic crossing-CSP, and vertex-circle
-order filters now exactly kill several previously live fixed selected-witness
-patterns, including
+The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic
+crossing-CSP, and vertex-circle order filters now exactly kill several
+previously live fixed selected-witness patterns, including
 `B12_3x4_danzer_lift`, `B20_4x5_FR_lift`, `C17_skew`, `C20_pm_4_9`,
 `C16_pm_1_6`, `C13_pm_3_5`, `C9_pm_2_4`, `P18_parity_balanced`, and
-`P24_parity_balanced`. These are fixed-pattern obstructions, not a general
-proof of the problem.
+`P24_parity_balanced`. The phi 4-cycle rectangle-trap filter also kills a
+registered fixed `n=9` selected-witness pattern containing
+`{0,6}->{2,8}->{1,5}->{4,7}->{0,6}`. These are fixed-pattern obstructions, not
+a general proof of the problem.
 
 The previous best numerical near-miss was `B12_3x4_danzer_lift`. It remains a
 useful degeneration diagnostic, but the fixed selected pattern is now exactly

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -113,6 +113,17 @@ The mutual-rhombus midpoint filter kills the fixed selected patterns
 `C13_pm_3_5`, and `C9_pm_2_4`. The pattern `C17_skew` is killed by an odd
 forced-perpendicularity cycle.
 
+The phi 4-cycle rectangle-trap filter kills a registered fixed `n=9`
+selected-witness pattern with directed cycle
+`{0,6}->{2,8}->{1,5}->{4,7}->{0,6}`. The cycle is not a reciprocal 2-cycle and
+not an odd perpendicularity cycle. The exact obstruction uses the cyclic
+subsequence `0,1,2,4,5,6,7,8`, a midpoint-rectangle normalization, and the
+identity `D1 + D3 + D5 + D7 = -4*a*b` with cyclic-order signs `a,b > 0`. This
+is a fixed-pattern obstruction only, not an `n=9` completeness theorem. See
+`docs/phi4-rectangle-trap.md`,
+`scripts/check_phi4_rectangle_trap.py`, and
+`data/certificates/n9_phi4_rectangle_trap.json`.
+
 Under the natural cyclic order, `P18_parity_balanced` and
 `P24_parity_balanced` are killed by adjacent-row two-overlap via the
 crossing-bisector lemma. As abstract incidence patterns with arbitrary cyclic

--- a/STATE.md
+++ b/STATE.md
@@ -40,9 +40,9 @@ claims.
 
 ## New exact fixed-pattern obstructions
 
-The crossing-bisector, mutual-rhombus, cyclic crossing-CSP, and vertex-circle
-order filters now exactly kill several previously live fixed selected-witness
-patterns. In particular,
+The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic
+crossing-CSP, and vertex-circle order filters now exactly kill several
+previously live fixed selected-witness patterns. In particular,
 `B12_3x4_danzer_lift` is no longer live as a fixed selected pattern: its
 mutual-rhombus midpoint equations force labels `[0,4,8]`, `[1,5,9]`,
 `[2,6,10]`, and `[3,7,11]` to coincide. The old numerical near-miss remains
@@ -54,6 +54,14 @@ Also killed as fixed selected patterns: `B20_4x5_FR_lift`, `C17_skew`,
 abstract-incidence obstruction uses the crossing constraints plus the
 vertex-circle order strict-cycle filter; `P24_parity_balanced` is already
 killed by the finite cyclic crossing CSP.
+
+The phi 4-cycle rectangle-trap filter kills a registered fixed `n=9`
+selected-witness pattern with directed cycle
+`{0,6}->{2,8}->{1,5}->{4,7}->{0,6}`. The obstruction is the exact determinant
+identity `D1 + D3 + D5 + D7 = -4*a*b` under cyclic-order signs `a,b > 0`.
+See `docs/phi4-rectangle-trap.md` and
+`data/certificates/n9_phi4_rectangle_trap.json`. This is not an `n=9`
+completeness result.
 
 ## Best saved near-miss
 

--- a/data/certificates/n9_phi4_rectangle_trap.json
+++ b/data/certificates/n9_phi4_rectangle_trap.json
@@ -1,0 +1,194 @@
+{
+  "S": [
+    [
+      1,
+      2,
+      3,
+      8
+    ],
+    [
+      0,
+      2,
+      4,
+      7
+    ],
+    [
+      1,
+      3,
+      5,
+      7
+    ],
+    [
+      1,
+      4,
+      6,
+      8
+    ],
+    [
+      0,
+      2,
+      5,
+      6
+    ],
+    [
+      3,
+      4,
+      6,
+      7
+    ],
+    [
+      2,
+      5,
+      7,
+      8
+    ],
+    [
+      0,
+      3,
+      6,
+      8
+    ],
+    [
+      0,
+      1,
+      4,
+      5
+    ]
+  ],
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "global_claim": "No general proof and no counterexample are claimed.",
+  "older_filter_diagnostics": {
+    "adjacent_two_overlap_violations": [],
+    "crossing_bisector_violations": [],
+    "forced_equality_classes": [],
+    "mutual_midpoint_matrix_rank": 0,
+    "odd_forced_perpendicularity_cycle": null
+  },
+  "pattern_name": "N9_phi4_rectangle_trap_selected_witness_pattern",
+  "phi_directed_4_cycles": [
+    [
+      [
+        0,
+        6
+      ],
+      [
+        2,
+        8
+      ],
+      [
+        1,
+        5
+      ],
+      [
+        4,
+        7
+      ]
+    ]
+  ],
+  "rectangle_trap_certificates": [
+    {
+      "coordinate_normalization": {
+        "A": [
+          "L0",
+          "0"
+        ],
+        "A_bar": [
+          "-L0",
+          "0"
+        ],
+        "B": [
+          "a",
+          "L1"
+        ],
+        "B_bar": [
+          "a",
+          "-L1"
+        ],
+        "C": [
+          "a + L2",
+          "b"
+        ],
+        "C_bar": [
+          "a - L2",
+          "b"
+        ],
+        "D": [
+          "0",
+          "b + L3"
+        ],
+        "D_bar": [
+          "0",
+          "b - L3"
+        ]
+      },
+      "cyclic_order_orientation": "supplied",
+      "cyclic_subsequence": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "determinant_identity": {
+        "contradiction": "Strict convexity requires D1,D3,D5,D7 > 0, but a,b > 0 makes their sum negative.",
+        "left": "D1 + D3 + D5 + D7",
+        "right": "-4*a*b"
+      },
+      "phi_cycle": [
+        [
+          0,
+          6
+        ],
+        [
+          2,
+          8
+        ],
+        [
+          1,
+          5
+        ],
+        [
+          4,
+          7
+        ]
+      ],
+      "positive_parameter_reasons": [
+        "Along chord A-A_bar, the B-B_bar crossing precedes the D-D_bar crossing; hence a > 0.",
+        "Along chord B-B_bar, the C-C_bar crossing precedes the A-A_bar crossing; hence b > 0."
+      ],
+      "roles": {
+        "A": 0,
+        "A_bar": 6,
+        "B": 2,
+        "B_bar": 8,
+        "C": 1,
+        "C_bar": 5,
+        "D": 4,
+        "D_bar": 7
+      },
+      "status": "EXACT_OBSTRUCTION",
+      "turn_determinants": {
+        "D1": "L1*L2 + L1*a - L2*L3 - L2*b - a*b",
+        "D3": "-L0*L3 + L2*L3 + L2*b - L3*a - a*b",
+        "D5": "-L0*L1 + L0*L3 - L0*b + L3*a - a*b",
+        "D7": "L0*L1 + L0*b - L1*L2 - L1*a - a*b"
+      },
+      "type": "phi4_rectangle_trap"
+    }
+  ],
+  "scope": "fixed selected-witness pattern only",
+  "trust_label": "EXACT_OBSTRUCTION"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ put detailed reconciliation in the canonical synthesis.
   proof-facing caveats.
 - [`mutual-rhombus-filter.md`](mutual-rhombus-filter.md): crossing-bisector and
   mutual-midpoint filters for fixed selected-witness patterns.
+- [`phi4-rectangle-trap.md`](phi4-rectangle-trap.md): exact even
+  perpendicularity 4-cycle obstruction for fixed selected-witness patterns.
 - [`altman-diagonal-sums.md`](altman-diagonal-sums.md): natural-order
   diagonal-sum obstruction for cyclic-offset patterns.
 - [`cyclic-crossing-csp.md`](cyclic-crossing-csp.md): exact cyclic-order

--- a/docs/phi4-rectangle-trap.md
+++ b/docs/phi4-rectangle-trap.md
@@ -1,0 +1,141 @@
+# Phi 4-cycle rectangle trap
+
+Status: `EXACT_OBSTRUCTION` for fixed selected-witness incidence patterns.
+
+This note records a fixed-pattern filter that is not covered by the existing
+mutual-rhombus 2-cycle or odd forced-perpendicularity-cycle filters. It does
+not prove Erdos Problem #97 and does not produce a counterexample.
+
+## Setup
+
+For a row-pair with exactly two common witnesses, write
+
+```text
+phi({x,y}) = S_x cap S_y.
+```
+
+The crossing-bisector lemma says that `{x,y}` is the perpendicular bisector of
+`phi({x,y})`, and that the midpoint of `phi({x,y})` lies on segment `xy`.
+
+Consider a directed `phi` 4-cycle
+
+```text
+e0 -> e1 -> e2 -> e3 -> e0
+```
+
+with eight distinct endpoint labels. Write
+
+```text
+e0 = {A,A_bar}
+e1 = {B,B_bar}
+e2 = {C,C_bar}
+e3 = {D,D_bar}
+```
+
+The rectangle trap applies when these eight labels occur in cyclic order
+
+```text
+A, C, B, D, C_bar, A_bar, D_bar, B_bar.
+```
+
+The same test is applied after reversing the supplied cyclic order, since the
+orientation of a polygon boundary is conventional.
+
+## Geometry
+
+After a rigid motion and reflection, the four perpendicular-bisector relations
+give the coordinate normalization
+
+```text
+A     = ( L0, 0)       A_bar = (-L0, 0)
+B     = ( a,  L1)      B_bar = ( a, -L1)
+C     = ( a + L2, b)   C_bar = ( a - L2, b)
+D     = ( 0, b + L3)   D_bar = ( 0, b - L3)
+```
+
+with positive half-lengths `L0,L1,L2,L3`.
+
+The cyclic order gives the signs of the midpoint rectangle offsets:
+
+- along chord `A-A_bar`, the `B-B_bar` crossing precedes the `D-D_bar`
+  crossing, so `a > 0`;
+- along chord `B-B_bar`, the `C-C_bar` crossing precedes the `A-A_bar`
+  crossing, so `b > 0`.
+
+These are ordinary chord-intersection order facts inside a strictly convex
+polygon: for a fixed diagonal, crossings with chords whose endpoints lie on
+opposite boundary arcs occur in the corresponding boundary order.
+
+## Determinant certificate
+
+Use the cyclic subsequence
+
+```text
+A, C, B, D, C_bar, A_bar, D_bar, B_bar.
+```
+
+Let `D_i` be the signed turn determinant at position `i` in this subsequence.
+Strict convexity requires every `D_i` to have the same strict sign after
+choosing the boundary orientation. In the orientation above, it requires
+`D_i > 0`.
+
+Exact expansion gives
+
+```text
+D1 =  L1*L2 + L1*a - L2*L3 - L2*b - a*b
+D3 = -L0*L3 + L2*L3 + L2*b - L3*a - a*b
+D5 = -L0*L1 + L0*L3 - L0*b + L3*a - a*b
+D7 =  L0*L1 + L0*b - L1*L2 - L1*a - a*b
+```
+
+and hence
+
+```text
+D1 + D3 + D5 + D7 = -4*a*b.
+```
+
+Since `a > 0` and `b > 0`, the right side is negative. Therefore these four
+strictly positive turns cannot coexist. This kills any fixed selected-witness
+pattern containing this directed cycle with this cyclic order type.
+
+## Registered n=9 certificate
+
+The first registered pattern killed by this filter is
+
+```text
+S0 = {1,2,3,8}
+S1 = {0,2,4,7}
+S2 = {1,3,5,7}
+S3 = {1,4,6,8}
+S4 = {0,2,5,6}
+S5 = {3,4,6,7}
+S6 = {2,5,7,8}
+S7 = {0,3,6,8}
+S8 = {0,1,4,5}
+```
+
+It has the directed cycle
+
+```text
+{0,6} -> {2,8} -> {1,5} -> {4,7} -> {0,6}
+```
+
+and cyclic subsequence
+
+```text
+0, 1, 2, 4, 5, 6, 7, 8.
+```
+
+The machine-readable certificate is
+`data/certificates/n9_phi4_rectangle_trap.json`.
+
+## Reproduction
+
+```bash
+python scripts/check_phi4_rectangle_trap.py --assert-expected
+python scripts/check_phi4_rectangle_trap.py --assert-expected --write
+pytest tests/test_incidence_filters.py -q
+```
+
+The `--write` command regenerates the JSON certificate. The artifact is a
+fixed-pattern obstruction only; it is not an `n=9` completeness result.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -84,6 +84,7 @@ local_repo:
     - "docs/n8-incidence-enumeration.md"
     - "docs/n8-exact-survivors.md"
     - "docs/n8-geometric-proof.md"
+    - "docs/phi4-rectangle-trap.md"
     - "docs/reproduction-log.md"
     - "docs/verification-contract.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 dev = [
   "pytest>=7",
   "PyYAML>=6",
+  "ruff>=0.15",
   "sympy>=1.12",
   "z3-solver>=4.12"
 ]
@@ -27,3 +28,6 @@ erdos97-search = "erdos97.search:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff]
+target-version = "py310"

--- a/scripts/check_affine_circuit_certificates.py
+++ b/scripts/check_affine_circuit_certificates.py
@@ -18,7 +18,6 @@ from erdos97.affine_circuit_certificates import (  # noqa: E402
     analysis_to_json,
     golden_decagon_example,
     lifted_matrix,
-    matrix_is_zero,
     minimal_cofactor_certificates,
     pair_gain_components,
     quotient_matrix,

--- a/scripts/check_mutual_rhombus_filter.py
+++ b/scripts/check_mutual_rhombus_filter.py
@@ -64,6 +64,8 @@ EXPECTED: dict[str, dict[str, object]] = {
 def pattern_status(summary: dict[str, object]) -> str:
     if summary["odd_cycle_length"]:
         return "exactly killed: odd forced-perpendicularity cycle"
+    if summary["rectangle_trap_4_cycles"]:
+        return "exactly killed: phi 4-cycle rectangle trap"
     classes = summary["forced_equality_classes"]
     if classes:
         return "exactly killed: mutual-rhombus midpoint equations"
@@ -101,6 +103,7 @@ def print_table(rows: list[dict[str, object]]) -> None:
         "phi",
         "odd",
         "mutual",
+        "rect4",
         "rank",
         "eq classes",
         "adj",
@@ -116,6 +119,7 @@ def print_table(rows: list[dict[str, object]]) -> None:
                 str(row["phi_edges"]),
                 str(row["odd_cycle_length"] or "-"),
                 str(row["mutual_phi_2_cycles"]),
+                str(row["rectangle_trap_4_cycles"]),
                 str(row["midpoint_matrix_rank"]),
                 compact_classes(row["forced_equality_classes"]),
                 str(len(row["adjacent_two_overlap_violations"])),  # type: ignore[arg-type]

--- a/scripts/check_phi4_rectangle_trap.py
+++ b/scripts/check_phi4_rectangle_trap.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Check and optionally write the n=9 phi 4-cycle rectangle-trap certificate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.incidence_filters import (  # noqa: E402
+    adjacent_two_overlap_violations,
+    crossing_bisector_violations,
+    forced_equal_classes_from_matrix,
+    mutual_midpoint_matrix,
+    odd_forced_perpendicular_cycle,
+    phi4_rectangle_trap_certificates,
+    phi_directed_4_cycles,
+)
+
+PATTERN_NAME = "N9_phi4_rectangle_trap_selected_witness_pattern"
+CERT_PATH = ROOT / "data" / "certificates" / "n9_phi4_rectangle_trap.json"
+
+N9_RECTANGLE_TRAP_PATTERN = [
+    [1, 2, 3, 8],
+    [0, 2, 4, 7],
+    [1, 3, 5, 7],
+    [1, 4, 6, 8],
+    [0, 2, 5, 6],
+    [3, 4, 6, 7],
+    [2, 5, 7, 8],
+    [0, 3, 6, 8],
+    [0, 1, 4, 5],
+]
+
+
+def build_payload() -> dict[str, object]:
+    matrix = mutual_midpoint_matrix(N9_RECTANGLE_TRAP_PATTERN)
+    order = list(range(len(N9_RECTANGLE_TRAP_PATTERN)))
+    certs = phi4_rectangle_trap_certificates(N9_RECTANGLE_TRAP_PATTERN, order)
+    return {
+        "pattern_name": PATTERN_NAME,
+        "trust_label": "EXACT_OBSTRUCTION",
+        "scope": "fixed selected-witness pattern only",
+        "global_claim": "No general proof and no counterexample are claimed.",
+        "cyclic_order": order,
+        "S": N9_RECTANGLE_TRAP_PATTERN,
+        "older_filter_diagnostics": {
+            "odd_forced_perpendicularity_cycle": odd_forced_perpendicular_cycle(
+                N9_RECTANGLE_TRAP_PATTERN
+            ),
+            "mutual_midpoint_matrix_rank": int(matrix.rank()),
+            "forced_equality_classes": forced_equal_classes_from_matrix(matrix, 9),
+            "adjacent_two_overlap_violations": adjacent_two_overlap_violations(
+                N9_RECTANGLE_TRAP_PATTERN, order
+            ),
+            "crossing_bisector_violations": crossing_bisector_violations(
+                N9_RECTANGLE_TRAP_PATTERN, order
+            ),
+        },
+        "phi_directed_4_cycles": [
+            [list(chord) for chord in cycle]
+            for cycle in phi_directed_4_cycles(N9_RECTANGLE_TRAP_PATTERN)
+        ],
+        "rectangle_trap_certificates": certs,
+    }
+
+
+def assert_expected(payload: dict[str, object]) -> None:
+    diagnostics = payload["older_filter_diagnostics"]
+    if not isinstance(diagnostics, dict):
+        raise AssertionError("older_filter_diagnostics should be a mapping")
+    if diagnostics["odd_forced_perpendicularity_cycle"] is not None:
+        raise AssertionError("unexpected odd forced-perpendicularity cycle")
+    if diagnostics["mutual_midpoint_matrix_rank"] != 0:
+        raise AssertionError("unexpected mutual midpoint rank")
+    if diagnostics["forced_equality_classes"]:
+        raise AssertionError("unexpected forced equality classes")
+    if diagnostics["adjacent_two_overlap_violations"]:
+        raise AssertionError("unexpected adjacent two-overlap violations")
+    if diagnostics["crossing_bisector_violations"]:
+        raise AssertionError("unexpected crossing-bisector violations")
+
+    certs = payload["rectangle_trap_certificates"]
+    if not isinstance(certs, list) or len(certs) != 1:
+        raise AssertionError(f"expected one rectangle-trap certificate, got {certs}")
+    cert = certs[0]
+    if not isinstance(cert, dict):
+        raise AssertionError("certificate should be a mapping")
+    if cert["phi_cycle"] != [[0, 6], [2, 8], [1, 5], [4, 7]]:
+        raise AssertionError(f"unexpected phi cycle: {cert['phi_cycle']}")
+    if cert["cyclic_subsequence"] != [0, 1, 2, 4, 5, 6, 7, 8]:
+        raise AssertionError(f"unexpected cyclic subsequence: {cert['cyclic_subsequence']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print the full JSON payload")
+    parser.add_argument("--write", action="store_true", help=f"write {CERT_PATH}")
+    parser.add_argument("--assert-expected", action="store_true", help="assert the known result")
+    args = parser.parse_args()
+
+    payload = build_payload()
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.write:
+        CERT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with CERT_PATH.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        certs = payload["rectangle_trap_certificates"]
+        print(f"{PATTERN_NAME}: {len(certs)} phi 4-cycle rectangle-trap certificate(s)")
+        if args.assert_expected:
+            print("OK: expected n=9 rectangle-trap obstruction verified")
+        if args.write:
+            print(f"wrote {CERT_PATH.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/incidence_filters.py
+++ b/src/erdos97/incidence_filters.py
@@ -180,6 +180,167 @@ def odd_forced_perpendicular_cycle(
     return None
 
 
+def _canonical_directed_cycle(
+    cycle: tuple[Chord, Chord, Chord, Chord],
+) -> tuple[Chord, Chord, Chord, Chord]:
+    rotations = [cycle[i:] + cycle[:i] for i in range(len(cycle))]
+    return min(rotations)
+
+
+def phi_directed_4_cycles(S: Sequence[Sequence[int]]) -> list[tuple[Chord, Chord, Chord, Chord]]:
+    """Return directed 4-cycles in the partial phi map, up to rotation."""
+    phis = phi_map(S)
+    cycles: set[tuple[Chord, Chord, Chord, Chord]] = set()
+
+    for e0 in sorted(phis):
+        e1 = phis[e0]
+        e2 = phis.get(e1)
+        if e2 is None:
+            continue
+        e3 = phis.get(e2)
+        if e3 is None:
+            continue
+        if phis.get(e3) != e0:
+            continue
+        cycle = (e0, e1, e2, e3)
+        if len(set(cycle)) != 4:
+            continue
+        cycles.add(_canonical_directed_cycle(cycle))
+
+    return sorted(cycles)
+
+
+def _other_endpoint(chord: Chord, endpoint: int) -> int:
+    if endpoint == chord[0]:
+        return chord[1]
+    if endpoint == chord[1]:
+        return chord[0]
+    raise ValueError(f"{endpoint} is not an endpoint of {chord}")
+
+
+def _induced_order(order: Sequence[int], labels: set[int]) -> tuple[int, ...]:
+    _positions(order)
+    seq = tuple(label for label in order if label in labels)
+    if len(seq) != len(labels):
+        missing = sorted(labels - set(seq))
+        raise ValueError(f"cyclic order is missing labels: {missing}")
+    return seq
+
+
+def _cyclically_equal(seq: Sequence[int], target: Sequence[int]) -> bool:
+    if len(seq) != len(target):
+        return False
+    if not seq:
+        return True
+    tup = tuple(seq)
+    want = tuple(target)
+    return any(tup[i:] + tup[:i] == want for i in range(len(tup)))
+
+
+def _rectangle_signature(
+    cycle: tuple[Chord, Chord, Chord, Chord],
+    order: Sequence[int],
+) -> tuple[tuple[int, ...], str] | None:
+    e0, e1, e2, e3 = cycle
+    labels = set(e0 + e1 + e2 + e3)
+    if len(labels) != 8:
+        return None
+
+    induced = _induced_order(order, labels)
+    reversed_induced = tuple(reversed(induced))
+
+    for A in e0:
+        A_bar = _other_endpoint(e0, A)
+        for B in e1:
+            B_bar = _other_endpoint(e1, B)
+            for C in e2:
+                C_bar = _other_endpoint(e2, C)
+                for D in e3:
+                    D_bar = _other_endpoint(e3, D)
+                    signature = (A, C, B, D, C_bar, A_bar, D_bar, B_bar)
+                    if _cyclically_equal(induced, signature):
+                        return signature, "supplied"
+                    if _cyclically_equal(reversed_induced, signature):
+                        return signature, "reversed"
+    return None
+
+
+def phi4_rectangle_trap_certificates(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+) -> list[dict[str, object]]:
+    """
+    Return exact certificates for the perpendicular-bisector 4-cycle trap.
+
+    The detected cyclic order type is
+
+        A, C, B, D, C_bar, A_bar, D_bar, B_bar
+
+    for a directed phi cycle e0 -> e1 -> e2 -> e3 -> e0, with
+    e0={A,A_bar}, e1={B,B_bar}, e2={C,C_bar}, and e3={D,D_bar}.
+    In the standard normalization this gives the determinant identity
+    D1 + D3 + D5 + D7 = -4*a*b. The endpoint order puts the e1/e3
+    crossings in this order along e0 and the e2/e0 crossings in this order
+    along e1, so a>0 and b>0. Strict convexity would make each D_i positive,
+    yielding an exact fixed-pattern obstruction.
+    """
+    if order is None:
+        order = list(range(len(S)))
+
+    out: list[dict[str, object]] = []
+    for cycle in phi_directed_4_cycles(S):
+        matched = _rectangle_signature(cycle, order)
+        if matched is None:
+            continue
+        signature, orientation = matched
+        A, C, B, D, C_bar, A_bar, D_bar, B_bar = signature
+        out.append(
+            {
+                "type": "phi4_rectangle_trap",
+                "status": "EXACT_OBSTRUCTION",
+                "phi_cycle": [_json_chord(chord) for chord in cycle],
+                "cyclic_subsequence": [int(label) for label in signature],
+                "cyclic_order_orientation": orientation,
+                "roles": {
+                    "A": int(A),
+                    "A_bar": int(A_bar),
+                    "B": int(B),
+                    "B_bar": int(B_bar),
+                    "C": int(C),
+                    "C_bar": int(C_bar),
+                    "D": int(D),
+                    "D_bar": int(D_bar),
+                },
+                "coordinate_normalization": {
+                    "A": ["L0", "0"],
+                    "A_bar": ["-L0", "0"],
+                    "B": ["a", "L1"],
+                    "B_bar": ["a", "-L1"],
+                    "C": ["a + L2", "b"],
+                    "C_bar": ["a - L2", "b"],
+                    "D": ["0", "b + L3"],
+                    "D_bar": ["0", "b - L3"],
+                },
+                "positive_parameter_reasons": [
+                    "Along chord A-A_bar, the B-B_bar crossing precedes the D-D_bar crossing; hence a > 0.",
+                    "Along chord B-B_bar, the C-C_bar crossing precedes the A-A_bar crossing; hence b > 0.",
+                ],
+                "turn_determinants": {
+                    "D1": "L1*L2 + L1*a - L2*L3 - L2*b - a*b",
+                    "D3": "-L0*L3 + L2*L3 + L2*b - L3*a - a*b",
+                    "D5": "-L0*L1 + L0*L3 - L0*b + L3*a - a*b",
+                    "D7": "L0*L1 + L0*b - L1*L2 - L1*a - a*b",
+                },
+                "determinant_identity": {
+                    "left": "D1 + D3 + D5 + D7",
+                    "right": "-4*a*b",
+                    "contradiction": "Strict convexity requires D1,D3,D5,D7 > 0, but a,b > 0 makes their sum negative.",
+                },
+            }
+        )
+    return out
+
+
 def mutual_phi_pairs(S: Sequence[Sequence[int]]) -> list[tuple[Chord, Chord]]:
     """Return unordered reciprocal pairs (e,f) with phi(e)=f and phi(f)=e."""
     phis = phi_map(S)
@@ -278,6 +439,7 @@ def filter_summary(
     forced_classes = forced_equal_classes_from_matrix(matrix, len(S))
     adjacent_violations = adjacent_two_overlap_violations(S, order)
     crossing_violations = crossing_bisector_violations(S, order)
+    rectangle_traps = phi4_rectangle_trap_certificates(S, order)
 
     return {
         "n": len(S),
@@ -294,4 +456,6 @@ def filter_summary(
         "crossing_bisector_violations": [
             _json_chord_pair(pair) for pair in crossing_violations
         ],
+        "rectangle_trap_4_cycles": len(rectangle_traps),
+        "rectangle_trap_certificates": rectangle_traps,
     }

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -15,9 +15,9 @@ This script is deliberately research-oriented:
 Dependencies: numpy, scipy. Optional: sympy, z3-solver.
 
 Example:
-  python erdos97_search.py --pattern C12_pm_2_5 --restarts 50 --mode polar --out best.json
-  python erdos97_search.py --list-patterns
-  python erdos97_search.py --verify best.json
+  erdos97-search --pattern C12_pm_2_5 --restarts 50 --mode polar --out best.json
+  erdos97-search --list-patterns
+  python -m erdos97.search --verify best.json
 """
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ import dataclasses
 import json
 import math
 import time
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -352,6 +352,16 @@ def validate_candidate_shape(P: Array, S: Pattern) -> List[str]:
         bad = [j for j in row if j < 0 or j >= n]
         if bad:
             errors.append(f"row {i} contains out-of-range targets: {bad}")
+
+    for a in range(n):
+        targets_a = set(S[a])
+        for b in range(a + 1, n):
+            common = targets_a.intersection(S[b])
+            if len(common) > 2:
+                errors.append(
+                    f"rows {a} and {b} share {len(common)} selected targets, "
+                    "exceeding the pairwise cap of 2"
+                )
 
     return errors
 
@@ -748,7 +758,10 @@ def result_to_json(result: SearchResult) -> Dict[str, object]:
 def load_json_result(path: str) -> Tuple[Array, Pattern]:
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    P = np.array(data["coordinates"], dtype=float)
+    coordinates = data.get("coordinates", data.get("coordinates_float"))
+    if coordinates is None:
+        raise KeyError("candidate JSON must contain coordinates or coordinates_float")
+    P = np.array(coordinates, dtype=float)
     S = [[int(j) for j in row] for row in data["S"]]
     return P, S
 

--- a/src/erdos97/stuck_sets.py
+++ b/src/erdos97/stuck_sets.py
@@ -303,7 +303,6 @@ def forward_ear_order(S: Pattern, threshold: int = 3) -> ForwardEarOrderResult:
     masks = rows_to_masks(S)
     best_seed: tuple[int, ...] | None = None
     best_closure_mask = 0
-    best_order: list[int] = []
 
     for seed in combinations(range(n), threshold):
         closure_mask = mask_from_vertices(seed)
@@ -321,7 +320,6 @@ def forward_ear_order(S: Pattern, threshold: int = 3) -> ForwardEarOrderResult:
         if closure_mask.bit_count() > best_closure_mask.bit_count():
             best_seed = seed
             best_closure_mask = closure_mask
-            best_order = order
         if closure_mask.bit_count() == n:
             return ForwardEarOrderResult(
                 exists=True,

--- a/tests/test_incidence.py
+++ b/tests/test_incidence.py
@@ -26,6 +26,10 @@ def write_candidate(path: pathlib.Path, coordinates: list[list[float]], S: list[
     path.write_text(json.dumps({"coordinates": coordinates, "S": S}), encoding="utf-8")
 
 
+def circulant_witnesses(n: int, offsets: list[int]) -> list[list[int]]:
+    return [[(i + offset) % n for offset in offsets] for i in range(n)]
+
+
 def test_built_in_patterns_have_outdegree_four_and_no_loops() -> None:
     for pattern in built_in_patterns().values():
         assert len(pattern.S) == pattern.n
@@ -74,14 +78,39 @@ def test_verify_json_rejects_duplicate_self_witness_rows(tmp_path: pathlib.Path)
 
 def test_verify_json_normalizes_before_acceptance(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "tiny_regular_pentagon.json"
-    witnesses = [[j for j in range(5) if j != i] for i in range(5)]
-    write_candidate(path, regular_ngon(5, scale=1e-12), witnesses)
+    witnesses = circulant_witnesses(7, [1, 2, 3, 5])
+    write_candidate(path, regular_ngon(7, scale=1e-12), witnesses)
 
     diag = verify_json(str(path), tol=1e-8)
 
     assert not diag["ok_at_tol"]
     assert diag["validation_errors"] == []
     assert diag["max_spread"] > 1.0
+
+
+def test_verify_json_accepts_certificate_template_coordinate_key(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "certificate_template.json"
+    witnesses = circulant_witnesses(7, [1, 2, 3, 5])
+    path.write_text(
+        json.dumps({"coordinates_float": regular_ngon(7), "S": witnesses}),
+        encoding="utf-8",
+    )
+
+    diag = verify_json(str(path), tol=1e-8)
+
+    assert not diag["ok_at_tol"]
+    assert diag["validation_errors"] == []
+
+
+def test_verify_json_rejects_pairwise_common_neighbor_cap_violation(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "bad_pairwise_cap.json"
+    witnesses = [[j for j in range(5) if j != i] for i in range(5)]
+    write_candidate(path, regular_ngon(5), witnesses)
+
+    diag = verify_json(str(path), tol=1e-8)
+
+    assert not diag["ok_at_tol"]
+    assert any("pairwise cap of 2" in err for err in diag["validation_errors"])
 
 
 def test_min_pair_distance_detects_duplicate_points() -> None:

--- a/tests/test_incidence_filters.py
+++ b/tests/test_incidence_filters.py
@@ -3,12 +3,28 @@ from __future__ import annotations
 from erdos97.incidence_filters import (
     adjacent_two_overlap_violations,
     chords_cross_in_order,
+    crossing_bisector_violations,
     forced_equal_classes_from_matrix,
     mutual_midpoint_matrix,
     odd_forced_perpendicular_cycle,
+    phi4_rectangle_trap_certificates,
+    phi_directed_4_cycles,
     phi_map,
 )
 from erdos97.search import built_in_patterns
+
+
+N9_RECTANGLE_TRAP_PATTERN = [
+    [1, 2, 3, 8],
+    [0, 2, 4, 7],
+    [1, 3, 5, 7],
+    [1, 4, 6, 8],
+    [0, 2, 5, 6],
+    [3, 4, 6, 7],
+    [2, 5, 7, 8],
+    [0, 3, 6, 8],
+    [0, 1, 4, 5],
+]
 
 
 def test_chords_cross_in_order() -> None:
@@ -104,6 +120,76 @@ def test_c17_skew_has_odd_forced_perpendicularity_cycle() -> None:
 
     assert cycle is not None
     assert len(cycle) % 2 == 1
+
+
+def test_n9_rectangle_trap_survives_older_phi_filters() -> None:
+    matrix = mutual_midpoint_matrix(N9_RECTANGLE_TRAP_PATTERN)
+
+    assert odd_forced_perpendicular_cycle(N9_RECTANGLE_TRAP_PATTERN) is None
+    assert matrix.rank() == 0
+    assert forced_equal_classes_from_matrix(matrix, 9) == []
+    assert adjacent_two_overlap_violations(N9_RECTANGLE_TRAP_PATTERN) == []
+    assert crossing_bisector_violations(N9_RECTANGLE_TRAP_PATTERN, list(range(9))) == []
+
+
+def test_n9_rectangle_trap_has_exact_phi4_certificate() -> None:
+    cycles = phi_directed_4_cycles(N9_RECTANGLE_TRAP_PATTERN)
+    certs = phi4_rectangle_trap_certificates(N9_RECTANGLE_TRAP_PATTERN)
+
+    assert cycles == [((0, 6), (2, 8), (1, 5), (4, 7))]
+    assert len(certs) == 1
+    cert = certs[0]
+    assert cert["status"] == "EXACT_OBSTRUCTION"
+    assert cert["phi_cycle"] == [[0, 6], [2, 8], [1, 5], [4, 7]]
+    assert cert["cyclic_subsequence"] == [0, 1, 2, 4, 5, 6, 7, 8]
+    assert cert["determinant_identity"] == {
+        "left": "D1 + D3 + D5 + D7",
+        "right": "-4*a*b",
+        "contradiction": (
+            "Strict convexity requires D1,D3,D5,D7 > 0, "
+            "but a,b > 0 makes their sum negative."
+        ),
+    }
+
+
+def test_n9_rectangle_trap_accepts_reversed_cyclic_order() -> None:
+    certs = phi4_rectangle_trap_certificates(
+        N9_RECTANGLE_TRAP_PATTERN,
+        list(reversed(range(9))),
+    )
+
+    assert len(certs) == 1
+    assert certs[0]["cyclic_order_orientation"] == "reversed"
+
+
+def test_phi4_rectangle_trap_determinant_identity_expands_exactly() -> None:
+    import sympy as sp
+
+    a, b, L0, L1, L2, L3 = sp.symbols("a b L0 L1 L2 L3")
+    points = [
+        (L0, 0),
+        (a + L2, b),
+        (a, L1),
+        (0, b + L3),
+        (a - L2, b),
+        (-L0, 0),
+        (0, b - L3),
+        (a, -L1),
+    ]
+
+    def orient(i: int):
+        p = sp.Matrix(points[i])
+        q = sp.Matrix(points[(i + 1) % len(points)])
+        r = sp.Matrix(points[(i + 2) % len(points)])
+        v = q - p
+        w = r - q
+        return sp.expand(v[0] * w[1] - v[1] * w[0])
+
+    determinants = [orient(i) for i in range(len(points))]
+
+    odd_sum = determinants[1] + determinants[3] + determinants[5] + determinants[7]
+
+    assert sp.factor(odd_sum) == -4 * a * b
 
 
 def test_parity_patterns_have_natural_order_adjacent_two_overlap_violations() -> None:


### PR DESCRIPTION
## Summary
- add an exact fixed-pattern phi 4-cycle rectangle-trap filter and a registered n=9 selected-witness certificate
- document the determinant identity obstruction and wire the certificate into the mutual-rhombus summary output
- add validation hygiene for certificate-style JSON, pairwise row-overlap caps, and ruff in CI

## Validation
- `python scripts/check_phi4_rectangle_trap.py --assert-expected --write`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

No general proof and no counterexample are claimed; this is a fixed selected-witness obstruction only.