### PR TITLE
Apply phi4 trap filter to stuck motifs

### DIFF
--- a/docs/stuck-set-miner.md
+++ b/docs/stuck-set-miner.md
@@ -73,8 +73,8 @@ python scripts/find_minimal_stuck_sets.py \
 
 The JSON output includes cheap exact filter diagnostics for the full fixed
 pattern: row-pair cap, column-pair cap, `phi` edge count, odd forced
-perpendicularity cycles, natural-order crossing violations, and the current
-minimum-radius short-chord filter result.
+perpendicularity cycles, phi 4-cycle rectangle traps, natural-order crossing
+violations, and the current minimum-radius short-chord filter result.
 
 ## Mining New Motifs
 
@@ -97,9 +97,10 @@ By default, the solver enforces:
 - adjacent-row overlap at most `1` in natural order;
 - two-overlap crossing compatibility in natural order.
 
-The post-solver filters also require no odd forced-perpendicularity cycle,
-radius-propagation survival, and incidence-level fragile-cover compatibility.
-Each of these can be relaxed with a named `--allow-*` flag.
+The post-solver filters also require no odd forced-perpendicularity cycle, no
+phi 4-cycle rectangle trap, radius-propagation survival, and incidence-level
+fragile-cover compatibility. Each of these can be relaxed with a named
+`--allow-*` flag.
 
 For motifs that are genuinely adversarial to the ear-orderable rank program,
 add:
@@ -133,6 +134,11 @@ n=10, stuck_size=4: found a surviving no-forward fixed-selection motif
 n=11, stuck_size=4: found a surviving no-forward fixed-selection motif
 n=12, stuck_size=4: found a surviving no-forward fixed-selection motif
 ```
+
+For the same `n=9`, `stuck_size=4`, `--max-models 220` run, the search
+exhausts after 90 inspected models. The rejection counts include
+`phi4_rectangle_trap: 22`, so the rectangle-trap filter is now an active part
+of the small no-forward motif screen.
 
 These are search diagnostics, not finite-case theorems.
 

--- a/scripts/mine_stuck_motifs.py
+++ b/scripts/mine_stuck_motifs.py
@@ -41,6 +41,7 @@ def main() -> int:
     parser.add_argument("--allow-adjacent-two-overlap", action="store_true", help="do not reject adjacent source rows with two overlaps")
     parser.add_argument("--allow-crossing-violations", action="store_true", help="do not reject two-overlap crossing violations")
     parser.add_argument("--allow-odd-cycle", action="store_true", help="do not reject odd forced-perpendicularity cycles")
+    parser.add_argument("--allow-rectangle-trap", action="store_true", help="do not reject phi 4-cycle rectangle-trap certificates")
     parser.add_argument("--allow-radius-obstruction", action="store_true", help="do not reject radius-cycle obstructions")
     parser.add_argument("--allow-no-fragile-cover", action="store_true", help="do not require incidence-level fragile cover")
     parser.add_argument(
@@ -63,6 +64,7 @@ def main() -> int:
         require_adjacent_overlap=not args.allow_adjacent_two_overlap,
         require_crossing=not args.allow_crossing_violations,
         require_no_odd_cycle=not args.allow_odd_cycle,
+        require_no_rectangle_trap=not args.allow_rectangle_trap,
         require_radius_pass=not args.allow_radius_obstruction,
         require_fragile_cover=not args.allow_no_fragile_cover,
         require_no_forward_ear_order=args.require_no_forward_ear_order,

--- a/scripts/sweep_stuck_motifs.py
+++ b/scripts/sweep_stuck_motifs.py
@@ -40,6 +40,7 @@ def main() -> int:
         help="base prefix; n, stuck size, and seed are appended for each item",
     )
     parser.add_argument("--require-no-forward-ear-order", action="store_true")
+    parser.add_argument("--allow-rectangle-trap", action="store_true")
     parser.add_argument("--fragile-cover-max-size", type=int)
     parser.add_argument("--radius-node-limit", type=int, default=100_000)
     parser.add_argument("--run-geometry", action="store_true")
@@ -69,6 +70,7 @@ def main() -> int:
             solver_seed=args.solver_seed,
             variable_prefix=args.variable_prefix,
             require_no_forward_ear_order=args.require_no_forward_ear_order,
+            require_no_rectangle_trap=not args.allow_rectangle_trap,
             radius_node_limit=args.radius_node_limit,
             fragile_cover_max_size=args.fragile_cover_max_size,
             run_geometry=args.run_geometry,

--- a/src/erdos97/stuck_motif_search.py
+++ b/src/erdos97/stuck_motif_search.py
@@ -37,6 +37,7 @@ class MotifSearchConfig:
     require_adjacent_overlap: bool = True
     require_crossing: bool = True
     require_no_odd_cycle: bool = True
+    require_no_rectangle_trap: bool = True
     require_radius_pass: bool = True
     require_fragile_cover: bool = True
     require_no_forward_ear_order: bool = False
@@ -120,6 +121,8 @@ def _candidate_rejection(
         and snapshot["odd_forced_perpendicular_cycle_length"] is not None
     ):
         return "odd_forced_perpendicular_cycle"
+    if config.require_no_rectangle_trap and snapshot["rectangle_trap_4_cycles"]:
+        return "phi4_rectangle_trap"
 
     radius = snapshot["radius_propagation"]
     if config.require_radius_pass and radius["obstructed"] is not False:
@@ -289,6 +292,7 @@ def filters_required_to_json(config: MotifSearchConfig) -> dict[str, object]:
         "require_adjacent_overlap": config.require_adjacent_overlap,
         "require_crossing": config.require_crossing,
         "require_no_odd_cycle": config.require_no_odd_cycle,
+        "require_no_rectangle_trap": config.require_no_rectangle_trap,
         "require_radius_pass": config.require_radius_pass,
         "require_fragile_cover": config.require_fragile_cover,
         "require_no_forward_ear_order": config.require_no_forward_ear_order,

--- a/src/erdos97/stuck_motif_sweep.py
+++ b/src/erdos97/stuck_motif_sweep.py
@@ -21,6 +21,7 @@ class SweepConfig:
     solver_seed: int = 0
     variable_prefix: str = "sweep"
     require_no_forward_ear_order: bool = False
+    require_no_rectangle_trap: bool = True
     radius_node_limit: int = 100_000
     fragile_cover_max_size: int | None = None
     run_geometry: bool = False
@@ -107,6 +108,7 @@ def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
                 variable_prefix=resolved_prefix,
                 radius_node_limit=config.radius_node_limit,
                 require_no_forward_ear_order=config.require_no_forward_ear_order,
+                require_no_rectangle_trap=config.require_no_rectangle_trap,
                 fragile_cover_max_size=config.fragile_cover_max_size,
             )
         )
@@ -149,6 +151,7 @@ def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
             "solver_seed": config.solver_seed,
             "variable_prefix": config.variable_prefix,
             "require_no_forward_ear_order": config.require_no_forward_ear_order,
+            "require_no_rectangle_trap": config.require_no_rectangle_trap,
             "run_geometry": config.run_geometry,
             "geometry_optimizer": config.geometry_optimizer,
             "geometry_mode": config.geometry_mode,

--- a/src/erdos97/stuck_sets.py
+++ b/src/erdos97/stuck_sets.py
@@ -29,6 +29,7 @@ from erdos97.incidence_filters import (
     adjacent_two_overlap_violations,
     crossing_bisector_violations,
     odd_forced_perpendicular_cycle,
+    phi4_rectangle_trap_certificates,
     phi_map,
 )
 from erdos97.min_radius_filter import (
@@ -863,6 +864,7 @@ def pattern_filter_snapshot(
     odd_cycle = odd_forced_perpendicular_cycle(S)
     adjacent = adjacent_two_overlap_violations(S, order)
     crossing = crossing_bisector_violations(S, order)
+    rectangle_traps = phi4_rectangle_trap_certificates(S, order)
     min_radius = minimum_radius_order_obstruction(S, order=order)
     radius = radius_propagation_obstruction(S, order=order, node_limit=radius_node_limit)
     covered = sorted({label for row in S for label in row})
@@ -877,6 +879,8 @@ def pattern_filter_snapshot(
         "column_pair_cap_violations": column_violations,
         "phi_edges": len(phi_map(S)),
         "odd_forced_perpendicular_cycle_length": len(odd_cycle) if odd_cycle else None,
+        "rectangle_trap_4_cycles": len(rectangle_traps),
+        "rectangle_trap_certificates": rectangle_traps,
         "adjacent_two_overlap_violations": [
             [[int(a), int(b)] for a, b in pair] for pair in adjacent
         ],

--- a/tests/test_stuck_motif_search.py
+++ b/tests/test_stuck_motif_search.py
@@ -18,6 +18,7 @@ def test_mine_stuck_motif_finds_strict_small_model() -> None:
     assert payload["motif"]["key_peeling_status"] == "STUCK_SET_FOUND"
     assert payload["motif"]["filters"]["adjacent_two_overlap_violations"] == []
     assert payload["motif"]["filters"]["crossing_bisector_violations"] == []
+    assert payload["motif"]["filters"]["rectangle_trap_4_cycles"] == 0
     assert payload["motif"]["filters"]["radius_propagation"]["status"] == "PASS_ACYCLIC_CHOICE"
     assert payload["motif"]["filters"]["fragile_cover"]["cover_stats"]["cover_exists"] is True
 
@@ -30,6 +31,7 @@ def test_mine_stuck_motif_relaxed_model_records_search_contract() -> None:
         require_adjacent_overlap=False,
         require_crossing=False,
         require_no_odd_cycle=False,
+        require_no_rectangle_trap=False,
         require_radius_pass=False,
         require_fragile_cover=False,
     )
@@ -39,6 +41,7 @@ def test_mine_stuck_motif_relaxed_model_records_search_contract() -> None:
     assert payload["status"] == "FOUND"
     assert payload["fixed_stuck_vertices"] == [0, 1, 2, 3]
     assert payload["filters_required"]["require_crossing"] is False
+    assert payload["filters_required"]["require_no_rectangle_trap"] is False
     assert payload["motif"]["motif_search"]["stuck_vertices_forced"] == [0, 1, 2, 3]
 
 

--- a/tests/test_stuck_motif_sweep.py
+++ b/tests/test_stuck_motif_sweep.py
@@ -50,5 +50,6 @@ def test_sweep_records_stable_item_variable_prefix() -> None:
     )
 
     assert sweep["config"]["variable_prefix"] == "sweep_contract"
+    assert sweep["config"]["require_no_rectangle_trap"] is True
     assert sweep["items"][0]["variable_prefix"] == "sweep_contract_9_4_0"
     assert sweep["items"][0]["status"] == "FOUND"

--- a/tests/test_stuck_sets.py
+++ b/tests/test_stuck_sets.py
@@ -14,6 +14,18 @@ from erdos97.stuck_sets import (
     result_to_json,
 )
 
+N9_RECTANGLE_TRAP_PATTERN = [
+    [1, 2, 3, 8],
+    [0, 2, 4, 7],
+    [1, 3, 5, 7],
+    [1, 4, 6, 8],
+    [0, 2, 5, 6],
+    [3, 4, 6, 7],
+    [2, 5, 7, 8],
+    [0, 3, 6, 8],
+    [0, 1, 4, 5],
+]
+
 
 def test_detects_fixed_selection_stuck_subset() -> None:
     S = [
@@ -97,6 +109,18 @@ def test_c19_skew_snapshot_records_sparse_filter_wall() -> None:
     assert stuck.examples[0].vertices == list(range(8))
     assert not greedy.success
     assert len(greedy.terminal_vertices) >= 4
+
+
+def test_pattern_snapshot_records_phi4_rectangle_trap() -> None:
+    filters = pattern_filter_snapshot(N9_RECTANGLE_TRAP_PATTERN)
+
+    assert filters["rectangle_trap_4_cycles"] == 1
+    assert filters["rectangle_trap_certificates"][0]["phi_cycle"] == [
+        [0, 6],
+        [2, 8],
+        [1, 5],
+        [4, 7],
+    ]
 
 
 def test_large_sidon_fragile_cover_window_is_truncated() -> None:


### PR DESCRIPTION
## Summary
- include phi 4-cycle rectangle-trap certificates in stuck-set filter snapshots
- reject rectangle-trap motifs by default in SMT stuck-motif mining and sweeps, with `--allow-rectangle-trap` escape hatches
- document the expanded filter contract and add regression coverage for the registered n=9 trap pattern

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check origin/main`
- `python -m ruff check .`
- `python -m pytest tests/test_stuck_sets.py tests/test_stuck_motif_search.py tests/test_stuck_motif_sweep.py -q`
- earlier full suite on this patch before rebase: `python -m pytest -q` -> `128 passed, 7 deselected`

No general proof and no counterexample are claimed.