### PR TITLE
[codex] Add n9 base-apex slack ledger

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`prompt-roadmap.md`](prompt-roadmap.md): prompt-derived planning roadmap and
   next recommended workstreams; heuristic guidance only, not mathematical
   evidence.
+- [`n9-base-apex-frontier.md`](n9-base-apex-frontier.md): corrected exploratory
+  slack ledger for the first `n=9` base-apex workstream; not a proof.
 - [`repo-roadmap.md`](repo-roadmap.md): staged repository plan.
 - [`initial-issues.md`](initial-issues.md): seed issue list.
 - [`../AGENTS.md`](../AGENTS.md): repository-level Codex guidance.

--- a/docs/n9-base-apex-frontier.md
+++ b/docs/n9-base-apex-frontier.md
@@ -1,0 +1,219 @@
+# n=9 base-apex frontier
+
+Status: exploratory research lead only. This note is not a proof, not a
+counterexample, and not a source for changing the repository's official/global
+status. The case `n >= 9` remains open.
+
+This note records the corrected bookkeeping target for extending the
+base-apex argument in `docs/n8-geometric-proof.md` from `n = 8` to `n = 9`.
+It supersedes an earlier informal slack recommendation from private archived
+exploration notes, but only as planning guidance.
+
+## Correct slack ledger
+
+Let `A` be a bad strictly convex `n`-gon and let `T(A)` be the number of
+isosceles triples `(p,{a,b})`, where `p` is the apex and `{a,b}` is the base.
+The base-apex count gives
+
+```text
+T(A) >= 6n
+T(A) <= n(n-2).
+```
+
+For `n = 9`, the upper-minus-baseline slack is
+
+```text
+n(n-2) - 6n = 9.
+```
+
+At a vertex, write the distance-class profile among the other eight vertices
+as a partition `(m_1,...,m_r)` with `sum m_i = 8` and `max m_i >= 4`. Its
+profile excess is
+
+```text
+s = sum_i binom(m_i,2) - 6.
+```
+
+The important correction is that the profile excesses do not have to sum to
+`9`. If `E` is the sum of profile excesses and `D` is the unused base-apex
+capacity, then the exact ledger is
+
+```text
+E + D = 9, with E >= 0 and D >= 0.
+```
+
+So `sum s_i <= 9`; equality is only the special case where every side and
+diagonal capacity is saturated.
+
+## n=9 profile table
+
+The possible vertex profiles and excesses are:
+
+```text
+s=0   (4,1,1,1,1)
+s=1   (4,2,1,1)
+s=2   (4,2,2)
+s=3   (4,3,1)
+s=4   (5,1,1,1)
+s=5   (5,2,1)
+s=6   (4,4)
+s=7   (5,3)
+s=9   (6,1,1)
+s=10  (6,2)
+s=15  (7,1)
+s=22  (8)
+```
+
+Only profiles with `s <= 9` can appear in an `n = 9` bad polygon, and even
+then only in combinations whose total profile excess is at most `9`.
+
+## Practical next target
+
+The first useful artifact is a finite ledger, not a theorem. It should:
+
+- enumerate all `n = 9` distance-class profiles and their excesses;
+- enumerate profile-excess distributions with total `E <= 9`;
+- carry the remaining slack as a separate capacity deficit `D = 9 - E`;
+- report conservative saturation guarantees for cyclic base families.
+
+This does not close `n = 9`. It identifies the exact places where a geometric
+anti-concentration lemma or a stronger turn-cover argument would need to enter.
+
+The first executable diagnostic is `scripts/explore_n9_base_apex.py`. It keeps
+the ledger separate from the turn-cover closure:
+
+```bash
+python scripts/explore_n9_base_apex.py --summary
+python scripts/explore_n9_base_apex.py --turn-cover
+python scripts/explore_n9_base_apex.py --motifs
+```
+
+## Turn-cover diagnostic
+
+Index the length-2 diagonal `{v_i,v_{i+2}}` by `i`. If it is fully saturated,
+then the short-side apex `v_{i+1}` is present, so
+
+```text
+|v_i v_{i+1}| = |v_{i+1} v_{i+2}|.
+```
+
+Index the length-3 diagonal `{v_i,v_{i+3}}` by `i`. If it is fully saturated,
+then its short-side apex is either `v_{i+1}` or `v_{i+2}`. When the neighboring
+length-2 diagonals `i` and `i+1` are also saturated, this gives the clause
+
+```text
+tau_{i+1} = 2*pi/3  or  tau_{i+2} = 2*pi/3.
+```
+
+With every length-2 and length-3 diagonal saturated, these clauses form the
+edge set of a 9-cycle, so the minimum turn cover has size `5`. That would
+contradict the total exterior-turn sum.
+
+The executable diagnostic finds that, using the strict-positivity threshold
+where three forced `2*pi/3` turns already exhaust the `2*pi` budget, at least
+three length-2/length-3 capacity deficits are needed to escape this particular
+closure. Using the more conservative "forced turns alone exceed `2*pi`"
+threshold, two such deficits suffice to escape.
+
+Among the 95 unlabeled profile-excess distributions with `E <= 9`, this
+conditional mechanism closes 65 distributions under the strict-positivity
+threshold and 50 under the conservative threshold. The remaining distributions
+need either stronger saturation information, an anti-concentration lemma, or a
+different geometric obstruction.
+
+The unresolved strict-threshold ledgers are exactly the low-profile-excess
+ones:
+
+```text
+E <= 6, equivalently D >= 3.
+```
+
+This reverses the original intuition in an important way. A pure
+anti-concentration lemma, by itself, does not close `n = 9`: if only the
+profiles with excess `0` and `1` are allowed, there are 10 unlabeled excess
+distributions and the current turn-cover diagnostic still leaves 7 unresolved.
+Those unresolved cases have too much unused base-apex capacity, not too much
+profile concentration.
+
+The next mathematical target is therefore sharper:
+
+```text
+Either prove E >= 7,
+or prove that D >= 3 cannot be placed so as to spoil the length-2/length-3
+turn-cover clauses,
+or add a separate obstruction for the low-excess ledgers.
+```
+
+## Minimum escape motifs
+
+The `--motifs` diagnostic classifies relevant length-2/length-3 saturation
+failures up to dihedral symmetry. A "relevant" deficit is one spent on a
+length-2 or length-3 diagonal, because only those bases participate in the
+turn-cover closure here. Deficits spent on sides or length-4 diagonals do not
+help escape this particular diagnostic.
+
+Under the strict-positivity threshold, the minimum relevant deficit count is
+`3`. There are `108` labelled escaping placements, falling into `8` dihedral
+classes:
+
+```text
+length-2 spoiled   length-3 spoiled
+----------------   ----------------
+{0,2}              {3}
+{0,2}              {5}
+{0,3}              {1}
+{0,4}              {5}
+{0,1,3}            {}
+{0,1,5}            {}
+{0,2,4}            {}
+{0,2,5}            {}
+```
+
+Under the conservative "forced turns alone exceed `2*pi`" threshold, the
+minimum relevant deficit count is `2`. There are `72` labelled escaping
+placements, falling into `6` dihedral classes:
+
+```text
+length-2 spoiled   length-3 spoiled
+----------------   ----------------
+{0}                {1}
+{0}                {3}
+{0,1}              {}
+{0,2}              {}
+{0,3}              {}
+{0,4}              {}
+```
+
+These motif lists give the next finite target. To improve the `n = 9`
+base-apex route, one needs a geometric reason that the relevant deficits cannot
+fall into these motifs, or a separate obstruction that attacks the motifs
+directly.
+
+This is still conditional bookkeeping. It does not say that `n = 9` is closed;
+it says that profile distributions with very small capacity deficit are the
+ones this exact turn-cover mechanism can attack directly.
+
+## Lemma target to refine
+
+The old shorthand "no high concentration" is too weak as stated. For example,
+the profile `(4,2,2)` has no class of size at least five and no second class of
+size at least three, but it still has profile excess `2`.
+
+A sharper target for the easy regime is:
+
+```text
+Only the profiles (4,1,1,1,1) and (4,2,1,1) survive the first geometric filters.
+```
+
+Even this does not force full saturation unless all nine vertices have excess
+`1`. The remaining capacity deficit still has to be accounted for explicitly.
+
+The research question is therefore:
+
+```text
+Can strict convexity force either enough profile excess, enough base saturation,
+or enough structured saturation in length-2 and length-3 diagonals to trigger
+the exterior-turn contradiction?
+```
+
+The current answer is unknown.

--- a/docs/repo-roadmap.md
+++ b/docs/repo-roadmap.md
@@ -15,7 +15,9 @@
 - Add exact/interval infeasibility checks for small fixed patterns.
 - Maintain the checked `n=8` incidence-completeness and exact-obstruction
   artifacts.
-- Use the `n=8` pipeline as the model for the first `n=9` frontier attempt.
+- Use the `n=8` pipeline as the model for the first `n=9` frontier attempt,
+  starting from the corrected profile-excess / capacity-deficit ledger in
+  `docs/n9-base-apex-frontier.md`.
 
 ## Phase 3: numerical exploration
 

--- a/scripts/explore_n9_base_apex.py
+++ b/scripts/explore_n9_base_apex.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Explore the corrected n=9 base-apex slack ledger."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_base_apex import (  # noqa: E402
+    distance_profiles,
+    deficit_placement_classes,
+    excess_distributions,
+    guaranteed_full_bases,
+    ledger_summary,
+    minimum_capacity_deficit_to_escape_turn_cover,
+    profile_assumption_summaries,
+    profile_ledger_cases,
+    turn_cover_diagnostic,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print the full JSON payload")
+    parser.add_argument("--summary", action="store_true", help="print a compact summary")
+    parser.add_argument(
+        "--distributions",
+        action="store_true",
+        help="include unlabeled profile-excess distributions",
+    )
+    parser.add_argument(
+        "--turn-cover",
+        action="store_true",
+        help="include the full-saturation turn-cover diagnostic",
+    )
+    parser.add_argument(
+        "--unresolved",
+        action="store_true",
+        help="include profile ledgers unresolved by the strict turn-cover diagnostic",
+    )
+    parser.add_argument(
+        "--assumptions",
+        action="store_true",
+        help="include standard profile-assumption summaries",
+    )
+    parser.add_argument(
+        "--motifs",
+        action="store_true",
+        help="include minimum deficit-placement motif classes",
+    )
+    args = parser.parse_args()
+
+    payload = ledger_summary()
+    if args.distributions:
+        payload["unlabeled_excess_distributions"] = [
+            dataclasses.asdict(row) for row in excess_distributions()
+        ]
+    if args.turn_cover:
+        payload["full_saturation_turn_cover"] = dataclasses.asdict(
+            turn_cover_diagnostic()
+        )
+        payload["strict_turn_cover_escape"] = dataclasses.asdict(
+            minimum_capacity_deficit_to_escape_turn_cover()
+        )
+    if args.unresolved:
+        payload["strict_unresolved_profile_ledgers"] = [
+            dataclasses.asdict(row)
+            for row in profile_ledger_cases(forced_by_turn_cover=False)
+        ]
+    if args.assumptions:
+        payload["standard_profile_assumption_summaries"] = [
+            dataclasses.asdict(row) for row in profile_assumption_summaries()
+        ]
+    if args.motifs:
+        payload["strict_minimum_escape_motif_classes"] = [
+            dataclasses.asdict(row) for row in deficit_placement_classes()
+        ]
+        payload["conservative_minimum_escape_motif_classes"] = [
+            dataclasses.asdict(row)
+            for row in deficit_placement_classes(contradiction_threshold=4)
+        ]
+    if (
+        args.json
+        or args.distributions
+        or args.turn_cover
+        or args.unresolved
+        or args.assumptions
+        or args.motifs
+    ):
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if args.summary:
+        assumption_summaries = payload["profile_assumption_summaries"]
+        compact = {
+            "n": payload["n"],
+            "status": payload["status"],
+            "base_apex_slack": payload["base_apex_slack"],
+            "profile_count": payload["profile_count"],
+            "profile_excess_values": payload["profile_excess_values"],
+            "unlabeled_excess_distribution_count": payload[
+                "unlabeled_excess_distribution_count"
+            ],
+            "strict_turn_cover_minimum_deficit_to_escape": payload[
+                "turn_cover_escape"
+            ]["strict_positive_threshold"]["minimum_capacity_deficit_to_escape"],
+            "conservative_turn_cover_minimum_deficit_to_escape": payload[
+                "turn_cover_escape"
+            ]["sum_exceeds_threshold"]["minimum_capacity_deficit_to_escape"],
+            "strict_minimum_escape_motif_classes": payload[
+                "minimum_escape_motif_summary"
+            ]["strict_positive_threshold"]["dihedral_class_count"],
+            "conservative_minimum_escape_motif_classes": payload[
+                "minimum_escape_motif_summary"
+            ]["sum_exceeds_threshold"]["dihedral_class_count"],
+            "strict_turn_cover_forced_distribution_count": payload[
+                "turn_cover_distribution_summary"
+            ]["strict_positive_threshold"]["forced_by_turn_cover_count"],
+            "conservative_turn_cover_forced_distribution_count": payload[
+                "turn_cover_distribution_summary"
+            ]["sum_exceeds_threshold"]["forced_by_turn_cover_count"],
+            "anti_concentration_0_1_distribution_count": assumption_summaries[0][
+                "distribution_count"
+            ],
+            "anti_concentration_0_1_unresolved_count": assumption_summaries[0][
+                "unresolved_by_turn_cover_count"
+            ],
+            "guaranteed_full_length2_bases_when_D_is_0": guaranteed_full_bases(
+                capacity_deficit=0,
+                cyclic_length=2,
+            ),
+            "guaranteed_full_length2_bases_when_D_is_4": guaranteed_full_bases(
+                capacity_deficit=4,
+                cyclic_length=2,
+            ),
+            "guaranteed_full_length2_bases_when_D_is_9": guaranteed_full_bases(
+                capacity_deficit=9,
+                cyclic_length=2,
+            ),
+        }
+        print(json.dumps(compact, indent=2, sort_keys=True))
+        return 0
+
+    print("n=9 base-apex profile ledger")
+    print("status: exploratory bookkeeping only")
+    print()
+    print("excess  profiles")
+    print("------  --------")
+    for profile in distance_profiles():
+        print(f"{profile.excess:>6}  {profile.parts}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_base_apex.py
+++ b/src/erdos97/n9_base_apex.py
@@ -1,0 +1,816 @@
+"""Exploratory n=9 base-apex slack ledger.
+
+This module is finite bookkeeping for research planning. It separates
+per-vertex distance-profile excess from unused base-apex capacity. It does not
+claim a proof of the n=9 case.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import Counter
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class DistanceProfile:
+    """One partition of the other vertices at a center."""
+
+    parts: tuple[int, ...]
+    isosceles_pairs: int
+    excess: int
+
+
+@dataclass(frozen=True)
+class ExcessDistribution:
+    """One sorted distribution of profile excess across all vertices."""
+
+    excesses: tuple[int, ...]
+    total_profile_excess: int
+    capacity_deficit: int
+
+
+@dataclass(frozen=True)
+class CyclicBaseFamily:
+    """A cyclic base family, grouped by shorter cyclic length."""
+
+    cyclic_length: int
+    base_count: int
+    capacity_per_base: int
+    total_capacity: int
+
+
+@dataclass(frozen=True)
+class TurnCoverDiagnostic:
+    """Turn-cover clauses forced by saturated length-2 and length-3 diagonals."""
+
+    n: int
+    saturated_length2: tuple[int, ...]
+    saturated_length3: tuple[int, ...]
+    turn_clauses: tuple[tuple[int, int], ...]
+    minimum_forced_turns: int
+    contradiction_threshold: int
+    forces_turn_contradiction: bool
+
+
+@dataclass(frozen=True)
+class TurnCoverEscape:
+    """Smallest length-2/length-3 capacity deficit escaping the diagnostic."""
+
+    n: int
+    contradiction_threshold: int
+    minimum_capacity_deficit: int
+    spoiled_length2: tuple[int, ...]
+    spoiled_length3: tuple[int, ...]
+    remaining_turn_clauses: tuple[tuple[int, int], ...]
+    remaining_minimum_forced_turns: int
+
+
+@dataclass(frozen=True)
+class ProfileLedgerCase:
+    """One profile-excess distribution decorated with turn-cover status."""
+
+    excesses: tuple[int, ...]
+    total_profile_excess: int
+    capacity_deficit: int
+    forced_by_turn_cover: bool
+    profile_multiset: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True)
+class ProfileAssumptionSummary:
+    """Effect of allowing only a selected set of profile-excess values."""
+
+    allowed_excesses: tuple[int, ...]
+    distribution_count: int
+    forced_by_turn_cover_count: int
+    unresolved_by_turn_cover_count: int
+    minimum_total_profile_excess: int | None
+    maximum_total_profile_excess: int | None
+
+
+@dataclass(frozen=True)
+class DeficitPlacementClass:
+    """One dihedral class of relevant length-2/length-3 saturation failures."""
+
+    n: int
+    relevant_deficit_count: int
+    contradiction_threshold: int
+    spoiled_length2: tuple[int, ...]
+    spoiled_length3: tuple[int, ...]
+    placement_count: int
+    remaining_minimum_forced_turns: int
+    remaining_turn_clause_count: int
+
+
+def binom2(value: int) -> int:
+    """Return ``binom(value, 2)`` for a nonnegative integer."""
+
+    if value < 0:
+        raise ValueError(f"value must be nonnegative, got {value}")
+    return value * (value - 1) // 2
+
+
+def integer_partitions(total: int, minimum: int = 1) -> Iterable[tuple[int, ...]]:
+    """Yield nondecreasing positive integer partitions of ``total``."""
+
+    if total < 0:
+        raise ValueError(f"total must be nonnegative, got {total}")
+    if total == 0:
+        yield ()
+        return
+    for first in range(minimum, total + 1):
+        for rest in integer_partitions(total - first, first):
+            yield (first, *rest)
+
+
+def distance_profiles(n: int = 9, witness_size: int = 4) -> list[DistanceProfile]:
+    """Return possible bad-vertex profiles for an ``n``-gon.
+
+    Profiles are nondecreasing partitions of the other ``n - 1`` vertices with
+    at least one distance class of size ``witness_size`` or larger.
+    """
+
+    if n <= witness_size:
+        raise ValueError(f"n must exceed witness_size, got n={n}")
+    baseline = binom2(witness_size)
+    profiles = []
+    for ascending_parts in integer_partitions(n - 1):
+        parts = tuple(reversed(ascending_parts))
+        if max(parts, default=0) < witness_size:
+            continue
+        pairs = sum(binom2(part) for part in parts)
+        profiles.append(
+            DistanceProfile(
+                parts=parts,
+                isosceles_pairs=pairs,
+                excess=pairs - baseline,
+            )
+        )
+    return sorted(profiles, key=lambda profile: (profile.excess, profile.parts))
+
+
+def profiles_by_excess(n: int = 9, witness_size: int = 4) -> dict[int, list[tuple[int, ...]]]:
+    """Group possible profiles by profile excess."""
+
+    grouped: dict[int, list[tuple[int, ...]]] = {}
+    for profile in distance_profiles(n, witness_size):
+        grouped.setdefault(profile.excess, []).append(profile.parts)
+    return grouped
+
+
+def profile_excess_values(n: int = 9, witness_size: int = 4) -> tuple[int, ...]:
+    """Return the sorted excess values available to a bad vertex."""
+
+    return tuple(sorted(profiles_by_excess(n, witness_size)))
+
+
+def base_apex_slack(n: int, witness_size: int = 4) -> int:
+    """Return the upper-minus-baseline base-apex slack."""
+
+    if n <= 0:
+        raise ValueError(f"n must be positive, got {n}")
+    return n * (n - 2) - binom2(witness_size) * n
+
+
+def excess_distributions(
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    total_excess_limit: int | None = None,
+) -> list[ExcessDistribution]:
+    """Return sorted profile-excess distributions within the slack budget.
+
+    The distributions are unlabeled: ``(0,1,2)`` and ``(2,1,0)`` are the same
+    record. Each record carries the remaining base-apex capacity deficit.
+    """
+
+    slack = base_apex_slack(n, witness_size)
+    if total_excess_limit is None:
+        total_excess_limit = slack
+    if total_excess_limit < 0:
+        raise ValueError(f"total_excess_limit must be nonnegative, got {total_excess_limit}")
+    limit = min(slack, total_excess_limit)
+    values = [value for value in profile_excess_values(n, witness_size) if value <= limit]
+    out: list[ExcessDistribution] = []
+
+    def search(start_index: int, slots_left: int, remaining: int, current: list[int]) -> None:
+        if slots_left == 0:
+            total = sum(current)
+            out.append(
+                ExcessDistribution(
+                    excesses=tuple(current),
+                    total_profile_excess=total,
+                    capacity_deficit=slack - total,
+                )
+            )
+            return
+        for index in range(start_index, len(values)):
+            value = values[index]
+            if value > remaining:
+                break
+            current.append(value)
+            search(index, slots_left - 1, remaining - value, current)
+            current.pop()
+
+    search(0, n, limit, [])
+    return sorted(out, key=lambda row: (row.total_profile_excess, row.excesses))
+
+
+def cyclic_base_families(n: int = 9) -> list[CyclicBaseFamily]:
+    """Return cyclic base families by shorter cyclic length."""
+
+    if n < 3:
+        raise ValueError(f"n must be at least 3, got {n}")
+    families = []
+    for cyclic_length in range(1, n // 2 + 1):
+        base_count = n if cyclic_length * 2 != n else n // 2
+        capacity_per_base = 1 if cyclic_length == 1 else 2
+        families.append(
+            CyclicBaseFamily(
+                cyclic_length=cyclic_length,
+                base_count=base_count,
+                capacity_per_base=capacity_per_base,
+                total_capacity=base_count * capacity_per_base,
+            )
+        )
+    return families
+
+
+def guaranteed_full_bases(
+    n: int = 9,
+    capacity_deficit: int = 0,
+    cyclic_length: int = 2,
+) -> int:
+    """Conservative lower bound on fully saturated bases in one cyclic family.
+
+    A single missing apex can spoil full saturation of one base. With no
+    geometric information about where deficits land, this is the only
+    unconditional family-level guarantee.
+    """
+
+    if capacity_deficit < 0:
+        raise ValueError(f"capacity_deficit must be nonnegative, got {capacity_deficit}")
+    family = next(
+        (
+            candidate
+            for candidate in cyclic_base_families(n)
+            if candidate.cyclic_length == cyclic_length
+        ),
+        None,
+    )
+    if family is None:
+        raise ValueError(f"cyclic_length {cyclic_length} is not available for n={n}")
+    return max(0, family.base_count - capacity_deficit)
+
+
+def turn_clauses_from_saturation(
+    n: int = 9,
+    saturated_length2: Iterable[int] | None = None,
+    saturated_length3: Iterable[int] | None = None,
+) -> tuple[tuple[int, int], ...]:
+    """Return turn clauses forced by saturated length-2/length-3 diagonals.
+
+    The length-2 diagonal with index ``i`` is the base ``{v_i, v_{i+2}}``.
+    Its saturation forces ``|v_i v_{i+1}| = |v_{i+1} v_{i+2}|``.
+
+    The length-3 diagonal with index ``i`` is the base ``{v_i, v_{i+3}}``.
+    If it is saturated, the short-side apex is either ``v_{i+1}`` or
+    ``v_{i+2}``. When the adjacent length-2 diagonals ``i`` and ``i+1`` are
+    also saturated, this forces at least one of the turns ``i+1`` or ``i+2``
+    to equal ``2*pi/3``.
+    """
+
+    if n < 4:
+        raise ValueError(f"n must be at least 4, got {n}")
+    if saturated_length2 is None:
+        saturated_length2_set = set(range(n))
+    else:
+        saturated_length2_set = {idx % n for idx in saturated_length2}
+    if saturated_length3 is None:
+        saturated_length3_set = set(range(n))
+    else:
+        saturated_length3_set = {idx % n for idx in saturated_length3}
+
+    clauses = []
+    for idx in range(n):
+        if (
+            idx in saturated_length3_set
+            and idx in saturated_length2_set
+            and (idx + 1) % n in saturated_length2_set
+        ):
+            clauses.append(((idx + 1) % n, (idx + 2) % n))
+    return tuple(clauses)
+
+
+def minimum_turn_hitting_set_size(
+    n: int,
+    clauses: Iterable[tuple[int, int]],
+) -> int:
+    """Return the minimum number of turns hitting all two-turn clauses."""
+
+    clause_tuple = tuple(clauses)
+    if not clause_tuple:
+        return 0
+    for size in range(n + 1):
+        for selected in itertools.combinations(range(n), size):
+            selected_set = set(selected)
+            if all(a in selected_set or b in selected_set for a, b in clause_tuple):
+                return size
+    raise RuntimeError("no hitting set found")
+
+
+def turn_cover_diagnostic(
+    n: int = 9,
+    *,
+    spoiled_length2: Iterable[int] = (),
+    spoiled_length3: Iterable[int] = (),
+    contradiction_threshold: int = 3,
+) -> TurnCoverDiagnostic:
+    """Return the turn-cover diagnostic after spoiling selected bases.
+
+    ``contradiction_threshold=3`` uses strict positivity of all other exterior
+    turns: three turns of size ``2*pi/3`` already exhaust the total turn budget.
+    ``contradiction_threshold=4`` is the more conservative "forced turns alone
+    exceed ``2*pi``" threshold used in the octagon proof note.
+    """
+
+    if contradiction_threshold <= 0:
+        raise ValueError(
+            f"contradiction_threshold must be positive, got {contradiction_threshold}"
+        )
+    all_indices = set(range(n))
+    saturated_length2 = tuple(sorted(all_indices - {idx % n for idx in spoiled_length2}))
+    saturated_length3 = tuple(sorted(all_indices - {idx % n for idx in spoiled_length3}))
+    clauses = turn_clauses_from_saturation(n, saturated_length2, saturated_length3)
+    minimum_forced_turns = minimum_turn_hitting_set_size(n, clauses)
+    return TurnCoverDiagnostic(
+        n=n,
+        saturated_length2=saturated_length2,
+        saturated_length3=saturated_length3,
+        turn_clauses=clauses,
+        minimum_forced_turns=minimum_forced_turns,
+        contradiction_threshold=contradiction_threshold,
+        forces_turn_contradiction=minimum_forced_turns >= contradiction_threshold,
+    )
+
+
+@lru_cache(maxsize=None)
+def minimum_capacity_deficit_to_escape_turn_cover(
+    n: int = 9,
+    *,
+    contradiction_threshold: int = 3,
+) -> TurnCoverEscape:
+    """Find the smallest length-2/length-3 deficit escaping turn-cover closure."""
+
+    if n > 12:
+        raise ValueError("brute-force escape search is intended for n <= 12")
+    masks_by_size: dict[int, list[tuple[int, ...]]] = {size: [] for size in range(n + 1)}
+    for mask in range(1 << n):
+        spoiled = tuple(idx for idx in range(n) if (mask >> idx) & 1)
+        masks_by_size[len(spoiled)].append(spoiled)
+
+    for cost in range(2 * n + 1):
+        for cost2 in range(max(0, cost - n), min(n, cost) + 1):
+            cost3 = cost - cost2
+            for spoiled2 in masks_by_size[cost2]:
+                for spoiled3 in masks_by_size[cost3]:
+                    diagnostic = turn_cover_diagnostic(
+                        n,
+                        spoiled_length2=spoiled2,
+                        spoiled_length3=spoiled3,
+                        contradiction_threshold=contradiction_threshold,
+                    )
+                    if not diagnostic.forces_turn_contradiction:
+                        return TurnCoverEscape(
+                            n=n,
+                            contradiction_threshold=contradiction_threshold,
+                            minimum_capacity_deficit=cost,
+                            spoiled_length2=spoiled2,
+                            spoiled_length3=spoiled3,
+                            remaining_turn_clauses=diagnostic.turn_clauses,
+                            remaining_minimum_forced_turns=diagnostic.minimum_forced_turns,
+                        )
+    raise RuntimeError("no escaping deficit pattern found")
+
+
+def capacity_deficit_forces_turn_cover(
+    capacity_deficit: int,
+    n: int = 9,
+    *,
+    contradiction_threshold: int = 3,
+) -> bool:
+    """Return whether any placement of this deficit still forces turn closure."""
+
+    if capacity_deficit < 0:
+        raise ValueError(f"capacity_deficit must be nonnegative, got {capacity_deficit}")
+    escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    )
+    return capacity_deficit < escape.minimum_capacity_deficit
+
+
+def transform_base_index(
+    n: int,
+    index: int,
+    cyclic_length: int,
+    *,
+    rotation: int = 0,
+    reflected: bool = False,
+) -> int:
+    """Transform a cyclic base index under a dihedral relabeling.
+
+    The base indexed by ``i`` and cyclic length ``k`` is ``{v_i, v_{i+k}}``.
+    A reflection sends it to the base indexed by ``rotation - i - k``.
+    """
+
+    if reflected:
+        return (rotation - index - cyclic_length) % n
+    return (index + rotation) % n
+
+
+def canonical_deficit_placement(
+    n: int,
+    spoiled_length2: Iterable[int],
+    spoiled_length3: Iterable[int],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return a dihedral canonical key for spoiled length-2/length-3 bases."""
+
+    spoiled2 = tuple(spoiled_length2)
+    spoiled3 = tuple(spoiled_length3)
+    keys = []
+    for rotation in range(n):
+        for reflected in (False, True):
+            keys.append(
+                (
+                    tuple(
+                        sorted(
+                            transform_base_index(
+                                n,
+                                index,
+                                2,
+                                rotation=rotation,
+                                reflected=reflected,
+                            )
+                            for index in spoiled2
+                        )
+                    ),
+                    tuple(
+                        sorted(
+                            transform_base_index(
+                                n,
+                                index,
+                                3,
+                                rotation=rotation,
+                                reflected=reflected,
+                            )
+                            for index in spoiled3
+                        )
+                    ),
+                )
+            )
+    return min(keys)
+
+
+def deficit_placement_classes(
+    n: int = 9,
+    *,
+    relevant_deficit_count: int | None = None,
+    contradiction_threshold: int = 3,
+    escaping_only: bool = True,
+) -> list[DeficitPlacementClass]:
+    """Return dihedral classes of length-2/length-3 deficit placements."""
+
+    if relevant_deficit_count is None:
+        relevant_deficit_count = minimum_capacity_deficit_to_escape_turn_cover(
+            n,
+            contradiction_threshold=contradiction_threshold,
+        ).minimum_capacity_deficit
+    if relevant_deficit_count < 0:
+        raise ValueError(
+            f"relevant_deficit_count must be nonnegative, got {relevant_deficit_count}"
+        )
+    grouped: Counter[tuple[tuple[int, ...], tuple[int, ...]]] = Counter()
+    for count2 in range(max(0, relevant_deficit_count - n), min(n, relevant_deficit_count) + 1):
+        count3 = relevant_deficit_count - count2
+        for spoiled2 in itertools.combinations(range(n), count2):
+            for spoiled3 in itertools.combinations(range(n), count3):
+                diagnostic = turn_cover_diagnostic(
+                    n,
+                    spoiled_length2=spoiled2,
+                    spoiled_length3=spoiled3,
+                    contradiction_threshold=contradiction_threshold,
+                )
+                if escaping_only and diagnostic.forces_turn_contradiction:
+                    continue
+                if not escaping_only and not diagnostic.forces_turn_contradiction:
+                    continue
+                grouped[canonical_deficit_placement(n, spoiled2, spoiled3)] += 1
+
+    out = []
+    for (spoiled2, spoiled3), placement_count in grouped.items():
+        diagnostic = turn_cover_diagnostic(
+            n,
+            spoiled_length2=spoiled2,
+            spoiled_length3=spoiled3,
+            contradiction_threshold=contradiction_threshold,
+        )
+        out.append(
+            DeficitPlacementClass(
+                n=n,
+                relevant_deficit_count=relevant_deficit_count,
+                contradiction_threshold=contradiction_threshold,
+                spoiled_length2=spoiled2,
+                spoiled_length3=spoiled3,
+                placement_count=placement_count,
+                remaining_minimum_forced_turns=diagnostic.minimum_forced_turns,
+                remaining_turn_clause_count=len(diagnostic.turn_clauses),
+            )
+        )
+    return sorted(
+        out,
+        key=lambda row: (
+            len(row.spoiled_length2),
+            row.spoiled_length2,
+            row.spoiled_length3,
+        ),
+    )
+
+
+def minimum_escape_motif_summary(
+    n: int = 9,
+    *,
+    contradiction_threshold: int = 3,
+) -> dict[str, object]:
+    """Summarize minimum relevant-deficit motifs escaping turn cover."""
+
+    classes = deficit_placement_classes(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    )
+    relevant_deficit_count = (
+        classes[0].relevant_deficit_count
+        if classes
+        else minimum_capacity_deficit_to_escape_turn_cover(
+            n,
+            contradiction_threshold=contradiction_threshold,
+        ).minimum_capacity_deficit
+    )
+    return {
+        "contradiction_threshold": contradiction_threshold,
+        "relevant_deficit_count": relevant_deficit_count,
+        "raw_escaping_placement_count": sum(row.placement_count for row in classes),
+        "dihedral_class_count": len(classes),
+        "classes": [
+            {
+                "spoiled_length2": list(row.spoiled_length2),
+                "spoiled_length3": list(row.spoiled_length3),
+                "placement_count": row.placement_count,
+                "remaining_minimum_forced_turns": row.remaining_minimum_forced_turns,
+                "remaining_turn_clause_count": row.remaining_turn_clause_count,
+            }
+            for row in classes
+        ],
+    }
+
+
+def turn_cover_distribution_summary(
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    contradiction_threshold: int = 3,
+) -> dict[str, object]:
+    """Summarize which excess distributions are closed by turn-cover alone."""
+
+    distributions = excess_distributions(n, witness_size)
+    escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    )
+    forced = [
+        row
+        for row in distributions
+        if row.capacity_deficit < escape.minimum_capacity_deficit
+    ]
+    deficit_counts = Counter(row.capacity_deficit for row in distributions)
+    return {
+        "contradiction_threshold": contradiction_threshold,
+        "minimum_capacity_deficit_to_escape": escape.minimum_capacity_deficit,
+        "distribution_count": len(distributions),
+        "forced_by_turn_cover_count": len(forced),
+        "unresolved_by_turn_cover_count": len(distributions) - len(forced),
+        "capacity_deficit_counts": {
+            str(deficit): deficit_counts[deficit]
+            for deficit in sorted(deficit_counts)
+        },
+    }
+
+
+def _canonical_profile_for_excess(
+    n: int = 9,
+    witness_size: int = 4,
+) -> dict[int, tuple[int, ...]]:
+    """Return the unique profile for each n=9 excess value.
+
+    The current n=9 table has one profile per excess. If a future ``n`` has
+    collisions, this helper intentionally fails so callers do not silently pick
+    an arbitrary profile.
+    """
+
+    grouped = profiles_by_excess(n, witness_size)
+    ambiguous = {excess: profiles for excess, profiles in grouped.items() if len(profiles) != 1}
+    if ambiguous:
+        raise ValueError(f"profile excess is not unique for this n: {ambiguous}")
+    return {excess: profiles[0] for excess, profiles in grouped.items()}
+
+
+def profile_ledger_cases(
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    contradiction_threshold: int = 3,
+    forced_by_turn_cover: bool | None = None,
+) -> list[ProfileLedgerCase]:
+    """Return profile-excess ledgers decorated by turn-cover status."""
+
+    profile_by_excess = _canonical_profile_for_excess(n, witness_size)
+    cases = []
+    for row in excess_distributions(n, witness_size):
+        forced = capacity_deficit_forces_turn_cover(
+            row.capacity_deficit,
+            n,
+            contradiction_threshold=contradiction_threshold,
+        )
+        if forced_by_turn_cover is not None and forced != forced_by_turn_cover:
+            continue
+        cases.append(
+            ProfileLedgerCase(
+                excesses=row.excesses,
+                total_profile_excess=row.total_profile_excess,
+                capacity_deficit=row.capacity_deficit,
+                forced_by_turn_cover=forced,
+                profile_multiset=tuple(profile_by_excess[value] for value in row.excesses),
+            )
+        )
+    return cases
+
+
+def profile_assumption_summary(
+    allowed_excesses: Iterable[int],
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    contradiction_threshold: int = 3,
+) -> ProfileAssumptionSummary:
+    """Summarize turn-cover closure under a profile-excess restriction."""
+
+    allowed = tuple(sorted(set(allowed_excesses)))
+    cases = [
+        case
+        for case in profile_ledger_cases(
+            n,
+            witness_size,
+            contradiction_threshold=contradiction_threshold,
+        )
+        if set(case.excesses).issubset(allowed)
+    ]
+    forced_count = sum(1 for case in cases if case.forced_by_turn_cover)
+    totals = [case.total_profile_excess for case in cases]
+    return ProfileAssumptionSummary(
+        allowed_excesses=allowed,
+        distribution_count=len(cases),
+        forced_by_turn_cover_count=forced_count,
+        unresolved_by_turn_cover_count=len(cases) - forced_count,
+        minimum_total_profile_excess=min(totals) if totals else None,
+        maximum_total_profile_excess=max(totals) if totals else None,
+    )
+
+
+def profile_assumption_summaries(
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    contradiction_threshold: int = 3,
+) -> list[ProfileAssumptionSummary]:
+    """Return standard summaries for increasingly permissive profile assumptions."""
+
+    return [
+        profile_assumption_summary(
+            allowed,
+            n,
+            witness_size,
+            contradiction_threshold=contradiction_threshold,
+        )
+        for allowed in [
+            (0, 1),
+            (0, 1, 2),
+            (0, 1, 2, 3),
+            (0, 1, 2, 3, 4, 5, 6),
+        ]
+    ]
+
+
+def ledger_summary(n: int = 9, witness_size: int = 4) -> dict[str, object]:
+    """Return a JSON-serializable summary of the n=9 slack ledger."""
+
+    profiles = distance_profiles(n, witness_size)
+    grouped = profiles_by_excess(n, witness_size)
+    distributions = excess_distributions(n, witness_size)
+    strict_escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=3,
+    )
+    conservative_escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=4,
+    )
+    return {
+        "n": n,
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "witness_size": witness_size,
+        "base_apex_slack": base_apex_slack(n, witness_size),
+        "profile_count": len(profiles),
+        "profile_excess_values": list(profile_excess_values(n, witness_size)),
+        "profiles_by_excess": {
+            str(excess): [list(parts) for parts in parts_list]
+            for excess, parts_list in grouped.items()
+        },
+        "unlabeled_excess_distribution_count": len(distributions),
+        "cyclic_base_families": [
+            {
+                "cyclic_length": family.cyclic_length,
+                "base_count": family.base_count,
+                "capacity_per_base": family.capacity_per_base,
+                "total_capacity": family.total_capacity,
+            }
+            for family in cyclic_base_families(n)
+        ],
+        "turn_cover_escape": {
+            "strict_positive_threshold": {
+                "contradiction_threshold": strict_escape.contradiction_threshold,
+                "minimum_capacity_deficit_to_escape": (
+                    strict_escape.minimum_capacity_deficit
+                ),
+                "example_spoiled_length2": list(strict_escape.spoiled_length2),
+                "example_spoiled_length3": list(strict_escape.spoiled_length3),
+                "remaining_minimum_forced_turns": (
+                    strict_escape.remaining_minimum_forced_turns
+                ),
+            },
+            "sum_exceeds_threshold": {
+                "contradiction_threshold": conservative_escape.contradiction_threshold,
+                "minimum_capacity_deficit_to_escape": (
+                    conservative_escape.minimum_capacity_deficit
+                ),
+                "example_spoiled_length2": list(conservative_escape.spoiled_length2),
+                "example_spoiled_length3": list(conservative_escape.spoiled_length3),
+                "remaining_minimum_forced_turns": (
+                    conservative_escape.remaining_minimum_forced_turns
+                ),
+            },
+        },
+        "turn_cover_distribution_summary": {
+            "strict_positive_threshold": turn_cover_distribution_summary(
+                n,
+                witness_size,
+                contradiction_threshold=3,
+            ),
+            "sum_exceeds_threshold": turn_cover_distribution_summary(
+                n,
+                witness_size,
+                contradiction_threshold=4,
+            ),
+        },
+        "profile_assumption_summaries": [
+            {
+                "allowed_excesses": list(summary.allowed_excesses),
+                "distribution_count": summary.distribution_count,
+                "forced_by_turn_cover_count": summary.forced_by_turn_cover_count,
+                "unresolved_by_turn_cover_count": summary.unresolved_by_turn_cover_count,
+                "minimum_total_profile_excess": summary.minimum_total_profile_excess,
+                "maximum_total_profile_excess": summary.maximum_total_profile_excess,
+            }
+            for summary in profile_assumption_summaries(n, witness_size)
+        ],
+        "minimum_escape_motif_summary": {
+            "strict_positive_threshold": minimum_escape_motif_summary(
+                n,
+                contradiction_threshold=3,
+            ),
+            "sum_exceeds_threshold": minimum_escape_motif_summary(
+                n,
+                contradiction_threshold=4,
+            ),
+        },
+        "notes": [
+            "No proof of the n=9 case is claimed.",
+            "Profile excess E and capacity deficit D satisfy E + D = base_apex_slack.",
+            "The previous shorthand sum s_i = 9 is only the fully saturated special case.",
+            "Turn-cover escape counts are conditional on length-2/length-3 saturation implications only.",
+            "Anti-concentration alone does not close n=9 in this ledger; low profile excess leaves capacity deficit to control.",
+        ],
+    }

--- a/tests/test_n9_base_apex.py
+++ b/tests/test_n9_base_apex.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from erdos97.n9_base_apex import (
+    base_apex_slack,
+    canonical_deficit_placement,
+    capacity_deficit_forces_turn_cover,
+    cyclic_base_families,
+    deficit_placement_classes,
+    distance_profiles,
+    excess_distributions,
+    guaranteed_full_bases,
+    ledger_summary,
+    minimum_capacity_deficit_to_escape_turn_cover,
+    minimum_escape_motif_summary,
+    profile_assumption_summaries,
+    profile_assumption_summary,
+    profile_ledger_cases,
+    profiles_by_excess,
+    turn_cover_distribution_summary,
+    turn_cover_diagnostic,
+)
+
+
+def test_n9_profile_table_matches_corrected_slack_ledger() -> None:
+    rows = [(profile.excess, profile.parts) for profile in distance_profiles()]
+
+    assert rows == [
+        (0, (4, 1, 1, 1, 1)),
+        (1, (4, 2, 1, 1)),
+        (2, (4, 2, 2)),
+        (3, (4, 3, 1)),
+        (4, (5, 1, 1, 1)),
+        (5, (5, 2, 1)),
+        (6, (4, 4)),
+        (7, (5, 3)),
+        (9, (6, 1, 1)),
+        (10, (6, 2)),
+        (15, (7, 1)),
+        (22, (8,)),
+    ]
+
+
+def test_n9_ledger_separates_profile_excess_from_capacity_deficit() -> None:
+    assert base_apex_slack(9) == 9
+
+    distributions = excess_distributions()
+    by_excesses = {row.excesses: row for row in distributions}
+
+    all_baseline = by_excesses[(0, 0, 0, 0, 0, 0, 0, 0, 0)]
+    assert all_baseline.total_profile_excess == 0
+    assert all_baseline.capacity_deficit == 9
+
+    all_one_excess = by_excesses[(1, 1, 1, 1, 1, 1, 1, 1, 1)]
+    assert all_one_excess.total_profile_excess == 9
+    assert all_one_excess.capacity_deficit == 0
+
+
+def test_n9_profiles_with_excess_above_budget_are_listed_but_not_distributable() -> None:
+    grouped = profiles_by_excess()
+    assert 10 in grouped
+    assert 15 in grouped
+    assert 22 in grouped
+
+    used_values = {value for row in excess_distributions() for value in row.excesses}
+    assert 10 not in used_values
+    assert 15 not in used_values
+    assert 22 not in used_values
+
+
+def test_n9_cyclic_family_saturation_bounds_are_conservative() -> None:
+    families = [
+        (
+            family.cyclic_length,
+            family.base_count,
+            family.capacity_per_base,
+            family.total_capacity,
+        )
+        for family in cyclic_base_families()
+    ]
+
+    assert families == [
+        (1, 9, 1, 9),
+        (2, 9, 2, 18),
+        (3, 9, 2, 18),
+        (4, 9, 2, 18),
+    ]
+
+    assert guaranteed_full_bases(capacity_deficit=0, cyclic_length=2) == 9
+    assert guaranteed_full_bases(capacity_deficit=4, cyclic_length=2) == 5
+    assert guaranteed_full_bases(capacity_deficit=9, cyclic_length=2) == 0
+
+
+def test_n9_summary_is_explicitly_nonclaiming() -> None:
+    summary = ledger_summary()
+
+    assert summary["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert summary["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert summary["base_apex_slack"] == 9
+    assert "No proof of the n=9 case is claimed." in summary["notes"]
+
+
+def test_full_saturation_turn_cover_has_odd_cycle_vertex_cover_size() -> None:
+    diagnostic = turn_cover_diagnostic()
+
+    assert diagnostic.turn_clauses == (
+        (1, 2),
+        (2, 3),
+        (3, 4),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 8),
+        (8, 0),
+        (0, 1),
+    )
+    assert diagnostic.minimum_forced_turns == 5
+    assert diagnostic.forces_turn_contradiction
+
+
+def test_three_length2_length3_deficits_escape_strict_turn_cover_diagnostic() -> None:
+    escape = minimum_capacity_deficit_to_escape_turn_cover()
+
+    assert escape.contradiction_threshold == 3
+    assert escape.minimum_capacity_deficit == 3
+    assert escape.remaining_minimum_forced_turns == 2
+    assert capacity_deficit_forces_turn_cover(2)
+    assert not capacity_deficit_forces_turn_cover(3)
+
+
+def test_two_deficits_escape_more_conservative_turn_cover_threshold() -> None:
+    escape = minimum_capacity_deficit_to_escape_turn_cover(contradiction_threshold=4)
+
+    assert escape.minimum_capacity_deficit == 2
+    assert escape.remaining_minimum_forced_turns == 3
+
+
+def test_turn_cover_distribution_summary_counts_closed_profile_ledgers() -> None:
+    strict_summary = turn_cover_distribution_summary()
+    conservative_summary = turn_cover_distribution_summary(contradiction_threshold=4)
+
+    assert strict_summary["distribution_count"] == 95
+    assert strict_summary["forced_by_turn_cover_count"] == 65
+    assert strict_summary["unresolved_by_turn_cover_count"] == 30
+    assert strict_summary["capacity_deficit_counts"]["0"] == 29
+    assert strict_summary["capacity_deficit_counts"]["2"] == 15
+
+    assert conservative_summary["forced_by_turn_cover_count"] == 50
+    assert conservative_summary["unresolved_by_turn_cover_count"] == 45
+
+
+def test_unresolved_profile_ledgers_are_exactly_low_excess_under_strict_threshold() -> None:
+    unresolved = profile_ledger_cases(forced_by_turn_cover=False)
+
+    assert len(unresolved) == 30
+    assert {case.capacity_deficit for case in unresolved} == {3, 4, 5, 6, 7, 8, 9}
+    assert max(case.total_profile_excess for case in unresolved) == 6
+    assert unresolved[0].excesses == (0, 0, 0, 0, 0, 0, 0, 0, 0)
+    assert unresolved[0].profile_multiset == ((4, 1, 1, 1, 1),) * 9
+
+
+def test_profile_assumption_summary_shows_anti_concentration_is_not_enough() -> None:
+    summary = profile_assumption_summary((0, 1))
+
+    assert summary.distribution_count == 10
+    assert summary.forced_by_turn_cover_count == 3
+    assert summary.unresolved_by_turn_cover_count == 7
+    assert summary.minimum_total_profile_excess == 0
+    assert summary.maximum_total_profile_excess == 9
+
+
+def test_standard_profile_assumption_summaries_are_monotone() -> None:
+    summaries = profile_assumption_summaries()
+
+    assert [row.allowed_excesses for row in summaries] == [
+        (0, 1),
+        (0, 1, 2),
+        (0, 1, 2, 3),
+        (0, 1, 2, 3, 4, 5, 6),
+    ]
+    assert [row.distribution_count for row in summaries] == [10, 30, 53, 90]
+    assert [row.unresolved_by_turn_cover_count for row in summaries] == [
+        7,
+        16,
+        23,
+        30,
+    ]
+
+
+def test_deficit_placement_canonicalization_respects_dihedral_symmetry() -> None:
+    key = canonical_deficit_placement(9, [0, 2], [3])
+    rotated_key = canonical_deficit_placement(9, [4, 6], [7])
+    reflected_key = canonical_deficit_placement(9, [5, 7], [3])
+
+    assert key == ((0, 2), (3,))
+    assert rotated_key == key
+    assert reflected_key == key
+
+
+def test_strict_minimum_escape_motifs_are_classified_up_to_dihedral_symmetry() -> None:
+    classes = deficit_placement_classes()
+
+    assert len(classes) == 8
+    assert sum(row.placement_count for row in classes) == 108
+    assert {row.remaining_minimum_forced_turns for row in classes} == {2}
+    assert [(row.spoiled_length2, row.spoiled_length3) for row in classes] == [
+        ((0, 2), (3,)),
+        ((0, 2), (5,)),
+        ((0, 3), (1,)),
+        ((0, 4), (5,)),
+        ((0, 1, 3), ()),
+        ((0, 1, 5), ()),
+        ((0, 2, 4), ()),
+        ((0, 2, 5), ()),
+    ]
+
+
+def test_conservative_minimum_escape_motifs_are_classified_up_to_dihedral_symmetry() -> None:
+    classes = deficit_placement_classes(contradiction_threshold=4)
+
+    assert len(classes) == 6
+    assert sum(row.placement_count for row in classes) == 72
+    assert {row.remaining_minimum_forced_turns for row in classes} == {3}
+    assert [(row.spoiled_length2, row.spoiled_length3) for row in classes] == [
+        ((0,), (1,)),
+        ((0,), (3,)),
+        ((0, 1), ()),
+        ((0, 2), ()),
+        ((0, 3), ()),
+        ((0, 4), ()),
+    ]
+
+
+def test_minimum_escape_motif_summary_is_included_in_ledger_summary() -> None:
+    summary = minimum_escape_motif_summary()
+    ledger = ledger_summary()
+
+    assert summary["relevant_deficit_count"] == 3
+    assert summary["raw_escaping_placement_count"] == 108
+    assert summary["dihedral_class_count"] == 8
+    assert ledger["minimum_escape_motif_summary"]["strict_positive_threshold"] == summary


### PR DESCRIPTION
## Summary

Extracts the n=9 base-apex slack ledger from PR #73 into a focused branch on current `main`.

This adds dependency-free finite bookkeeping for the corrected profile-excess / capacity-deficit ledger, including turn-cover escape diagnostics and minimum deficit-placement motif summaries. The accompanying doc keeps the work explicitly exploratory: no n=9 proof, no counterexample, and no change to the official/global problem status.

## Files

- `src/erdos97/n9_base_apex.py`
- `tests/test_n9_base_apex.py`
- `scripts/explore_n9_base_apex.py`
- `docs/n9-base-apex-frontier.md`
- `docs/index.md`
- `docs/repo-roadmap.md`

## Review Notes

This split intentionally excludes the stale PR #73 row-circle files, the small-counterexamples paper, and all binary blobs. It also removes the local-only archive path from the restored provenance note.

## Validation

- `python -m pytest tests/test_n9_base_apex.py -q`
- `python scripts/explore_n9_base_apex.py --summary`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python -m ruff check src/erdos97/n9_base_apex.py scripts/explore_n9_base_apex.py tests/test_n9_base_apex.py`