### PR TITLE
[codex] Record late n9 archive provenance

### DIFF
--- a/data/certificates/n9_late_archive_provenance.json
+++ b/data/certificates/n9_late_archive_provenance.json
@@ -1,0 +1,93 @@
+{
+  "type": "n9_late_archive_provenance_v1",
+  "trust": "REVIEW_PENDING_PROVENANCE",
+  "scope": "External n=9 archive material reviewed as corroborating provenance only; this file does not promote the n=9 claim to source-of-truth status.",
+  "reviewed_on": "2026-05-03",
+  "source_directory": "C:\\Users\\User\\Desktop\\code\\erd archive\\outputs\\data\\1\\2",
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "The official/global status remains falsifiable/open.",
+    "The repo-native review-pending n=9 checker remains data/certificates/n9_vertex_circle_exhaustive.json.",
+    "Elapsed timings from generated artifacts are intentionally excluded from these stable counts.",
+    "The zip verifier was not executed during integration; only static zip members and JSON summaries were inspected."
+  ],
+  "files": [
+    {
+      "file": "erdos97_n9_vertex_circle_certificate.json",
+      "bytes": 311904,
+      "sha256": "142d25283fe114c05863f66515e21c1e2b76c0c8dade22b3b545c97ab5248b5a",
+      "disposition": "Not imported verbatim; generated certificate with timing fields and a stronger trust label than this repo should accept before independent review."
+    },
+    {
+      "file": "n9_vertex_circle_exclusion.py",
+      "bytes": 15721,
+      "sha256": "c2283900fb16aeb3b96ae245f57571721d86a35dd506357b9362ab616f8fc819",
+      "disposition": "Not imported verbatim; useful independent sequential row-order cross-check of the repo-native vertex-circle checker."
+    },
+    {
+      "file": "erdos97_n9_exclusion_report.md",
+      "bytes": 10036,
+      "sha256": "ed16eae27bb6423d797c5b2b1294023844bd98e372475b0288685851ab3a8f27",
+      "disposition": "Not imported verbatim; raw report text is superseded by repo documentation with review-pending status language."
+    },
+    {
+      "file": "erdos97_n9_certificates_and_scripts.zip",
+      "bytes": 31563,
+      "sha256": "09ce587b10801f1854bf769a30bd0b904b2f67998bd34179f61fcab76ccb1a92",
+      "disposition": "Not imported verbatim; binary archive with unreviewed scripts. Static JSON summaries were inspected, but embedded code was not executed."
+    },
+    {
+      "file": "erdos97_result (4).md",
+      "bytes": 12113,
+      "sha256": "bdc2b70ae784fcdde32c94ef421013472b5ab799293170dddfdb4522b5a1e5f8",
+      "disposition": "Not imported verbatim; raw row0 quotient report uses stronger conclusion language than this repo should publish before review."
+    }
+  ],
+  "summaries": {
+    "sequential_vertex_circle_exclusion": {
+      "source_script": "n9_vertex_circle_exclusion.py",
+      "verified_by_local_run": true,
+      "command": "python n9_vertex_circle_exclusion.py --assert-closed",
+      "n": 9,
+      "row_size": 4,
+      "row0_case_count": 70,
+      "all_row0_closed": true,
+      "total_nodes_visited": 37614,
+      "total_row_options_considered": 2628150,
+      "total_full_patterns_reached": 0,
+      "total_rejection_counts": {
+        "adjacent_two_overlap": 255354,
+        "crossing_bisector": 1163137,
+        "row_pair_intersection_cap": 1102641,
+        "vertex_circle_self_edge": 34445,
+        "vertex_circle_strict_cycle": 35029
+      },
+      "relationship_to_repo_native_checker": "Corroborates the same n=9 selected-witness vertex-circle obstruction with a natural row-order search and different pruning counts."
+    },
+    "row0_quotient_certificate_bundle": {
+      "source_archive": "erdos97_n9_certificates_and_scripts.zip",
+      "zip_member_count": 25,
+      "row_certificate_files": 17,
+      "static_json_summaries_read": [
+        "n9_certificate_bundle_summary.json",
+        "n9_scan_summary_38.json"
+      ],
+      "embedded_verifier_executed_during_integration": false,
+      "n": 9,
+      "canonical_row0_count": 38,
+      "row_count_with_full_patterns": 17,
+      "full_patterns": 102,
+      "classification_counts": {
+        "accepted_frontier": 0,
+        "kalmanson_certificate": 70,
+        "mutual_midpoint_collapse": 0,
+        "odd_forced_perpendicular_cycle": 11,
+        "phi4_rectangle_trap": 21
+      },
+      "max_kalmanson_inequalities": 12,
+      "max_kalmanson_weight": 9,
+      "relationship_to_repo_native_checker": "Uses a row0 reflection quotient and mixed exact obstruction certificates; count conventions differ from the 70-row0 vertex-circle exhaustive checker."
+    }
+  }
+}

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -76,10 +76,27 @@ python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q
 
 The raw incoming bundle is preserved under
 `incoming/archive-output-2026-05-03/`. That folder includes two additional n=9
-Kalmanson verifier variants with different symmetry/count conventions:
-184 labelled patterns / 16 dihedral classes, and 102 row-0 reflection
-representatives with positive Kalmanson/Farkas certificates. Those are useful
-audit material, but they are not the canonical repo check introduced here.
+Kalmanson verifier variants with different symmetry/count conventions, plus a
+later external batch summarized in
+`data/certificates/n9_late_archive_provenance.json`. Those are useful audit
+material, but they are not the canonical repo check introduced here.
+
+## Later archive cross-checks
+
+A later external batch added two corroborating n=9 stories:
+
+- a sequential row-order vertex-circle checker, locally rerun with
+  `--assert-closed`, closes all 70 row0 choices with 37,614 visited nodes,
+  2,628,150 row options considered, and zero full patterns reached;
+- a row0-reflection-quotient certificate bundle reports 38 canonical row0
+  classes, 102 full patterns, and classifications into 70 Kalmanson/Farkas
+  certificates, 21 phi4 rectangle traps, and 11 odd forced-perpendicularity
+  cycles, with no accepted frontier.
+
+The zip bundle's embedded verifier was not executed during integration because
+it is unreviewed external code. Its static JSON summaries and hashes are
+recorded only as review-pending provenance; the verifier should be ported or
+reviewed in-repo before those counts become a canonical check.
 
 ## Review standard
 
@@ -93,3 +110,6 @@ artifact, an independent review should check:
   rows and selected-distance equalities that are already fixed;
 - that the raw 184/16 and 102-certificate archive variants agree with the
   repo-native checker once their symmetry conventions are made explicit.
+- that the sequential vertex-circle script and row0-quotient bundle in the
+  late archive are independent enough to count as corroboration rather than
+  just differently packaged output from the same search.

--- a/incoming/archive-output-2026-05-03/README.md
+++ b/incoming/archive-output-2026-05-03/README.md
@@ -29,6 +29,21 @@ machine-checked selected-witness `n <= 8` artifact.
 | `verify_erdos97_n9.py` | `1aa05135de87771adc64c26e1b2e89239388e7583dfa2da50950fddeb8ca677e` | Raw 184-pattern/16-orbit verifier variant; preserved for review. |
 | `verify_erdos97_n9_output.txt` | `b57e51c297c2fd6bda0f101100fab6f21458576a71c4164c86242f0ce73cf137` | Reproduced by the raw verifier variant; not the canonical repo check. |
 
+## Late external files reviewed
+
+These additional files were also checked from the same external archive
+directory. They are not copied here verbatim. Their stable hashes and distilled
+counts are recorded in
+`data/certificates/n9_late_archive_provenance.json`.
+
+| File | SHA256 | Disposition |
+| --- | --- | --- |
+| `erdos97_n9_vertex_circle_certificate.json` | `142d25283fe114c05863f66515e21c1e2b76c0c8dade22b3b545c97ab5248b5a` | Generated sequential vertex-circle certificate; not imported verbatim because it includes timing fields and a stronger trust label than this repo should accept before independent review. |
+| `n9_vertex_circle_exclusion.py` | `c2283900fb16aeb3b96ae245f57571721d86a35dd506357b9362ab616f8fc819` | Standalone sequential row-order vertex-circle checker; locally rerun with `--assert-closed`, but not imported because the repo-native checker already covers the canonical executable path. |
+| `erdos97_n9_exclusion_report.md` | `ed16eae27bb6423d797c5b2b1294023844bd98e372475b0288685851ab3a8f27` | Raw report; superseded by repo documentation with review-pending language. |
+| `erdos97_n9_certificates_and_scripts.zip` | `09ce587b10801f1854bf769a30bd0b904b2f67998bd34179f61fcab76ccb1a92` | Binary certificate/script bundle; static JSON summaries were inspected, but embedded verifier code was not executed during this integration. |
+| `erdos97_result (4).md` | `bdc2b70ae784fcdde32c94ef421013472b5ab799293170dddfdb4522b5a1e5f8` | Raw row0 quotient report; not imported verbatim because it uses stronger conclusion language than the repo should publish before review. |
+
 ## Review notes
 
 The n=9 material has three related but distinct computational stories:
@@ -36,7 +51,9 @@ The n=9 material has three related but distinct computational stories:
 - a vertex-circle exhaustive search whose cross-check leaves 184 full
   assignments before the vertex-circle filter and kills all 184;
 - a 184-labelled-pattern / 16-dihedral-class Kalmanson-gap verifier;
-- a 102-row0-reflection-representative Kalmanson/Farkas certificate verifier.
+- a 102-row0-reflection-representative obstruction bundle combining
+  Kalmanson/Farkas certificates, phi4 rectangle traps, and odd forced
+  perpendicularity cycles.
 
 The repo-native integration currently promotes only the first item as a
 review-pending executable artifact. The other two are kept here because their

--- a/tests/test_n9_late_archive_provenance.py
+++ b/tests/test_n9_late_archive_provenance.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "data" / "certificates" / "n9_late_archive_provenance.json"
+
+
+def test_n9_late_archive_provenance_is_review_pending() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert payload["type"] == "n9_late_archive_provenance_v1"
+    assert payload["trust"] == "REVIEW_PENDING_PROVENANCE"
+    assert any("No general proof" in note for note in payload["notes"])
+    assert any("No counterexample" in note for note in payload["notes"])
+
+
+def test_sequential_vertex_circle_counts_are_stable() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    summary = payload["summaries"]["sequential_vertex_circle_exclusion"]
+
+    assert summary["verified_by_local_run"] is True
+    assert summary["row0_case_count"] == 70
+    assert summary["all_row0_closed"] is True
+    assert summary["total_nodes_visited"] == 37614
+    assert summary["total_row_options_considered"] == 2628150
+    assert summary["total_full_patterns_reached"] == 0
+    assert summary["total_rejection_counts"] == {
+        "adjacent_two_overlap": 255354,
+        "crossing_bisector": 1163137,
+        "row_pair_intersection_cap": 1102641,
+        "vertex_circle_self_edge": 34445,
+        "vertex_circle_strict_cycle": 35029,
+    }
+
+
+def test_row0_quotient_bundle_is_static_provenance_only() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    summary = payload["summaries"]["row0_quotient_certificate_bundle"]
+
+    assert summary["embedded_verifier_executed_during_integration"] is False
+    assert summary["zip_member_count"] == 25
+    assert summary["row_certificate_files"] == 17
+    assert summary["canonical_row0_count"] == 38
+    assert summary["row_count_with_full_patterns"] == 17
+    assert summary["full_patterns"] == 102
+    assert summary["classification_counts"] == {
+        "accepted_frontier": 0,
+        "kalmanson_certificate": 70,
+        "mutual_midpoint_collapse": 0,
+        "odd_forced_perpendicular_cycle": 11,
+        "phi4_rectangle_trap": 21,
+    }


### PR DESCRIPTION
## Summary

- add a compact review-pending provenance artifact for the late external n=9 archive batch
- record stable hashes, reproduced sequential vertex-circle counts, and static zip-summary counts without importing raw reports or the binary zip as authority
- update the n=9 vertex-circle note and archive README to explain the disposition and review standard

## Validation

- `python -m pytest tests\test_n9_late_archive_provenance.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `git diff --check`
- `python scripts\enumerate_n8_incidence.py --summary`
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `python scripts\check_n9_vertex_circle_exhaustive.py --assert-expected`
- `python -m pytest -q`

## Notes

The zip bundle verifier was not executed during integration because it is unreviewed external code. Only static JSON summaries and hashes are recorded. This PR does not claim a general proof, a counterexample, or a source-of-truth promotion for n=9.