### PR TITLE
[codex] Mine n9 vertex-circle obstruction shapes

### DIFF
--- a/data/certificates/n9_vertex_circle_obstruction_shapes.json
+++ b/data/certificates/n9_vertex_circle_obstruction_shapes.json
@@ -1,0 +1,377 @@
+{
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "interpretation": [
+    "All strict-cycle obstructions found here have length 2 or 3.",
+    "All self-edge obstructions found here have distance-equality paths of length at most 8.",
+    "This suggests a general proof target: force a self-edge or directed cycle in the quotient graph whose vertices are selected-distance classes and whose directed edges come from vertex-circle interval containment.",
+    "The existing C19 caveat shows this quotient-graph obstruction alone is not yet a global solution route."
+  ],
+  "n": 9,
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "The official/global status remains falsifiable/open.",
+    "This diagnostic identifies obstruction shapes; it is not a separate n=9 proof path."
+  ],
+  "obstruction_status_counts": {
+    "self_edge": 158,
+    "strict_cycle": 26
+  },
+  "pre_vertex_circle_search": {
+    "full_assignments": 184,
+    "nodes_visited": 100817,
+    "row0_choices": 70
+  },
+  "representatives": {
+    "self_edge": {
+      "conflict": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      },
+      "distance_equality_path": [
+        {
+          "next_pair": [
+            0,
+            8
+          ],
+          "row": 8
+        },
+        {
+          "next_pair": [
+            0,
+            1
+          ],
+          "row": 0
+        },
+        {
+          "next_pair": [
+            1,
+            2
+          ],
+          "row": 1
+        }
+      ],
+      "selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ]
+    },
+    "strict_cycle": {
+      "cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            1,
+            3
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "inner_span": 2,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            0,
+            2
+          ],
+          "outer_span": 3,
+          "row": 1,
+          "witness_order": [
+            2,
+            3,
+            5,
+            0
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            5
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            0,
+            5
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            3
+          ],
+          "outer_span": 2,
+          "row": 1,
+          "witness_order": [
+            2,
+            3,
+            5,
+            0
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            1,
+            5
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            5
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            5,
+            7
+          ],
+          "outer_span": 3,
+          "row": 6,
+          "witness_order": [
+            7,
+            8,
+            1,
+            5
+          ]
+        }
+      ],
+      "selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ]
+    }
+  },
+  "row_size": 4,
+  "scope": "Diagnostic mining of the 184 complete n=9 selected-witness assignments that survive pair/crossing/count filters before vertex-circle obstruction.",
+  "self_edge_summary": {
+    "assignments": 158,
+    "equality_path_length_counts": {
+      "3": 92,
+      "4": 41,
+      "5": 14,
+      "6": 6,
+      "7": 4,
+      "8": 1
+    },
+    "first_conflict_row_counts": {
+      "0": 118,
+      "1": 14,
+      "2": 8,
+      "3": 6,
+      "4": 4,
+      "5": 2,
+      "6": 2,
+      "7": 2,
+      "8": 2
+    },
+    "max_equality_path_length": 8,
+    "shared_endpoint_counts": {
+      "0": 11,
+      "1": 147
+    }
+  },
+  "strict_cycle_summary": {
+    "assignments": 26,
+    "cycle_edge_row_participation_counts": {
+      "0": 14,
+      "1": 16,
+      "2": 13,
+      "3": 2,
+      "4": 4,
+      "5": 1,
+      "6": 2,
+      "7": 2,
+      "8": 2
+    },
+    "cycle_length_counts": {
+      "2": 22,
+      "3": 4
+    },
+    "span_signature_counts": {
+      "((2, 1), (2, 1))": 2,
+      "((2, 1), (2, 1), (3, 2))": 1,
+      "((2, 1), (3, 1))": 8,
+      "((2, 1), (3, 1), (3, 2))": 1,
+      "((2, 1), (3, 2))": 3,
+      "((3, 1), (3, 1))": 6,
+      "((3, 1), (3, 1), (3, 1))": 2,
+      "((3, 1), (3, 2))": 3
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "type": "n9_vertex_circle_obstruction_shapes_v1"
+}

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -54,6 +54,11 @@ filters from the vertex-circle filter: 184 complete selected-witness systems
 survive before vertex-circle reasoning, and every one is killed by an exact
 vertex-circle obstruction.
 
+The companion diagnostic `docs/n9-vertex-circle-obstruction-shapes.md` mines
+those 184 obstructions. It finds 158 self-edge contradictions and 26 strict
+directed cycles; every strict cycle has length 2 or 3. That diagnostic is meant
+to guide a possible general lemma, not to strengthen the repo claim by itself.
+
 ## Commands
 
 Run the stable checker and assert the expected counts:
@@ -113,3 +118,5 @@ artifact, an independent review should check:
 - that the sequential vertex-circle script and row0-quotient bundle in the
   late archive are independent enough to count as corroboration rather than
   just differently packaged output from the same search.
+- that the obstruction-shape diagnostic really reflects reusable templates
+  rather than artifacts of the first conflict selected by the miner.

--- a/docs/n9-vertex-circle-obstruction-shapes.md
+++ b/docs/n9-vertex-circle-obstruction-shapes.md
@@ -1,0 +1,84 @@
+# n=9 Vertex-circle Obstruction Shapes
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This note mines the complete `n=9` selected-witness assignments that survive
+the pair, crossing, indegree, and witness-pair count filters before the
+vertex-circle filter is applied. It does not claim a general proof of Erdos
+Problem #97 and does not claim a counterexample. The official/global status
+remains falsifiable/open.
+
+## Result
+
+The diagnostic enumerates the same 184 pre-vertex-circle assignments recorded
+by `docs/n9-vertex-circle-exhaustive.md` and classifies the first
+vertex-circle obstruction in each assignment.
+
+Checked counts:
+
+```text
+pre-vertex-circle full assignments: 184
+self-edge contradictions: 158
+strict directed cycles: 26
+strict cycle lengths: 22 of length 2, 4 of length 3
+self-edge equality path lengths: 92 length-3, 41 length-4, 14 length-5,
+  6 length-6, 4 length-7, 1 length-8
+```
+
+The checked-in diagnostic artifact is
+`data/certificates/n9_vertex_circle_obstruction_shapes.json`.
+
+## Why this matters
+
+The obstruction shapes are small enough to point at a plausible general proof
+target. Quotient all ordinary pair distances by the selected-distance
+equalities. Each selected row then contributes strict directed inequalities
+between quotient classes whenever one witness-witness chord properly contains
+another in the vertex-circle angular order.
+
+A realized bad configuration would need this strict graph to be irreflexive and
+acyclic. The `n=9` frontier instead always forces either:
+
+- a self-edge, meaning a strict chord-containment inequality inside one
+  selected-distance class; or
+- a directed strict cycle, which is impossible for real distances.
+
+This suggests the next lemma to hunt:
+
+```text
+For sufficiently constrained selected-witness incidence systems, the
+distance-class quotient graph forced by vertex-circle interval containment has
+a self-edge or directed cycle.
+```
+
+That lemma is not proved here. The existing `C19_skew` caveat in
+`docs/vertex-circle-order-filter.md` shows that the current vertex-circle
+quotient graph alone is not enough for a global solution. The likely proof path
+is to combine this quotient-graph obstruction with stronger order information,
+Altman/Kalmanson inequalities, or radius propagation.
+
+## Reproduction
+
+Generate and check the diagnostic artifact:
+
+```bash
+python scripts/analyze_n9_vertex_circle_obstruction_shapes.py \
+  --assert-expected \
+  --write
+```
+
+Run the targeted artifact test:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_obstruction_shapes.py -q
+```
+
+## Review questions
+
+- Are the mined self-edge equality paths exposing a common incidence motif, or
+  are they merely shortest paths in a dense selected-distance equality graph?
+- Can the length-2 and length-3 strict cycles be described by a small set of
+  cyclic-order templates?
+- Which extra condition rules out the known `C19_skew` vertex-circle survivor:
+  Altman diagonal sums, Kalmanson inequalities, radius propagation, or a
+  sharper vertex-circle inequality?

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -101,7 +101,32 @@ Acceptance standard: a written review should either promote the checker to the
 same repo-local finite-case status as `n <= 8`, or identify the exact
 mathematical or implementation gap.
 
-## Priority 6 - keep the frontier separate
+## Priority 6 - mine a reusable vertex-circle lemma
+
+Target: `docs/n9-vertex-circle-obstruction-shapes.md`.
+
+The n=9 obstruction-shape diagnostic shows that the 184 pre-vertex-circle
+frontier assignments are killed by 158 self-edges and 26 strict cycles, all
+strict cycles having length 2 or 3. This makes the most promising proof push a
+quotient-graph lemma: selected-distance equalities collapse ordinary pair
+distances into classes, vertex-circle interval containment orients strict
+edges between classes, and realizability requires the resulting strict graph to
+be irreflexive and acyclic.
+
+Next steps:
+
+- classify the self-edge equality paths into incidence motifs;
+- normalize the length-2 and length-3 strict cycles up to dihedral relabeling;
+- test whether the same motifs appear in the P18 obstruction and fail in the
+  known `C19_skew` vertex-circle survivor;
+- identify the extra exact ingredient needed for `C19_skew`, likely
+  Altman/Kalmanson or stronger radius propagation.
+
+Acceptance standard: a reusable lemma should state precise incidence/order
+hypotheses and produce a self-edge or strict cycle without enumerating all n=9
+selected-witness assignments.
+
+## Priority 7 - keep the frontier separate
 
 Keep `n >= 9`, abstract `C19_skew`, and broader SAT/SMT work separate from the
 small-case claim. The round-two Kalmanson certificate kills one fixed
@@ -109,7 +134,7 @@ small-case claim. The round-two Kalmanson certificate kills one fixed
 research-frontier workstreams, not prerequisites for the repo-local `n <= 8`
 artifact.
 
-## Priority 7 - extend the C13 Kalmanson pilot
+## Priority 8 - extend the C13 Kalmanson pilot
 
 The first C13 Kalmanson pilot now kills the registered non-natural
 `C13_sidon_1_2_4_10` order with an exact 34-inequality certificate. Before
@@ -118,7 +143,7 @@ pilot toward all cyclic orders: normalize by dihedral symmetry, prune partial
 orders cheaply, run LP dual checks on closed branches, and emit exact integer
 certificates for branches that close.
 
-## Priority 8 - strengthen only productive filters
+## Priority 9 - strengthen only productive filters
 
 The minimum-radius short-chord filter in `docs/minimum-radius-filter.md` is a
 valid exact necessary condition, but it is weak: it does not kill `C19_skew`.

--- a/scripts/analyze_n9_vertex_circle_obstruction_shapes.py
+++ b/scripts/analyze_n9_vertex_circle_obstruction_shapes.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Mine obstruction shapes in the n=9 vertex-circle frontier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_counts,
+    obstruction_shape_summary,
+)
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_obstruction_shapes.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
+    parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = obstruction_shape_summary()
+    if args.assert_expected:
+        assert_expected_counts(payload)
+    if args.write:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        search = payload["pre_vertex_circle_search"]
+        print("n=9 vertex-circle obstruction shape diagnostic")
+        print(f"nodes visited: {search['nodes_visited']}")
+        print(f"pre-vertex-circle full assignments: {search['full_assignments']}")
+        print(f"status counts: {payload['obstruction_status_counts']}")
+        print(
+            "strict-cycle lengths: "
+            f"{payload['strict_cycle_summary']['cycle_length_counts']}"
+        )
+        print(
+            "self-edge equality path lengths: "
+            f"{payload['self_edge_summary']['equality_path_length_counts']}"
+        )
+        if args.assert_expected:
+            print("OK: obstruction shape counts verified")
+        if args.write:
+            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_vertex_circle_obstruction_shapes.py
+++ b/src/erdos97/n9_vertex_circle_obstruction_shapes.py
@@ -1,0 +1,304 @@
+"""Mine vertex-circle obstruction shapes for n=9 survivor assignments.
+
+This module is diagnostic. It does not prove Erdos Problem #97 and does not
+promote the review-pending n=9 finite-case checker to source-of-truth status.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict, deque
+from itertools import combinations
+from typing import Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.vertex_circle_order_filter import (
+    Pair,
+    StrictInequality,
+    pair,
+    vertex_circle_order_obstruction,
+)
+
+EXPECTED_PRE_VERTEX_CIRCLE_NODES = 100_817
+EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS = 184
+EXPECTED_STATUS_COUNTS = {"self_edge": 158, "strict_cycle": 26}
+EXPECTED_STRICT_CYCLE_LENGTH_COUNTS = {2: 22, 3: 4}
+EXPECTED_SELF_EDGE_PATH_LENGTH_COUNTS = {3: 92, 4: 41, 5: 14, 6: 6, 7: 4, 8: 1}
+EXPECTED_SELF_EDGE_SHARED_ENDPOINT_COUNTS = {0: 11, 1: 147}
+
+
+Assignment = dict[int, int]
+
+
+def _json_pair(item: Pair) -> list[int]:
+    return [int(item[0]), int(item[1])]
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _rows_from_assignment(assign: Assignment) -> list[list[int]]:
+    return [list(n9.MASK_BITS[assign[center]]) for center in range(n9.N)]
+
+
+def pre_vertex_circle_assignments() -> tuple[list[Assignment], int]:
+    """Return full n=9 assignments before applying vertex-circle filtering."""
+    assignments: list[Assignment] = []
+    nodes = 0
+
+    def search(
+        assign: Assignment,
+        column_counts: list[int],
+        witness_pair_counts: list[int],
+    ) -> None:
+        nonlocal nodes
+        nodes += 1
+        if len(assign) == n9.N:
+            assignments.append(dict(sorted(assign.items())))
+            return
+
+        best_center = None
+        best_options = None
+        for center in range(n9.N):
+            if center in assign:
+                continue
+            opts = n9.valid_options_for_center(
+                center,
+                assign,
+                column_counts,
+                witness_pair_counts,
+            )
+            if best_options is None or len(opts) < len(best_options):
+                best_center = center
+                best_options = opts
+                if not opts:
+                    break
+        if not best_options:
+            return
+
+        center = best_center
+        assert center is not None
+        for row_mask in best_options:
+            assign[center] = row_mask
+            for target in n9.MASK_BITS[row_mask]:
+                column_counts[target] += 1
+            for pair_index in n9.ROW_PAIR_INDICES[row_mask]:
+                witness_pair_counts[pair_index] += 1
+
+            search(assign, column_counts, witness_pair_counts)
+
+            for pair_index in n9.ROW_PAIR_INDICES[row_mask]:
+                witness_pair_counts[pair_index] -= 1
+            for target in n9.MASK_BITS[row_mask]:
+                column_counts[target] -= 1
+            del assign[center]
+
+    for row0 in n9.OPTIONS[0]:
+        assign = {0: row0}
+        column_counts = [0] * n9.N
+        witness_pair_counts = [0] * len(n9.PAIRS)
+        for target in n9.MASK_BITS[row0]:
+            column_counts[target] += 1
+        for pair_index in n9.ROW_PAIR_INDICES[row0]:
+            witness_pair_counts[pair_index] += 1
+        if n9.vertex_circle_status(assign) == "ok":
+            search(assign, column_counts, witness_pair_counts)
+
+    return assignments, nodes
+
+
+def _distance_equality_graph(
+    rows: Sequence[Sequence[int]],
+) -> dict[Pair, list[tuple[Pair, int]]]:
+    graph: dict[Pair, list[tuple[Pair, int]]] = defaultdict(list)
+    for center, row in enumerate(rows):
+        selected_pairs = [pair(center, witness) for witness in row]
+        for first, second in combinations(selected_pairs, 2):
+            graph[first].append((second, center))
+            graph[second].append((first, center))
+    for item in graph:
+        graph[item].sort()
+    return graph
+
+
+def _distance_equality_path(
+    rows: Sequence[Sequence[int]],
+    start: Pair,
+    end: Pair,
+) -> list[dict[str, object]]:
+    graph = _distance_equality_graph(rows)
+    queue: deque[tuple[Pair, list[dict[str, object]]]] = deque([(start, [])])
+    seen = {start}
+    while queue:
+        current, path = queue.popleft()
+        if current == end:
+            return path
+        for next_pair, row in graph.get(current, []):
+            if next_pair in seen:
+                continue
+            seen.add(next_pair)
+            queue.append(
+                (
+                    next_pair,
+                    path
+                    + [
+                        {
+                            "row": int(row),
+                            "next_pair": _json_pair(next_pair),
+                        }
+                    ],
+                )
+            )
+    raise AssertionError(f"distance classes are disconnected: {start} -> {end}")
+
+
+def _json_inequality(edge: StrictInequality) -> dict[str, object]:
+    return {
+        "row": int(edge.row),
+        "witness_order": [int(label) for label in edge.witness_order],
+        "outer_interval": [int(idx) for idx in edge.outer_interval],
+        "inner_interval": [int(idx) for idx in edge.inner_interval],
+        "outer_pair": _json_pair(edge.outer_pair),
+        "inner_pair": _json_pair(edge.inner_pair),
+        "outer_class": _json_pair(edge.outer_class),
+        "inner_class": _json_pair(edge.inner_class),
+        "outer_span": int(edge.outer_interval[1] - edge.outer_interval[0]),
+        "inner_span": int(edge.inner_interval[1] - edge.inner_interval[0]),
+    }
+
+
+def obstruction_shape_summary() -> dict[str, object]:
+    """Return a stable diagnostic summary of n=9 vertex-circle obstructions."""
+    assignments, nodes = pre_vertex_circle_assignments()
+    status_counts: Counter[str] = Counter()
+    self_edge_rows: Counter[int] = Counter()
+    self_edge_path_lengths: Counter[int] = Counter()
+    self_edge_shared_endpoints: Counter[int] = Counter()
+    strict_cycle_lengths: Counter[int] = Counter()
+    strict_cycle_rows: Counter[int] = Counter()
+    strict_cycle_span_signatures: Counter[str] = Counter()
+    representatives: dict[str, object] = {}
+
+    for assign in assignments:
+        rows = _rows_from_assignment(assign)
+        result = vertex_circle_order_obstruction(rows, list(n9.ORDER), "n9")
+        if result.self_edge_conflicts:
+            status_counts["self_edge"] += 1
+            edge = result.self_edge_conflicts[0]
+            equality_path = _distance_equality_path(
+                rows,
+                edge.outer_pair,
+                edge.inner_pair,
+            )
+            self_edge_rows[edge.row] += 1
+            self_edge_path_lengths[len(equality_path)] += 1
+            shared = len(set(edge.outer_pair) & set(edge.inner_pair))
+            self_edge_shared_endpoints[shared] += 1
+            representatives.setdefault(
+                "self_edge",
+                {
+                    "selected_rows": rows,
+                    "conflict": _json_inequality(edge),
+                    "distance_equality_path": equality_path,
+                },
+            )
+            continue
+
+        if not result.cycle_edges:
+            raise AssertionError("pre-vertex-circle survivor was not obstructed")
+        status_counts["strict_cycle"] += 1
+        strict_cycle_lengths[len(result.cycle_edges)] += 1
+        span_signature = tuple(
+            sorted(
+                (
+                    edge.outer_interval[1] - edge.outer_interval[0],
+                    edge.inner_interval[1] - edge.inner_interval[0],
+                )
+                for edge in result.cycle_edges
+            )
+        )
+        strict_cycle_span_signatures[str(span_signature)] += 1
+        for edge in result.cycle_edges:
+            strict_cycle_rows[edge.row] += 1
+        representatives.setdefault(
+            "strict_cycle",
+            {
+                "selected_rows": rows,
+                "cycle_edges": [_json_inequality(edge) for edge in result.cycle_edges],
+            },
+        )
+
+    payload = {
+        "type": "n9_vertex_circle_obstruction_shapes_v1",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "scope": "Diagnostic mining of the 184 complete n=9 selected-witness assignments that survive pair/crossing/count filters before vertex-circle obstruction.",
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "The official/global status remains falsifiable/open.",
+            "This diagnostic identifies obstruction shapes; it is not a separate n=9 proof path.",
+        ],
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "pre_vertex_circle_search": {
+            "row0_choices": len(n9.OPTIONS[0]),
+            "nodes_visited": int(nodes),
+            "full_assignments": len(assignments),
+        },
+        "obstruction_status_counts": dict(sorted(status_counts.items())),
+        "self_edge_summary": {
+            "assignments": int(status_counts["self_edge"]),
+            "first_conflict_row_counts": _json_counter(self_edge_rows),
+            "equality_path_length_counts": _json_counter(self_edge_path_lengths),
+            "shared_endpoint_counts": _json_counter(self_edge_shared_endpoints),
+            "max_equality_path_length": max(self_edge_path_lengths),
+        },
+        "strict_cycle_summary": {
+            "assignments": int(status_counts["strict_cycle"]),
+            "cycle_length_counts": _json_counter(strict_cycle_lengths),
+            "cycle_edge_row_participation_counts": _json_counter(strict_cycle_rows),
+            "span_signature_counts": {
+                key: int(strict_cycle_span_signatures[key])
+                for key in sorted(strict_cycle_span_signatures)
+            },
+        },
+        "representatives": representatives,
+        "interpretation": [
+            "All strict-cycle obstructions found here have length 2 or 3.",
+            "All self-edge obstructions found here have distance-equality paths of length at most 8.",
+            "This suggests a general proof target: force a self-edge or directed cycle in the quotient graph whose vertices are selected-distance classes and whose directed edges come from vertex-circle interval containment.",
+            "The existing C19 caveat shows this quotient-graph obstruction alone is not yet a global solution route.",
+        ],
+    }
+    assert_expected_counts(payload)
+    return payload
+
+
+def assert_expected_counts(payload: dict[str, object]) -> None:
+    """Assert that the diagnostic still matches the checked n=9 frontier."""
+    search = payload["pre_vertex_circle_search"]
+    if not isinstance(search, dict):
+        raise AssertionError("missing pre-vertex-circle search block")
+    if search["nodes_visited"] != EXPECTED_PRE_VERTEX_CIRCLE_NODES:
+        raise AssertionError(f"unexpected nodes: {search['nodes_visited']}")
+    if search["full_assignments"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError(f"unexpected full assignments: {search['full_assignments']}")
+    if payload["obstruction_status_counts"] != EXPECTED_STATUS_COUNTS:
+        raise AssertionError(f"unexpected status counts: {payload['obstruction_status_counts']}")
+    self_edge = payload["self_edge_summary"]
+    strict_cycle = payload["strict_cycle_summary"]
+    if not isinstance(self_edge, dict) or not isinstance(strict_cycle, dict):
+        raise AssertionError("missing obstruction summary block")
+    if self_edge["equality_path_length_counts"] != _json_counter(
+        Counter(EXPECTED_SELF_EDGE_PATH_LENGTH_COUNTS)
+    ):
+        raise AssertionError("unexpected self-edge path length counts")
+    if self_edge["shared_endpoint_counts"] != _json_counter(
+        Counter(EXPECTED_SELF_EDGE_SHARED_ENDPOINT_COUNTS)
+    ):
+        raise AssertionError("unexpected self-edge shared endpoint counts")
+    if strict_cycle["cycle_length_counts"] != _json_counter(
+        Counter(EXPECTED_STRICT_CYCLE_LENGTH_COUNTS)
+    ):
+        raise AssertionError("unexpected strict-cycle length counts")

--- a/tests/test_n9_vertex_circle_obstruction_shapes.py
+++ b/tests/test_n9_vertex_circle_obstruction_shapes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    assert_expected_counts,
+    obstruction_shape_summary,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_obstruction_shapes.json"
+
+
+def test_n9_vertex_circle_obstruction_shape_artifact_counts() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert_expected_counts(payload)
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert payload["obstruction_status_counts"] == {
+        "self_edge": 158,
+        "strict_cycle": 26,
+    }
+    assert payload["strict_cycle_summary"]["cycle_length_counts"] == {
+        "2": 22,
+        "3": 4,
+    }
+    assert payload["self_edge_summary"]["max_equality_path_length"] == 8
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_n9_vertex_circle_obstruction_shape_artifact_is_current() -> None:
+    checked_in = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert obstruction_shape_summary() == checked_in


### PR DESCRIPTION
## Summary

- add a diagnostic miner for the 184 n=9 assignments that survive before vertex-circle filtering
- record a compact obstruction-shape artifact showing 158 self-edge contradictions and 26 strict cycles, with strict cycles only of length 2 or 3
- document the quotient-graph lemma target as the next promising proof direction while preserving review-pending/non-overclaiming status

## Why

This moves the most promising path from aggregate n=9 counts toward reusable structure: selected-distance equalities form quotient classes, vertex-circle interval containments orient strict inequalities, and realizability requires the strict graph to be irreflexive and acyclic. The new diagnostic gives concrete obstruction motifs to normalize next.

## Validation

- `python scripts\analyze_n9_vertex_circle_obstruction_shapes.py --assert-expected`
- `python -m pytest tests\test_n9_vertex_circle_obstruction_shapes.py -q`
- `python -m pytest tests\test_n9_vertex_circle_obstruction_shapes.py -q -m "artifact and exhaustive"`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `git diff --check`
- `python scripts\enumerate_n8_incidence.py --summary`
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `python scripts\check_n9_vertex_circle_exhaustive.py --assert-expected`
- `python -m pytest -q`

## Notes

This is diagnostic and review-pending. It does not claim a general proof, a counterexample, or a source-of-truth promotion for n=9.