### PR TITLE
[codex] Sync ruff dependency snapshot

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -5,5 +5,6 @@ numpy==2.4.4
 scipy==1.17.1
 pytest==9.0.3
 PyYAML==6.0.3
+ruff==0.15.11
 sympy==1.14.0
 z3-solver==4.16.0.0


### PR DESCRIPTION
## Summary
- add `ruff==0.15.11` to the checked dependency snapshot
- keep `requirements-lock.txt` aligned with the new ruff CI/dev dependency from PR #68

## Validation
- `python scripts/check_text_clean.py`
- `git diff --check`

No general proof and no counterexample are claimed.