### PR TITLE
[codex] Document alternating two-radius obstruction

### DIFF
--- a/docs/failed-ideas.md
+++ b/docs/failed-ideas.md
@@ -129,6 +129,14 @@ the inner radius below the alternating convexity threshold. In the notation of
 `S/R > cos h`. This is a useful perturbative base, not a live counterexample
 candidate.
 
+A later incoming note broadened the lesson: even without the quarter-turn
+selected-distance equations, the strictly convex alternating two-radius regular
+family has strictly ordered paired distances at every vertex, so it cannot
+produce four equal-distance witnesses. The same note also records that the
+fixed selected-witness pattern of the exact concave alternating decagon has no
+cyclic order satisfying the two-overlap crossing filter. See
+`docs/two-orbit-radius-propagation.md`.
+
 [^lit]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
 [^forest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/11_forest_lemma_counterexample_review.md`.
 [^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.

--- a/docs/two-orbit-radius-propagation.md
+++ b/docs/two-orbit-radius-propagation.md
@@ -129,6 +129,92 @@ cos h = 1 - h^2/2 + O(h^4).
 The first-order inward term in `x` is the obstruction. Convexity needs only a
 quadratic radial drop, while the equality equations force a linear radial drop.
 
+## Broader alternating two-radius family
+
+A related incoming note checked the full alternating two-radius regular family,
+without imposing the quarter-turn selected-distance equations above. Let
+`m >= 4`, `h = pi/m`, and place vertices on equally spaced rays with radii
+alternating between `1` and `b`:
+
+```text
+p_{2j}   = exp(2ijh),
+p_{2j+1} = b exp((2j+1)ih).
+```
+
+The same consecutive-turn calculation gives strict convexity in the natural
+alternating order exactly when
+
+```text
+cos h < b < sec h.
+```
+
+For an even vertex, paired offsets have squared distances
+
+```text
+D_k(b) =
+  2 - 2 cos(kh)                 if k is even,
+  1 + b^2 - 2b cos(kh)          if k is odd.
+```
+
+The exact checker records endpoint certificates proving
+`D_1 < D_2 < ... < D_{m-1}` throughout the strict-convexity interval:
+
+- for even `k`, `D_{k+1} - D_k` is increasing in `b`, so its minimum is at
+  `b = cos h` and equals `sin h * (2 sin((k+1)h) - sin h) > 0`;
+- for odd `k`, `D_{k+1} - D_k` is decreasing in `b`, so its minimum is at
+  `b = sec h` and equals
+  `sin h * (2 cos h sin((k+1)h) - sin h) / cos^2 h > 0`.
+
+Odd vertices reduce to the same check by replacing `b` with `1/b` and scaling
+distances by `b^2`. Thus this alternating two-radius regular family has no
+four-equal-distance vertex while it is strictly convex. This is an exact killed
+family, not a proof of Erdos Problem #97.
+
+The command
+
+```bash
+python scripts/check_two_orbit_radius_propagation.py \
+  --alternating-family \
+  --m 4 \
+  --m-max 12 \
+  --assert-alternating-family
+```
+
+checks the stored endpoint certificates for the listed `m` values.
+
+## Concave decagon fixed pattern
+
+The exact concave alternating decagon behind this family has selected rows
+
+```text
+0: 2 3 7 8
+1: 0 2 5 7
+2: 0 4 5 9
+3: 2 4 7 9
+4: 1 2 6 7
+5: 1 4 6 9
+6: 3 4 8 9
+7: 1 3 6 8
+8: 0 1 5 6
+9: 0 3 5 8
+```
+
+This fixed selected-witness pattern passes the two-circle row-overlap cap, but
+it fails the cyclic-order crossing filter. The finite search has 30 forced
+two-overlap crossings and checks all `10!/20 = 181440` cyclic orders modulo
+rotation and reversal. No cyclic order satisfies all crossings.
+
+Run:
+
+```bash
+python scripts/check_two_orbit_radius_propagation.py \
+  --decagon-crossing \
+  --assert-decagon-crossing
+```
+
+This kills only the fixed selected-witness pattern above. It is not an `n=10`
+completeness theorem.
+
 ## Reproducible checker
 
 The exact checker is implemented in
@@ -140,6 +226,8 @@ Useful commands:
 python scripts/check_two_orbit_radius_propagation.py --t 2 --assert-expected
 python scripts/check_two_orbit_radius_propagation.py --t 2 --assert-expected --verify-all-rows
 python scripts/check_two_orbit_radius_propagation.py --t 3 --json
+python scripts/check_two_orbit_radius_propagation.py --alternating-family --m 5 --assert-alternating-family
+python scripts/check_two_orbit_radius_propagation.py --decagon-crossing --assert-decagon-crossing
 ```
 
 The checker reports `status: exact_ansatz_obstruction_not_general_proof`.

--- a/incoming/archive-output-2026-05-03/README.md
+++ b/incoming/archive-output-2026-05-03/README.md
@@ -21,6 +21,7 @@ machine-checked selected-witness `n <= 8` artifact.
 | `erdos97_n9_result.md` | `acef027ba26f63a650dfe47155b322b3ebd72bd8d552ca76a8aad6a400989652` | Raw n=9 report variant; not imported as a tracked artifact because it uses theorem-style language before independent review. |
 | `erdos97_result (1).md` | `e30673ff9ac2e2037a3adff4fdd47404625b0cbcf22e53ddbc8a313e1e014f` | Raw mixed attempt report; not imported as a tracked artifact because the C13 material is already covered by existing Kalmanson notes. |
 | `erdos97_result.md` | `ee9c38ed2b0dd24fe5f7cd4a952d3f99a97b8ad07f4f4832253053053c28b171` | Raw mixed attempt report; not imported as a tracked artifact because the C13 material is already covered by existing Kalmanson notes. |
+| `erdos97_result (2).md` | `c9962bbc1f05939d46889fc0249894cf6562d687430156b2003b8f9af3a30ebe` | Raw alternating two-radius / concave decagon report; distilled into `docs/two-orbit-radius-propagation.md` and checker tests rather than imported verbatim. |
 | `n9_vertex_circle_crosscheck_output.txt` | `51333a65d8b80a3f7c2c99ccbdc39d3eb9818f4b0d58927a004884b013785c20` | Reproduced by the repo-native n=9 vertex-circle checker. |
 | `n9_vertex_circle_exhaustive.py` | `49c98e01cab3d0292ebb0fdb37b9d4ea46dccd0cd595ce7fb25a799a674bfb61` | Raw standalone n=9 exhaustive script; refactored into `src/erdos97/n9_vertex_circle_exhaustive.py`. |
 | `n9_vertex_circle_exhaustive_output.txt` | `7043c238fac825bd5706c53351705f45dcd133309cc56c777e01380ea837430a` | Reproduced by the repo-native n=9 vertex-circle checker. |

--- a/scripts/check_two_orbit_radius_propagation.py
+++ b/scripts/check_two_orbit_radius_propagation.py
@@ -14,7 +14,11 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.two_orbit_radius_propagation import (  # noqa: E402
+    alternating_decagon_crossing_search,
     alternating_turns,
+    alternating_two_radius_family_summary,
+    alternating_two_radius_family_to_json,
+    cyclic_crossing_search_to_json,
     linearized_escape_summary,
     linearized_escape_to_json,
     selected_distance_residuals,
@@ -83,6 +87,26 @@ def assert_linearized_escape(t: int) -> None:
         raise AssertionError("linearized escape does not preserve equalities")
 
 
+def assert_alternating_family(m: int) -> None:
+    summary = alternating_two_radius_family_summary(m)
+    if summary.status != "exact_family_obstruction_not_general_proof":
+        raise AssertionError(f"unexpected alternating-family status for m={m}")
+    if not summary.all_gap_certificates_positive:
+        raise AssertionError(f"not all adjacent gap certificates are positive for m={m}")
+
+
+def assert_decagon_crossing() -> None:
+    summary = alternating_decagon_crossing_search()
+    if summary.status != "NO_CYCLIC_ORDER":
+        raise AssertionError(f"unexpected decagon crossing status: {summary.status}")
+    if summary.constraint_count != 30:
+        raise AssertionError(f"unexpected decagon constraint count: {summary.constraint_count}")
+    if summary.normalized_order_count != 181_440:
+        raise AssertionError(
+            f"unexpected normalized order count: {summary.normalized_order_count}"
+        )
+
+
 def print_summary(t: int) -> None:
     summary = two_orbit_summary(t)
     print("t  m  n  distance_eq  A_gap  B_gap  turn_B<0  turn_A>0  forced_concave")
@@ -94,6 +118,27 @@ def print_summary(t: int) -> None:
     )
     print(f"S/R = {summary.ratio}")
     print(f"cos(h) - S/R = {summary.cos_minus_ratio}")
+
+
+def print_alternating_family_summary(m: int, *, m_max: int | None) -> None:
+    rows = [
+        alternating_two_radius_family_summary(current_m)
+        for current_m in range(m, (m_max or m) + 1)
+    ]
+    print("m  n  status                                      gap certificates")
+    for row in rows:
+        print(
+            f"{row.m}  {row.n}  {row.status:<42}  "
+            f"{len(row.gap_certificates)} positive={row.all_gap_certificates_positive}"
+        )
+
+
+def print_decagon_crossing_summary() -> None:
+    summary = alternating_decagon_crossing_search()
+    print("alternating concave decagon crossing search")
+    print(f"constraints: {summary.constraint_count}")
+    print(f"normalized orders checked: {summary.normalized_order_count}")
+    print(f"status: {summary.status}")
 
 
 def print_linearized_escape_summary(t: int, *, t_max: int | None) -> None:
@@ -126,8 +171,34 @@ def print_linearized_escape_summary(t: int, *, t_max: int | None) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--t", type=int, default=2, help="positive integer with m=4t")
+    parser.add_argument("--m", type=int, default=5, help="integer m >= 4 for alternating-family checks")
     parser.add_argument("--json", action="store_true", help="print JSON")
     parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument(
+        "--alternating-family",
+        action="store_true",
+        help="check the broader alternating two-radius regular 2m-gon family",
+    )
+    parser.add_argument(
+        "--m-max",
+        type=int,
+        help="with --alternating-family, scan every m from --m through --m-max",
+    )
+    parser.add_argument(
+        "--assert-alternating-family",
+        action="store_true",
+        help="assert that selected alternating-family m values have positive gap certificates",
+    )
+    parser.add_argument(
+        "--decagon-crossing",
+        action="store_true",
+        help="check cyclic-order crossings for the fixed concave alternating decagon pattern",
+    )
+    parser.add_argument(
+        "--assert-decagon-crossing",
+        action="store_true",
+        help="assert the fixed concave decagon pattern has no cyclic order",
+    )
     parser.add_argument(
         "--linearized-escape",
         action="store_true",
@@ -157,8 +228,17 @@ def main() -> int:
 
     if args.t_max is not None and args.t_max < args.t:
         raise SystemExit("--t-max must be at least --t")
+    if args.m_max is not None and args.m_max < args.m:
+        raise SystemExit("--m-max must be at least --m")
     if args.assert_linearized_escape and not args.linearized_escape:
         raise SystemExit("--assert-linearized-escape requires --linearized-escape")
+    if args.assert_alternating_family and not args.alternating_family:
+        raise SystemExit("--assert-alternating-family requires --alternating-family")
+    if args.assert_decagon_crossing and not args.decagon_crossing:
+        raise SystemExit("--assert-decagon-crossing requires --decagon-crossing")
+    modes = [args.linearized_escape, args.alternating_family, args.decagon_crossing]
+    if sum(bool(mode) for mode in modes) > 1:
+        raise SystemExit("choose only one special mode")
 
     if args.linearized_escape:
         t_values = range(args.t, (args.t_max or args.t) + 1)
@@ -181,6 +261,38 @@ def main() -> int:
             print_linearized_escape_summary(args.t, t_max=args.t_max)
             if args.assert_linearized_escape:
                 print("OK: linearized escape expectation verified")
+        return 0
+
+    if args.alternating_family:
+        m_values = range(args.m, (args.m_max or args.m) + 1)
+        rows = [
+            alternating_two_radius_family_to_json(
+                alternating_two_radius_family_summary(current_m)
+            )
+            for current_m in m_values
+        ]
+        if args.assert_alternating_family:
+            for current_m in m_values:
+                assert_alternating_family(current_m)
+        if args.json:
+            output: object = rows[0] if args.m_max is None else rows
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            print_alternating_family_summary(args.m, m_max=args.m_max)
+            if args.assert_alternating_family:
+                print("OK: alternating-family expectation verified")
+        return 0
+
+    if args.decagon_crossing:
+        summary = alternating_decagon_crossing_search()
+        if args.assert_decagon_crossing:
+            assert_decagon_crossing()
+        if args.json:
+            print(json.dumps(cyclic_crossing_search_to_json(summary), indent=2, sort_keys=True))
+        else:
+            print_decagon_crossing_summary()
+            if args.assert_decagon_crossing:
+                print("OK: decagon crossing expectation verified")
         return 0
 
     if args.assert_expected:

--- a/src/erdos97/two_orbit_radius_propagation.py
+++ b/src/erdos97/two_orbit_radius_propagation.py
@@ -16,7 +16,10 @@ than ``cos(h)``, so this symmetric ansatz is exactly concave.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import combinations, permutations
 from typing import Sequence
+
+from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
 
 
 def _sympy():
@@ -67,9 +70,51 @@ class TwoOrbitLinearizedEscapeSummary:
     direction: list[list[float]] | None
 
 
+@dataclass(frozen=True)
+class AlternatingTwoRadiusGapCertificate:
+    """One adjacent paired-distance gap certificate for the alternating family."""
+
+    k: int
+    parity: str
+    endpoint: str
+    gap_at_endpoint: object
+    positive: bool
+
+
+@dataclass(frozen=True)
+class AlternatingTwoRadiusFamilySummary:
+    """Exact monotonicity summary for the alternating two-radius regular family."""
+
+    m: int
+    n: int
+    h: object
+    convexity_lower: object
+    convexity_upper: object
+    gap_certificates: list[AlternatingTwoRadiusGapCertificate]
+    all_gap_certificates_positive: bool
+    status: str
+
+
+@dataclass(frozen=True)
+class CyclicCrossingSearchSummary:
+    """Finite cyclic-order crossing search summary for one fixed pattern."""
+
+    pattern: str
+    n: int
+    constraint_count: int
+    normalized_order_count: int
+    survivor: tuple[int, ...] | None
+    status: str
+
+
 def _check_t(t: int) -> None:
     if not isinstance(t, int) or t < 1:
         raise ValueError("t must be a positive integer")
+
+
+def _check_m(m: int) -> None:
+    if not isinstance(m, int) or m < 4:
+        raise ValueError("m must be an integer >= 4")
 
 
 def forced_ratio(t: int):
@@ -311,6 +356,133 @@ def linearized_escape_summary(
     )
 
 
+def alternating_two_radius_family_summary(
+    m: int,
+) -> AlternatingTwoRadiusFamilySummary:
+    """Return exact endpoint certificates for the alternating two-radius family.
+
+    The family has vertices on equally spaced rays with radii alternating
+    between ``1`` and ``b``. In the strict-convexity interval
+    ``cos(pi/m) < b < sec(pi/m)``, the paired distances from each vertex are
+    strictly ordered, so no paired-offset collision can create four equal
+    distances.
+    """
+
+    _check_m(m)
+    sp = _sympy()
+    h = sp.pi / m
+    s = sp.sin(h)
+    c = sp.cos(h)
+    certificates: list[AlternatingTwoRadiusGapCertificate] = []
+    for k in range(1, m - 1):
+        if k % 2 == 0:
+            gap = sp.simplify(s * (2 * sp.sin((k + 1) * h) - s))
+            certificates.append(
+                AlternatingTwoRadiusGapCertificate(
+                    k=k,
+                    parity="even",
+                    endpoint="b=cos(pi/m)",
+                    gap_at_endpoint=gap,
+                    positive=_is_positive(gap),
+                )
+            )
+        else:
+            gap = sp.simplify(
+                s * (2 * c * sp.sin((k + 1) * h) - s) / (c * c)
+            )
+            certificates.append(
+                AlternatingTwoRadiusGapCertificate(
+                    k=k,
+                    parity="odd",
+                    endpoint="b=sec(pi/m)",
+                    gap_at_endpoint=gap,
+                    positive=_is_positive(gap),
+                )
+            )
+    all_positive = all(item.positive for item in certificates)
+    return AlternatingTwoRadiusFamilySummary(
+        m=m,
+        n=2 * m,
+        h=h,
+        convexity_lower=c,
+        convexity_upper=sp.simplify(1 / c),
+        gap_certificates=certificates,
+        all_gap_certificates_positive=all_positive,
+        status=(
+            "exact_family_obstruction_not_general_proof"
+            if all_positive
+            else "certificate_check_failed"
+        ),
+    )
+
+
+ALTERNATING_DECAGON_PATTERN: list[list[int]] = [
+    [2, 3, 7, 8],
+    [0, 2, 5, 7],
+    [0, 4, 5, 9],
+    [2, 4, 7, 9],
+    [1, 2, 6, 7],
+    [1, 4, 6, 9],
+    [3, 4, 8, 9],
+    [1, 3, 6, 8],
+    [0, 1, 5, 6],
+    [0, 3, 5, 8],
+]
+
+
+def two_overlap_crossing_constraints(
+    pattern: Sequence[Sequence[int]],
+) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    """Return source/witness chord crossings forced by two-row overlaps."""
+
+    witness_sets = [set(row) for row in pattern]
+    constraints: list[tuple[tuple[int, int], tuple[int, int]]] = []
+    for i, j in combinations(range(len(pattern)), 2):
+        common = sorted(witness_sets[i] & witness_sets[j])
+        if len(common) == 2:
+            constraints.append(
+                (
+                    normalize_chord(i, j),
+                    normalize_chord(common[0], common[1]),
+                )
+            )
+        elif len(common) > 2:
+            raise ValueError(f"rows {i} and {j} share more than two witnesses")
+    return constraints
+
+
+def alternating_decagon_crossing_search() -> CyclicCrossingSearchSummary:
+    """Exhaustively check cyclic orders for the concave alternating decagon pattern."""
+
+    n = len(ALTERNATING_DECAGON_PATTERN)
+    constraints = two_overlap_crossing_constraints(ALTERNATING_DECAGON_PATTERN)
+    count = 0
+    survivor: tuple[int, ...] | None = None
+    for perm in permutations(range(1, n)):
+        order = (0,) + perm
+        if order[1] > order[-1]:
+            continue
+        count += 1
+        if all(
+            chords_cross_in_order(source, target, order)
+            for source, target in constraints
+        ):
+            survivor = order
+            break
+    return CyclicCrossingSearchSummary(
+        pattern="alternating_concave_decagon",
+        n=n,
+        constraint_count=len(constraints),
+        normalized_order_count=count,
+        survivor=survivor,
+        status=(
+            "NO_CYCLIC_ORDER"
+            if survivor is None
+            else "CYCLIC_ORDER_SURVIVOR_FOUND"
+        ),
+    )
+
+
 def summary_to_json(summary: TwoOrbitSummary) -> dict[str, object]:
     """Return a JSON-friendly exact summary."""
     return {
@@ -333,6 +505,60 @@ def summary_to_json(summary: TwoOrbitSummary) -> dict[str, object]:
         "interpretation": (
             "The equality equations force S/R below cos(h), while strict "
             "convexity of the alternating polygon requires S/R > cos(h)."
+        ),
+    }
+
+
+def alternating_two_radius_family_to_json(
+    summary: AlternatingTwoRadiusFamilySummary,
+) -> dict[str, object]:
+    """Return a JSON-friendly alternating-family summary."""
+
+    return {
+        "type": "alternating_two_radius_regular_family",
+        "status": summary.status,
+        "m": summary.m,
+        "n": summary.n,
+        "h": str(summary.h),
+        "convexity_interval": {
+            "lower": str(summary.convexity_lower),
+            "upper": str(summary.convexity_upper),
+        },
+        "gap_certificates": [
+            {
+                "k": item.k,
+                "parity": item.parity,
+                "endpoint": item.endpoint,
+                "gap_at_endpoint": str(item.gap_at_endpoint),
+                "positive": item.positive,
+            }
+            for item in summary.gap_certificates
+        ],
+        "all_gap_certificates_positive": summary.all_gap_certificates_positive,
+        "interpretation": (
+            "Inside the strict-convexity interval, adjacent paired-distance "
+            "gaps are positive, so paired offsets are strictly ordered. The "
+            "family cannot give four equal-distance witnesses at a vertex."
+        ),
+    }
+
+
+def cyclic_crossing_search_to_json(
+    summary: CyclicCrossingSearchSummary,
+) -> dict[str, object]:
+    """Return a JSON-friendly cyclic crossing search summary."""
+
+    return {
+        "type": "fixed_pattern_cyclic_crossing_search",
+        "pattern": summary.pattern,
+        "status": summary.status,
+        "n": summary.n,
+        "constraint_count": summary.constraint_count,
+        "normalized_order_count": summary.normalized_order_count,
+        "survivor": None if summary.survivor is None else list(summary.survivor),
+        "interpretation": (
+            "This is a fixed selected-witness pattern obstruction only; it is "
+            "not an n=10 completeness theorem and not a counterexample."
         ),
     }
 

--- a/tests/test_two_orbit_radius_propagation.py
+++ b/tests/test_two_orbit_radius_propagation.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import sympy as sp
 
 from erdos97.two_orbit_radius_propagation import (
+    alternating_decagon_crossing_search,
+    alternating_two_radius_family_summary,
+    alternating_two_radius_family_to_json,
     alternating_turns,
+    cyclic_crossing_search_to_json,
     linearized_escape_summary,
     linearized_escape_to_json,
     selected_distance_residuals,
@@ -79,3 +83,44 @@ def test_linearized_escape_json_keeps_claim_boundary_explicit() -> None:
     assert row["status"] == "LINEARIZED_ESCAPE_FOUND"
     assert row["trust_label"] == "NUMERICAL_LINEARIZED_DIAGNOSTIC"
     assert "not a counterexample" in str(row["interpretation"])
+
+
+def test_alternating_two_radius_family_has_positive_gap_certificates() -> None:
+    for m in range(4, 13):
+        summary = alternating_two_radius_family_summary(m)
+
+        assert summary.status == "exact_family_obstruction_not_general_proof"
+        assert summary.n == 2 * m
+        assert len(summary.gap_certificates) == m - 2
+        assert summary.all_gap_certificates_positive
+        assert all(item.positive for item in summary.gap_certificates)
+
+
+def test_alternating_two_radius_family_json_keeps_scope_narrow() -> None:
+    row = alternating_two_radius_family_to_json(
+        alternating_two_radius_family_summary(5)
+    )
+
+    assert row["type"] == "alternating_two_radius_regular_family"
+    assert row["status"] == "exact_family_obstruction_not_general_proof"
+    assert row["all_gap_certificates_positive"] is True
+    assert "family cannot give four equal-distance witnesses" in str(row["interpretation"])
+
+
+def test_alternating_decagon_pattern_has_no_cyclic_crossing_order() -> None:
+    summary = alternating_decagon_crossing_search()
+
+    assert summary.pattern == "alternating_concave_decagon"
+    assert summary.status == "NO_CYCLIC_ORDER"
+    assert summary.constraint_count == 30
+    assert summary.normalized_order_count == 181_440
+    assert summary.survivor is None
+
+
+def test_alternating_decagon_crossing_json_keeps_scope_narrow() -> None:
+    row = cyclic_crossing_search_to_json(alternating_decagon_crossing_search())
+
+    assert row["type"] == "fixed_pattern_cyclic_crossing_search"
+    assert row["status"] == "NO_CYCLIC_ORDER"
+    assert row["survivor"] is None
+    assert "not an n=10 completeness theorem" in str(row["interpretation"])


### PR DESCRIPTION
## Summary

- Extends the existing two-orbit radius-propagation checker with exact endpoint certificates for the broader alternating two-radius regular family.
- Adds a finite cyclic-order crossing search for the fixed concave alternating decagon selected-witness pattern.
- Documents both as narrow killed-family/fixed-pattern results and records the incoming archive report hash without importing the raw prose.

## Validation

- `python scripts/check_two_orbit_radius_propagation.py --alternating-family --m 4 --m-max 12 --assert-alternating-family`
- `python scripts/check_two_orbit_radius_propagation.py --decagon-crossing --assert-decagon-crossing`
- `python -m pytest tests/test_two_orbit_radius_propagation.py -q`
- `python -m ruff check src/erdos97/two_orbit_radius_propagation.py scripts/check_two_orbit_radius_propagation.py tests/test_two_orbit_radius_propagation.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m pytest -q`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`