### PR TITLE
[codex] add C13 Kalmanson pilot certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ is `data/certificates/round2/c19_kalmanson_known_order_unsat.json`. This is a
 fixed-order obstruction only; it does not kill abstract `C19_skew` across all
 cyclic orders.
 
+A C13 Kalmanson pilot kills one registered non-natural
+`C13_sidon_1_2_4_10` order `[5,0,10,8,9,7,4,6,2,11,12,3,1]` by the exact
+certificate `data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json`.
+This is also fixed-order only; it does not settle the abstract Sidon pattern
+over all cyclic orders.
+
 The previous best numerical near-miss was `B12_3x4_danzer_lift`. It remains a
 useful degeneration diagnostic, but the fixed selected pattern is now exactly
 killed by the mutual-rhombus midpoint filter. The saved numerical artifact is

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -142,6 +142,16 @@ equalities. This is a fixed-order obstruction only; it does not kill abstract
 `scripts/check_kalmanson_certificate.py`, and
 `data/certificates/round2/c19_kalmanson_known_order_unsat.json`.
 
+The C13 Kalmanson pilot kills the registered non-natural
+`C13_sidon_1_2_4_10` order `[5,0,10,8,9,7,4,6,2,11,12,3,1]`. The certificate is
+a positive integer sum of 34 strict Kalmanson distance inequalities whose total
+coefficient vector is exactly zero after selected-distance quotienting. This is
+also a fixed-order obstruction only; it does not kill abstract
+`C13_sidon_1_2_4_10` over all cyclic orders. See
+`docs/kalmanson-c13-pilot.md`, `scripts/find_kalmanson_certificate.py`,
+`scripts/check_kalmanson_certificate.py`, and
+`data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json`.
+
 The bounded `n=9` incidence/CSP frontier scan in
 `data/certificates/n9_incidence_frontier_bounded.json` fixes the natural order
 and row `0` to the registered seed row `{1,2,3,8}`. In that row0-fixed slice,
@@ -158,8 +168,9 @@ selected witness quadruple being concyclic around its center. It numerically
 obstructs the registered `C19_skew` abstract order with margin about
 `-0.00264843`; this is `NUMERICAL_NONLINEAR_DIAGNOSTIC` only and requires
 exactification before it can be used as an obstruction. The registered
-`C13_sidon_1_2_4_10` order currently records optimizer failure, not a clean
-obstruction. The follow-up active-set artifact
+`C13_sidon_1_2_4_10` order records optimizer failure in this row-circle
+Ptolemy diagnostic, but it is now killed by the separate fixed-order Kalmanson
+certificate above. The follow-up active-set artifact
 `data/certificates/c19_row_circle_ptolemy_active_set.json` records the
 optimized C19 distance classes and tight numerical constraints for
 exactification work, including a SciPy SLSQP multiplier summary; it is not an
@@ -249,6 +260,7 @@ search-history artifacts, not as live candidates.
    and `14` exact certificates.
 2. Push the finite incidence/exact pipeline toward `n=9`, or identify the first
    survivor class that blocks scaling.
-3. Investigate abstract `C19_skew` beyond the natural-order Altman obstruction
-   and the single fixed-order round-two Kalmanson certificate.
+3. Investigate abstract `C19_skew` and `C13_sidon_1_2_4_10` beyond their
+   natural-order Altman obstructions and registered fixed-order Kalmanson
+   certificates.
 4. Add interval-arithmetic verification for convexity and distance equations.

--- a/STATE.md
+++ b/STATE.md
@@ -63,6 +63,12 @@ distance inequalities whose coefficient vector is exactly zero after
 selected-distance quotienting. This kills only that fixed order; it is not an
 abstract `C19_skew` impossibility proof. See `docs/round2/round2_merged_report.md`.
 
+A C13 Kalmanson pilot also kills the registered non-natural
+`C13_sidon_1_2_4_10` order `[5,0,10,8,9,7,4,6,2,11,12,3,1]` by an exact
+34-inequality Kalmanson/Farkas certificate. This is again a fixed-order
+obstruction only; it does not settle the abstract Sidon pattern across all
+cyclic orders. See `docs/kalmanson-c13-pilot.md`.
+
 The phi 4-cycle rectangle-trap filter kills a registered fixed `n=9`
 selected-witness pattern with directed cycle
 `{0,6}->{2,8}->{1,5}->{4,7}->{0,6}`. The obstruction is the exact determinant
@@ -103,8 +109,11 @@ verification threshold and the other collapses to a non-strict configuration.[^c
    order above is now exactly killed by the round-two Kalmanson certificate.
    The abstract pattern across all cyclic orders is still not closed.
 2. `C13_sidon_1_2_4_10`: (13,4,1) Singer planar-difference-set circulant.
-   `|S_a cap S_b| = 1` for every distinct pair. No exact filter currently
-   kills it. NUMERICAL_EVIDENCE only: see below.
+   `|S_a cap S_b| = 1` for every distinct pair. The natural order is killed by
+   Altman linear certificates, and the registered non-natural sparse-filter
+   survivor is killed by the exact C13 Kalmanson pilot. The abstract pattern
+   across all cyclic orders is still not closed. NUMERICAL_EVIDENCE only: see
+   below.
 
 ## Numerical status: C13 Sidon-type circulant
 

--- a/data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json
+++ b/data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json
@@ -1,0 +1,378 @@
+{
+  "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+  "certificate_type": "kalmanson_strict_inequality_farkas",
+  "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+  "cyclic_order": [
+    5,
+    0,
+    10,
+    8,
+    9,
+    7,
+    4,
+    6,
+    2,
+    11,
+    12,
+    3,
+    1
+  ],
+  "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+  "inequalities": [
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        5,
+        0,
+        8,
+        7
+      ],
+      "weight": 384
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        5,
+        10,
+        9,
+        4
+      ],
+      "weight": 539
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        5,
+        8,
+        6,
+        3
+      ],
+      "weight": 900
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        5,
+        7,
+        4,
+        2
+      ],
+      "weight": 1172
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        5,
+        7,
+        12,
+        3
+      ],
+      "weight": 517
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        5,
+        4,
+        6,
+        3
+      ],
+      "weight": 117
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        5,
+        12,
+        3,
+        1
+      ],
+      "weight": 517
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        0,
+        10,
+        8,
+        4
+      ],
+      "weight": 384
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        0,
+        10,
+        4,
+        2
+      ],
+      "weight": 923
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        0,
+        9,
+        4,
+        1
+      ],
+      "weight": 623
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        0,
+        9,
+        11,
+        12
+      ],
+      "weight": 388
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        0,
+        7,
+        4,
+        1
+      ],
+      "weight": 384
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        0,
+        7,
+        6,
+        12
+      ],
+      "weight": 133
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        0,
+        4,
+        11,
+        12
+      ],
+      "weight": 549
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        0,
+        4,
+        11,
+        1
+      ],
+      "weight": 133
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        0,
+        6,
+        2,
+        1
+      ],
+      "weight": 133
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        10,
+        8,
+        9,
+        11
+      ],
+      "weight": 112
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        10,
+        8,
+        12,
+        1
+      ],
+      "weight": 192
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        10,
+        9,
+        7,
+        4
+      ],
+      "weight": 413
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        10,
+        9,
+        6,
+        3
+      ],
+      "weight": 493
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        10,
+        4,
+        6,
+        2
+      ],
+      "weight": 923
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        10,
+        4,
+        3,
+        1
+      ],
+      "weight": 493
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        8,
+        9,
+        7,
+        2
+      ],
+      "weight": 1172
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        8,
+        9,
+        12,
+        1
+      ],
+      "weight": 192
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        8,
+        2,
+        12,
+        3
+      ],
+      "weight": 900
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        9,
+        7,
+        4,
+        3
+      ],
+      "weight": 759
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        9,
+        4,
+        6,
+        11
+      ],
+      "weight": 549
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        9,
+        4,
+        12,
+        1
+      ],
+      "weight": 549
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        9,
+        6,
+        2,
+        11
+      ],
+      "weight": 150
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        9,
+        6,
+        3,
+        1
+      ],
+      "weight": 266
+    },
+    {
+      "kind": "K1_diag_gt_sides",
+      "quad": [
+        9,
+        2,
+        11,
+        1
+      ],
+      "weight": 1322
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        7,
+        11,
+        12,
+        1
+      ],
+      "weight": 384
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        6,
+        2,
+        11,
+        12
+      ],
+      "weight": 399
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        6,
+        11,
+        12,
+        1
+      ],
+      "weight": 399
+    }
+  ],
+  "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+  "num_inequalities": 34,
+  "pattern": {
+    "circulant_offsets": [
+      1,
+      2,
+      4,
+      10
+    ],
+    "n": 13,
+    "name": "C13_sidon_1_2_4_10"
+  },
+  "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+  "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+  "weight_sum": 17463
+}

--- a/data/certificates/sparse_order_survivors.json
+++ b/data/certificates/sparse_order_survivors.json
@@ -17,6 +17,16 @@
         "constraint_count": 0,
         "passes": true
       },
+      "kalmanson_certificate": {
+        "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+        "distance_classes_after_selected_equalities": 39,
+        "max_weight": 1322,
+        "obstructed": true,
+        "path": "data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json",
+        "positive_inequalities": 34,
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+        "weight_sum": 17463
+      },
       "minimum_radius": {
         "blocked_center_count": 4,
         "obstructed": false,
@@ -63,7 +73,8 @@
         "rows_with_uncovered_consecutive_pair_count": 9,
         "trivial_empty_radius_choice_exists": false
       },
-      "survives_current_exact_filters": true,
+      "survives_current_exact_filters": false,
+      "survives_pre_kalmanson_filters": true,
       "vertex_circle": {
         "cycle": false,
         "obstructed": false,
@@ -87,6 +98,16 @@
       "crossing": {
         "constraint_count": 0,
         "passes": true
+      },
+      "kalmanson_certificate": {
+        "claim_strength": "Exact obstruction for this fixed selected-witness pattern and this fixed cyclic order only; does not kill abstract C19_skew.",
+        "distance_classes_after_selected_equalities": 114,
+        "max_weight": 334665404,
+        "obstructed": true,
+        "path": "data/certificates/round2/c19_kalmanson_known_order_unsat.json",
+        "positive_inequalities": 94,
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+        "weight_sum": 6283316065
       },
       "minimum_radius": {
         "blocked_center_count": 0,
@@ -150,7 +171,8 @@
         "rows_with_uncovered_consecutive_pair_count": 19,
         "trivial_empty_radius_choice_exists": true
       },
-      "survives_current_exact_filters": true,
+      "survives_current_exact_filters": false,
+      "survives_pre_kalmanson_filters": true,
       "vertex_circle": {
         "cycle": false,
         "obstructed": false,
@@ -162,8 +184,9 @@
   "notes": [
     "No general proof of Erdos Problem #97 is claimed.",
     "No counterexample is claimed.",
-    "Surviving all listed filters is not evidence of realizability."
+    "The registered C13 and C19 orders survive the older sparse-frontier filters but are killed by fixed-order Kalmanson/Farkas certificates.",
+    "A fixed-order Kalmanson obstruction is not an abstract all-order obstruction."
   ],
   "trust": "FIXED_ORDER_EXACT_FILTER_DIAGNOSTIC",
-  "type": "sparse_order_survivor_filter_sweep_v1"
+  "type": "sparse_order_survivor_filter_sweep_v2"
 }

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -8,7 +8,7 @@ designs only; geometric realization is a separate problem.
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
 | 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | natural-order status: exactly killed by Altman diagonal-order sums; one registered non-natural order `[18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1]` is killed by the round-two Kalmanson/Farkas certificate; abstract-incidence status across all cyclic orders remains open |
-| 11 | `C13_sidon_1_2_4_10` | 13 | offsets `{1,2,4,10}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; SLSQP evidence plateaus at `eq_rms ~ 0.84` under strict convexity margins |
+| 11 | `C13_sidon_1_2_4_10` | 13 | offsets `{1,2,4,10}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; registered non-natural order `[5,0,10,8,9,7,4,6,2,11,12,3,1]` killed by exact Kalmanson/Farkas certificate; abstract-incidence status across all cyclic orders remains open; SLSQP evidence plateaus at `eq_rms ~ 0.84` under strict convexity margins |
 | 12 | `C25_sidon_2_5_9_14` | 25 | offsets `{2,5,9,14}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; cataloged but not yet run numerically |
 | 13 | `C29_sidon_1_3_7_15` | 29 | offsets `{1,3,7,15}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; cataloged but not yet run numerically |
 
@@ -16,12 +16,12 @@ The live abstract-incidence patterns above pass the row-overlap filter
 `|S_i cap S_j| <= 2` before numerical optimization. `C19_skew`'s natural-order
 realization and one registered non-natural order are already exactly obstructed;
 its all-orders abstract status is tracked separately.[^comp] The Sidon natural
-orders are also exactly obstructed by
-Altman linear certificates, but their arbitrary abstract-order status remains
-separate. A registered non-natural `C13_sidon_1_2_4_10` order survives the
-current fixed-order exact filters; see `docs/sparse-frontier-diagnostic.md`.
-The Sidon entries are incidence-pattern leads, not geometric realizability
-claims. The minimum-radius short-chord filter is also
+orders are also exactly obstructed by Altman linear certificates. The registered
+non-natural `C13_sidon_1_2_4_10` order that survived the earlier sparse
+frontier filters is now exactly killed by a fixed-order Kalmanson/Farkas
+certificate; see `docs/kalmanson-c13-pilot.md`. The arbitrary abstract-order
+Sidon status remains separate. The Sidon entries are incidence-pattern leads,
+not geometric realizability claims. The minimum-radius short-chord filter is also
 recorded as a weak exact necessary test, but it does not kill `C19_skew` in
 natural order or as currently implemented; see `docs/minimum-radius-filter.md`.
 For the first fixed-selection stuck-set/radius/fragile-cover pass over this

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -101,6 +101,29 @@ The related `C17_skew` Ptolemy-log artifact in
 a method note and verifier regression. It does not move the live wall, because
 `C17_skew` was already exactly killed by earlier fixed-pattern filters.
 
+### Fixed-order Kalmanson/Farkas obstruction for C13_sidon_1_2_4_10
+
+Status: `EXACT_OBSTRUCTION` for one fixed selected-witness pattern and one
+fixed cyclic order only.
+
+For the `C13_sidon_1_2_4_10` selected-witness pattern with offsets
+`[1,2,4,10]` and cyclic order
+
+```text
+[5,0,10,8,9,7,4,6,2,11,12,3,1]
+```
+
+the checked certificate
+`data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json` gives a
+positive integer combination of 34 strict Kalmanson distance inequalities whose
+total coefficient vector is exactly zero after quotienting by the
+selected-distance equalities. Summing the strict inequalities gives `0 > 0`.
+
+This is not a proof that abstract `C13_sidon_1_2_4_10` is impossible across all
+cyclic orders, and it is not a proof of Erdos #97. See
+`docs/kalmanson-c13-pilot.md`, `docs/round2/kalmanson_distance_filter.md`, and
+`scripts/check_kalmanson_certificate.py`.
+
 ## Lemmas
 
 ### Circle-intersection cap

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,15 +37,17 @@ put detailed reconciliation in the canonical synthesis.
   row-wise convexity-distance filter for cyclic orders.
 - [`metric-order-lp.md`](metric-order-lp.md): combined fixed-order LP
   diagnostic using Altman gaps, vertex-circle inequalities, and triangle
-  inequalities; records a miss on the registered sparse-order survivors.
+  inequalities; records a relaxation miss on the registered sparse orders.
 - [`round2/round2_merged_report.md`](round2/round2_merged_report.md):
   round-two fixed-order `C19_skew` Kalmanson/Farkas certificate and C17 method
   note summary.
 - [`round2/kalmanson_distance_filter.md`](round2/kalmanson_distance_filter.md):
   exact Kalmanson distance certificate format for fixed cyclic orders.
+- [`kalmanson-c13-pilot.md`](kalmanson-c13-pilot.md): exact fixed-order
+  Kalmanson/Farkas certificate for the registered non-natural C13 Sidon order.
 - [`ptolemy-order-nlp.md`](ptolemy-order-nlp.md): numerical nonlinear
-  diagnostic adding Ptolemy inequalities for cyclic quadrilaterals; still a
-  miss on the registered sparse-order survivors.
+  diagnostic adding Ptolemy inequalities for cyclic quadrilaterals; records a
+  relaxation miss on the registered sparse orders.
 - [`two-orbit-radius-propagation.md`](two-orbit-radius-propagation.md): exact
   obstruction for a half-step two-orbit near-regular ansatz.
 - [`minimum-radius-filter.md`](minimum-radius-filter.md): weak exact

--- a/docs/kalmanson-c13-pilot.md
+++ b/docs/kalmanson-c13-pilot.md
@@ -1,0 +1,76 @@
+# C13 Kalmanson Pilot
+
+Status: `EXACT_OBSTRUCTION` for one fixed selected-witness pattern and one
+fixed cyclic order only.
+
+This note records a small Kalmanson/Farkas pilot on the registered non-natural
+`C13_sidon_1_2_4_10` order that previously survived the sparse-frontier fixed
+filters.
+
+It does not prove the abstract `C13_sidon_1_2_4_10` pattern impossible across
+all cyclic orders, and it does not prove Erdos Problem #97.
+
+## Fixed Order Killed
+
+Pattern:
+
+```text
+C13_sidon_1_2_4_10
+n = 13
+offsets = [1, 2, 4, 10]
+cyclic order = [5,0,10,8,9,7,4,6,2,11,12,3,1]
+```
+
+Certificate:
+
+```text
+data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json
+```
+
+The certificate is a positive integer combination of strict convex-quadrilateral
+Kalmanson distance inequalities. After quotienting ordinary pair-distance
+variables by the selected row equalities, the total coefficient vector is
+exactly zero, giving the contradiction `0 > 0`.
+
+Checked summary:
+
+```text
+positive inequalities: 34
+distance classes after selected equalities: 39
+weight sum: 17463
+max weight: 1322
+```
+
+## Reproduction
+
+Generate and check the certificate:
+
+```bash
+python scripts/find_kalmanson_certificate.py \
+  --name C13_sidon_1_2_4_10 \
+  --n 13 \
+  --offsets 1,2,4,10 \
+  --order 5,0,10,8,9,7,4,6,2,11,12,3,1 \
+  --assert-found \
+  --summary-json
+
+python scripts/check_kalmanson_certificate.py \
+  data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json \
+  --summary-json
+```
+
+The finder uses a numerical LP only to locate a support. It then recovers the
+one-dimensional rational nullspace on that support, clears denominators, and
+checks the resulting exact integer certificate with
+`scripts/check_kalmanson_certificate.py`.
+
+## Frontier Impact
+
+The registered C13 order still remains useful as a benchmark: it survives the
+older crossing, Altman, vertex-circle, minimum-radius, and radius-propagation
+filters, but it is no longer a live fixed-order survivor once Kalmanson/Farkas
+certificates are included.
+
+The remaining C13 question is all-order: whether every cyclic order of this
+fixed abstract incidence pattern has an exact obstruction, or whether some
+other order can survive stronger Euclidean constraints.

--- a/docs/metric-order-lp.md
+++ b/docs/metric-order-lp.md
@@ -26,8 +26,10 @@ python scripts/check_metric_order_lp.py \
   --out data/certificates/metric_order_lp_survivors.json
 ```
 
-The checked-in artifact covers the registered sparse-order survivors from
-`data/certificates/sparse_order_survivors.json`.
+The checked-in artifact covers the registered sparse orders from
+`data/certificates/sparse_order_survivors.json`. These orders survive this
+metric LP relaxation, but they are killed by separate fixed-order
+Kalmanson/Farkas certificates.
 
 ## Snapshot
 
@@ -37,9 +39,10 @@ The checked-in artifact covers the registered sparse-order survivors from
 | `C19_skew:vertex_circle_survivor` | 19 | `PASS_METRIC_ORDER_LP_RELAXATION` | `0.00143164` | 114 | 3086 | 2907 |
 
 Thus this combined relaxation still does not kill the two registered
-non-natural sparse survivors. In particular, adding all triangle inequalities
-to the Altman and vertex-circle linear constraints leaves positive-margin
-solutions.
+non-natural sparse orders. In particular, adding all triangle inequalities to
+the Altman and vertex-circle linear constraints leaves positive-margin
+solutions; the later Kalmanson/Farkas certificates use stronger strict
+convex-quadrilateral distance inequalities.
 
 ## Interpretation
 

--- a/docs/ptolemy-order-nlp.md
+++ b/docs/ptolemy-order-nlp.md
@@ -34,9 +34,10 @@ python scripts/check_ptolemy_order_nlp.py \
 | `C13_sidon_1_2_4_10:sample_full_filter_survivor` | 13 | `PASS_PTOLEMY_ORDER_NLP_RELAXATION` | `0.00176461` | 980 | 715 |
 | `C19_skew:vertex_circle_survivor` | 19 | `PASS_PTOLEMY_ORDER_NLP_RELAXATION` | `0.00106142` | 3086 | 3876 |
 
-Thus Ptolemy constraints alone still do not close the registered sparse-order
-survivors. This is a miss of the current nonlinear relaxation, not evidence
-that either abstract order is realizable.
+Thus Ptolemy constraints alone still do not close the registered sparse orders.
+This is a miss of this nonlinear relaxation, not evidence that either abstract
+order is realizable. The registered fixed orders are killed separately by
+Kalmanson/Farkas certificates.
 
 ## Interpretation
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -89,12 +89,14 @@ small-case claim. The round-two Kalmanson certificate kills one fixed
 research-frontier workstreams, not prerequisites for the repo-local `n <= 8`
 artifact.
 
-## Priority 6 - pilot Kalmanson order search on C13
+## Priority 6 - extend the C13 Kalmanson pilot
 
-Before attempting exhaustive `C19_skew` cyclic-order search, build a smaller
-Kalmanson cyclic-order CSP pilot on `C13`: normalize by dihedral symmetry,
-prune partial orders cheaply, run LP dual checks on closed branches, and emit
-exact integer certificates for branches that close.
+The first C13 Kalmanson pilot now kills the registered non-natural
+`C13_sidon_1_2_4_10` order with an exact 34-inequality certificate. Before
+attempting exhaustive `C19_skew` cyclic-order search, extend the smaller C13
+pilot toward all cyclic orders: normalize by dihedral symmetry, prune partial
+orders cheaply, run LP dual checks on closed branches, and emit exact integer
+certificates for branches that close.
 
 ## Priority 7 - strengthen only productive filters
 

--- a/docs/round2/kalmanson_distance_filter.md
+++ b/docs/round2/kalmanson_distance_filter.md
@@ -49,6 +49,17 @@ Strict inequalities: 94
 Distance classes: 114
 ```
 
+The same certificate format now also checks the C13 pilot certificate:
+
+```text
+File: data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json
+Pattern: C13_sidon_1_2_4_10
+Offsets: [1,2,4,10]
+Cyclic order: [5,0,10,8,9,7,4,6,2,11,12,3,1]
+Strict inequalities: 34
+Distance classes: 39
+```
+
 Safe claim:
 
 ```text

--- a/docs/round2/round2_merged_report.md
+++ b/docs/round2/round2_merged_report.md
@@ -109,7 +109,10 @@ Round three should try to decompose or explain the C19 certificate by grouping i
 
 ## Recommended round-three priority
 
-The next major task is an exhaustive Kalmanson cyclic-order CSP/search, but it should be piloted on C13 before C19.
+The first C13 pilot killed the registered non-natural `C13_sidon_1_2_4_10` order
+by an exact 34-inequality Kalmanson/Farkas certificate. The next major task is
+an exhaustive Kalmanson cyclic-order CSP/search, still scaling from C13 before
+C19.
 
 Suggested sequence:
 

--- a/docs/row-circle-ptolemy-nlp.md
+++ b/docs/row-circle-ptolemy-nlp.md
@@ -38,8 +38,8 @@ row equalities, and combines:
 The generated artifact is
 `data/certificates/row_circle_ptolemy_nlp_sparse_orders.json`.
 
-For the registered `C19_skew` abstract-order survivor, SLSQP terminates
-successfully with a negative strictness margin:
+For the registered `C19_skew` order, SLSQP terminates successfully with a
+negative strictness margin:
 
 ```text
 max_margin = -0.00264843
@@ -51,15 +51,16 @@ obstruction. It should be treated as a promising target for exactification.
 
 For the registered `C13_sidon_1_2_4_10` order, SLSQP reports incompatible
 inequality constraints from the LP-based start and leaves small but nonzero
-Ptolemy/row-equality residuals. That is recorded as optimizer failure, not as
-an obstruction.
+Ptolemy/row-equality residuals. That is recorded as optimizer failure in this
+diagnostic, not as a row-circle Ptolemy obstruction. The same fixed order is
+killed separately by the exact C13 Kalmanson pilot.
 
 ## C19 Active-Set Snapshot
 
 The exactification helper
 `scripts/dump_row_circle_ptolemy_snapshot.py` records the optimized
 distance-class vector and the active numerical constraints for the registered
-`C19_skew` survivor. The generated artifact is
+`C19_skew` order. The generated artifact is
 `data/certificates/c19_row_circle_ptolemy_active_set.json`.
 
 It records:

--- a/docs/sidon-patterns.md
+++ b/docs/sidon-patterns.md
@@ -159,16 +159,19 @@ run before the C13 plateau signature is independently understood.
 
 ## Non-natural C13 survivor order
 
-The current exact fixed-order filters miss the registered order
+The older sparse-frontier fixed-order filters missed the registered order
 
 ```text
 5,0,10,8,9,7,4,6,2,11,12,3,1
 ```
 
 for `C13_sidon_1_2_4_10`; see
-`data/certificates/sparse_order_survivors.json`. The search engine supports
-this directly via `--cyclic-order`, relabelling the incidence pattern so the
-supplied order becomes the natural boundary order.
+`data/certificates/sparse_order_survivors.json`. The C13 Kalmanson pilot now
+kills this same fixed order by an exact 34-inequality certificate; see
+`docs/kalmanson-c13-pilot.md`. This does not settle the abstract pattern across
+all cyclic orders. The search engine supports this order directly via
+`--cyclic-order`, relabelling the incidence pattern so the supplied order
+becomes the natural boundary order.
 
 The first constrained SLSQP run on this non-natural order is stored in
 `data/runs/C13_sidon_order_survivor_slsqp_m1e-4_seed20260502.json`. It reports

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -225,16 +225,19 @@ This closes the radius-propagation route for the sparse frontier as currently
 implemented. A proof or counterexample must use additional geometry or a
 strictly stronger sparse-overlap mechanism.
 
-## Registered Exact-Filter Survivors
+## Registered Sparse-Filter Survivors
 
 The combined exact-filter sweep is checked in at
-`data/certificates/sparse_order_survivors.json`. It currently records two
-non-natural cyclic orders that survive every listed fixed-order exact filter:
+`data/certificates/sparse_order_survivors.json`. It records two non-natural
+cyclic orders that survive the older sparse-frontier fixed-order filters
+(crossing, Altman, vertex-circle, minimum-radius, and radius-propagation). Both
+registered orders are now killed when fixed-order Kalmanson/Farkas certificates
+are included.
 
-| Pattern | Order label | n | Vertex-circle | Altman linear | Radius propagation | Empty radius choice |
-|---|---|---:|---|---|---|---|
-| `C13_sidon_1_2_4_10` | `sample_full_filter_survivor` | 13 | pass | no certificate found | pass with 4 strict edges | no |
-| `C19_skew` | `vertex_circle_survivor` | 19 | pass | no certificate found | pass with 0 strict edges | yes |
+| Pattern | Order label | n | Pre-Kalmanson filters | Kalmanson status |
+|---|---|---:|---|---|
+| `C13_sidon_1_2_4_10` | `sample_full_filter_survivor` | 13 | pass | exact fixed-order obstruction, 34 inequalities |
+| `C19_skew` | `vertex_circle_survivor` | 19 | pass | exact fixed-order obstruction, 94 inequalities |
 
 The `C13` order is:
 
@@ -248,12 +251,12 @@ The `C19` order is:
 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1
 ```
 
-These are adversarial objects for the current proof search, not
-counterexamples. In particular, the `C13` order only says the present exact
-filters miss this abstract order; numerical optimization remains separate and
-does not certify realizability.
+These remain adversarial objects for filter development, not counterexamples.
+In particular, the fixed-order Kalmanson kills do not prove either abstract
+incidence pattern impossible across all cyclic orders.
 
-The first constrained numerical run on the registered `C13` survivor order is:
+The first constrained numerical run on the registered `C13` sparse-filter order
+is:
 
 ```bash
 python -m erdos97.search \
@@ -273,7 +276,8 @@ It returns `eq_rms = 0.6569` and `max_spread = 2.728` with convexity margin
 `1e-4`. This is still a large residual, so it is negative numerical evidence
 for this particular order as a counterexample target, not a near-miss.
 
-The first constrained numerical run on the registered `C19` survivor order is:
+The first constrained numerical run on the registered `C19` sparse-filter order
+is:
 
 ```bash
 python -m erdos97.search \
@@ -301,7 +305,8 @@ a proof of non-realizability and not a counterexample.
 
 The combined fixed-order LP diagnostic in `docs/metric-order-lp.md` adds all
 ordinary triangle inequalities to the Altman adjacent-gap and vertex-circle
-strict inequalities. It still passes both registered sparse-order survivors:
+strict inequalities. It still passes both registered sparse orders before
+Kalmanson/Farkas certificates are included:
 
 | Pattern order | Max margin | Distance classes | Inequalities |
 |---|---:|---:|---:|
@@ -314,7 +319,7 @@ constraints.
 
 The Ptolemy-strengthened nonlinear diagnostic in `docs/ptolemy-order-nlp.md`
 adds every cyclic-quadrilateral Ptolemy inequality. It still passes both
-registered sparse-order survivors:
+registered sparse orders before Kalmanson/Farkas certificates are included:
 
 | Pattern order | Max margin | Linear inequalities | Ptolemy inequalities |
 |---|---:|---:|---:|

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -83,6 +83,12 @@ local_repo:
       certificate: "data/certificates/round2/c19_kalmanson_known_order_unsat.json"
       verifier: "scripts/check_kalmanson_certificate.py"
       claim_scope: "fixed selected-witness pattern plus fixed cyclic order only; does not kill abstract C19_skew across all cyclic orders"
+    - pattern: "C13_sidon_1_2_4_10"
+      status: "exact fixed-order Kalmanson/Farkas obstruction"
+      cyclic_order: "[5,0,10,8,9,7,4,6,2,11,12,3,1]"
+      certificate: "data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json"
+      verifier: "scripts/check_kalmanson_certificate.py"
+      claim_scope: "fixed selected-witness pattern plus fixed cyclic order only; does not kill abstract C13_sidon_1_2_4_10 across all cyclic orders"
   best_numerical_object: "B12_3x4_danzer_lift near-miss; rejected as proof/counterexample."
   main_entry_points:
     - "STATE.md"

--- a/scripts/check_sparse_order_survivors.py
+++ b/scripts/check_sparse_order_survivors.py
@@ -13,6 +13,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from check_kalmanson_certificate import check_certificate_file  # noqa: E402
 from erdos97.altman_diagonal_sums import (  # noqa: E402
     altman_order_linear_certificate,
     altman_order_obstruction,
@@ -58,6 +59,19 @@ REGISTERED_ORDERS: dict[str, dict[str, list[int]]] = {
     },
 }
 
+KALMANSON_CERTIFICATES: dict[str, Path] = {
+    "C13_sidon_1_2_4_10:sample_full_filter_survivor": (
+        ROOT / "data" / "certificates" / "c13_sidon_order_survivor_kalmanson_unsat.json"
+    ),
+    "C19_skew:vertex_circle_survivor": (
+        ROOT
+        / "data"
+        / "certificates"
+        / "round2"
+        / "c19_kalmanson_known_order_unsat.json"
+    ),
+}
+
 
 def parse_order(raw: str) -> list[int]:
     try:
@@ -71,6 +85,7 @@ def evaluate_order(
     order: list[int],
     order_label: str,
 ) -> dict[str, object]:
+    case = f"{pattern.name}:{order_label}"
     constraints = crossing_constraints(pattern.S)
     crossing_ok = all_constraints_cross(order, constraints)
     altman_signature = altman_order_obstruction(pattern.S, order, pattern.name)
@@ -84,7 +99,7 @@ def evaluate_order(
         order=order,
         max_row_examples=0,
     )
-    survives = (
+    survives_pre_kalmanson = (
         crossing_ok
         and not altman_signature.altman_contradiction
         and altman_linear.obstructed is False
@@ -92,12 +107,15 @@ def evaluate_order(
         and not min_radius.obstructed
         and radius.obstructed is False
     )
+    kalmanson = kalmanson_status(case, pattern, order)
+    survives = survives_pre_kalmanson and not kalmanson["obstructed"]
     return {
-        "case": f"{pattern.name}:{order_label}",
+        "case": case,
         "pattern": pattern.name,
         "n": pattern.n,
         "order_label": order_label,
         "order": order,
+        "survives_pre_kalmanson_filters": survives_pre_kalmanson,
         "survives_current_exact_filters": survives,
         "crossing": {
             "constraint_count": len(constraints),
@@ -138,6 +156,7 @@ def evaluate_order(
                 else sum(len(choice.inequality_edges) for choice in radius.acyclic_choice)
             ),
         },
+        "kalmanson_certificate": kalmanson,
         "sparse_frontier": {
             "rows_with_uncovered_consecutive_pair": (
                 sparse["rows_with_uncovered_consecutive_pair"]
@@ -153,6 +172,41 @@ def evaluate_order(
             "Fixed-order exact-filter diagnostic only. Surviving all listed "
             "filters is not evidence of geometric realizability."
         ),
+    }
+
+
+def kalmanson_status(
+    case: str,
+    pattern: PatternInfo,
+    order: list[int],
+) -> dict[str, object]:
+    path = KALMANSON_CERTIFICATES.get(case)
+    if path is None:
+        return {
+            "status": "NO_REGISTERED_KALMANSON_CERTIFICATE",
+            "obstructed": False,
+        }
+
+    result = check_certificate_file(path)
+    certificate = json.loads(path.read_text(encoding="utf-8"))
+    if result.pattern != pattern.name:
+        raise ValueError(f"{path} pattern {result.pattern} does not match {pattern.name}")
+    if result.n != pattern.n:
+        raise ValueError(f"{path} n {result.n} does not match {pattern.n}")
+    if certificate.get("cyclic_order") != order:
+        raise ValueError(f"{path} cyclic order does not match registered {case}")
+
+    return {
+        "status": result.status,
+        "obstructed": result.zero_sum_verified,
+        "path": path.relative_to(ROOT).as_posix(),
+        "positive_inequalities": result.positive_inequalities,
+        "distance_classes_after_selected_equalities": (
+            result.distance_classes_after_selected_equalities
+        ),
+        "weight_sum": result.weight_sum,
+        "max_weight": result.max_weight,
+        "claim_strength": result.claim_strength,
     }
 
 
@@ -175,18 +229,24 @@ def assert_expected(rows: list[dict[str, object]]) -> None:
     if missing:
         raise AssertionError(f"missing expected case(s): {', '.join(missing)}")
     for case in sorted(expected):
-        if by_case[case]["survives_current_exact_filters"] is not True:
-            raise AssertionError(f"{case} did not survive current exact filters")
+        if by_case[case]["survives_pre_kalmanson_filters"] is not True:
+            raise AssertionError(f"{case} did not survive pre-Kalmanson filters")
+        kalmanson = by_case[case]["kalmanson_certificate"]
+        if not isinstance(kalmanson, dict) or kalmanson["obstructed"] is not True:
+            raise AssertionError(f"{case} is missing its Kalmanson obstruction")
+        if by_case[case]["survives_current_exact_filters"] is not False:
+            raise AssertionError(f"{case} unexpectedly survived current exact filters")
 
 
 def payload(rows: list[dict[str, object]]) -> dict[str, object]:
     return {
-        "type": "sparse_order_survivor_filter_sweep_v1",
+        "type": "sparse_order_survivor_filter_sweep_v2",
         "trust": "FIXED_ORDER_EXACT_FILTER_DIAGNOSTIC",
         "notes": [
             "No general proof of Erdos Problem #97 is claimed.",
             "No counterexample is claimed.",
-            "Surviving all listed filters is not evidence of realizability.",
+            "The registered C13 and C19 orders survive the older sparse-frontier filters but are killed by fixed-order Kalmanson/Farkas certificates.",
+            "A fixed-order Kalmanson obstruction is not an abstract all-order obstruction.",
         ],
         "cases": rows,
     }
@@ -197,6 +257,7 @@ def print_table(rows: list[dict[str, object]]) -> None:
         "case",
         "n",
         "survives",
+        "kalmanson",
         "vertex",
         "altman",
         "radius",
@@ -207,6 +268,7 @@ def print_table(rows: list[dict[str, object]]) -> None:
             str(row["case"]),
             str(row["n"]),
             str(row["survives_current_exact_filters"]),
+            str(row["kalmanson_certificate"]["obstructed"]),
             str(row["vertex_circle"]["obstructed"]),
             str(row["altman_linear_certificate"]["status"]),
             str(row["radius_propagation"]["status"]),

--- a/scripts/find_kalmanson_certificate.py
+++ b/scripts/find_kalmanson_certificate.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Find a fixed-order Kalmanson/Farkas certificate by LP and exactification.
+
+The search is deliberately fixed-pattern and fixed-order.  A found certificate
+proves only that selected-distance equalities for the supplied circulant
+pattern are inconsistent with the supplied cyclic order and strict convex
+Kalmanson distance inequalities.
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+import numpy as np
+import sympy as sp
+from scipy.optimize import linprog
+
+from check_kalmanson_certificate import (
+    build_distance_classes,
+    check_certificate_dict,
+    inequality_terms,
+)
+
+
+KINDS = ("K1_diag_gt_sides", "K2_diag_gt_other")
+
+
+class InequalityRow(NamedTuple):
+    kind: str
+    quad: tuple[int, int, int, int]
+    vector: tuple[int, ...]
+
+
+def parse_int_list(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated integer list: {raw}") from exc
+
+
+def all_kalmanson_rows(
+    n: int,
+    offsets: Sequence[int],
+    order: Sequence[int],
+) -> list[InequalityRow]:
+    classes = build_distance_classes(n, offsets)
+    class_count = len(set(classes.values()))
+    rows: list[InequalityRow] = []
+    for quad in itertools.combinations(order, 4):
+        for kind in KINDS:
+            vector = [0] * class_count
+            for pair, coeff in inequality_terms(kind, quad):
+                vector[classes[pair]] += coeff
+            rows.append(InequalityRow(kind, tuple(int(v) for v in quad), tuple(vector)))
+    return rows
+
+
+def lp_support(rows: Sequence[InequalityRow], tol: float) -> list[int] | None:
+    matrix = np.array([row.vector for row in rows], dtype=float)
+    class_count = matrix.shape[1]
+    a_eq = np.vstack([matrix.T, np.ones((1, len(rows)))])
+    b_eq = np.zeros(class_count + 1)
+    b_eq[-1] = 1.0
+    result = linprog(
+        np.zeros(len(rows)),
+        A_eq=a_eq,
+        b_eq=b_eq,
+        bounds=(0, None),
+        method="highs",
+    )
+    if not result.success:
+        return None
+    return [idx for idx, weight in enumerate(result.x) if weight > tol]
+
+
+def exact_positive_weights(
+    rows: Sequence[InequalityRow],
+    support: Sequence[int],
+) -> list[int] | None:
+    class_count = len(rows[0].vector)
+    matrix = sp.Matrix([[rows[idx].vector[col] for idx in support] for col in range(class_count)])
+    nullspace = matrix.nullspace()
+    if len(nullspace) != 1:
+        return None
+    vector = nullspace[0]
+    if all(value < 0 for value in vector):
+        vector = -vector
+    if not all(value > 0 for value in vector):
+        return None
+
+    denominator_lcm = 1
+    for value in vector:
+        denominator_lcm = int(sp.lcm(denominator_lcm, value.q))
+    weights = [int(value * denominator_lcm) for value in vector]
+    divisor = 0
+    for weight in weights:
+        divisor = math.gcd(divisor, abs(weight))
+    return [weight // divisor for weight in weights]
+
+
+def certificate_payload(
+    name: str,
+    n: int,
+    offsets: Sequence[int],
+    order: Sequence[int],
+    rows: Sequence[InequalityRow],
+    support: Sequence[int],
+    weights: Sequence[int],
+) -> dict[str, object]:
+    inequalities = [
+        {
+            "weight": int(weight),
+            "quad": list(rows[idx].quad),
+            "kind": rows[idx].kind,
+        }
+        for idx, weight in zip(support, weights)
+    ]
+    return {
+        "certificate_type": "kalmanson_strict_inequality_farkas",
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+        "pattern": {
+            "name": name,
+            "n": n,
+            "circulant_offsets": [int(offset) for offset in offsets],
+        },
+        "cyclic_order": [int(label) for label in order],
+        "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+        "distance_equalities": (
+            "for each row i, all distances d(i,w), w in S_i, are identified"
+        ),
+        "inequality_lemma": (
+            "for every convex quadrilateral a,b,c,d in cyclic order, "
+            "d(a,c)+d(b,d)>d(a,b)+d(c,d) and "
+            "d(a,c)+d(b,d)>d(a,d)+d(b,c)"
+        ),
+        "certificate_logic": (
+            "the listed positive integer combination of Kalmanson strict "
+            "inequalities has zero total coefficient after quotienting by "
+            "selected-distance equalities, giving 0 > 0"
+        ),
+        "num_inequalities": len(inequalities),
+        "weight_sum": int(sum(weights)),
+        "inequalities": inequalities,
+        "claim_strength": (
+            "Exact obstruction for this fixed selected-witness pattern and "
+            "fixed cyclic order only; not an abstract all-order obstruction."
+        ),
+    }
+
+
+def find_certificate(
+    name: str,
+    n: int,
+    offsets: Sequence[int],
+    order: Sequence[int],
+    tol: float,
+) -> dict[str, object] | None:
+    if sorted(order) != list(range(n)):
+        raise ValueError("cyclic order must be a permutation of 0..n-1")
+    rows = all_kalmanson_rows(n, offsets, order)
+    support = lp_support(rows, tol)
+    if support is None:
+        return None
+    weights = exact_positive_weights(rows, support)
+    if weights is None:
+        return None
+    cert = certificate_payload(name, n, offsets, order, rows, support, weights)
+    check_certificate_dict(cert)
+    return cert
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True, help="pattern name for the certificate")
+    parser.add_argument("--n", required=True, type=int)
+    parser.add_argument("--offsets", required=True, type=parse_int_list)
+    parser.add_argument("--order", required=True, type=parse_int_list)
+    parser.add_argument("--out", type=Path, help="optional certificate output path")
+    parser.add_argument("--tol", type=float, default=1e-9, help="LP support threshold")
+    parser.add_argument("--assert-found", action="store_true")
+    parser.add_argument("--summary-json", action="store_true")
+    args = parser.parse_args()
+
+    cert = find_certificate(args.name, args.n, args.offsets, args.order, args.tol)
+    if cert is None:
+        summary = {
+            "status": "NO_EXACT_KALMANSON_CERTIFICATE_FOUND",
+            "pattern": args.name,
+            "n": args.n,
+        }
+        if args.summary_json:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        elif args.assert_found:
+            print("no exact Kalmanson certificate found")
+        return 1 if args.assert_found else 0
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(cert, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary = check_certificate_dict(cert)._asdict()
+    if args.summary_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "found exact Kalmanson certificate "
+            f"for {summary['pattern']} with {summary['positive_inequalities']} inequalities"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kalmanson_certificate.py
+++ b/tests/test_kalmanson_certificate.py
@@ -11,6 +11,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "check_kalmanson_certificate.py"
 C19 = ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_unsat.json"
 C17_TRANSLATION = ROOT / "data" / "certificates" / "round2" / "c17_skew_kalmanson_from_ptolemy_method_note.json"
+C13 = ROOT / "data" / "certificates" / "c13_sidon_order_survivor_kalmanson_unsat.json"
 
 
 def load_module():
@@ -48,6 +49,43 @@ def test_c17_ptolemy_translation_is_valid_kalmanson_certificate() -> None:
     assert summary.positive_inequalities == 17
     assert summary.max_weight == 1
     assert summary.distance_classes_after_selected_equalities == 85
+
+
+def test_c13_sidon_survivor_kalmanson_certificate() -> None:
+    module = load_module()
+    summary = module.check_certificate_file(C13)
+    assert summary.pattern == "C13_sidon_1_2_4_10"
+    assert summary.positive_inequalities == 34
+    assert summary.distance_classes_after_selected_equalities == 39
+    assert summary.weight_sum == 17463
+    assert summary.max_weight == 1322
+
+
+def test_find_kalmanson_certificate_reproduces_c13_summary() -> None:
+    finder = ROOT / "scripts" / "find_kalmanson_certificate.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(finder),
+            "--name",
+            "C13_sidon_1_2_4_10",
+            "--n",
+            "13",
+            "--offsets",
+            "1,2,4,10",
+            "--order",
+            "5,0,10,8,9,7,4,6,2,11,12,3,1",
+            "--assert-found",
+            "--summary-json",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    summary = json.loads(result.stdout)
+    assert summary["pattern"] == "C13_sidon_1_2_4_10"
+    assert summary["positive_inequalities"] == 34
+    assert summary["zero_sum_verified"] is True
 
 
 def test_kalmanson_checker_rejects_wrong_weight_sum() -> None:

--- a/tests/test_sparse_order_survivors.py
+++ b/tests/test_sparse_order_survivors.py
@@ -32,8 +32,12 @@ def test_registered_sparse_order_survivors_match_artifact() -> None:
     c13 = by_case["C13_sidon_1_2_4_10:sample_full_filter_survivor"]
     c19 = by_case["C19_skew:vertex_circle_survivor"]
 
-    assert c13["survives_current_exact_filters"] is True
+    assert c13["survives_pre_kalmanson_filters"] is True
+    assert c13["survives_current_exact_filters"] is False
     assert c13["vertex_circle"]["obstructed"] is False
     assert c13["radius_propagation"]["acyclic_choice_edge_count"] == 4
-    assert c19["survives_current_exact_filters"] is True
+    assert c13["kalmanson_certificate"]["positive_inequalities"] == 34
+    assert c19["survives_pre_kalmanson_filters"] is True
+    assert c19["survives_current_exact_filters"] is False
+    assert c19["kalmanson_certificate"]["positive_inequalities"] == 94
     assert c19["sparse_frontier"]["trivial_empty_radius_choice_exists"] is True


### PR DESCRIPTION
## What changed

- Added `scripts/find_kalmanson_certificate.py`, which finds fixed-order Kalmanson/Farkas certificates by LP support search followed by exact rational nullspace recovery.
- Added `data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json`, an exact 34-inequality certificate killing the registered non-natural `C13_sidon_1_2_4_10` order `[5,0,10,8,9,7,4,6,2,11,12,3,1]`.
- Updated sparse-frontier artifacts and docs so the older sparse-filter survivors are distinguished from current Kalmanson-obstructed fixed orders.
- Updated README/STATE/RESULTS/claims/metadata without changing the global status: no general proof and no counterexample are claimed.

## Claim scope

This is an exact obstruction for one fixed selected-witness pattern and one fixed cyclic order only. It does not settle abstract `C13_sidon_1_2_4_10` across all cyclic orders and does not prove Erdos Problem #97.

## Validation

- `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json --summary-json`
- `python scripts/find_kalmanson_certificate.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --order 5,0,10,8,9,7,4,6,2,11,12,3,1 --assert-found --summary-json`
- `python scripts/check_sparse_order_survivors.py --assert-expected --json`
- `python -m pytest tests/test_kalmanson_certificate.py tests/test_sparse_order_survivors.py -q`
- `python -m ruff check .`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python scripts/independent_check_n8_artifacts.py --check --json`