### PR TITLE
[codex] Canonicalize n9 vertex-circle motif families

### DIFF
--- a/data/certificates/n9_vertex_circle_motif_families.json
+++ b/data/certificates/n9_vertex_circle_motif_families.json
@@ -1,0 +1,2459 @@
+{
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "dihedral_incidence_families": {
+    "families": [
+      {
+        "family_id": "F01",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                0,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                0,
+                1
+              ],
+              "row": 0
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            0,
+            2,
+            4,
+            7
+          ],
+          [
+            1,
+            3,
+            5,
+            7
+          ],
+          [
+            1,
+            4,
+            6,
+            8
+          ],
+          [
+            0,
+            2,
+            5,
+            6
+          ],
+          [
+            3,
+            4,
+            6,
+            7
+          ],
+          [
+            2,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            5
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F02",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                1,
+                7
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                6,
+                7
+              ],
+              "row": 7
+            },
+            {
+              "next_pair": [
+                5,
+                6
+              ],
+              "row": 6
+            },
+            {
+              "next_pair": [
+                2,
+                5
+              ],
+              "row": 5
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            1,
+            3,
+            5,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            8
+          ],
+          [
+            2,
+            4,
+            6,
+            7
+          ],
+          [
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            0,
+            2,
+            5,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F03",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                0,
+                1
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                0,
+                8
+              ],
+              "row": 0
+            },
+            {
+              "next_pair": [
+                4,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                3,
+                4
+              ],
+              "row": 4
+            },
+            {
+              "next_pair": [
+                2,
+                3
+              ],
+              "row": 3
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            0,
+            3,
+            5,
+            7
+          ],
+          [
+            1,
+            3,
+            4,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            8
+          ],
+          [
+            2,
+            4,
+            6,
+            7
+          ],
+          [
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            2,
+            5,
+            6
+          ],
+          [
+            0,
+            1,
+            4,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F04",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                0,
+                1
+              ],
+              "row": 0
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                2,
+                3
+              ],
+              "row": 2
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            6
+          ],
+          [
+            0,
+            2,
+            3,
+            5
+          ],
+          [
+            1,
+            3,
+            4,
+            8
+          ],
+          [
+            0,
+            2,
+            4,
+            7
+          ],
+          [
+            2,
+            5,
+            6,
+            8
+          ],
+          [
+            1,
+            3,
+            6,
+            7
+          ],
+          [
+            4,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            1,
+            5,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F05",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              7,
+              1,
+              3,
+              5
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                2,
+                3
+              ],
+              "row": 3
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            },
+            {
+              "next_pair": [
+                1,
+                7
+              ],
+              "row": 1
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            6
+          ],
+          [
+            2,
+            5,
+            7,
+            8
+          ],
+          [
+            1,
+            3,
+            4,
+            8
+          ],
+          [
+            0,
+            2,
+            4,
+            7
+          ],
+          [
+            0,
+            1,
+            5,
+            6
+          ],
+          [
+            2,
+            3,
+            6,
+            8
+          ],
+          [
+            1,
+            3,
+            5,
+            7
+          ],
+          [
+            0,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F06",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              7
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                4,
+                5
+              ],
+              "row": 4
+            },
+            {
+              "next_pair": [
+                5,
+                6
+              ],
+              "row": 5
+            },
+            {
+              "next_pair": [
+                2,
+                6
+              ],
+              "row": 6
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            7
+          ],
+          [
+            0,
+            2,
+            3,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            8
+          ],
+          [
+            1,
+            3,
+            5,
+            7
+          ],
+          [
+            3,
+            4,
+            6,
+            8
+          ],
+          [
+            0,
+            2,
+            5,
+            7
+          ],
+          [
+            1,
+            5,
+            6,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F07",
+        "orbit_size": 6,
+        "representative_obstruction": {
+          "cycle_edges": [
+            {
+              "inner_class": [
+                0,
+                3
+              ],
+              "inner_interval": [
+                1,
+                3
+              ],
+              "inner_pair": [
+                0,
+                3
+              ],
+              "inner_span": 2,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                0,
+                2
+              ],
+              "outer_span": 3,
+              "row": 1,
+              "witness_order": [
+                2,
+                3,
+                5,
+                0
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                5
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                5
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                3
+              ],
+              "outer_interval": [
+                1,
+                3
+              ],
+              "outer_pair": [
+                0,
+                3
+              ],
+              "outer_span": 2,
+              "row": 1,
+              "witness_order": [
+                2,
+                3,
+                5,
+                0
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                1,
+                5
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                5
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                5,
+                7
+              ],
+              "outer_span": 3,
+              "row": 6,
+              "witness_order": [
+                7,
+                8,
+                1,
+                5
+              ]
+            }
+          ],
+          "status": "strict_cycle"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            0,
+            2,
+            3,
+            5
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            7
+          ],
+          [
+            3,
+            5,
+            6,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            2,
+            6,
+            8
+          ],
+          [
+            1,
+            3,
+            6,
+            7
+          ]
+        ],
+        "status": "strict_cycle",
+        "status_counts": {
+          "strict_cycle": 6
+        }
+      },
+      {
+        "family_id": "F08",
+        "orbit_size": 2,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                0,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                0,
+                1
+              ],
+              "row": 0
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            0,
+            2,
+            3,
+            5
+          ],
+          [
+            1,
+            3,
+            4,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            7
+          ],
+          [
+            3,
+            5,
+            6,
+            8
+          ],
+          [
+            0,
+            4,
+            6,
+            7
+          ],
+          [
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            2,
+            6,
+            8
+          ],
+          [
+            0,
+            1,
+            3,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 2
+        }
+      },
+      {
+        "family_id": "F09",
+        "orbit_size": 6,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                0,
+                1
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                0,
+                2
+              ],
+              "row": 0
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            7
+          ],
+          [
+            2,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            2,
+            5,
+            6
+          ],
+          [
+            1,
+            3,
+            6,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 6
+        }
+      },
+      {
+        "family_id": "F10",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                7,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                2,
+                7
+              ],
+              "row": 7
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            1,
+            3,
+            4,
+            7
+          ],
+          [
+            0,
+            2,
+            4,
+            6
+          ],
+          [
+            2,
+            3,
+            5,
+            7
+          ],
+          [
+            1,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            4,
+            5,
+            7
+          ],
+          [
+            2,
+            5,
+            6,
+            8
+          ],
+          [
+            0,
+            1,
+            6,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F11",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              3,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              8
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                6,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                6,
+                7
+              ],
+              "row": 6
+            },
+            {
+              "next_pair": [
+                5,
+                7
+              ],
+              "row": 7
+            },
+            {
+              "next_pair": [
+                3,
+                5
+              ],
+              "row": 5
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            1,
+            4,
+            5,
+            7
+          ],
+          [
+            0,
+            2,
+            4,
+            6
+          ],
+          [
+            1,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            2,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            1,
+            5,
+            6
+          ],
+          [
+            2,
+            3,
+            6,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 18
+        }
+      },
+      {
+        "family_id": "F12",
+        "orbit_size": 18,
+        "representative_obstruction": {
+          "cycle_edges": [
+            {
+              "inner_class": [
+                0,
+                3
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                0,
+                3
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                2
+              ],
+              "outer_pair": [
+                0,
+                6
+              ],
+              "outer_span": 2,
+              "row": 8,
+              "witness_order": [
+                0,
+                3,
+                6,
+                7
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                1
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                3
+              ],
+              "outer_interval": [
+                1,
+                3
+              ],
+              "outer_pair": [
+                1,
+                6
+              ],
+              "outer_span": 2,
+              "row": 3,
+              "witness_order": [
+                4,
+                6,
+                0,
+                1
+              ]
+            }
+          ],
+          "status": "strict_cycle"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            5,
+            6
+          ],
+          [
+            2,
+            4,
+            7,
+            8
+          ],
+          [
+            1,
+            3,
+            5,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            0,
+            2,
+            5,
+            7
+          ],
+          [
+            2,
+            3,
+            6,
+            8
+          ],
+          [
+            1,
+            3,
+            4,
+            7
+          ],
+          [
+            0,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            7
+          ]
+        ],
+        "status": "strict_cycle",
+        "status_counts": {
+          "strict_cycle": 18
+        }
+      },
+      {
+        "family_id": "F13",
+        "orbit_size": 2,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              5
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              5,
+              7
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                3,
+                5
+              ],
+              "row": 5
+            },
+            {
+              "next_pair": [
+                1,
+                3
+              ],
+              "row": 3
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            5,
+            7
+          ],
+          [
+            2,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            1,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            2,
+            5,
+            6
+          ],
+          [
+            1,
+            3,
+            6,
+            7
+          ],
+          [
+            2,
+            4,
+            7,
+            8
+          ],
+          [
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 2
+        }
+      },
+      {
+        "family_id": "F14",
+        "orbit_size": 2,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              6,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                0,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                0,
+                1
+              ],
+              "row": 0
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            2,
+            6,
+            8
+          ],
+          [
+            0,
+            2,
+            3,
+            7
+          ],
+          [
+            1,
+            3,
+            4,
+            8
+          ],
+          [
+            0,
+            2,
+            4,
+            5
+          ],
+          [
+            1,
+            3,
+            5,
+            6
+          ],
+          [
+            2,
+            4,
+            6,
+            7
+          ],
+          [
+            3,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            4,
+            6,
+            8
+          ],
+          [
+            0,
+            1,
+            5,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 2
+        }
+      },
+      {
+        "family_id": "F15",
+        "orbit_size": 2,
+        "representative_obstruction": {
+          "conflict": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              4,
+              8
+            ]
+          },
+          "distance_equality_path": [
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                2,
+                3
+              ],
+              "row": 2
+            },
+            {
+              "next_pair": [
+                3,
+                4
+              ],
+              "row": 3
+            }
+          ],
+          "status": "self_edge"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            3,
+            4,
+            8
+          ],
+          [
+            0,
+            2,
+            4,
+            5
+          ],
+          [
+            1,
+            3,
+            5,
+            6
+          ],
+          [
+            2,
+            4,
+            6,
+            7
+          ],
+          [
+            3,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            4,
+            6,
+            8
+          ],
+          [
+            0,
+            1,
+            5,
+            7
+          ],
+          [
+            1,
+            2,
+            6,
+            8
+          ],
+          [
+            0,
+            2,
+            3,
+            7
+          ]
+        ],
+        "status": "self_edge",
+        "status_counts": {
+          "self_edge": 2
+        }
+      },
+      {
+        "family_id": "F16",
+        "orbit_size": 2,
+        "representative_obstruction": {
+          "cycle_edges": [
+            {
+              "inner_class": [
+                0,
+                2
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                8
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                0,
+                3
+              ],
+              "outer_span": 3,
+              "row": 2,
+              "witness_order": [
+                3,
+                5,
+                8,
+                0
+              ]
+            },
+            {
+              "inner_class": [
+                1,
+                2
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                2,
+                4
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                2,
+                8
+              ],
+              "outer_span": 3,
+              "row": 1,
+              "witness_order": [
+                2,
+                4,
+                7,
+                8
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                1,
+                3
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                1,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                1,
+                7
+              ],
+              "outer_span": 3,
+              "row": 0,
+              "witness_order": [
+                1,
+                3,
+                6,
+                7
+              ]
+            }
+          ],
+          "status": "strict_cycle"
+        },
+        "representative_selected_rows": [
+          [
+            1,
+            3,
+            6,
+            7
+          ],
+          [
+            2,
+            4,
+            7,
+            8
+          ],
+          [
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            1,
+            2,
+            5,
+            7
+          ],
+          [
+            2,
+            3,
+            6,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            1,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            2,
+            5,
+            6
+          ]
+        ],
+        "status": "strict_cycle",
+        "status_counts": {
+          "strict_cycle": 2
+        }
+      }
+    ],
+    "family_count": 16,
+    "orbit_size_counts": {
+      "18": 9,
+      "2": 5,
+      "6": 2
+    },
+    "status_family_counts": {
+      "self_edge": 13,
+      "strict_cycle": 3
+    }
+  },
+  "interpretation": [
+    "The 184 labelled pre-vertex-circle assignments collapse to 16 full selected-witness row-system orbits under dihedral cyclic symmetry.",
+    "Those 16 orbits split into 13 self-edge families and 3 strict-cycle families.",
+    "Literal first-conflict paths are still too detailed to be theorem templates; the useful next compression is to classify the representative family obstructions by incidence motifs.",
+    "This narrows the next proof-search task, but it does not prove a general vertex-circle lemma."
+  ],
+  "loose_obstruction_shapes": {
+    "self_edge_shape_buckets": [
+      {
+        "count": 41,
+        "equality_path_length": 3,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 37,
+        "equality_path_length": 3,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 22,
+        "equality_path_length": 4,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 16,
+        "equality_path_length": 4,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 7,
+        "equality_path_length": 3,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 0
+      },
+      {
+        "count": 7,
+        "equality_path_length": 3,
+        "inner_span": 2,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 7,
+        "equality_path_length": 5,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 6,
+        "equality_path_length": 5,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 3,
+        "equality_path_length": 4,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 0
+      },
+      {
+        "count": 3,
+        "equality_path_length": 6,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 3,
+        "equality_path_length": 7,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 2,
+        "equality_path_length": 6,
+        "inner_span": 2,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 1,
+        "equality_path_length": 5,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 0
+      },
+      {
+        "count": 1,
+        "equality_path_length": 6,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 1,
+        "equality_path_length": 7,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoints": 1
+      },
+      {
+        "count": 1,
+        "equality_path_length": 8,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoints": 1
+      }
+    ],
+    "self_edge_shape_family_count": 16,
+    "strict_cycle_span_buckets": [
+      {
+        "count": 8,
+        "cycle_length": 2,
+        "span_signature": [
+          [
+            2,
+            1
+          ],
+          [
+            3,
+            1
+          ]
+        ]
+      },
+      {
+        "count": 6,
+        "cycle_length": 2,
+        "span_signature": [
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            1
+          ]
+        ]
+      },
+      {
+        "count": 3,
+        "cycle_length": 2,
+        "span_signature": [
+          [
+            2,
+            1
+          ],
+          [
+            3,
+            2
+          ]
+        ]
+      },
+      {
+        "count": 3,
+        "cycle_length": 2,
+        "span_signature": [
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            2
+          ]
+        ]
+      },
+      {
+        "count": 2,
+        "cycle_length": 2,
+        "span_signature": [
+          [
+            2,
+            1
+          ],
+          [
+            2,
+            1
+          ]
+        ]
+      },
+      {
+        "count": 2,
+        "cycle_length": 3,
+        "span_signature": [
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            1
+          ]
+        ]
+      },
+      {
+        "count": 1,
+        "cycle_length": 3,
+        "span_signature": [
+          [
+            2,
+            1
+          ],
+          [
+            2,
+            1
+          ],
+          [
+            3,
+            2
+          ]
+        ]
+      },
+      {
+        "count": 1,
+        "cycle_length": 3,
+        "span_signature": [
+          [
+            2,
+            1
+          ],
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            2
+          ]
+        ]
+      }
+    ],
+    "strict_cycle_span_family_count": 8
+  },
+  "n": 9,
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "The official/global status remains falsifiable/open.",
+    "Dihedral incidence families are selected-witness row-system orbits under rotations and reflections of the cyclic labels.",
+    "Loose obstruction shapes intentionally discard labels; they are proof-search hints, not complete certificates."
+  ],
+  "obstruction_status_counts": {
+    "self_edge": 158,
+    "strict_cycle": 26
+  },
+  "pre_vertex_circle_search": {
+    "full_assignments": 184,
+    "nodes_visited": 100817,
+    "row0_choices": 70
+  },
+  "row_size": 4,
+  "scope": "Canonicalized diagnostic families for the 184 complete n=9 selected-witness assignments before vertex-circle obstruction.",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "type": "n9_vertex_circle_motif_families_v1"
+}

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -1,0 +1,82 @@
+# n=9 Vertex-circle Motif Families
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This note canonicalizes the 184 labelled `n=9` selected-witness assignments
+that survive the non-vertex-circle filters. It does not claim a general proof
+of Erdos Problem #97 and does not claim a counterexample. The official/global
+status remains falsifiable/open.
+
+## Dihedral Incidence Families
+
+Under rotations and reflections of the cyclic labels, the 184 labelled
+pre-vertex-circle assignments collapse to 16 full selected-witness incidence
+families.
+
+Checked counts:
+
+```text
+labelled assignments: 184
+dihedral incidence families: 16
+orbit sizes: 9 families of size 18, 2 families of size 6, 5 families of size 2
+self-edge families: 13
+strict-cycle families: 3
+```
+
+This is the main new information. Literal first-conflict certificates remain
+too detailed to read as a theorem template, but the complete frontier is small
+after cyclic symmetry.
+
+The checked-in artifact is
+`data/certificates/n9_vertex_circle_motif_families.json`.
+
+## Loose Obstruction Shapes
+
+As a deliberately coarse diagnostic, the artifact also buckets the first
+obstruction by label-free shape data:
+
+- self-edge buckets record the number of shared endpoints in the strict
+  inequality, the shortest selected-distance equality path length, and the
+  outer/inner witness-interval spans;
+- strict-cycle buckets record the cycle length and the multiset of
+  outer/inner witness-interval spans around the cycle.
+
+Those coarse buckets give 16 self-edge shape families and 8 strict-cycle span
+families. These are proof-search hints only. They discard too much incidence
+data to be certificates.
+
+## Proof Implication
+
+The next useful mathematical question is now sharper:
+
+```text
+Can each of the 16 dihedral incidence families be replaced by a reusable
+local lemma, preferably one that also explains why the same obstruction
+must appear beyond n=9?
+```
+
+A promising route is to classify the 13 self-edge families by the equality
+path that brings an outer and inner vertex-circle chord into the same selected
+distance class, and classify the 3 strict-cycle families by the directed
+quotient-cycle template.
+
+The current result still does not solve the global problem. The known
+`C19_skew` order that survives the vertex-circle filter remains the guardrail:
+any general lemma must either add hypotheses that exclude that survivor or
+combine vertex-circle structure with an extra exact ingredient.
+
+## Reproduction
+
+Generate and check the motif-family artifact:
+
+```bash
+python scripts/analyze_n9_vertex_circle_motif_families.py \
+  --assert-expected \
+  --write
+```
+
+Run the targeted artifact test:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_motif_families.py -q
+```

--- a/docs/n9-vertex-circle-obstruction-shapes.md
+++ b/docs/n9-vertex-circle-obstruction-shapes.md
@@ -28,6 +28,11 @@ self-edge equality path lengths: 92 length-3, 41 length-4, 14 length-5,
 The checked-in diagnostic artifact is
 `data/certificates/n9_vertex_circle_obstruction_shapes.json`.
 
+The companion family diagnostic
+`docs/n9-vertex-circle-motif-families.md` canonicalizes the same 184 labelled
+assignments under dihedral cyclic symmetry. It finds 16 full selected-witness
+incidence families: 13 self-edge families and 3 strict-cycle families.
+
 ## Why this matters
 
 The obstruction shapes are small enough to point at a plausible general proof
@@ -79,6 +84,8 @@ python -m pytest tests/test_n9_vertex_circle_obstruction_shapes.py -q
   are they merely shortest paths in a dense selected-distance equality graph?
 - Can the length-2 and length-3 strict cycles be described by a small set of
   cyclic-order templates?
+- Can the 16 dihedral incidence families be replaced by local lemmas that do
+  not enumerate all n=9 row systems?
 - Which extra condition rules out the known `C19_skew` vertex-circle survivor:
   Altman diagonal sums, Kalmanson inequalities, radius propagation, or a
   sharper vertex-circle inequality?

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -103,7 +103,8 @@ mathematical or implementation gap.
 
 ## Priority 6 - mine a reusable vertex-circle lemma
 
-Target: `docs/n9-vertex-circle-obstruction-shapes.md`.
+Target: `docs/n9-vertex-circle-obstruction-shapes.md` and
+`docs/n9-vertex-circle-motif-families.md`.
 
 The n=9 obstruction-shape diagnostic shows that the 184 pre-vertex-circle
 frontier assignments are killed by 158 self-edges and 26 strict cycles, all
@@ -115,8 +116,9 @@ be irreflexive and acyclic.
 
 Next steps:
 
-- classify the self-edge equality paths into incidence motifs;
-- normalize the length-2 and length-3 strict cycles up to dihedral relabeling;
+- classify the 13 self-edge dihedral incidence families into local lemmas;
+- classify the 3 strict-cycle dihedral incidence families into directed
+  quotient-cycle templates;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - identify the extra exact ingredient needed for `C19_skew`, likely

--- a/scripts/analyze_n9_vertex_circle_motif_families.py
+++ b/scripts/analyze_n9_vertex_circle_motif_families.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Canonicalize motif families in the n=9 vertex-circle frontier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_motif_family_counts,
+    motif_family_summary,
+)
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_motif_families.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
+    parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = motif_family_summary()
+    if args.assert_expected:
+        assert_expected_motif_family_counts(payload)
+    if args.write:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        search = payload["pre_vertex_circle_search"]
+        families = payload["dihedral_incidence_families"]
+        shapes = payload["loose_obstruction_shapes"]
+        print("n=9 vertex-circle motif-family diagnostic")
+        print(f"pre-vertex-circle full assignments: {search['full_assignments']}")
+        print(f"dihedral incidence families: {families['family_count']}")
+        print(f"orbit size counts: {families['orbit_size_counts']}")
+        print(f"family status counts: {families['status_family_counts']}")
+        print(
+            "loose self-edge shape families: "
+            f"{shapes['self_edge_shape_family_count']}"
+        )
+        print(
+            "strict-cycle span shape families: "
+            f"{shapes['strict_cycle_span_family_count']}"
+        )
+        if args.assert_expected:
+            print("OK: motif-family counts verified")
+        if args.write:
+            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_vertex_circle_obstruction_shapes.py
+++ b/src/erdos97/n9_vertex_circle_obstruction_shapes.py
@@ -24,9 +24,16 @@ EXPECTED_STATUS_COUNTS = {"self_edge": 158, "strict_cycle": 26}
 EXPECTED_STRICT_CYCLE_LENGTH_COUNTS = {2: 22, 3: 4}
 EXPECTED_SELF_EDGE_PATH_LENGTH_COUNTS = {3: 92, 4: 41, 5: 14, 6: 6, 7: 4, 8: 1}
 EXPECTED_SELF_EDGE_SHARED_ENDPOINT_COUNTS = {0: 11, 1: 147}
+EXPECTED_DIHEDRAL_INCIDENCE_FAMILIES = 16
+EXPECTED_DIHEDRAL_INCIDENCE_ORBIT_SIZE_COUNTS = {2: 5, 6: 2, 18: 9}
+EXPECTED_DIHEDRAL_STATUS_FAMILY_COUNTS = {"self_edge": 13, "strict_cycle": 3}
+EXPECTED_SELF_EDGE_LOOSE_SHAPE_FAMILIES = 16
+EXPECTED_STRICT_CYCLE_SPAN_SHAPE_FAMILIES = 8
 
 
 Assignment = dict[int, int]
+Rows = list[list[int]]
+CanonicalRows = tuple[tuple[int, ...], ...]
 
 
 def _json_pair(item: Pair) -> list[int]:
@@ -39,6 +46,35 @@ def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
 
 def _rows_from_assignment(assign: Assignment) -> list[list[int]]:
     return [list(n9.MASK_BITS[assign[center]]) for center in range(n9.N)]
+
+
+def _dihedral_maps() -> list[tuple[int, ...]]:
+    return [
+        tuple((direction * label + shift) % n9.N for label in range(n9.N))
+        for direction in (1, -1)
+        for shift in range(n9.N)
+    ]
+
+
+def _transform_rows(rows: Sequence[Sequence[int]], label_map: Sequence[int]) -> Rows:
+    transformed: list[list[int] | None] = [None] * n9.N
+    for center, row in enumerate(rows):
+        transformed[label_map[center]] = sorted(label_map[witness] for witness in row)
+    if any(row is None for row in transformed):  # pragma: no cover - defensive
+        raise AssertionError("dihedral map did not produce a complete row system")
+    return [list(row) for row in transformed if row is not None]
+
+
+def canonical_dihedral_rows(rows: Sequence[Sequence[int]]) -> CanonicalRows:
+    """Return the canonical dihedral representative of a row system."""
+    return min(
+        tuple(tuple(row) for row in _transform_rows(rows, label_map))
+        for label_map in _dihedral_maps()
+    )
+
+
+def _rows_to_json(rows: Sequence[Sequence[int]]) -> Rows:
+    return [[int(value) for value in row] for row in rows]
 
 
 def pre_vertex_circle_assignments() -> tuple[list[Assignment], int]:
@@ -167,6 +203,121 @@ def _json_inequality(edge: StrictInequality) -> dict[str, object]:
     }
 
 
+def _self_edge_representative(
+    rows: Sequence[Sequence[int]],
+    edge: StrictInequality,
+) -> dict[str, object]:
+    return {
+        "status": "self_edge",
+        "conflict": _json_inequality(edge),
+        "distance_equality_path": _distance_equality_path(
+            rows,
+            edge.outer_pair,
+            edge.inner_pair,
+        ),
+    }
+
+
+def _obstruction_representative(rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    result = vertex_circle_order_obstruction(rows, list(n9.ORDER), "n9")
+    if result.self_edge_conflicts:
+        return _self_edge_representative(rows, result.self_edge_conflicts[0])
+    if result.cycle_edges:
+        return {
+            "status": "strict_cycle",
+            "cycle_edges": [_json_inequality(edge) for edge in result.cycle_edges],
+        }
+    raise AssertionError("pre-vertex-circle survivor was not obstructed")
+
+
+def _status_for_rows(rows: Sequence[Sequence[int]]) -> str:
+    result = vertex_circle_order_obstruction(rows, list(n9.ORDER), "n9")
+    if result.self_edge_conflicts:
+        return "self_edge"
+    if result.cycle_edges:
+        return "strict_cycle"
+    raise AssertionError("pre-vertex-circle survivor was not obstructed")
+
+
+def _loose_self_edge_key(
+    edge: StrictInequality,
+    equality_path_length: int,
+) -> tuple[int, int, int, int]:
+    return (
+        len(set(edge.outer_pair) & set(edge.inner_pair)),
+        equality_path_length,
+        edge.outer_interval[1] - edge.outer_interval[0],
+        edge.inner_interval[1] - edge.inner_interval[0],
+    )
+
+
+def _cycle_span_key(edges: Sequence[StrictInequality]) -> tuple[int, tuple[tuple[int, int], ...]]:
+    return (
+        len(edges),
+        tuple(
+            sorted(
+                (
+                    edge.outer_interval[1] - edge.outer_interval[0],
+                    edge.inner_interval[1] - edge.inner_interval[0],
+                )
+                for edge in edges
+            )
+        ),
+    )
+
+
+def _json_loose_self_edge_shapes(
+    counter: Counter[tuple[int, int, int, int]],
+) -> list[dict[str, int]]:
+    rows = []
+    for key, count in counter.items():
+        shared, path_length, outer_span, inner_span = key
+        rows.append(
+            {
+                "count": int(count),
+                "shared_endpoints": int(shared),
+                "equality_path_length": int(path_length),
+                "outer_span": int(outer_span),
+                "inner_span": int(inner_span),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -row["count"],
+            row["shared_endpoints"],
+            row["equality_path_length"],
+            row["outer_span"],
+            row["inner_span"],
+        ),
+    )
+
+
+def _json_cycle_span_shapes(
+    counter: Counter[tuple[int, tuple[tuple[int, int], ...]]],
+) -> list[dict[str, object]]:
+    rows = []
+    for (cycle_length, span_signature), count in counter.items():
+        rows.append(
+            {
+                "count": int(count),
+                "cycle_length": int(cycle_length),
+                "span_signature": [
+                    [int(outer_span), int(inner_span)]
+                    for outer_span, inner_span in span_signature
+                ],
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (
+            -int(row["count"]),
+            int(row["cycle_length"]),
+            row["span_signature"],
+        ),
+    )
+
+
 def obstruction_shape_summary() -> dict[str, object]:
     """Return a stable diagnostic summary of n=9 vertex-circle obstructions."""
     assignments, nodes = pre_vertex_circle_assignments()
@@ -275,6 +426,102 @@ def obstruction_shape_summary() -> dict[str, object]:
     return payload
 
 
+def motif_family_summary() -> dict[str, object]:
+    """Return dihedral and loose-shape families for n=9 obstructions."""
+    assignments, nodes = pre_vertex_circle_assignments()
+    families: dict[CanonicalRows, list[Rows]] = defaultdict(list)
+    status_counts: Counter[str] = Counter()
+    loose_self_shapes: Counter[tuple[int, int, int, int]] = Counter()
+    cycle_span_shapes: Counter[tuple[int, tuple[tuple[int, int], ...]]] = Counter()
+
+    for assign in assignments:
+        rows = _rows_from_assignment(assign)
+        families[canonical_dihedral_rows(rows)].append(rows)
+        result = vertex_circle_order_obstruction(rows, list(n9.ORDER), "n9")
+        if result.self_edge_conflicts:
+            status_counts["self_edge"] += 1
+            edge = result.self_edge_conflicts[0]
+            equality_path = _distance_equality_path(
+                rows,
+                edge.outer_pair,
+                edge.inner_pair,
+            )
+            loose_self_shapes[_loose_self_edge_key(edge, len(equality_path))] += 1
+            continue
+        if not result.cycle_edges:
+            raise AssertionError("pre-vertex-circle survivor was not obstructed")
+        status_counts["strict_cycle"] += 1
+        cycle_span_shapes[_cycle_span_key(result.cycle_edges)] += 1
+
+    orbit_size_counts: Counter[int] = Counter()
+    family_status_counts: Counter[str] = Counter()
+    family_rows = []
+    for family_id, (canonical_rows, members) in enumerate(
+        sorted(families.items()),
+        start=1,
+    ):
+        orbit_size_counts[len(members)] += 1
+        member_statuses = Counter(_status_for_rows(rows) for rows in members)
+        if len(member_statuses) != 1:
+            raise AssertionError(f"mixed obstruction status in family {family_id}")
+        status = next(iter(member_statuses))
+        family_status_counts[status] += 1
+        representative_rows = [list(row) for row in canonical_rows]
+        representative = _obstruction_representative(representative_rows)
+        family_rows.append(
+            {
+                "family_id": f"F{family_id:02d}",
+                "orbit_size": len(members),
+                "status": status,
+                "status_counts": dict(sorted(member_statuses.items())),
+                "representative_selected_rows": _rows_to_json(representative_rows),
+                "representative_obstruction": representative,
+            }
+        )
+
+    payload = {
+        "type": "n9_vertex_circle_motif_families_v1",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "scope": "Canonicalized diagnostic families for the 184 complete n=9 selected-witness assignments before vertex-circle obstruction.",
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "The official/global status remains falsifiable/open.",
+            "Dihedral incidence families are selected-witness row-system orbits under rotations and reflections of the cyclic labels.",
+            "Loose obstruction shapes intentionally discard labels; they are proof-search hints, not complete certificates.",
+        ],
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "pre_vertex_circle_search": {
+            "row0_choices": len(n9.OPTIONS[0]),
+            "nodes_visited": int(nodes),
+            "full_assignments": len(assignments),
+        },
+        "obstruction_status_counts": dict(sorted(status_counts.items())),
+        "dihedral_incidence_families": {
+            "family_count": len(families),
+            "orbit_size_counts": _json_counter(orbit_size_counts),
+            "status_family_counts": dict(sorted(family_status_counts.items())),
+            "families": family_rows,
+        },
+        "loose_obstruction_shapes": {
+            "self_edge_shape_family_count": len(loose_self_shapes),
+            "self_edge_shape_buckets": _json_loose_self_edge_shapes(loose_self_shapes),
+            "strict_cycle_span_family_count": len(cycle_span_shapes),
+            "strict_cycle_span_buckets": _json_cycle_span_shapes(cycle_span_shapes),
+        },
+        "interpretation": [
+            "The 184 labelled pre-vertex-circle assignments collapse to 16 full selected-witness row-system orbits under dihedral cyclic symmetry.",
+            "Those 16 orbits split into 13 self-edge families and 3 strict-cycle families.",
+            "Literal first-conflict paths are still too detailed to be theorem templates; the useful next compression is to classify the representative family obstructions by incidence motifs.",
+            "This narrows the next proof-search task, but it does not prove a general vertex-circle lemma.",
+        ],
+    }
+    assert_expected_motif_family_counts(payload)
+    return payload
+
+
 def assert_expected_counts(payload: dict[str, object]) -> None:
     """Assert that the diagnostic still matches the checked n=9 frontier."""
     search = payload["pre_vertex_circle_search"]
@@ -302,3 +549,36 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
         Counter(EXPECTED_STRICT_CYCLE_LENGTH_COUNTS)
     ):
         raise AssertionError("unexpected strict-cycle length counts")
+
+
+def assert_expected_motif_family_counts(payload: dict[str, object]) -> None:
+    """Assert that motif-family diagnostics match the checked n=9 frontier."""
+    search = payload["pre_vertex_circle_search"]
+    if not isinstance(search, dict):
+        raise AssertionError("missing pre-vertex-circle search block")
+    if search["nodes_visited"] != EXPECTED_PRE_VERTEX_CIRCLE_NODES:
+        raise AssertionError(f"unexpected nodes: {search['nodes_visited']}")
+    if search["full_assignments"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError(f"unexpected full assignments: {search['full_assignments']}")
+    if payload["obstruction_status_counts"] != EXPECTED_STATUS_COUNTS:
+        raise AssertionError(f"unexpected status counts: {payload['obstruction_status_counts']}")
+
+    families = payload["dihedral_incidence_families"]
+    shapes = payload["loose_obstruction_shapes"]
+    if not isinstance(families, dict) or not isinstance(shapes, dict):
+        raise AssertionError("missing family or shape block")
+    if families["family_count"] != EXPECTED_DIHEDRAL_INCIDENCE_FAMILIES:
+        raise AssertionError(f"unexpected family count: {families['family_count']}")
+    if families["orbit_size_counts"] != _json_counter(
+        Counter(EXPECTED_DIHEDRAL_INCIDENCE_ORBIT_SIZE_COUNTS)
+    ):
+        raise AssertionError("unexpected orbit size counts")
+    if families["status_family_counts"] != EXPECTED_DIHEDRAL_STATUS_FAMILY_COUNTS:
+        raise AssertionError("unexpected family status counts")
+    if shapes["self_edge_shape_family_count"] != EXPECTED_SELF_EDGE_LOOSE_SHAPE_FAMILIES:
+        raise AssertionError("unexpected self-edge loose shape count")
+    if (
+        shapes["strict_cycle_span_family_count"]
+        != EXPECTED_STRICT_CYCLE_SPAN_SHAPE_FAMILIES
+    ):
+        raise AssertionError("unexpected strict-cycle span shape count")

--- a/tests/test_n9_vertex_circle_motif_families.py
+++ b/tests/test_n9_vertex_circle_motif_families.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    assert_expected_motif_family_counts,
+    motif_family_summary,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_motif_families.json"
+
+
+def test_n9_vertex_circle_motif_family_artifact_counts() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert_expected_motif_family_counts(payload)
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert payload["obstruction_status_counts"] == {
+        "self_edge": 158,
+        "strict_cycle": 26,
+    }
+    families = payload["dihedral_incidence_families"]
+    assert families["family_count"] == 16
+    assert families["orbit_size_counts"] == {"2": 5, "6": 2, "18": 9}
+    assert families["status_family_counts"] == {
+        "self_edge": 13,
+        "strict_cycle": 3,
+    }
+    shapes = payload["loose_obstruction_shapes"]
+    assert shapes["self_edge_shape_family_count"] == 16
+    assert shapes["strict_cycle_span_family_count"] == 8
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_n9_vertex_circle_motif_family_artifact_is_current() -> None:
+    checked_in = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert motif_family_summary() == checked_in


### PR DESCRIPTION
## Summary

- add a motif-family diagnostic that canonicalizes the 184 pre-vertex-circle n=9 assignments under dihedral cyclic symmetry
- record a new artifact showing the frontier collapses to 16 selected-witness incidence families: 13 self-edge families and 3 strict-cycle families
- add loose first-obstruction buckets and documentation that frames them as proof-search hints, not theorem certificates

## Why

The previous obstruction-shape pass showed every n=9 survivor dies by a small vertex-circle contradiction, but literal first-conflict paths stayed too detailed. This pass finds the stronger compression at the incidence level: only 16 dihedral row-system families remain. That gives a more concrete target for replacing finite enumeration with local lemmas.

## Validation

- `python scripts\analyze_n9_vertex_circle_motif_families.py --assert-expected`
- `python -m pytest tests\test_n9_vertex_circle_motif_families.py -q`
- `python -m pytest tests\test_n9_vertex_circle_motif_families.py -q -m "artifact and exhaustive"`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `git diff --check`
- `python scripts\enumerate_n8_incidence.py --summary`
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `python scripts\check_n9_vertex_circle_exhaustive.py --assert-expected`
- `python -m pytest -q`
- `python scripts\analyze_n9_vertex_circle_obstruction_shapes.py --assert-expected`
- `python -m pytest tests\test_n9_vertex_circle_obstruction_shapes.py -q -m "artifact and exhaustive"`

## Notes

This remains diagnostic and review-pending. It does not claim a general proof, a counterexample, or a source-of-truth promotion for n=9.