### PR TITLE
Reduce C19 row-circle duplicate multipliers

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -152,7 +152,10 @@ obstruction. The follow-up active-set artifact
 `data/certificates/c19_row_circle_ptolemy_active_set.json` records the
 optimized C19 distance classes and tight numerical constraints for
 exactification work, including a SciPy SLSQP multiplier summary; it is not an
-exact certificate.
+exact certificate. The companion multiplier-reduction artifact pairs all 19
+row-circle equalities with their duplicate global Ptolemy rows and reduces the
+largest absolute combined multiplier to `24`, clarifying that the largest raw
+weights are redundancy noise.
 
 Under the natural cyclic order, `P18_parity_balanced` and
 `P24_parity_balanced` are killed by adjacent-row two-overlap via the

--- a/data/certificates/c19_row_circle_multiplier_reduction.json
+++ b/data/certificates/c19_row_circle_multiplier_reduction.json
@@ -1,0 +1,420 @@
+{
+  "case": "C19_skew:vertex_circle_survivor",
+  "max_abs_combined_multiplier": 24.0,
+  "max_abs_original_global_multiplier": 2.9536216041122086e+17,
+  "max_abs_original_row_multiplier": 2.9536216041122086e+17,
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "This file only reduces numerical SLSQP multiplier bookkeeping.",
+    "Large row-circle equality multipliers often cancel against the matching global Ptolemy inequality multiplier."
+  ],
+  "pattern": "C19_skew",
+  "reductions": [
+    {
+      "center": 0,
+      "combined_multiplier": -8.5,
+      "global_ptolemy_index": 3174,
+      "global_ptolemy_multiplier": 2779634870796429.0,
+      "global_slack": -8.131516293641283e-20,
+      "global_vertices": [
+        5,
+        9,
+        11,
+        16
+      ],
+      "row_multiplier": -2779634870796437.5,
+      "row_residual": -8.131516293641283e-20,
+      "row_witnesses": [
+        5,
+        9,
+        11,
+        16
+      ]
+    },
+    {
+      "center": 1,
+      "combined_multiplier": -6.0,
+      "global_ptolemy_index": 945,
+      "global_ptolemy_multiplier": 9133759889765804.0,
+      "global_slack": -1.6263032587282567e-19,
+      "global_vertices": [
+        10,
+        17,
+        6,
+        12
+      ],
+      "row_multiplier": -9133759889765810.0,
+      "row_residual": -1.6263032587282567e-19,
+      "row_witnesses": [
+        10,
+        17,
+        6,
+        12
+      ]
+    },
+    {
+      "center": 2,
+      "combined_multiplier": -24.0,
+      "global_ptolemy_index": 212,
+      "global_ptolemy_multiplier": 5.1444391731506344e+16,
+      "global_slack": 2.710505431213761e-20,
+      "global_vertices": [
+        18,
+        7,
+        11,
+        13
+      ],
+      "row_multiplier": -5.144439173150637e+16,
+      "row_residual": 2.710505431213761e-20,
+      "row_witnesses": [
+        13,
+        18,
+        7,
+        11
+      ]
+    },
+    {
+      "center": 3,
+      "combined_multiplier": -16.0,
+      "global_ptolemy_index": 3659,
+      "global_ptolemy_multiplier": 1881706753910407.2,
+      "global_slack": -1.3552527156068805e-20,
+      "global_vertices": [
+        14,
+        12,
+        0,
+        8
+      ],
+      "row_multiplier": -1881706753910423.2,
+      "row_residual": -1.3552527156068805e-20,
+      "row_witnesses": [
+        14,
+        12,
+        0,
+        8
+      ]
+    },
+    {
+      "center": 4,
+      "combined_multiplier": -13.676838730040094,
+      "global_ptolemy_index": 3507,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": 5.421010862427522e-20,
+      "global_vertices": [
+        9,
+        13,
+        15,
+        1
+      ],
+      "row_multiplier": -13.676838730040094,
+      "row_residual": 5.421010862427522e-20,
+      "row_witnesses": [
+        15,
+        1,
+        9,
+        13
+      ]
+    },
+    {
+      "center": 5,
+      "combined_multiplier": -2.0,
+      "global_ptolemy_index": 1342,
+      "global_ptolemy_multiplier": 8037236362360544.0,
+      "global_slack": -8.131516293641283e-20,
+      "global_vertices": [
+        10,
+        14,
+        2,
+        16
+      ],
+      "row_multiplier": -8037236362360546.0,
+      "row_residual": -8.131516293641283e-20,
+      "row_witnesses": [
+        14,
+        2,
+        16,
+        10
+      ]
+    },
+    {
+      "center": 6,
+      "combined_multiplier": -6.215570020825521,
+      "global_ptolemy_index": 2185,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": -1.0842021724855044e-19,
+      "global_vertices": [
+        17,
+        3,
+        11,
+        15
+      ],
+      "row_multiplier": -6.215570020825521,
+      "row_residual": -1.0842021724855044e-19,
+      "row_witnesses": [
+        3,
+        11,
+        15,
+        17
+      ]
+    },
+    {
+      "center": 7,
+      "combined_multiplier": -3.6085312137592593,
+      "global_ptolemy_index": 781,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": -2.168404344971009e-19,
+      "global_vertices": [
+        18,
+        4,
+        16,
+        12
+      ],
+      "row_multiplier": -3.6085312137592593,
+      "row_residual": -2.168404344971009e-19,
+      "row_witnesses": [
+        4,
+        16,
+        12,
+        18
+      ]
+    },
+    {
+      "center": 8,
+      "combined_multiplier": -2.9708432177104807,
+      "global_ptolemy_index": 2267,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": 2.981555974335137e-19,
+      "global_vertices": [
+        17,
+        5,
+        13,
+        0
+      ],
+      "row_multiplier": -2.9708432177104807,
+      "row_residual": 2.981555974335137e-19,
+      "row_witnesses": [
+        17,
+        5,
+        13,
+        0
+      ]
+    },
+    {
+      "center": 9,
+      "combined_multiplier": -8.381777567745562,
+      "global_ptolemy_index": 406,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": 1.3552527156068805e-20,
+      "global_vertices": [
+        18,
+        6,
+        14,
+        1
+      ],
+      "row_multiplier": -8.381777567745562,
+      "row_residual": 1.3552527156068805e-20,
+      "row_witnesses": [
+        14,
+        1,
+        18,
+        6
+      ]
+    },
+    {
+      "center": 10,
+      "combined_multiplier": -20.747550122891493,
+      "global_ptolemy_index": 1994,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": 1.3552527156068805e-20,
+      "global_vertices": [
+        7,
+        2,
+        15,
+        0
+      ],
+      "row_multiplier": -20.747550122891493,
+      "row_residual": 1.3552527156068805e-20,
+      "row_witnesses": [
+        7,
+        2,
+        15,
+        0
+      ]
+    },
+    {
+      "center": 11,
+      "combined_multiplier": -13.446308902464649,
+      "global_ptolemy_index": 3150,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": -4.0657581468206416e-20,
+      "global_vertices": [
+        3,
+        16,
+        8,
+        1
+      ],
+      "row_multiplier": -13.446308902464649,
+      "row_residual": -4.0657581468206416e-20,
+      "row_witnesses": [
+        16,
+        8,
+        1,
+        3
+      ]
+    },
+    {
+      "center": 12,
+      "combined_multiplier": -4.0,
+      "global_ptolemy_index": 2311,
+      "global_ptolemy_multiplier": 2.0944707398739044e+16,
+      "global_slack": -2.710505431213761e-20,
+      "global_vertices": [
+        17,
+        9,
+        2,
+        4
+      ],
+      "row_multiplier": -2.094470739873905e+16,
+      "row_residual": -2.710505431213761e-20,
+      "row_witnesses": [
+        17,
+        9,
+        2,
+        4
+      ]
+    },
+    {
+      "center": 13,
+      "combined_multiplier": -9.649961121558633,
+      "global_ptolemy_index": 45,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": 4.0657581468206416e-20,
+      "global_vertices": [
+        18,
+        10,
+        3,
+        5
+      ],
+      "row_multiplier": -9.649961121558633,
+      "row_residual": 4.0657581468206416e-20,
+      "row_witnesses": [
+        18,
+        10,
+        3,
+        5
+      ]
+    },
+    {
+      "center": 14,
+      "combined_multiplier": -5.21875,
+      "global_ptolemy_index": 2773,
+      "global_ptolemy_multiplier": 255506584962536.44,
+      "global_slack": 0.0,
+      "global_vertices": [
+        6,
+        11,
+        4,
+        0
+      ],
+      "row_multiplier": -255506584962541.66,
+      "row_residual": 0.0,
+      "row_witnesses": [
+        11,
+        4,
+        0,
+        6
+      ]
+    },
+    {
+      "center": 15,
+      "combined_multiplier": -19.0,
+      "global_ptolemy_index": 1829,
+      "global_ptolemy_multiplier": 2957269404909588.5,
+      "global_slack": 8.131516293641283e-20,
+      "global_vertices": [
+        7,
+        5,
+        12,
+        1
+      ],
+      "row_multiplier": -2957269404909607.5,
+      "row_residual": 8.131516293641283e-20,
+      "row_witnesses": [
+        1,
+        7,
+        5,
+        12
+      ]
+    },
+    {
+      "center": 16,
+      "combined_multiplier": -4.572315491083952,
+      "global_ptolemy_index": 2796,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": -4.0657581468206416e-20,
+      "global_vertices": [
+        6,
+        2,
+        13,
+        8
+      ],
+      "row_multiplier": -4.572315491083952,
+      "row_residual": -4.0657581468206416e-20,
+      "row_witnesses": [
+        8,
+        6,
+        2,
+        13
+      ]
+    },
+    {
+      "center": 17,
+      "combined_multiplier": -8.313886326798208,
+      "global_ptolemy_index": 1704,
+      "global_ptolemy_multiplier": 0.0,
+      "global_slack": 6.776263578034403e-20,
+      "global_vertices": [
+        7,
+        3,
+        9,
+        14
+      ],
+      "row_multiplier": -8.313886326798208,
+      "row_residual": 6.776263578034403e-20,
+      "row_witnesses": [
+        3,
+        9,
+        14,
+        7
+      ]
+    },
+    {
+      "center": 18,
+      "combined_multiplier": 0.0,
+      "global_ptolemy_index": 1471,
+      "global_ptolemy_multiplier": 2.9536216041122086e+17,
+      "global_slack": 1.3552527156068805e-20,
+      "global_vertices": [
+        10,
+        4,
+        15,
+        8
+      ],
+      "row_multiplier": -2.9536216041122086e+17,
+      "row_residual": 1.3552527156068805e-20,
+      "row_witnesses": [
+        10,
+        4,
+        15,
+        8
+      ]
+    }
+  ],
+  "row_global_duplicate_count": 19,
+  "source_snapshot": "data/certificates/c19_row_circle_ptolemy_active_set.json",
+  "status": "ROW_CIRCLE_PTOLEMY_NLP_NUMERICAL_OBSTRUCTION",
+  "trust": "NUMERICAL_NONLINEAR_DIAGNOSTIC",
+  "type": "row_circle_ptolemy_multiplier_reduction_v1",
+  "unmatched_rows": []
+}

--- a/docs/row-circle-ptolemy-nlp.md
+++ b/docs/row-circle-ptolemy-nlp.md
@@ -78,6 +78,13 @@ exactification attempt. In the current snapshot, the nonzero multiplier counts
 are 19 linear inequalities, 57 global Ptolemy inequalities, and all 19
 row-circle equalities.
 
+The reduction artifact
+`data/certificates/c19_row_circle_multiplier_reduction.json` matches each
+row-circle equality with the duplicate global Ptolemy inequality on the same
+four witnesses. All 19 rows match. After combining each duplicate pair, the
+largest absolute multiplier drops from about `2.95e17` to `24`, showing that
+most of the enormous multipliers are redundant-constraint cancellation noise.
+
 ## Reproduction
 
 ```bash

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -345,6 +345,14 @@ tight global Ptolemy rows, 19 row-circle equality rows, and the SLSQP
 multiplier summary. It is numerical support data only, intended to make a later
 exact certificate search reproducible.
 
+The companion multiplier-reduction artifact
+`data/certificates/c19_row_circle_multiplier_reduction.json` pairs every
+row-circle equality with the duplicate tight global Ptolemy row on the same
+four witnesses. Combining those duplicate multipliers reduces the maximum
+absolute multiplier from about `2.95e17` to `24`, so the huge weights in the raw
+snapshot should be treated as redundancy noise, not as a stable exact
+certificate.
+
 ## Interpretation
 
 The radius-propagation filter chooses one possible short consecutive witness

--- a/scripts/reduce_row_circle_multipliers.py
+++ b/scripts/reduce_row_circle_multipliers.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Reduce duplicate row/global Ptolemy multipliers in a snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+PT_LABELS = ("ac", "bd", "ab", "cd", "bc", "ad")
+
+
+def ptolemy_key(row: dict[str, Any]) -> tuple[tuple[int, int], tuple[tuple[int, int], tuple[int, int]]]:
+    classes = row["classes"]
+    values = {label: int(classes[label]["class_index"]) for label in PT_LABELS}
+    negative = tuple(sorted((values["ac"], values["bd"])))
+    positive = tuple(
+        sorted(
+            (
+                tuple(sorted((values["ab"], values["cd"]))),
+                tuple(sorted((values["bc"], values["ad"]))),
+            )
+        )
+    )
+    return negative, positive
+
+
+def reduce_snapshot(snapshot: dict[str, Any], source: str) -> dict[str, Any]:
+    by_key: dict[object, list[dict[str, Any]]] = {}
+    for row in snapshot["tight_ptolemy_rows"]:
+        by_key.setdefault(ptolemy_key(row), []).append(row)
+
+    reductions = []
+    unmatched = []
+    for row in snapshot["row_ptolemy_rows"]:
+        matches = by_key.get(ptolemy_key(row), [])
+        if len(matches) != 1:
+            unmatched.append(
+                {
+                    "center": row["center"],
+                    "witnesses": row["witnesses"],
+                    "match_count": len(matches),
+                }
+            )
+            continue
+        match = matches[0]
+        row_multiplier = float(row.get("multiplier", 0.0))
+        ptolemy_multiplier = float(match.get("multiplier", 0.0))
+        reductions.append(
+            {
+                "center": row["center"],
+                "row_witnesses": row["witnesses"],
+                "global_ptolemy_index": match["index"],
+                "global_vertices": match["vertices"],
+                "row_multiplier": row_multiplier,
+                "global_ptolemy_multiplier": ptolemy_multiplier,
+                "combined_multiplier": row_multiplier + ptolemy_multiplier,
+                "row_residual": row["residual"],
+                "global_slack": match["slack"],
+            }
+        )
+
+    combined = [abs(row["combined_multiplier"]) for row in reductions]
+    original_row = [abs(row["row_multiplier"]) for row in reductions]
+    original_global = [abs(row["global_ptolemy_multiplier"]) for row in reductions]
+    return {
+        "type": "row_circle_ptolemy_multiplier_reduction_v1",
+        "trust": "NUMERICAL_NONLINEAR_DIAGNOSTIC",
+        "source_snapshot": source,
+        "pattern": snapshot["pattern"],
+        "case": snapshot["case"],
+        "status": snapshot["status"],
+        "row_global_duplicate_count": len(reductions),
+        "unmatched_rows": unmatched,
+        "max_abs_original_row_multiplier": max(original_row) if original_row else None,
+        "max_abs_original_global_multiplier": max(original_global) if original_global else None,
+        "max_abs_combined_multiplier": max(combined) if combined else None,
+        "reductions": reductions,
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "This file only reduces numerical SLSQP multiplier bookkeeping.",
+            "Large row-circle equality multipliers often cancel against the matching global Ptolemy inequality multiplier.",
+        ],
+    }
+
+
+def assert_expected(payload: dict[str, Any]) -> None:
+    if payload["case"] != "C19_skew:vertex_circle_survivor":
+        raise AssertionError(f"unexpected case: {payload['case']}")
+    if payload["row_global_duplicate_count"] != 19:
+        raise AssertionError("expected all 19 row equalities to match a global Ptolemy row")
+    if payload["unmatched_rows"]:
+        raise AssertionError(f"unexpected unmatched rows: {payload['unmatched_rows']}")
+    max_combined = payload["max_abs_combined_multiplier"]
+    if not isinstance(max_combined, float) or max_combined > 25:
+        raise AssertionError(f"unexpected reduced multiplier scale: {max_combined}")
+    max_original = payload["max_abs_original_row_multiplier"]
+    if not isinstance(max_original, float) or max_original < 1e16:
+        raise AssertionError(f"expected large original multipliers: {max_original}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--snapshot",
+        default="data/certificates/c19_row_circle_ptolemy_active_set.json",
+        help="input row-circle Ptolemy snapshot JSON",
+    )
+    parser.add_argument("--out", required=True, help="write reduced JSON payload")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    snapshot_path = Path(args.snapshot)
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    payload = reduce_snapshot(snapshot, args.snapshot)
+    if args.assert_expected:
+        assert_expected(payload)
+    with Path(args.out).open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(
+        f"{payload['case']} row-global duplicates={payload['row_global_duplicate_count']} "
+        f"max_combined={payload['max_abs_combined_multiplier']:.6g}"
+    )
+    if args.assert_expected:
+        print("OK: row-circle multiplier reduction expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_row_circle_multiplier_reduction.py
+++ b/tests/test_row_circle_multiplier_reduction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_c19_multiplier_reduction_records_duplicate_cancellations() -> None:
+    payload = json.loads(
+        (ROOT / "data" / "certificates" / "c19_row_circle_multiplier_reduction.json")
+        .read_text(encoding="utf-8")
+    )
+
+    assert payload["type"] == "row_circle_ptolemy_multiplier_reduction_v1"
+    assert payload["trust"] == "NUMERICAL_NONLINEAR_DIAGNOSTIC"
+    assert payload["case"] == "C19_skew:vertex_circle_survivor"
+    assert payload["row_global_duplicate_count"] == 19
+    assert payload["unmatched_rows"] == []
+    assert payload["max_abs_original_row_multiplier"] > 1e16
+    assert payload["max_abs_original_global_multiplier"] > 1e16
+    assert payload["max_abs_combined_multiplier"] <= 25
+    assert len(payload["reductions"]) == 19
+
+
+def test_row_circle_multiplier_reduction_cli_import_smoke() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/reduce_row_circle_multipliers.py", "--help"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Reduce duplicate" in result.stdout


### PR DESCRIPTION
## Summary
- add a reducer for row-circle/global-Ptolemy duplicate multipliers in the C19 active-set snapshot
- record that all 19 row-circle equalities match duplicate tight global Ptolemy rows
- document that combining duplicate pairs reduces the largest absolute multiplier from about 2.95e17 to 24, so the huge raw multipliers are redundancy noise

## Validation
- `python scripts/reduce_row_circle_multipliers.py --out data/certificates/c19_row_circle_multiplier_reduction.json --assert-expected`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check scripts/reduce_row_circle_multipliers.py tests/test_row_circle_multiplier_reduction.py`
- `python -m pytest tests/test_row_circle_multiplier_reduction.py tests/test_row_circle_ptolemy_snapshot.py -q`
- `python -m pytest -q`

No general proof and no counterexample are claimed; this is numerical multiplier bookkeeping for exactification.