### PR TITLE
[codex] Compare n9 vertex-circle cores to frontier patterns

### DIFF
--- a/data/certificates/n9_vertex_circle_frontier_comparison.json
+++ b/data/certificates/n9_vertex_circle_frontier_comparison.json
@@ -1,0 +1,245 @@
+{
+  "exact_core_embedding_results": [
+    {
+      "checked_core_count": 16,
+      "cyclic_order_preserving_maps_tested": 13127400,
+      "exact_core_embedding_hits": 0,
+      "hits": [],
+      "order": [
+        0,
+        8,
+        4,
+        15,
+        1,
+        5,
+        11,
+        9,
+        3,
+        7,
+        17,
+        13,
+        2,
+        6,
+        14,
+        10,
+        16,
+        12
+      ],
+      "pattern": "P18_parity_balanced"
+    },
+    {
+      "checked_core_count": 16,
+      "cyclic_order_preserving_maps_tested": 24337404,
+      "exact_core_embedding_hits": 0,
+      "hits": [],
+      "order": [
+        18,
+        10,
+        7,
+        17,
+        6,
+        3,
+        5,
+        9,
+        14,
+        11,
+        2,
+        13,
+        4,
+        16,
+        12,
+        15,
+        0,
+        8,
+        1
+      ],
+      "pattern": "C19_skew"
+    }
+  ],
+  "interpretation": [
+    "No n=9 local core embeds exactly into the recorded P18 or C19 row systems under this strict row-preserving test.",
+    "P18 is still killed by a local strict-cycle core of size 6, and its span signature matches an n=9 strict-cycle shape bucket.",
+    "The recorded C19 order still passes the vertex-circle filter, so any global route needs an additional exact ingredient or a sharper vertex-circle condition."
+  ],
+  "n9_local_core_artifact": "data/certificates/n9_vertex_circle_local_cores.json",
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "The official/global status remains falsifiable/open.",
+    "Exact core embeddings require a cyclic-order-preserving injection whose selected rows match exactly."
+  ],
+  "pattern_vertex_circle_results": [
+    {
+      "core_rows": [
+        2,
+        9,
+        12,
+        13,
+        16,
+        17
+      ],
+      "core_size": 6,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              16
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  9,
+                  16
+                ],
+                "row": 9
+              },
+              {
+                "next_pair": [
+                  2,
+                  16
+                ],
+                "row": 16
+              }
+            ],
+            "start_pair": [
+              1,
+              9
+            ]
+          },
+          "inner_pair": [
+            1,
+            9
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            9,
+            13
+          ],
+          "outer_span": 3,
+          "strict_row": 17
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              9,
+              13
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  13
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  9,
+                  13
+                ],
+                "row": 13
+              }
+            ],
+            "start_pair": [
+              2,
+              10
+            ]
+          },
+          "inner_pair": [
+            2,
+            10
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            2,
+            16
+          ],
+          "outer_span": 2,
+          "strict_row": 12
+        }
+      ],
+      "matching_n9_strict_cycle_span_bucket_count": 8,
+      "obstructed": true,
+      "order": [
+        0,
+        8,
+        4,
+        15,
+        1,
+        5,
+        11,
+        9,
+        3,
+        7,
+        17,
+        13,
+        2,
+        6,
+        14,
+        10,
+        16,
+        12
+      ],
+      "pattern": "P18_parity_balanced",
+      "span_signature": [
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "status": "strict_cycle",
+      "vertex_support": [
+        0,
+        1,
+        2,
+        5,
+        6,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17
+      ],
+      "vertex_support_size": 14
+    },
+    {
+      "obstructed": false,
+      "order": [
+        18,
+        10,
+        7,
+        17,
+        6,
+        3,
+        5,
+        9,
+        14,
+        11,
+        2,
+        13,
+        4,
+        16,
+        12,
+        15,
+        0,
+        8,
+        1
+      ],
+      "pattern": "C19_skew",
+      "status": "passes_vertex_circle_filter"
+    }
+  ],
+  "scope": "Compare exact n=9 local cores with P18 and C19 frontier vertex-circle behavior.",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "type": "n9_vertex_circle_frontier_comparison_v1"
+}

--- a/docs/n9-vertex-circle-frontier-comparison.md
+++ b/docs/n9-vertex-circle-frontier-comparison.md
@@ -1,0 +1,58 @@
+# n=9 Vertex-circle Frontier Comparison
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This note compares the `n=9` local-core motifs with two larger fixed-pattern
+frontier checks: the P18 pattern killed by the vertex-circle filter and the
+recorded `C19_skew` order that passes it. It does not claim a general proof of
+Erdos Problem #97 and does not claim a counterexample. The official/global
+status remains falsifiable/open.
+
+## Exact Core Embeddings
+
+Using a strict cyclic-order-preserving row match, no checked `n=9` local core
+embeds exactly into either recorded larger pattern:
+
+```text
+P18_parity_balanced: 0 exact n=9 local-core embeddings
+C19_skew:            0 exact n=9 local-core embeddings
+```
+
+Here "exact" means that every selected row in the local core maps to a selected
+row with exactly the same four selected witnesses. This is intentionally strict;
+it prevents treating the n=9 cores as a general theorem by wishful analogy.
+
+## P18 And C19
+
+The P18 order recorded in `docs/vertex-circle-order-filter.md` is still killed
+by a local strict-cycle core:
+
+```text
+P18 local core size: 6 selected rows
+P18 vertex support: 14 vertices
+P18 strict-cycle span signature: [[2,1], [3,1]]
+matching n=9 strict-cycle span bucket count: 8
+```
+
+So P18 does not literally contain one of the n=9 local cores, but it does share
+one of the same coarse strict-cycle span shapes.
+
+The recorded `C19_skew` order still passes the vertex-circle filter. This
+remains the guardrail for the proof route: the current quotient-graph
+vertex-circle obstruction is not enough by itself.
+
+## Reproduction
+
+Generate and check the comparison artifact:
+
+```bash
+python scripts/compare_n9_vertex_circle_frontier.py \
+  --assert-expected \
+  --write
+```
+
+Run the targeted artifact test:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_frontier_comparison.py -q
+```

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -69,6 +69,11 @@ This is still not a solution. The next question is whether those local cores
 are forced by general incidence and cyclic-order constraints, or whether they
 are special to the n=9 enumeration.
 
+The comparison in `docs/n9-vertex-circle-frontier-comparison.md` shows the
+caution needed here: the n=9 cores do not embed exactly into the recorded P18
+or C19 patterns. P18 is killed by a related loose strict-cycle shape, while the
+recorded C19 order still passes the vertex-circle filter.
+
 ## Reproduction
 
 Generate and check the local-core artifact:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -123,6 +123,9 @@ Next steps:
   to keep those lemmas small;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
+- use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:
+  exact n=9 cores do not embed into P18 or C19, although P18 shares a loose
+  strict-cycle span shape;
 - identify the extra exact ingredient needed for `C19_skew`, likely
   Altman/Kalmanson or stronger radius propagation.
 

--- a/scripts/compare_n9_vertex_circle_frontier.py
+++ b/scripts/compare_n9_vertex_circle_frontier.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Compare n=9 vertex-circle local cores with P18 and C19 frontier patterns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_vertex_circle_frontier_comparison import (  # noqa: E402
+    assert_expected_frontier_comparison,
+    frontier_comparison_summary,
+)
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_frontier_comparison.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
+    parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = frontier_comparison_summary()
+    if args.assert_expected:
+        assert_expected_frontier_comparison(payload)
+    if args.write:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 vertex-circle frontier comparison")
+        for result in payload["exact_core_embedding_results"]:
+            print(
+                f"{result['pattern']} exact n=9 core embeddings: "
+                f"{result['exact_core_embedding_hits']}"
+            )
+        for result in payload["pattern_vertex_circle_results"]:
+            print(f"{result['pattern']} vertex-circle status: {result['status']}")
+        if args.assert_expected:
+            print("OK: frontier comparison counts verified")
+        if args.write:
+            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_vertex_circle_frontier_comparison.py
+++ b/src/erdos97/n9_vertex_circle_frontier_comparison.py
@@ -1,0 +1,329 @@
+"""Compare n=9 vertex-circle local cores with larger frontier patterns."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Sequence
+
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    _distance_equality_path,
+    _json_pair,
+    local_core_summary,
+    motif_family_summary,
+)
+from erdos97.search import built_in_patterns
+from erdos97.vertex_circle_order_filter import StrictInequality, vertex_circle_order_obstruction
+
+P18_CROSSING_COMPATIBLE_ORDER = [
+    0,
+    8,
+    4,
+    15,
+    1,
+    5,
+    11,
+    9,
+    3,
+    7,
+    17,
+    13,
+    2,
+    6,
+    14,
+    10,
+    16,
+    12,
+]
+
+C19_VERTEX_CIRCLE_ACYCLIC_ORDER = [
+    18,
+    10,
+    7,
+    17,
+    6,
+    3,
+    5,
+    9,
+    14,
+    11,
+    2,
+    13,
+    4,
+    16,
+    12,
+    15,
+    0,
+    8,
+    1,
+]
+
+EXPECTED_EXACT_CORE_EMBEDDING_HITS = {
+    "P18_parity_balanced": 0,
+    "C19_skew": 0,
+}
+EXPECTED_P18_CORE_SIZE = 6
+EXPECTED_P18_VERTEX_SUPPORT_SIZE = 14
+EXPECTED_P18_STRICT_CYCLE_SPAN_SIGNATURE = [[2, 1], [3, 1]]
+
+
+def _source_order_variants(vertices: Sequence[int]) -> list[list[int]]:
+    ordered = sorted(vertices)
+    return [ordered, list(reversed(ordered))]
+
+
+def _cyclic_order_preserving_maps(
+    source_vertices: Sequence[int],
+    target_n: int,
+):
+    source_vertices = sorted(source_vertices)
+    source_size = len(source_vertices)
+    for target_subset in combinations(range(target_n), source_size):
+        target_order = list(target_subset)
+        for source_order in _source_order_variants(source_vertices):
+            for shift in range(source_size):
+                yield {
+                    source_order[idx]: target_order[(idx + shift) % source_size]
+                    for idx in range(source_size)
+                }
+
+
+def _core_vertex_support(certificate: dict[str, object]) -> set[int]:
+    vertices: set[int] = set()
+    for row in certificate["core_selected_rows"]:
+        if not isinstance(row, dict):
+            raise AssertionError("malformed core row")
+        vertices.add(int(row["row"]))
+        vertices.update(int(witness) for witness in row["witnesses"])
+    return vertices
+
+
+def _core_embeds_in_pattern(
+    certificate: dict[str, object],
+    target_rows: Sequence[Sequence[int]],
+) -> tuple[bool, dict[int, int] | None, int]:
+    core_rows = certificate["core_selected_rows"]
+    source_vertices = _core_vertex_support(certificate)
+    attempts = 0
+    for label_map in _cyclic_order_preserving_maps(source_vertices, len(target_rows)):
+        attempts += 1
+        ok = True
+        for row in core_rows:
+            if not isinstance(row, dict):
+                raise AssertionError("malformed core row")
+            target_center = label_map[int(row["row"])]
+            target_witnesses = {label_map[int(witness)] for witness in row["witnesses"]}
+            if set(target_rows[target_center]) != target_witnesses:
+                ok = False
+                break
+        if ok:
+            return True, label_map, attempts
+    return False, None, attempts
+
+
+def _span_signature(edges: Sequence[StrictInequality]) -> list[list[int]]:
+    return [
+        [int(outer_span), int(inner_span)]
+        for outer_span, inner_span in sorted(
+            (
+                edge.outer_interval[1] - edge.outer_interval[0],
+                edge.inner_interval[1] - edge.inner_interval[0],
+            )
+            for edge in edges
+        )
+    ]
+
+
+def _cycle_core(
+    rows: Sequence[Sequence[int]],
+    edges: Sequence[StrictInequality],
+) -> dict[str, object]:
+    core_rows = {edge.row for edge in edges}
+    cycle_steps = []
+    for idx, edge in enumerate(edges):
+        next_edge = edges[(idx + 1) % len(edges)]
+        equality_path = _distance_equality_path(rows, edge.inner_pair, next_edge.outer_pair)
+        core_rows.update(int(step["row"]) for step in equality_path)
+        cycle_steps.append(
+            {
+                "strict_row": int(edge.row),
+                "outer_pair": _json_pair(edge.outer_pair),
+                "inner_pair": _json_pair(edge.inner_pair),
+                "outer_span": int(edge.outer_interval[1] - edge.outer_interval[0]),
+                "inner_span": int(edge.inner_interval[1] - edge.inner_interval[0]),
+                "equality_to_next_outer_pair": {
+                    "start_pair": _json_pair(edge.inner_pair),
+                    "end_pair": _json_pair(next_edge.outer_pair),
+                    "path": equality_path,
+                },
+            }
+        )
+    vertex_support = set(core_rows)
+    for row in core_rows:
+        vertex_support.update(rows[row])
+    return {
+        "status": "strict_cycle",
+        "cycle_length": len(edges),
+        "span_signature": _span_signature(edges),
+        "core_rows": [int(row) for row in sorted(core_rows)],
+        "core_size": len(core_rows),
+        "vertex_support": [int(vertex) for vertex in sorted(vertex_support)],
+        "vertex_support_size": len(vertex_support),
+        "cycle_steps": cycle_steps,
+    }
+
+
+def _pattern_vertex_circle_summary(
+    name: str,
+    rows: Sequence[Sequence[int]],
+    order: Sequence[int],
+    n9_strict_cycle_span_counts: dict[tuple[tuple[int, int], ...], int],
+) -> dict[str, object]:
+    result = vertex_circle_order_obstruction(rows, order, name)
+    if not result.obstructed:
+        return {
+            "pattern": name,
+            "obstructed": False,
+            "status": "passes_vertex_circle_filter",
+            "order": list(order),
+        }
+    if result.self_edge_conflicts:
+        return {
+            "pattern": name,
+            "obstructed": True,
+            "status": "self_edge",
+            "order": list(order),
+        }
+    core = _cycle_core(rows, result.cycle_edges)
+    span_key = tuple(tuple(item) for item in core["span_signature"])
+    core.update(
+        {
+            "pattern": name,
+            "obstructed": True,
+            "order": list(order),
+            "matching_n9_strict_cycle_span_bucket_count": n9_strict_cycle_span_counts.get(
+                span_key,
+                0,
+            ),
+        }
+    )
+    return core
+
+
+def frontier_comparison_summary() -> dict[str, object]:
+    """Return exact-embedding and loose-shape comparisons for frontier patterns."""
+    local_payload = local_core_summary()
+    motif_payload = motif_family_summary()
+    certificates = local_payload["certificates"]
+    patterns = built_in_patterns()
+    target_specs = {
+        "P18_parity_balanced": P18_CROSSING_COMPATIBLE_ORDER,
+        "C19_skew": C19_VERTEX_CIRCLE_ACYCLIC_ORDER,
+    }
+
+    embedding_results = []
+    for pattern_name, order in target_specs.items():
+        rows = patterns[pattern_name].S
+        hits = []
+        attempts = 0
+        for certificate in certificates:
+            hit, label_map, certificate_attempts = _core_embeds_in_pattern(
+                certificate,
+                rows,
+            )
+            attempts += certificate_attempts
+            if hit:
+                hits.append(
+                    {
+                        "family_id": certificate["family_id"],
+                        "status": certificate["status"],
+                        "core_size": certificate["core_size"],
+                        "label_map": {
+                            str(source): int(target)
+                            for source, target in sorted(label_map.items())
+                        },
+                    }
+                )
+        embedding_results.append(
+            {
+                "pattern": pattern_name,
+                "order": list(order),
+                "exact_core_embedding_hits": len(hits),
+                "checked_core_count": len(certificates),
+                "cyclic_order_preserving_maps_tested": attempts,
+                "hits": hits,
+            }
+        )
+
+    strict_cycle_span_counts = {}
+    for bucket in motif_payload["loose_obstruction_shapes"]["strict_cycle_span_buckets"]:
+        key = tuple(tuple(item) for item in bucket["span_signature"])
+        strict_cycle_span_counts[key] = int(bucket["count"])
+
+    pattern_summaries = [
+        _pattern_vertex_circle_summary(
+            "P18_parity_balanced",
+            patterns["P18_parity_balanced"].S,
+            P18_CROSSING_COMPATIBLE_ORDER,
+            strict_cycle_span_counts,
+        ),
+        _pattern_vertex_circle_summary(
+            "C19_skew",
+            patterns["C19_skew"].S,
+            C19_VERTEX_CIRCLE_ACYCLIC_ORDER,
+            strict_cycle_span_counts,
+        ),
+    ]
+
+    payload = {
+        "type": "n9_vertex_circle_frontier_comparison_v1",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "scope": "Compare exact n=9 local cores with P18 and C19 frontier vertex-circle behavior.",
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "The official/global status remains falsifiable/open.",
+            "Exact core embeddings require a cyclic-order-preserving injection whose selected rows match exactly.",
+        ],
+        "n9_local_core_artifact": "data/certificates/n9_vertex_circle_local_cores.json",
+        "exact_core_embedding_results": embedding_results,
+        "pattern_vertex_circle_results": pattern_summaries,
+        "interpretation": [
+            "No n=9 local core embeds exactly into the recorded P18 or C19 row systems under this strict row-preserving test.",
+            "P18 is still killed by a local strict-cycle core of size 6, and its span signature matches an n=9 strict-cycle shape bucket.",
+            "The recorded C19 order still passes the vertex-circle filter, so any global route needs an additional exact ingredient or a sharper vertex-circle condition.",
+        ],
+    }
+    assert_expected_frontier_comparison(payload)
+    return payload
+
+
+def assert_expected_frontier_comparison(payload: dict[str, object]) -> None:
+    """Assert expected frontier comparison counts."""
+    embeddings = payload["exact_core_embedding_results"]
+    if not isinstance(embeddings, list):
+        raise AssertionError("missing embedding results")
+    for result in embeddings:
+        if not isinstance(result, dict):
+            raise AssertionError("malformed embedding result")
+        expected = EXPECTED_EXACT_CORE_EMBEDDING_HITS[result["pattern"]]
+        if result["exact_core_embedding_hits"] != expected:
+            raise AssertionError(f"unexpected embedding hits for {result['pattern']}")
+
+    pattern_results = {
+        result["pattern"]: result for result in payload["pattern_vertex_circle_results"]
+    }
+    p18 = pattern_results["P18_parity_balanced"]
+    if not p18["obstructed"] or p18["status"] != "strict_cycle":
+        raise AssertionError("P18 should have a strict-cycle obstruction")
+    if p18["core_size"] != EXPECTED_P18_CORE_SIZE:
+        raise AssertionError(f"unexpected P18 core size: {p18['core_size']}")
+    if p18["vertex_support_size"] != EXPECTED_P18_VERTEX_SUPPORT_SIZE:
+        raise AssertionError("unexpected P18 vertex support size")
+    if p18["span_signature"] != EXPECTED_P18_STRICT_CYCLE_SPAN_SIGNATURE:
+        raise AssertionError("unexpected P18 span signature")
+    if p18["matching_n9_strict_cycle_span_bucket_count"] <= 0:
+        raise AssertionError("P18 span signature should appear among n=9 buckets")
+
+    c19 = pattern_results["C19_skew"]
+    if c19["obstructed"] or c19["status"] != "passes_vertex_circle_filter":
+        raise AssertionError("C19 recorded order should pass vertex-circle filter")

--- a/tests/test_n9_vertex_circle_frontier_comparison.py
+++ b/tests/test_n9_vertex_circle_frontier_comparison.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_frontier_comparison import (
+    assert_expected_frontier_comparison,
+    frontier_comparison_summary,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_frontier_comparison.json"
+
+
+def test_n9_vertex_circle_frontier_comparison_artifact_counts() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert_expected_frontier_comparison(payload)
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    embedding_hits = {
+        result["pattern"]: result["exact_core_embedding_hits"]
+        for result in payload["exact_core_embedding_results"]
+    }
+    assert embedding_hits == {"P18_parity_balanced": 0, "C19_skew": 0}
+    pattern_results = {
+        result["pattern"]: result for result in payload["pattern_vertex_circle_results"]
+    }
+    assert pattern_results["P18_parity_balanced"]["status"] == "strict_cycle"
+    assert pattern_results["P18_parity_balanced"]["core_size"] == 6
+    assert pattern_results["C19_skew"]["status"] == "passes_vertex_circle_filter"
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_n9_vertex_circle_frontier_comparison_artifact_is_current() -> None:
+    checked_in = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert frontier_comparison_summary() == checked_in


### PR DESCRIPTION
## Summary

- add a comparison diagnostic for exact n=9 local-core embeddings into P18 and C19 frontier patterns
- record that no n=9 local core embeds exactly into the recorded P18 or C19 row systems under a strict cyclic-order-preserving row match
- extract the P18 local strict-cycle core and note that its loose span signature matches an n=9 strict-cycle bucket, while the recorded C19 order still passes vertex-circle filtering

## Why

This is a guardrail for the proof route. The local n=9 cores are promising, but they do not literally explain P18 or C19 by exact embedding. P18 shares a looser strict-cycle shape; C19 still shows the current quotient-graph vertex-circle obstruction is not enough on its own.

## Validation

- `python scripts\compare_n9_vertex_circle_frontier.py --assert-expected --write`
- `python -m pytest tests\test_n9_vertex_circle_frontier_comparison.py -q`
- `python -m pytest tests\test_n9_vertex_circle_frontier_comparison.py -q -m "artifact and exhaustive"`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `git diff --check`
- `python scripts\analyze_n9_vertex_circle_local_cores.py --assert-expected`
- `python scripts\enumerate_n8_incidence.py --summary`
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `python scripts\check_n9_vertex_circle_exhaustive.py --assert-expected`
- `python -m pytest -q`

## Notes

This remains diagnostic and review-pending. It does not claim a general proof, a counterexample, or a source-of-truth promotion for n=9.