### PR TITLE
[codex] Extract n9 vertex-circle local cores

### DIFF
--- a/data/certificates/n9_vertex_circle_local_cores.json
+++ b/data/certificates/n9_vertex_circle_local_cores.json
@@ -1,0 +1,2285 @@
+{
+  "certificates": [
+    {
+      "core_rows": [
+        0,
+        1,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F01",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        2,
+        5,
+        6,
+        7
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "row": 5,
+          "witnesses": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "row": 6,
+          "witnesses": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "row": 7,
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        }
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F02",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "row": 3,
+          "witnesses": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "row": 4,
+          "witnesses": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            1,
+            4,
+            7
+          ]
+        }
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F03",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        2
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            1,
+            3,
+            4,
+            8
+          ]
+        }
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F04",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          5,
+          0
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        1,
+        2,
+        3,
+        6
+      ],
+      "core_selected_rows": [
+        {
+          "row": 1,
+          "witnesses": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "row": 3,
+          "witnesses": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 6,
+          "witnesses": [
+            1,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          3,
+          7
+        ]
+      },
+      "family_id": "F05",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          5
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "row": 4,
+          "witnesses": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "row": 5,
+          "witnesses": [
+            3,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "row": 6,
+          "witnesses": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          4
+        ]
+      },
+      "family_id": "F06",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          7
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        5,
+        6
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "row": 5,
+          "witnesses": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 6,
+          "witnesses": [
+            1,
+            5,
+            7,
+            8
+          ]
+        }
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              3
+            ],
+            "path": [],
+            "start_pair": [
+              0,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              1,
+              3
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              5,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  7
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              0,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  2
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              1,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              1,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              5,
+              7
+            ],
+            "outer_span": 3,
+            "row": 6,
+            "witness_order": [
+              7,
+              8,
+              1,
+              5
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "orbit_size": 6,
+      "status": "strict_cycle"
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F08",
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        2
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        }
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F09",
+      "orbit_size": 6,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        2,
+        7,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 7,
+          "witnesses": [
+            2,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            1,
+            6,
+            7
+          ]
+        }
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F10",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        1,
+        5,
+        6,
+        7,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "row": 5,
+          "witnesses": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 6,
+          "witnesses": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "row": 7,
+          "witnesses": [
+            0,
+            1,
+            5,
+            6
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            2,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          3,
+          8
+        ]
+      },
+      "family_id": "F11",
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          3,
+          5,
+          8,
+          0
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        3,
+        6,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "row": 3,
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "row": 6,
+          "witnesses": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  6
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              0,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              3,
+              6,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              0,
+              1
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [
+              4,
+              6,
+              0,
+              1
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "orbit_size": 18,
+      "status": "strict_cycle"
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "row": 3,
+          "witnesses": [
+            1,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "row": 5,
+          "witnesses": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          5
+        ]
+      },
+      "family_id": "F13",
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          5,
+          7
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            2,
+            3,
+            7
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            1,
+            5,
+            7
+          ]
+        }
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F14",
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          6,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            0,
+            2,
+            4,
+            5
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "row": 3,
+          "witnesses": [
+            2,
+            4,
+            6,
+            7
+          ]
+        }
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          4
+        ]
+      },
+      "family_id": "F15",
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          4,
+          8
+        ]
+      }
+    },
+    {
+      "core_rows": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "core_selected_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            3,
+            6,
+            7
+          ]
+        },
+        {
+          "row": 1,
+          "witnesses": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "row": 3,
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "row": 4,
+          "witnesses": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "row": 8,
+          "witnesses": [
+            0,
+            2,
+            5,
+            6
+          ]
+        }
+      ],
+      "core_size": 6,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              0,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 3,
+            "row": 2,
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              2,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              4,
+              7,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              3
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  3
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              6,
+              7
+            ]
+          }
+        }
+      ],
+      "family_id": "F16",
+      "orbit_size": 2,
+      "status": "strict_cycle"
+    }
+  ],
+  "core_size_counts": {
+    "3": 5,
+    "4": 6,
+    "5": 2,
+    "6": 3
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "family_count": 16,
+  "interpretation": [
+    "Every dihedral n=9 motif family has a local vertex-circle certificate using at most 6 selected rows.",
+    "The self-edge cores are one strict chord-containment inequality plus a selected-distance equality path.",
+    "The strict-cycle cores are directed cycles of strict inequalities, with selected-distance equality paths connecting each inner chord to the next outer chord.",
+    "These are promising lemma candidates, but they still cover only the n=9 motif representatives."
+  ],
+  "max_core_size": 6,
+  "n": 9,
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "The official/global status remains falsifiable/open.",
+    "Each core verifies only a representative n=9 motif family under the recorded cyclic order."
+  ],
+  "row_size": 4,
+  "scope": "Local row-core certificates for the 16 dihedral n=9 vertex-circle motif families.",
+  "status_core_size_counts": {
+    "self_edge": {
+      "3": 5,
+      "4": 4,
+      "5": 2,
+      "6": 2
+    },
+    "strict_cycle": {
+      "4": 2,
+      "6": 1
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "type": "n9_vertex_circle_local_cores_v1"
+}

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -1,0 +1,86 @@
+# n=9 Vertex-circle Local Cores
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This note records local row-core certificates for the 16 dihedral
+selected-witness motif families in the `n=9` vertex-circle frontier. It does
+not claim a general proof of Erdos Problem #97 and does not claim a
+counterexample. The official/global status remains falsifiable/open.
+
+## Core Counts
+
+Each of the 16 motif-family representatives has a local vertex-circle
+certificate using at most 6 selected rows.
+
+Checked counts:
+
+```text
+local core size counts:
+  3 rows: 5 families
+  4 rows: 6 families
+  5 rows: 2 families
+  6 rows: 3 families
+
+self-edge cores:
+  3 rows: 5 families
+  4 rows: 4 families
+  5 rows: 2 families
+  6 rows: 2 families
+
+strict-cycle cores:
+  4 rows: 2 families
+  6 rows: 1 family
+```
+
+The checked-in artifact is
+`data/certificates/n9_vertex_circle_local_cores.json`.
+
+## Certificate Shape
+
+A self-edge core consists of:
+
+- one strict vertex-circle chord-containment inequality
+  `outer chord > inner chord`;
+- a selected-distance equality path showing that the outer and inner chord
+  lengths lie in the same selected-distance class.
+
+Together these give `d > d`, an immediate contradiction.
+
+A strict-cycle core consists of:
+
+- a directed cycle of strict vertex-circle inequalities;
+- selected-distance equality paths connecting each inner chord to the next
+  outer chord in the cycle.
+
+Together these give a strict chain returning to its starting distance class.
+
+## Why This Is Progress
+
+The n=9 frontier no longer looks like 184 unrelated assignments. It now looks
+like 16 symmetry families, each with a row-local proof core of size at most 6.
+That is close to the right granularity for human lemmas:
+
+```text
+If a selected-witness incidence pattern contains one of these local row-core
+motifs in the recorded cyclic order, then it is impossible.
+```
+
+This is still not a solution. The next question is whether those local cores
+are forced by general incidence and cyclic-order constraints, or whether they
+are special to the n=9 enumeration.
+
+## Reproduction
+
+Generate and check the local-core artifact:
+
+```bash
+python scripts/analyze_n9_vertex_circle_local_cores.py \
+  --assert-expected \
+  --write
+```
+
+Run the targeted artifact test:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_local_cores.py -q
+```

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -30,6 +30,10 @@ after cyclic symmetry.
 The checked-in artifact is
 `data/certificates/n9_vertex_circle_motif_families.json`.
 
+The local-core follow-up in `docs/n9-vertex-circle-local-cores.md` shows that
+each of the 16 family representatives has a vertex-circle certificate using at
+most 6 selected rows.
+
 ## Loose Obstruction Shapes
 
 As a deliberately coarse diagnostic, the artifact also buckets the first
@@ -59,6 +63,9 @@ A promising route is to classify the 13 self-edge families by the equality
 path that brings an outer and inner vertex-circle chord into the same selected
 distance class, and classify the 3 strict-cycle families by the directed
 quotient-cycle template.
+
+The local-core diagnostic reduces this to a row-local problem: the family
+representatives need only 3 to 6 rows to certify the contradiction.
 
 The current result still does not solve the global problem. The known
 `C19_skew` order that survives the vertex-circle filter remains the guardrail:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -119,6 +119,8 @@ Next steps:
 - classify the 13 self-edge dihedral incidence families into local lemmas;
 - classify the 3 strict-cycle dihedral incidence families into directed
   quotient-cycle templates;
+- use `docs/n9-vertex-circle-local-cores.md` as the row-local certificate list
+  to keep those lemmas small;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - identify the extra exact ingredient needed for `C19_skew`, likely

--- a/scripts/analyze_n9_vertex_circle_local_cores.py
+++ b/scripts/analyze_n9_vertex_circle_local_cores.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Extract local row-core certificates for n=9 vertex-circle motif families."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_local_core_counts,
+    local_core_summary,
+)
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
+    parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = local_core_summary()
+    if args.assert_expected:
+        assert_expected_local_core_counts(payload)
+    if args.write:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 vertex-circle local-core diagnostic")
+        print(f"dihedral motif families: {payload['family_count']}")
+        print(f"core size counts: {payload['core_size_counts']}")
+        print(f"status/core size counts: {payload['status_core_size_counts']}")
+        print(f"max core size: {payload['max_core_size']}")
+        if args.assert_expected:
+            print("OK: local core counts verified")
+        if args.write:
+            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_vertex_circle_obstruction_shapes.py
+++ b/src/erdos97/n9_vertex_circle_obstruction_shapes.py
@@ -29,6 +29,11 @@ EXPECTED_DIHEDRAL_INCIDENCE_ORBIT_SIZE_COUNTS = {2: 5, 6: 2, 18: 9}
 EXPECTED_DIHEDRAL_STATUS_FAMILY_COUNTS = {"self_edge": 13, "strict_cycle": 3}
 EXPECTED_SELF_EDGE_LOOSE_SHAPE_FAMILIES = 16
 EXPECTED_STRICT_CYCLE_SPAN_SHAPE_FAMILIES = 8
+EXPECTED_LOCAL_CORE_SIZE_COUNTS = {3: 5, 4: 6, 5: 2, 6: 3}
+EXPECTED_LOCAL_CORE_STATUS_SIZE_COUNTS = {
+    "self_edge": {3: 5, 4: 4, 5: 2, 6: 2},
+    "strict_cycle": {4: 2, 6: 1},
+}
 
 
 Assignment = dict[int, int]
@@ -40,8 +45,21 @@ def _json_pair(item: Pair) -> list[int]:
     return [int(item[0]), int(item[1])]
 
 
+def _pair_from_json(item: Sequence[int]) -> Pair:
+    if len(item) != 2:
+        raise AssertionError(f"expected pair, got {item}")
+    return pair(int(item[0]), int(item[1]))
+
+
 def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
     return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _json_nested_counter(counter: Counter[tuple[str, int]]) -> dict[str, dict[str, int]]:
+    nested: dict[str, Counter[int]] = defaultdict(Counter)
+    for (status, size), count in counter.items():
+        nested[status][size] = int(count)
+    return {status: _json_counter(nested[status]) for status in sorted(nested)}
 
 
 def _rows_from_assignment(assign: Assignment) -> list[list[int]]:
@@ -75,6 +93,16 @@ def canonical_dihedral_rows(rows: Sequence[Sequence[int]]) -> CanonicalRows:
 
 def _rows_to_json(rows: Sequence[Sequence[int]]) -> Rows:
     return [[int(value) for value in row] for row in rows]
+
+
+def _core_rows_to_json(
+    rows: Sequence[Sequence[int]],
+    centers: Sequence[int],
+) -> list[dict[str, object]]:
+    return [
+        {"row": int(center), "witnesses": [int(witness) for witness in rows[center]]}
+        for center in sorted(centers)
+    ]
 
 
 def pre_vertex_circle_assignments() -> tuple[list[Assignment], int]:
@@ -203,6 +231,10 @@ def _json_inequality(edge: StrictInequality) -> dict[str, object]:
     }
 
 
+def _path_rows(path: Sequence[dict[str, object]]) -> set[int]:
+    return {int(step["row"]) for step in path}
+
+
 def _self_edge_representative(
     rows: Sequence[Sequence[int]],
     edge: StrictInequality,
@@ -251,7 +283,9 @@ def _loose_self_edge_key(
     )
 
 
-def _cycle_span_key(edges: Sequence[StrictInequality]) -> tuple[int, tuple[tuple[int, int], ...]]:
+def _cycle_span_key(
+    edges: Sequence[StrictInequality],
+) -> tuple[int, tuple[tuple[int, int], ...]]:
     return (
         len(edges),
         tuple(
@@ -316,6 +350,219 @@ def _json_cycle_span_shapes(
             row["span_signature"],
         ),
     )
+
+
+def _self_edge_core_certificate(
+    family_id: str,
+    orbit_size: int,
+    rows: Sequence[Sequence[int]],
+    edge: StrictInequality,
+) -> dict[str, object]:
+    equality_path = _distance_equality_path(rows, edge.outer_pair, edge.inner_pair)
+    core_rows = {edge.row} | _path_rows(equality_path)
+    return {
+        "family_id": family_id,
+        "orbit_size": int(orbit_size),
+        "status": "self_edge",
+        "core_size": len(core_rows),
+        "core_rows": [int(row) for row in sorted(core_rows)],
+        "core_selected_rows": _core_rows_to_json(rows, sorted(core_rows)),
+        "strict_inequality": _json_inequality(edge),
+        "distance_equality": {
+            "start_pair": _json_pair(edge.outer_pair),
+            "end_pair": _json_pair(edge.inner_pair),
+            "path": equality_path,
+        },
+    }
+
+
+def _strict_cycle_core_certificate(
+    family_id: str,
+    orbit_size: int,
+    rows: Sequence[Sequence[int]],
+    edges: Sequence[StrictInequality],
+) -> dict[str, object]:
+    cycle_steps = []
+    core_rows = {edge.row for edge in edges}
+    for idx, edge in enumerate(edges):
+        next_edge = edges[(idx + 1) % len(edges)]
+        equality_path = _distance_equality_path(
+            rows,
+            edge.inner_pair,
+            next_edge.outer_pair,
+        )
+        core_rows.update(_path_rows(equality_path))
+        cycle_steps.append(
+            {
+                "strict_inequality": _json_inequality(edge),
+                "equality_to_next_outer_pair": {
+                    "start_pair": _json_pair(edge.inner_pair),
+                    "end_pair": _json_pair(next_edge.outer_pair),
+                    "path": equality_path,
+                },
+            }
+        )
+    return {
+        "family_id": family_id,
+        "orbit_size": int(orbit_size),
+        "status": "strict_cycle",
+        "core_size": len(core_rows),
+        "core_rows": [int(row) for row in sorted(core_rows)],
+        "core_selected_rows": _core_rows_to_json(rows, sorted(core_rows)),
+        "cycle_length": len(edges),
+        "cycle_steps": cycle_steps,
+    }
+
+
+def _local_core_certificate(
+    family_id: str,
+    orbit_size: int,
+    rows: Sequence[Sequence[int]],
+) -> dict[str, object]:
+    result = vertex_circle_order_obstruction(rows, list(n9.ORDER), "n9")
+    if result.self_edge_conflicts:
+        return _self_edge_core_certificate(
+            family_id,
+            orbit_size,
+            rows,
+            result.self_edge_conflicts[0],
+        )
+    if result.cycle_edges:
+        return _strict_cycle_core_certificate(
+            family_id,
+            orbit_size,
+            rows,
+            result.cycle_edges,
+        )
+    raise AssertionError("pre-vertex-circle survivor was not obstructed")
+
+
+def _core_row_map(certificate: dict[str, object]) -> dict[int, list[int]]:
+    rows: dict[int, list[int]] = {}
+    for item in certificate["core_selected_rows"]:
+        if not isinstance(item, dict):
+            raise AssertionError("malformed core row")
+        center = int(item["row"])
+        witnesses = [int(witness) for witness in item["witnesses"]]
+        if len(witnesses) != n9.ROW_SIZE:
+            raise AssertionError(f"row {center} has {len(witnesses)} witnesses")
+        if center in witnesses:
+            raise AssertionError(f"row {center} selects itself")
+        if center in rows:
+            raise AssertionError(f"duplicate core row {center}")
+        rows[center] = sorted(witnesses)
+    return rows
+
+
+def _selected_pairs_for_core_row(rows: dict[int, list[int]], center: int) -> set[Pair]:
+    return {pair(center, witness) for witness in rows[center]}
+
+
+def _validate_strict_inequality(
+    rows: dict[int, list[int]],
+    edge: dict[str, object],
+) -> None:
+    center = int(edge["row"])
+    if center not in rows:
+        raise AssertionError(f"strict row {center} missing from core")
+    witness_order = [int(label) for label in edge["witness_order"]]
+    expected_order = sorted(
+        rows[center],
+        key=lambda witness: (witness - center) % n9.N,
+    )
+    if witness_order != expected_order:
+        raise AssertionError(f"bad witness order in row {center}")
+
+    outer_interval = [int(idx) for idx in edge["outer_interval"]]
+    inner_interval = [int(idx) for idx in edge["inner_interval"]]
+    outer_start, outer_end = outer_interval
+    inner_start, inner_end = inner_interval
+    contains = (
+        outer_start <= inner_start
+        and inner_end <= outer_end
+        and (outer_start < inner_start or inner_end < outer_end)
+    )
+    if not contains:
+        raise AssertionError("strict inequality intervals are not nested")
+    outer_pair = pair(witness_order[outer_start], witness_order[outer_end])
+    inner_pair = pair(witness_order[inner_start], witness_order[inner_end])
+    if outer_pair != _pair_from_json(edge["outer_pair"]):
+        raise AssertionError("outer pair does not match interval endpoints")
+    if inner_pair != _pair_from_json(edge["inner_pair"]):
+        raise AssertionError("inner pair does not match interval endpoints")
+
+
+def _validate_equality_path(
+    rows: dict[int, list[int]],
+    start_pair: Pair,
+    end_pair: Pair,
+    path: Sequence[dict[str, object]],
+) -> None:
+    current = start_pair
+    for step in path:
+        row = int(step["row"])
+        if row not in rows:
+            raise AssertionError(f"equality path row {row} missing from core")
+        next_pair = _pair_from_json(step["next_pair"])
+        selected_pairs = _selected_pairs_for_core_row(rows, row)
+        if current not in selected_pairs or next_pair not in selected_pairs:
+            raise AssertionError(
+                f"row {row} does not equate {current} and {next_pair}"
+            )
+        current = next_pair
+    if current != end_pair:
+        raise AssertionError(f"equality path ends at {current}, expected {end_pair}")
+
+
+def verify_local_core_certificate(certificate: dict[str, object]) -> None:
+    """Verify a local self-edge or strict-cycle core certificate."""
+    rows = _core_row_map(certificate)
+    if sorted(rows) != [int(row) for row in certificate["core_rows"]]:
+        raise AssertionError("core row list does not match core_selected_rows")
+    if len(rows) != int(certificate["core_size"]):
+        raise AssertionError("core_size does not match core_selected_rows")
+    status = certificate["status"]
+    if status == "self_edge":
+        edge = certificate["strict_inequality"]
+        if not isinstance(edge, dict):
+            raise AssertionError("malformed strict inequality")
+        _validate_strict_inequality(rows, edge)
+        equality = certificate["distance_equality"]
+        if not isinstance(equality, dict):
+            raise AssertionError("malformed distance equality")
+        start_pair = _pair_from_json(equality["start_pair"])
+        end_pair = _pair_from_json(equality["end_pair"])
+        if start_pair != _pair_from_json(edge["outer_pair"]):
+            raise AssertionError("self-edge equality must start at outer pair")
+        if end_pair != _pair_from_json(edge["inner_pair"]):
+            raise AssertionError("self-edge equality must end at inner pair")
+        _validate_equality_path(rows, start_pair, end_pair, equality["path"])
+        return
+    if status == "strict_cycle":
+        cycle_steps = certificate["cycle_steps"]
+        if len(cycle_steps) != int(certificate["cycle_length"]):
+            raise AssertionError("cycle_length does not match cycle_steps")
+        for step in cycle_steps:
+            edge = step["strict_inequality"]
+            equality = step["equality_to_next_outer_pair"]
+            if not isinstance(edge, dict) or not isinstance(equality, dict):
+                raise AssertionError("malformed cycle step")
+            _validate_strict_inequality(rows, edge)
+            start_pair = _pair_from_json(equality["start_pair"])
+            end_pair = _pair_from_json(equality["end_pair"])
+            if start_pair != _pair_from_json(edge["inner_pair"]):
+                raise AssertionError("cycle equality must start at inner pair")
+            _validate_equality_path(rows, start_pair, end_pair, equality["path"])
+        edges = [step["strict_inequality"] for step in cycle_steps]
+        for idx, edge in enumerate(edges):
+            equality = cycle_steps[idx]["equality_to_next_outer_pair"]
+            next_edge = edges[(idx + 1) % len(edges)]
+            if _pair_from_json(equality["end_pair"]) != _pair_from_json(
+                next_edge["outer_pair"]
+            ):
+                raise AssertionError("cycle equality does not reach next outer pair")
+        return
+    raise AssertionError(f"unknown local core status {status!r}")
 
 
 def obstruction_shape_summary() -> dict[str, object]:
@@ -522,6 +769,56 @@ def motif_family_summary() -> dict[str, object]:
     return payload
 
 
+def local_core_summary() -> dict[str, object]:
+    """Return local row-core certificates for the 16 n=9 motif families."""
+    motif_payload = motif_family_summary()
+    certificates = []
+    core_size_counts: Counter[int] = Counter()
+    status_core_size_counts: Counter[tuple[str, int]] = Counter()
+    for family in motif_payload["dihedral_incidence_families"]["families"]:
+        if not isinstance(family, dict):
+            raise AssertionError("malformed family row")
+        certificate = _local_core_certificate(
+            str(family["family_id"]),
+            int(family["orbit_size"]),
+            family["representative_selected_rows"],
+        )
+        verify_local_core_certificate(certificate)
+        certificates.append(certificate)
+        core_size = int(certificate["core_size"])
+        status = str(certificate["status"])
+        core_size_counts[core_size] += 1
+        status_core_size_counts[(status, core_size)] += 1
+
+    payload = {
+        "type": "n9_vertex_circle_local_cores_v1",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "scope": "Local row-core certificates for the 16 dihedral n=9 vertex-circle motif families.",
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "The official/global status remains falsifiable/open.",
+            "Each core verifies only a representative n=9 motif family under the recorded cyclic order.",
+        ],
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "family_count": len(certificates),
+        "core_size_counts": _json_counter(core_size_counts),
+        "status_core_size_counts": _json_nested_counter(status_core_size_counts),
+        "max_core_size": max(core_size_counts),
+        "certificates": certificates,
+        "interpretation": [
+            "Every dihedral n=9 motif family has a local vertex-circle certificate using at most 6 selected rows.",
+            "The self-edge cores are one strict chord-containment inequality plus a selected-distance equality path.",
+            "The strict-cycle cores are directed cycles of strict inequalities, with selected-distance equality paths connecting each inner chord to the next outer chord.",
+            "These are promising lemma candidates, but they still cover only the n=9 motif representatives.",
+        ],
+    }
+    assert_expected_local_core_counts(payload)
+    return payload
+
+
 def assert_expected_counts(payload: dict[str, object]) -> None:
     """Assert that the diagnostic still matches the checked n=9 frontier."""
     search = payload["pre_vertex_circle_search"]
@@ -582,3 +879,28 @@ def assert_expected_motif_family_counts(payload: dict[str, object]) -> None:
         != EXPECTED_STRICT_CYCLE_SPAN_SHAPE_FAMILIES
     ):
         raise AssertionError("unexpected strict-cycle span shape count")
+
+
+def assert_expected_local_core_counts(payload: dict[str, object]) -> None:
+    """Assert that local core diagnostics match the checked n=9 motifs."""
+    if payload["family_count"] != EXPECTED_DIHEDRAL_INCIDENCE_FAMILIES:
+        raise AssertionError(f"unexpected family count: {payload['family_count']}")
+    if payload["core_size_counts"] != _json_counter(
+        Counter(EXPECTED_LOCAL_CORE_SIZE_COUNTS)
+    ):
+        raise AssertionError("unexpected local core size counts")
+    expected_status_sizes = {
+        status: _json_counter(Counter(counts))
+        for status, counts in sorted(EXPECTED_LOCAL_CORE_STATUS_SIZE_COUNTS.items())
+    }
+    if payload["status_core_size_counts"] != expected_status_sizes:
+        raise AssertionError("unexpected local core status/size counts")
+    if payload["max_core_size"] != max(EXPECTED_LOCAL_CORE_SIZE_COUNTS):
+        raise AssertionError(f"unexpected max core size: {payload['max_core_size']}")
+    certificates = payload["certificates"]
+    if len(certificates) != EXPECTED_DIHEDRAL_INCIDENCE_FAMILIES:
+        raise AssertionError("unexpected local core certificate count")
+    for certificate in certificates:
+        if not isinstance(certificate, dict):
+            raise AssertionError("malformed local core certificate")
+        verify_local_core_certificate(certificate)

--- a/tests/test_n9_vertex_circle_local_cores.py
+++ b/tests/test_n9_vertex_circle_local_cores.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    assert_expected_local_core_counts,
+    local_core_summary,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+
+
+def test_n9_vertex_circle_local_core_artifact_counts() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert_expected_local_core_counts(payload)
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert payload["family_count"] == 16
+    assert payload["core_size_counts"] == {"3": 5, "4": 6, "5": 2, "6": 3}
+    assert payload["status_core_size_counts"] == {
+        "self_edge": {"3": 5, "4": 4, "5": 2, "6": 2},
+        "strict_cycle": {"4": 2, "6": 1},
+    }
+    assert payload["max_core_size"] == 6
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_n9_vertex_circle_local_core_artifact_is_current() -> None:
+    checked_in = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert local_core_summary() == checked_in


### PR DESCRIPTION
## Summary

- add a local-core diagnostic for the 16 dihedral n=9 vertex-circle motif families
- record row-local certificates showing every family has a vertex-circle contradiction using at most 6 selected rows
- add a verifier that checks selected-distance equality paths and nested vertex-circle strict inequalities from the stored core rows

## Why

The previous pass compressed 184 labelled survivors to 16 motif families. This pass turns those families into smaller proof candidates: 5 cores use 3 rows, 6 use 4 rows, 2 use 5 rows, and 3 use 6 rows. This is closer to a human lemma inventory than a finite enumeration table.

## Validation

- `python scripts\analyze_n9_vertex_circle_local_cores.py --assert-expected`
- `python -m pytest tests\test_n9_vertex_circle_local_cores.py -q`
- `python -m pytest tests\test_n9_vertex_circle_local_cores.py -q -m "artifact and exhaustive"`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `git diff --check`
- `python scripts\analyze_n9_vertex_circle_motif_families.py --assert-expected`
- `python scripts\analyze_n9_vertex_circle_obstruction_shapes.py --assert-expected`
- `python scripts\enumerate_n8_incidence.py --summary`
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `python scripts\check_n9_vertex_circle_exhaustive.py --assert-expected`
- `python -m pytest -q`

## Notes

This remains diagnostic and review-pending. It does not claim a general proof, a counterexample, or a source-of-truth promotion for n=9.