### PR TITLE
[codex] Add compact Kalmanson two-certificates

### DIFF
--- a/data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json
+++ b/data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json
@@ -1,0 +1,61 @@
+{
+  "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+  "certificate_type": "kalmanson_strict_inequality_farkas",
+  "certificate_variant": "kalmanson_two_inequality_inverse_pair",
+  "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+  "cyclic_order": [
+    5,
+    0,
+    10,
+    8,
+    9,
+    7,
+    4,
+    6,
+    2,
+    11,
+    12,
+    3,
+    1
+  ],
+  "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+  "finder": "scripts/find_kalmanson_two_certificate.py",
+  "inequalities": [
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        5,
+        0,
+        9,
+        3
+      ],
+      "weight": 1
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        5,
+        10,
+        8,
+        9
+      ],
+      "weight": 1
+    }
+  ],
+  "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+  "num_inequalities": 2,
+  "pattern": {
+    "circulant_offsets": [
+      1,
+      2,
+      4,
+      10
+    ],
+    "n": 13,
+    "name": "C13_sidon_1_2_4_10"
+  },
+  "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+  "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+  "support_selection": "Among exact inverse row pairs, prefer fewer nonzero distance classes, then larger selected-distance class support, then deterministic row order.",
+  "weight_sum": 2
+}

--- a/data/certificates/round2/c19_kalmanson_known_order_two_unsat.json
+++ b/data/certificates/round2/c19_kalmanson_known_order_two_unsat.json
@@ -1,0 +1,67 @@
+{
+  "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+  "certificate_type": "kalmanson_strict_inequality_farkas",
+  "certificate_variant": "kalmanson_two_inequality_inverse_pair",
+  "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+  "cyclic_order": [
+    18,
+    10,
+    7,
+    17,
+    6,
+    3,
+    5,
+    9,
+    14,
+    11,
+    2,
+    13,
+    4,
+    16,
+    12,
+    15,
+    0,
+    8,
+    1
+  ],
+  "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+  "finder": "scripts/find_kalmanson_two_certificate.py",
+  "inequalities": [
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        18,
+        10,
+        7,
+        2
+      ],
+      "weight": 1
+    },
+    {
+      "kind": "K2_diag_gt_other",
+      "quad": [
+        7,
+        5,
+        2,
+        16
+      ],
+      "weight": 1
+    }
+  ],
+  "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+  "num_inequalities": 2,
+  "pattern": {
+    "circulant_offsets": [
+      -8,
+      -3,
+      5,
+      9
+    ],
+    "n": 19,
+    "name": "C19_skew"
+  },
+  "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+  "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+  "support_selection": "Among exact inverse row pairs, prefer fewer nonzero distance classes, then larger selected-distance class support, then deterministic row order.",
+  "weight_sum": 2
+}

--- a/data/certificates/sparse_order_survivors.json
+++ b/data/certificates/sparse_order_survivors.json
@@ -20,12 +20,12 @@
       "kalmanson_certificate": {
         "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
         "distance_classes_after_selected_equalities": 39,
-        "max_weight": 1322,
+        "max_weight": 1,
         "obstructed": true,
-        "path": "data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json",
-        "positive_inequalities": 34,
+        "path": "data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json",
+        "positive_inequalities": 2,
         "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
-        "weight_sum": 17463
+        "weight_sum": 2
       },
       "minimum_radius": {
         "blocked_center_count": 4,
@@ -100,14 +100,14 @@
         "passes": true
       },
       "kalmanson_certificate": {
-        "claim_strength": "Exact obstruction for this fixed selected-witness pattern and this fixed cyclic order only; does not kill abstract C19_skew.",
+        "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
         "distance_classes_after_selected_equalities": 114,
-        "max_weight": 334665404,
+        "max_weight": 1,
         "obstructed": true,
-        "path": "data/certificates/round2/c19_kalmanson_known_order_unsat.json",
-        "positive_inequalities": 94,
+        "path": "data/certificates/round2/c19_kalmanson_known_order_two_unsat.json",
+        "positive_inequalities": 2,
         "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
-        "weight_sum": 6283316065
+        "weight_sum": 2
       },
       "minimum_radius": {
         "blocked_center_count": 0,

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -86,10 +86,12 @@ cyclic order
 ```
 
 the checked certificate
-`data/certificates/round2/c19_kalmanson_known_order_unsat.json` gives a
-positive integer combination of 94 strict Kalmanson distance inequalities whose
+`data/certificates/round2/c19_kalmanson_known_order_two_unsat.json` gives a
+positive integer combination of 2 strict Kalmanson distance inequalities whose
 total coefficient vector is exactly zero after quotienting by the
 selected-distance equalities. Summing the strict inequalities gives `0 > 0`.
+The earlier 94-inequality certificate remains checked as provenance at
+`data/certificates/round2/c19_kalmanson_known_order_unsat.json`.
 
 This is not a proof that abstract `C19_skew` is impossible across all cyclic
 orders, and it is not a proof of Erdos #97. See
@@ -114,10 +116,12 @@ For the `C13_sidon_1_2_4_10` selected-witness pattern with offsets
 ```
 
 the checked certificate
-`data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json` gives a
-positive integer combination of 34 strict Kalmanson distance inequalities whose
+`data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json` gives a
+positive integer combination of 2 strict Kalmanson distance inequalities whose
 total coefficient vector is exactly zero after quotienting by the
 selected-distance equalities. Summing the strict inequalities gives `0 > 0`.
+The earlier 34-inequality certificate remains checked as provenance at
+`data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json`.
 
 This is not a proof that abstract `C13_sidon_1_2_4_10` is impossible across all
 cyclic orders, and it is not a proof of Erdos #97. See

--- a/docs/kalmanson-c13-pilot.md
+++ b/docs/kalmanson-c13-pilot.md
@@ -24,7 +24,7 @@ cyclic order = [5,0,10,8,9,7,4,6,2,11,12,3,1]
 Certificate:
 
 ```text
-data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json
+data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json
 ```
 
 The certificate is a positive integer combination of strict convex-quadrilateral
@@ -35,18 +35,23 @@ exactly zero, giving the contradiction `0 > 0`.
 Checked summary:
 
 ```text
-positive inequalities: 34
+positive inequalities: 2
 distance classes after selected equalities: 39
-weight sum: 17463
-max weight: 1322
+weight sum: 2
+max weight: 1
 ```
+
+The earlier 34-inequality certificate remains checked at
+`data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json` as
+provenance, but the two-inequality inverse-pair certificate is the preferred
+review target.
 
 ## Reproduction
 
 Generate and check the certificate:
 
 ```bash
-python scripts/find_kalmanson_certificate.py \
+python scripts/find_kalmanson_two_certificate.py \
   --name C13_sidon_1_2_4_10 \
   --n 13 \
   --offsets 1,2,4,10 \
@@ -55,14 +60,13 @@ python scripts/find_kalmanson_certificate.py \
   --summary-json
 
 python scripts/check_kalmanson_certificate.py \
-  data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json \
+  data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json \
   --summary-json
 ```
 
-The finder uses a numerical LP only to locate a support. It then recovers the
-one-dimensional rational nullspace on that support, clears denominators, and
-checks the resulting exact integer certificate with
-`scripts/check_kalmanson_certificate.py`.
+The compact finder does not use numerical optimization. It scans the exact
+Kalmanson rows for an inverse pair and checks the resulting weight-`1,1`
+certificate with `scripts/check_kalmanson_certificate.py`.
 
 ## Frontier Impact
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -136,10 +136,17 @@ selected-witness assignments.
 ## Priority 7 - keep the frontier separate
 
 Keep `n >= 9`, abstract `C19_skew`, and broader SAT/SMT work separate from the
-small-case claim. The round-two Kalmanson certificate kills one fixed
-`C19_skew` cyclic order, not the abstract pattern over all orders. These are
+small-case claim. The compact round-two Kalmanson certificate kills one fixed
+`C19_skew` cyclic order with two strict inequalities, not the abstract pattern
+over all orders. These are
 research-frontier workstreams, not prerequisites for the repo-local `n <= 8`
 artifact.
+
+Next exact frontier step: turn the two-inequality Kalmanson inverse-pair
+finder into an all-order avoidance search. A positive result would show every
+cyclic order of a fixed sparse pattern contains some inverse-pair obstruction;
+a negative result would produce a new registered order that needs stronger
+geometry.
 
 ## Priority 8 - extend the C13 Kalmanson pilot
 

--- a/docs/round2/kalmanson_distance_filter.md
+++ b/docs/round2/kalmanson_distance_filter.md
@@ -38,26 +38,47 @@ K2_diag_gt_other: d(a,c)+d(b,d) > d(a,d)+d(b,c)
 
 The checker builds selected-distance equivalence classes, expands each inequality as an integer vector over those classes, and verifies that the positive weighted sum is exactly zero. The contradiction is then `0 > 0`.
 
-## Promoted certificate
+## Promoted compact certificate
 
 ```text
-File: data/certificates/round2/c19_kalmanson_known_order_unsat.json
+File: data/certificates/round2/c19_kalmanson_known_order_two_unsat.json
 Pattern: C19_skew
 Offsets: [-8,-3,5,9]
 Cyclic order: [18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1]
-Strict inequalities: 94
+Strict inequalities: 2
 Distance classes: 114
+Max weight: 1
 ```
 
-The same certificate format now also checks the C13 pilot certificate:
+The same certificate format now also checks the compact C13 pilot certificate:
 
 ```text
-File: data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json
+File: data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json
 Pattern: C13_sidon_1_2_4_10
 Offsets: [1,2,4,10]
 Cyclic order: [5,0,10,8,9,7,4,6,2,11,12,3,1]
-Strict inequalities: 34
+Strict inequalities: 2
 Distance classes: 39
+Max weight: 1
+```
+
+The earlier larger certificates remain checked as provenance:
+`data/certificates/round2/c19_kalmanson_known_order_unsat.json` has 94
+inequalities, and
+`data/certificates/c13_sidon_order_survivor_kalmanson_unsat.json` has 34.
+The compact files are preferred for review because each is just an inverse pair
+of strict Kalmanson rows whose coefficient vectors cancel exactly.
+
+Regenerate the compact C19 certificate with:
+
+```bash
+python scripts/find_kalmanson_two_certificate.py \
+  --name C19_skew \
+  --n 19 \
+  --offsets=-8,-3,5,9 \
+  --order 18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1 \
+  --assert-found \
+  --out data/certificates/round2/c19_kalmanson_known_order_two_unsat.json
 ```
 
 Safe claim:

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -236,8 +236,12 @@ are included.
 
 | Pattern | Order label | n | Pre-Kalmanson filters | Kalmanson status |
 |---|---|---:|---|---|
-| `C13_sidon_1_2_4_10` | `sample_full_filter_survivor` | 13 | pass | exact fixed-order obstruction, 34 inequalities |
-| `C19_skew` | `vertex_circle_survivor` | 19 | pass | exact fixed-order obstruction, 94 inequalities |
+| `C13_sidon_1_2_4_10` | `sample_full_filter_survivor` | 13 | pass | exact fixed-order obstruction, 2 inequalities |
+| `C19_skew` | `vertex_circle_survivor` | 19 | pass | exact fixed-order obstruction, 2 inequalities |
+
+Both compact Kalmanson certificates are inverse pairs with weights `1,1`.
+The earlier 34- and 94-inequality certificates remain checked as provenance,
+but the two-inequality versions are the preferred review targets.
 
 The `C13` order is:
 

--- a/scripts/check_round2_certificates.py
+++ b/scripts/check_round2_certificates.py
@@ -22,15 +22,19 @@ def load_script(name: str, path: Path) -> Any:
 def main() -> int:
     kal = load_script("check_kalmanson_certificate", ROOT / "scripts" / "check_kalmanson_certificate.py")
     pto = load_script("check_ptolemy_log_filter", ROOT / "scripts" / "check_ptolemy_log_filter.py")
-    c19 = ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_unsat.json"
+    c19 = ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_two_unsat.json"
+    c19_legacy = ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_unsat.json"
     c17_pto = ROOT / "data" / "certificates" / "round2" / "c17_skew_ptolemy_log_certificate.json"
     c17_kal = ROOT / "data" / "certificates" / "round2" / "c17_skew_kalmanson_from_ptolemy_method_note.json"
     c19_summary = dict(kal.check_certificate_file(c19)._asdict())
     c19_summary["path"] = str(c19.relative_to(ROOT))
+    c19_legacy_summary = dict(kal.check_certificate_file(c19_legacy)._asdict())
+    c19_legacy_summary["path"] = str(c19_legacy.relative_to(ROOT))
     c17_kal_summary = dict(kal.check_certificate_file(c17_kal)._asdict())
     c17_kal_summary["path"] = str(c17_kal.relative_to(ROOT))
     summaries = {
-        "c19_kalmanson_promoted": c19_summary,
+        "c19_kalmanson_promoted_compact": c19_summary,
+        "c19_kalmanson_legacy_large": c19_legacy_summary,
         "c17_ptolemy_method_note": pto.verify_certificate_object(json.loads(c17_pto.read_text(encoding="utf-8"))),
         "c17_kalmanson_translation_regression": c17_kal_summary,
     }

--- a/scripts/check_sparse_order_survivors.py
+++ b/scripts/check_sparse_order_survivors.py
@@ -61,14 +61,17 @@ REGISTERED_ORDERS: dict[str, dict[str, list[int]]] = {
 
 KALMANSON_CERTIFICATES: dict[str, Path] = {
     "C13_sidon_1_2_4_10:sample_full_filter_survivor": (
-        ROOT / "data" / "certificates" / "c13_sidon_order_survivor_kalmanson_unsat.json"
+        ROOT
+        / "data"
+        / "certificates"
+        / "c13_sidon_order_survivor_kalmanson_two_unsat.json"
     ),
     "C19_skew:vertex_circle_survivor": (
         ROOT
         / "data"
         / "certificates"
         / "round2"
-        / "c19_kalmanson_known_order_unsat.json"
+        / "c19_kalmanson_known_order_two_unsat.json"
     ),
 }
 

--- a/scripts/find_kalmanson_two_certificate.py
+++ b/scripts/find_kalmanson_two_certificate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Find a two-inequality Kalmanson/Farkas certificate for one fixed order.
+
+This searches the fixed-order Kalmanson rows for an inverse pair: two strict
+Kalmanson inequalities whose coefficient vectors cancel exactly after
+quotienting by the selected-distance equalities.  Such a pair gives a tiny
+``0 > 0`` certificate with weights ``1, 1``.
+
+The result is still fixed-pattern and fixed-cyclic-order only.  It is not an
+all-order obstruction and does not prove Erdos Problem #97.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_kalmanson_certificate import (  # noqa: E402
+    build_distance_classes,
+    check_certificate_dict,
+)
+from find_kalmanson_certificate import (  # noqa: E402
+    InequalityRow,
+    all_kalmanson_rows,
+    certificate_payload,
+    parse_int_list,
+)
+
+
+def _nonzero_indices(vector: Sequence[int]) -> list[int]:
+    return [idx for idx, value in enumerate(vector) if value != 0]
+
+
+def _class_sizes(n: int, offsets: Sequence[int]) -> dict[int, int]:
+    classes = build_distance_classes(n, offsets)
+    return dict(Counter(classes.values()))
+
+
+def _candidate_sort_key(
+    pair: tuple[int, int],
+    rows: Sequence[InequalityRow],
+    sizes: dict[int, int],
+) -> tuple[int, int, int, int, int]:
+    """Prefer the most local-looking inverse pair, then deterministic order."""
+
+    left, right = pair
+    nonzero = _nonzero_indices(rows[left].vector)
+    total_class_size = sum(sizes[idx] for idx in nonzero)
+    min_class_size = min((sizes[idx] for idx in nonzero), default=0)
+    return (len(nonzero), -total_class_size, -min_class_size, left, right)
+
+
+def inverse_pairs(rows: Sequence[InequalityRow]) -> list[tuple[int, int]]:
+    """Return row-index pairs whose coefficient vectors are exact negatives."""
+
+    by_vector: dict[tuple[int, ...], list[int]] = {}
+    pairs: list[tuple[int, int]] = []
+    for idx, row in enumerate(rows):
+        vector = tuple(row.vector)
+        negative = tuple(-value for value in vector)
+        for left in by_vector.get(negative, []):
+            pairs.append((left, idx))
+        by_vector.setdefault(vector, []).append(idx)
+    return pairs
+
+
+def find_two_certificate(
+    name: str,
+    n: int,
+    offsets: Sequence[int],
+    order: Sequence[int],
+) -> tuple[dict[str, object], dict[str, object]] | None:
+    """Return a compact certificate and summary, if an inverse pair exists."""
+
+    if sorted(order) != list(range(n)):
+        raise ValueError("cyclic order must be a permutation of 0..n-1")
+    rows = all_kalmanson_rows(n, offsets, order)
+    pairs = inverse_pairs(rows)
+    if not pairs:
+        return None
+
+    sizes = _class_sizes(n, offsets)
+    left, right = min(pairs, key=lambda item: _candidate_sort_key(item, rows, sizes))
+    certificate = certificate_payload(
+        name=name,
+        n=n,
+        offsets=offsets,
+        order=order,
+        rows=rows,
+        support=[left, right],
+        weights=[1, 1],
+    )
+    certificate["certificate_variant"] = "kalmanson_two_inequality_inverse_pair"
+    certificate["finder"] = "scripts/find_kalmanson_two_certificate.py"
+    certificate["support_selection"] = (
+        "Among exact inverse row pairs, prefer fewer nonzero distance classes, "
+        "then larger selected-distance class support, then deterministic row order."
+    )
+    check = check_certificate_dict(certificate)
+    nonzero = _nonzero_indices(rows[left].vector)
+    summary = {
+        **check._asdict(),
+        "inverse_pair_candidates": len(pairs),
+        "selected_support_indices": [left, right],
+        "nonzero_distance_class_count": len(nonzero),
+        "nonzero_distance_classes": nonzero,
+        "nonzero_class_sizes": [sizes[idx] for idx in nonzero],
+    }
+    return certificate, summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True, help="pattern name for the certificate")
+    parser.add_argument("--n", required=True, type=int)
+    parser.add_argument("--offsets", required=True, type=parse_int_list)
+    parser.add_argument("--order", required=True, type=parse_int_list)
+    parser.add_argument("--out", type=Path, help="optional certificate output path")
+    parser.add_argument("--assert-found", action="store_true")
+    parser.add_argument("--summary-json", action="store_true")
+    args = parser.parse_args()
+
+    result = find_two_certificate(args.name, args.n, args.offsets, args.order)
+    if result is None:
+        summary = {
+            "status": "NO_TWO_INEQUALITY_KALMANSON_CERTIFICATE_FOUND",
+            "pattern": args.name,
+            "n": args.n,
+        }
+        if args.summary_json:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        elif args.assert_found:
+            print("no two-inequality Kalmanson certificate found")
+        return 1 if args.assert_found else 0
+
+    certificate, summary = result
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(certificate, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.summary_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "found two-inequality Kalmanson certificate "
+            f"for {summary['pattern']} using rows "
+            f"{summary['selected_support_indices']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kalmanson_certificate.py
+++ b/tests/test_kalmanson_certificate.py
@@ -10,8 +10,10 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "check_kalmanson_certificate.py"
 C19 = ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_unsat.json"
+C19_TWO = ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_two_unsat.json"
 C17_TRANSLATION = ROOT / "data" / "certificates" / "round2" / "c17_skew_kalmanson_from_ptolemy_method_note.json"
 C13 = ROOT / "data" / "certificates" / "c13_sidon_order_survivor_kalmanson_unsat.json"
+C13_TWO = ROOT / "data" / "certificates" / "c13_sidon_order_survivor_kalmanson_two_unsat.json"
 
 
 def load_module():
@@ -42,6 +44,18 @@ def test_c19_kalmanson_certificate_exact_summary() -> None:
     assert summary.zero_sum_verified is True
 
 
+def test_c19_compact_two_inequality_kalmanson_certificate() -> None:
+    module = load_module()
+    summary = module.check_certificate_file(C19_TWO)
+    assert summary.pattern == "C19_skew"
+    assert summary.n == 19
+    assert summary.positive_inequalities == 2
+    assert summary.distance_classes_after_selected_equalities == 114
+    assert summary.weight_sum == 2
+    assert summary.max_weight == 1
+    assert summary.zero_sum_verified is True
+
+
 def test_c17_ptolemy_translation_is_valid_kalmanson_certificate() -> None:
     module = load_module()
     summary = module.check_certificate_file(C17_TRANSLATION)
@@ -59,6 +73,16 @@ def test_c13_sidon_survivor_kalmanson_certificate() -> None:
     assert summary.distance_classes_after_selected_equalities == 39
     assert summary.weight_sum == 17463
     assert summary.max_weight == 1322
+
+
+def test_c13_compact_two_inequality_kalmanson_certificate() -> None:
+    module = load_module()
+    summary = module.check_certificate_file(C13_TWO)
+    assert summary.pattern == "C13_sidon_1_2_4_10"
+    assert summary.positive_inequalities == 2
+    assert summary.distance_classes_after_selected_equalities == 39
+    assert summary.weight_sum == 2
+    assert summary.max_weight == 1
 
 
 def test_find_kalmanson_certificate_reproduces_c13_summary() -> None:
@@ -85,6 +109,34 @@ def test_find_kalmanson_certificate_reproduces_c13_summary() -> None:
     summary = json.loads(result.stdout)
     assert summary["pattern"] == "C13_sidon_1_2_4_10"
     assert summary["positive_inequalities"] == 34
+    assert summary["zero_sum_verified"] is True
+
+
+def test_find_kalmanson_two_certificate_reproduces_c19_summary() -> None:
+    finder = ROOT / "scripts" / "find_kalmanson_two_certificate.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(finder),
+            "--name",
+            "C19_skew",
+            "--n",
+            "19",
+            "--offsets=-8,-3,5,9",
+            "--order",
+            "18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1",
+            "--assert-found",
+            "--summary-json",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    summary = json.loads(result.stdout)
+    assert summary["pattern"] == "C19_skew"
+    assert summary["positive_inequalities"] == 2
+    assert summary["max_weight"] == 1
+    assert summary["inverse_pair_candidates"] >= 1
     assert summary["zero_sum_verified"] is True
 
 

--- a/tests/test_round2_package.py
+++ b/tests/test_round2_package.py
@@ -13,6 +13,8 @@ SCRIPT = ROOT / "scripts" / "check_round2_certificates.py"
 def test_round2_package_checker() -> None:
     result = subprocess.run([sys.executable, str(SCRIPT)], check=True, text=True, capture_output=True)
     payload = json.loads(result.stdout)
-    assert payload["c19_kalmanson_promoted"]["zero_sum_verified"] is True
+    assert payload["c19_kalmanson_promoted_compact"]["zero_sum_verified"] is True
+    assert payload["c19_kalmanson_promoted_compact"]["positive_inequalities"] == 2
+    assert payload["c19_kalmanson_legacy_large"]["zero_sum_verified"] is True
     assert payload["c17_ptolemy_method_note"]["verified_zero_sum"] is True
     assert payload["c17_kalmanson_translation_regression"]["zero_sum_verified"] is True

--- a/tests/test_sparse_order_survivors.py
+++ b/tests/test_sparse_order_survivors.py
@@ -36,8 +36,10 @@ def test_registered_sparse_order_survivors_match_artifact() -> None:
     assert c13["survives_current_exact_filters"] is False
     assert c13["vertex_circle"]["obstructed"] is False
     assert c13["radius_propagation"]["acyclic_choice_edge_count"] == 4
-    assert c13["kalmanson_certificate"]["positive_inequalities"] == 34
+    assert c13["kalmanson_certificate"]["positive_inequalities"] == 2
+    assert c13["kalmanson_certificate"]["max_weight"] == 1
     assert c19["survives_pre_kalmanson_filters"] is True
     assert c19["survives_current_exact_filters"] is False
-    assert c19["kalmanson_certificate"]["positive_inequalities"] == 94
+    assert c19["kalmanson_certificate"]["positive_inequalities"] == 2
+    assert c19["kalmanson_certificate"]["max_weight"] == 1
     assert c19["sparse_frontier"]["trivial_empty_radius_choice_exists"] is True


### PR DESCRIPTION
## Summary

- add an exact inverse-pair finder for two-inequality Kalmanson/Farkas certificates
- add compact fixed-order certificates for the registered C13 and C19 sparse survivor orders, each with 2 strict inequalities and max weight 1
- update the sparse survivor sweep, round-two checker, claims, and docs to prefer the compact certificates while keeping the older large certificates as provenance

## Why

The registered sparse survivor orders were already killed by fixed-order Kalmanson certificates, but the previous C19 certificate had 94 inequalities and very large weights. The compact inverse-pair certificates are much easier to audit and point to a sharper all-order avoidance-search direction. This still does not claim an all-order C19 obstruction or a proof of Erdos #97.

## Validation

- `python -m pytest tests\test_kalmanson_certificate.py tests\test_sparse_order_survivors.py -q`
- `python scripts\check_round2_certificates.py`
- `python scripts\check_kalmanson_certificate.py data\certificates\round2\c19_kalmanson_known_order_two_unsat.json data\certificates\c13_sidon_order_survivor_kalmanson_two_unsat.json`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `git diff --check`
- `python scripts\enumerate_n8_incidence.py --summary`
- `python scripts\analyze_n8_exact_survivors.py --check --json`
- `python scripts\check_sparse_order_survivors.py --assert-expected`
- `python -m pytest -q`