### PR TITLE
Sync Codex guidance and artifact audits

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -22,6 +22,15 @@
 - name: EXACTIFICATION
   color: "006b75"
   description: Algebraic, interval, SMT, or certificate work.
+- name: ARTIFACT_AUDIT
+  color: "1f883d"
+  description: Reproducibility checks for generated or checked-in artifacts.
+- name: FRONTIER
+  color: "6f42c1"
+  description: Research-frontier work that must not change global status by itself.
+- name: DOC_SYNC
+  color: "d4c5f9"
+  description: Documentation, metadata, or source-of-truth alignment.
 - name: SAT_SMT
   color: "0052cc"
   description: Finite abstraction or solver encoding.

--- a/.github/workflows/artifact-audit.yml
+++ b/.github/workflows/artifact-audit.yml
@@ -1,0 +1,33 @@
+name: artifact audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e .[dev]
+      - run: python scripts/check_status_consistency.py --max-official-status-age-days 90
+      - run: python scripts/check_artifact_provenance.py
+      - name: Run artifact audit
+        run: python scripts/run_artifact_audit.py --output-dir artifact-audit-results
+      - name: Upload artifact audit summaries
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-audit-${{ github.sha }}
+          path: artifact-audit-results/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
       - run: pip install -e .[dev]
       - run: python scripts/check_text_clean.py
       - run: python scripts/check_status_consistency.py
+      - run: python scripts/check_artifact_provenance.py
       - run: git diff --check
-      - run: ruff check .
-      - run: pytest -q
+      - run: python -m ruff check .
+      - run: python -m pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ dist/
 # Large or transient search outputs
 outputs/
 runs/tmp/
+artifact-audit-results/
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,26 +25,61 @@ Erdos Problem #97. It is not a solved-proof repository.
 
 ## Test commands
 
-Run these after documentation or code changes:
+Before changing mathematical claims, read `README.md`, `STATE.md`,
+`RESULTS.md`, `metadata/erdos97.yaml`, `docs/claims.md`, and
+`docs/review-priorities.md`. For task selection, also read
+`docs/codex-backlog.md`.
+
+Run the fast tier after documentation or code changes:
 
 ```bash
 python scripts/check_text_clean.py
 python scripts/check_status_consistency.py
+python scripts/check_artifact_provenance.py
 git diff --check
-pytest -q
+python -m ruff check .
+python -m pytest -q
 ```
 
-For finite-case artifacts, also run:
+The same fast tier is available as:
 
 ```bash
+make verify-fast
+```
+
+For finite-case or public theorem-style artifact changes, also run the
+artifact tier or explain exactly which command could not be run and why:
+
+```bash
+python scripts/independent_check_n8_artifacts.py --check --json
 python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
+python scripts/check_round2_certificates.py
+python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```
+
+The artifact tier is available as:
+
+```bash
+make verify-artifacts
+```
+
+The scheduled/manual GitHub artifact audit runs the same artifact commands with
+metadata capture. Locally, use:
+
+```bash
+python scripts/check_status_consistency.py --max-official-status-age-days 90
+make audit-artifacts
 ```
 
 ## Research hygiene
 
 - Separate exact proofs from heuristics and numerical evidence.
 - Label claims using the repo trust taxonomy.
+- Keep fixed-pattern, fixed-order, all-order-for-one-pattern, `n <= 8`
+  repo-local, and review-pending `n=9` artifacts in separate claim scopes.
 - Prefer small reproducible JSON artifacts over screenshots or prose-only
   claims.
 - Record failed approaches clearly enough that future work avoids repeating

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+PYTHON ?= python
+
+.PHONY: verify-fast verify-n8 verify-kalmanson verify-n9-review verify-artifacts audit-artifacts verify-all
+
+verify-fast:
+	$(PYTHON) scripts/check_text_clean.py
+	$(PYTHON) scripts/check_status_consistency.py
+	$(PYTHON) scripts/check_artifact_provenance.py
+	git diff --check
+	$(PYTHON) -m ruff check .
+	$(PYTHON) -m pytest -q
+
+verify-n8:
+	$(PYTHON) scripts/independent_check_n8_artifacts.py --check --json
+	$(PYTHON) scripts/enumerate_n8_incidence.py --summary
+	$(PYTHON) scripts/analyze_n8_exact_survivors.py --check --json
+
+verify-kalmanson:
+	$(PYTHON) scripts/check_round2_certificates.py
+	$(PYTHON) scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+	$(PYTHON) scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
+	$(PYTHON) scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+
+verify-n9-review:
+	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+
+verify-artifacts: verify-n8 verify-kalmanson verify-n9-review
+
+audit-artifacts:
+	$(PYTHON) scripts/check_artifact_provenance.py
+	$(PYTHON) scripts/run_artifact_audit.py --output-dir artifact-audit-results
+
+verify-all: verify-fast verify-artifacts

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/oeis-possibilities.md`](docs/oeis-possibilities.md).
 - For repository-level Codex guidance, read [`AGENTS.md`](AGENTS.md).
 - For runnable verification, start with [`scripts/verify_candidate.py`](scripts/verify_candidate.py).
-- For current work items, see [Issues #1-#7](https://github.com/davidiach/erdos97/issues).
+- For current work items, see [`docs/review-priorities.md`](docs/review-priorities.md),
+  [`docs/codex-backlog.md`](docs/codex-backlog.md), and the live
+  [open GitHub issues](https://github.com/davidiach/erdos97/issues).
 
 ## Problem
 
@@ -247,14 +249,54 @@ Use these labels consistently:
 python -m venv .venv
 source .venv/bin/activate
 pip install -e .[dev]
+make verify-fast
+```
+
+If `make` is not available, run the fast tier directly:
+
+```bash
 python scripts/check_text_clean.py
 python scripts/check_status_consistency.py
-pytest -q
+python scripts/check_artifact_provenance.py
+git diff --check
+python -m ruff check .
+python -m pytest -q
+```
+
+Artifact and frontier checks are slower and should be run before finite-case,
+certificate, or public theorem-style updates:
+
+```bash
+make verify-artifacts
+```
+
+The manual/scheduled artifact-audit workflow runs the same artifact commands
+with command, commit, Python version, dependency snapshot, elapsed-time, and
+output-hash metadata:
+
+```bash
+python scripts/check_status_consistency.py --max-official-status-age-days 90
+make audit-artifacts
+```
+
+Equivalent raw commands:
+
+```bash
+python scripts/independent_check_n8_artifacts.py --check --json
 python scripts/check_round2_certificates.py
 python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
+python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```
+
+Useful exploratory commands:
+
+```bash
 erdos97-search --list-patterns
 erdos97-search --verify data/runs/best_B12_slsqp_m1e-6.json --tol 1e-6
+python scripts/interval_verify_candidate.py data/runs/best_B12_slsqp_m1e-6.json
 python scripts/check_mutual_rhombus_filter.py --assert-expected
 python scripts/check_vertex_circle_order_filter.py --pattern P18_parity_balanced --search --assert-obstructed
 python scripts/check_min_radius_filter.py --pattern C19_skew --assert-pass
@@ -316,9 +358,12 @@ If you use this repository, please cite it using [`CITATION.cff`](CITATION.cff).
 
 ## Maintenance checklist
 
-- Run `pytest -q`.
+- Run `make verify-fast` or the equivalent raw fast-tier commands.
+- Run `make verify-artifacts` before finite-case, certificate, or public
+  theorem-style updates, or record why a command could not be run.
 - Run `python scripts/check_text_clean.py`.
 - Run `python scripts/check_status_consistency.py`.
 - Confirm this README still says no general proof and no counterexample are claimed.
 - Create labels matching `.github/labels.yml`.
-- Open the seed issues listed in `docs/initial-issues.md`.
+- Keep current-work pointers aligned with `docs/review-priorities.md`,
+  `docs/codex-backlog.md`, and the live GitHub issue list.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -1,0 +1,205 @@
+# Codex Backlog
+
+Status: operational planning guidance only; not mathematical evidence.
+
+Live open issues were checked through GitHub on 2026-05-04. This backlog is a
+Codex-facing companion to `docs/review-priorities.md`; it does not change the
+repository claims. No general proof and no counterexample are claimed, and the
+official/global status remains falsifiable/open unless manually rechecked and
+updated from the official source.
+
+## Task CB-83 - Decompose C19 Kalmanson Certificate
+
+Issue: <https://github.com/davidiach/erdos97/issues/83>
+
+Read first:
+
+- `docs/round2/round2_merged_report.md`
+- `docs/round2/kalmanson_distance_filter.md`
+- `docs/kalmanson-certificate-diagnostics.md`
+- `reports/c19_kalmanson_diagnostics.json`
+- `data/certificates/round2/c19_kalmanson_known_order_unsat.json`
+- `data/certificates/round2/c19_kalmanson_known_order_two_unsat.json`
+
+Commands:
+
+```bash
+python scripts/check_round2_certificates.py
+python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+python scripts/analyze_kalmanson_certificates.py
+```
+
+Expected artifacts:
+
+- a reproducible diagnostic script or update to an existing report generator;
+- a checked JSON or Markdown report summarizing support groups, smaller
+  dependencies, or negative results.
+
+Acceptance criteria:
+
+- The compact two-inequality certificate and the earlier 94-inequality
+  certificate both remain valid.
+- Any structural decomposition is reproducible without notebooks.
+- Documentation keeps one fixed `C19_skew` cyclic order separate from abstract
+  `C19_skew` over all orders.
+
+Trust delta: may improve fixed-order certificate understanding or produce a
+new fixed-order exact obstruction. It may not promote abstract `C19_skew`, any
+`n >= 9` finite case, or Erdos Problem #97.
+
+Forbidden overclaiming text:
+
+- "C19_skew is impossible"
+- "all cyclic orders of C19 are killed"
+- "this closes the frontier"
+
+## Task CB-82 - Attack n=9 Base-Apex Low-Excess Ledgers
+
+Issue: <https://github.com/davidiach/erdos97/issues/82>
+
+Read first:
+
+- `docs/n9-base-apex-frontier.md`
+- `src/erdos97/n9_base_apex.py`
+- `scripts/explore_n9_base_apex.py`
+- `data/certificates/n9_vertex_circle_exhaustive.json`
+- `docs/n9-vertex-circle-exhaustive.md`
+
+Commands:
+
+```bash
+python scripts/explore_n9_base_apex.py
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```
+
+Expected artifacts:
+
+- a JSON or Markdown report listing which low-excess ledgers remain;
+- a checker update only if the new obstruction is exact and reproducible.
+
+Acceptance criteria:
+
+- Remaining `E <= 6` / `D >= 3` or related low-excess cases are enumerated
+  explicitly.
+- Any new obstruction states exact incidence/order hypotheses.
+- The n=9 status is not promoted unless every required case is certified.
+
+Trust delta: may promote a conditional ledger obstruction or a review-pending
+n=9 subcase. It may not promote the full n=9 selected-witness case without a
+complete checked pipeline and independent review path.
+
+Forbidden overclaiming text:
+
+- "n=9 is proved"
+- "the vertex-circle checker is independently reviewed"
+- "this updates the official Erdos #97 status"
+
+## Task CB-81 - Pilot Kalmanson Cyclic-Order CSP On C13
+
+Issue: <https://github.com/davidiach/erdos97/issues/81>
+
+Read first:
+
+- `docs/kalmanson-two-order-search.md`
+- `docs/c13-kalmanson-order-pilot.md`
+- `docs/c13-kalmanson-prefix-branch-pilot.md`
+- `scripts/check_kalmanson_two_order_search.py`
+- `data/certificates/c13_sidon_all_orders_kalmanson_two_search.json`
+
+Commands:
+
+```bash
+python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
+python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+```
+
+Expected artifacts:
+
+- deterministic branch/pruning counts;
+- exact certificates for closed branches when new branches are added;
+- documentation separating fixed-order, all-order-for-one-pattern, and
+  heuristic diagnostics.
+
+Acceptance criteria:
+
+- Rotation fixing is justified only by circulant translation symmetry.
+- The all-order statement remains scoped to the fixed abstract
+  `C13_sidon_1_2_4_10` selected-witness pattern.
+- The C13 pilot is used only as a benchmark for larger sparse frontiers.
+
+Trust delta: may improve or reproduce
+`EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN` for C13. It may not prove
+anything about abstract `C19_skew` or Erdos Problem #97.
+
+Forbidden overclaiming text:
+
+- "C13 proves the method works for C19"
+- "Kalmanson closes the sparse frontier"
+- "this is evidence of a general proof"
+
+## Task CB-5 - Add Interval-Arithmetic Verifier
+
+Issue: <https://github.com/davidiach/erdos97/issues/5>
+
+Read first:
+
+- `scripts/verify_candidate.py`
+- `src/erdos97/search.py`
+- `data/runs/best_B12_slsqp_m1e-6.json`
+- `certificates/best_B12_certificate_template.json`
+- `docs/exactification-plan.md`
+- `docs/verification-contract.md`
+
+Commands:
+
+```bash
+erdos97-search --verify data/runs/best_B12_slsqp_m1e-6.json --tol 1e-6
+python scripts/verify_candidate.py data/runs/best_B12_slsqp_m1e-6.json
+python -m pytest tests/test_search_hygiene.py -q
+```
+
+Expected artifacts:
+
+- `src/erdos97/interval_verify.py` or an equivalent module;
+- `scripts/interval_verify_candidate.py` or an equivalent CLI;
+- tests that reject the saved B12 near-miss as a counterexample.
+
+Current entrypoint:
+
+```bash
+python scripts/interval_verify_candidate.py data/runs/best_B12_slsqp_m1e-6.json
+```
+
+The current entrypoint certifies interval bounds only. It deliberately rejects
+the saved B12 near-miss and reserves exact acceptance for rational-coordinate
+inputs under `coordinates_exact`.
+
+Acceptance criteria:
+
+- The verifier distinguishes malformed input, floating near-miss,
+  interval-certified strict convexity with uncertified equality, and exact or
+  algebraic acceptance.
+- JSON output includes validation errors, residual bounds, claim strength, and
+  failure mode.
+- No floating candidate is promoted to a counterexample.
+
+Trust delta: may promote selected candidate checks from numerical evidence to
+interval-certified validation only when interval hypotheses are actually met.
+It may not certify exact distance equalities from floating residuals alone.
+
+Forbidden overclaiming text:
+
+- "B12 is a counterexample"
+- "near miss"
+- "intervals prove exact equality" unless the interval certificate really does
+
+## Cross-Cutting Rules
+
+- Run `make verify-fast` or the raw fast tier after code or documentation
+  changes.
+- Run `make verify-artifacts` or `make audit-artifacts` before finite-case,
+  certificate, or public theorem-style updates.
+- Update `README.md`, `STATE.md`, `RESULTS.md`, and `metadata/erdos97.yaml`
+  together only when a task changes source-of-truth status.
+- Keep archived/provenance statements marked when superseded.
+- Do not prepare OEIS submissions from AI-generated output.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -8,6 +8,9 @@ claimed, the official/global status remains falsifiable/open, and the local
 `n <= 8` selected-witness result remains repo-local and machine-checked pending
 independent review.
 
+For a Codex-ready task list with issue links, commands, acceptance criteria,
+trust deltas, and forbidden overclaiming text, see `docs/codex-backlog.md`.
+
 ## Priority 1 - review the octagon proof note
 
 Target: `docs/n8-geometric-proof.md`.

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -13,19 +13,54 @@
 - It does not claim the `n=8` artifact has had independent external review.
 - It does not claim that the round-two `C19_skew` Kalmanson certificate kills
   all cyclic orders of the abstract pattern.
+- It does not claim that the exact all-order C13 result proves Erdos Problem
+  #97; that result is only for one fixed abstract selected-witness pattern.
 
-## Minimal reproduction commands
+## Fast reproduction commands
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 pip install -e .[dev]
+make verify-fast
+```
+
+If `make` is not available, run:
+
+```bash
 python scripts/check_text_clean.py
 python scripts/check_status_consistency.py
-pytest -q
-python scripts/check_round2_certificates.py
+python scripts/check_artifact_provenance.py
+git diff --check
+python -m ruff check .
+python -m pytest -q
+```
+
+## Artifact audit commands
+
+Run these before finite-case, certificate, or public theorem-style updates:
+
+```bash
+make verify-artifacts
+```
+
+For CI-style audit metadata, run:
+
+```bash
+python scripts/check_status_consistency.py --max-official-status-age-days 90
+make audit-artifacts
+```
+
+Equivalent raw commands:
+
+```bash
+python scripts/independent_check_n8_artifacts.py --check --json
 python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
+python scripts/check_round2_certificates.py
+python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 ```
 
 For a version-matched reproduction run, replace `pip install -e .[dev]` with:
@@ -117,9 +152,21 @@ Check:
 - that `scripts/check_kalmanson_certificate.py` reconstructs the selected
   distance quotient from the declared `C19_skew` offsets;
 - that every listed quadrilateral is in the declared cyclic order;
-- that all 94 weights are positive integers;
+- that the compact two-inequality certificate has positive integer weights and
+  zero total coefficient sum;
+- that the earlier 94-inequality certificate remains valid as provenance;
 - that the weighted coefficient sum is exactly zero;
 - that the result is recorded only as a fixed-order obstruction.
+
+## Review target F - C13 all-order two-certificate search
+
+Check:
+
+- that `scripts/check_kalmanson_two_order_search.py` fixes label `0` only by
+  translation symmetry for the circulant pattern;
+- that the search result is an all-order statement only for the fixed abstract
+  `C13_sidon_1_2_4_10` selected-witness pattern;
+- that the result is not described as a general proof of Erdos Problem #97.
 
 ## Known weak points / independent review requests
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1,0 +1,148 @@
+schema: erdos97.generated_artifacts.v1
+claim_scope: >
+  Manifest for generated or generator-owned artifacts. This is provenance and
+  edit-policy metadata only; it does not prove Erdos Problem #97 and does not
+  claim a counterexample.
+
+artifacts:
+  - id: n8_reconstructed_survivors
+    path: data/incidence/n8_reconstructed_15_survivors.json
+    kind: finite_case_artifact
+    generator: scripts/enumerate_n8_incidence.py
+    command: python scripts/enumerate_n8_incidence.py --summary
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: INCIDENCE_COMPLETENESS
+    claim_scope: Repo-local n=8 selected-witness survivor classes only.
+    json_top_level_type: list
+    forbidden_claims:
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
+  - id: n8_incidence_completeness
+    path: data/incidence/n8_incidence_completeness.json
+    kind: finite_case_artifact
+    generator: scripts/enumerate_n8_incidence.py
+    command: python scripts/enumerate_n8_incidence.py --summary
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: INCIDENCE_COMPLETENESS
+    claim_scope: Repo-local n=8 incidence completeness artifact.
+    json_top_level_type: object
+    expected_json:
+      n: 8
+      status: INCIDENCE_COMPLETENESS
+      canonical_survivor_class_count: 15
+      matches_existing_reconstructed_survivors: true
+    forbidden_claims:
+      - public theorem
+      - general proof of Erdos Problem #97
+
+  - id: n8_compatible_orders
+    path: data/incidence/n8_compatible_orders.json
+    kind: finite_case_artifact
+    generator: scripts/analyze_n8_exact_survivors.py
+    command: python scripts/analyze_n8_exact_survivors.py --check --json --check-compatible-orders-data data/incidence/n8_compatible_orders.json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: EXACT_OBSTRUCTION
+    claim_scope: Repo-local n=8 compatible cyclic-order audit data.
+    json_top_level_type: object
+    forbidden_claims:
+      - independent external review
+      - general proof of Erdos Problem #97
+
+  - id: n8_exact_analysis
+    path: certificates/n8_exact_analysis.json
+    kind: certificate_artifact
+    generator: scripts/analyze_n8_exact_survivors.py
+    command: python scripts/analyze_n8_exact_survivors.py --check --json --check-exact-analysis-data certificates/n8_exact_analysis.json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: EXACT_OBSTRUCTION
+    claim_scope: Repo-local n=8 exact survivor obstruction artifact pending external review.
+    json_top_level_type: object
+    forbidden_claims:
+      - public theorem
+      - counterexample to Erdos Problem #97
+
+  - id: c19_fixed_order_two_kalmanson
+    path: data/certificates/round2/c19_kalmanson_known_order_two_unsat.json
+    kind: certificate_artifact
+    generator: scripts/find_kalmanson_two_certificate.py
+    command: python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: EXACT_OBSTRUCTION
+    claim_scope: Exact obstruction for one fixed C19_skew cyclic order only.
+    json_top_level_type: object
+    expected_json:
+      certificate_type: kalmanson_strict_inequality_farkas
+      certificate_variant: kalmanson_two_inequality_inverse_pair
+      pattern.name: C19_skew
+      status: EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER
+      weight_sum: 2
+    forbidden_claims:
+      - all cyclic orders of C19 are killed
+      - C19_skew is impossible
+      - general proof of Erdos Problem #97
+
+  - id: c13_fixed_order_two_kalmanson
+    path: data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json
+    kind: certificate_artifact
+    generator: scripts/find_kalmanson_two_certificate.py
+    command: python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: EXACT_OBSTRUCTION
+    claim_scope: Exact obstruction for one fixed C13 selected-witness cyclic order only.
+    json_top_level_type: object
+    expected_json:
+      certificate_type: kalmanson_strict_inequality_farkas
+      certificate_variant: kalmanson_two_inequality_inverse_pair
+      pattern.name: C13_sidon_1_2_4_10
+      status: EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER
+      weight_sum: 2
+    forbidden_claims:
+      - C13 proves the method works for C19
+      - general proof of Erdos Problem #97
+
+  - id: c13_all_orders_kalmanson_two_search
+    path: data/certificates/c13_sidon_all_orders_kalmanson_two_search.json
+    kind: exhaustive_search_artifact
+    generator: scripts/check_kalmanson_two_order_search.py
+    command: python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN
+    claim_scope: All-order obstruction for one fixed abstract C13 selected-witness pattern only.
+    json_top_level_type: object
+    expected_json:
+      pattern.name: C13_sidon_1_2_4_10
+      status: EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION
+      trust: EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN
+      survivor_order: null
+    forbidden_claims:
+      - C13 proves the method works for C19
+      - this is evidence of a general proof
+      - general proof of Erdos Problem #97
+
+  - id: n9_vertex_circle_exhaustive
+    path: data/certificates/n9_vertex_circle_exhaustive.json
+    kind: finite_case_artifact
+    generator: scripts/check_n9_vertex_circle_exhaustive.py
+    command: python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING
+    claim_scope: Review-pending n=9 selected-witness finite-case checker output only.
+    json_top_level_type: object
+    expected_json:
+      n: 9
+      row_size: 4
+      trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING
+      main_search.full_assignments: 0
+    forbidden_claims:
+      - n=9 is proved
+      - official/global status update
+      - general proof of Erdos Problem #97

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate the generated-artifact provenance manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "metadata" / "generated_artifacts.yaml"
+SCHEMA = "erdos97.generated_artifacts.v1"
+
+KNOWN_TRUST = {
+    "EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
+    "EXACT_OBSTRUCTION",
+    "INCIDENCE_COMPLETENESS",
+    "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING",
+    "REVIEW_PENDING_PROVENANCE",
+}
+PROVENANCE_MODES = {"embedded", "manifest_only_legacy"}
+JSON_TOP_LEVEL_TYPES = {
+    "object": dict,
+    "list": list,
+}
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("manifest top level must be a mapping")
+    return payload
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dotted_get(payload: Any, dotted_key: str) -> Any:
+    current = payload
+    for part in dotted_key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(dotted_key)
+        current = current[part]
+    return current
+
+
+def validate_manifest(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        errors.append("artifacts must be a nonempty list")
+        return errors
+
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        label = f"artifacts[{index}]"
+        if not isinstance(artifact, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        errors.extend(validate_artifact(artifact, label, seen_ids, seen_paths))
+    return errors
+
+
+def validate_artifact(
+    artifact: dict[str, Any],
+    label: str,
+    seen_ids: set[str],
+    seen_paths: set[str],
+) -> list[str]:
+    errors: list[str] = []
+    required_strings = ("id", "path", "kind", "generator", "command", "claim_scope", "trust")
+    for key in required_strings:
+        value = artifact.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{label}.{key} must be a nonempty string")
+
+    ident = artifact.get("id")
+    if isinstance(ident, str):
+        if ident in seen_ids:
+            errors.append(f"{label}.id {ident!r} is duplicated")
+        seen_ids.add(ident)
+
+    raw_path = artifact.get("path")
+    if isinstance(raw_path, str):
+        if raw_path in seen_paths:
+            errors.append(f"{label}.path {raw_path!r} is duplicated")
+        seen_paths.add(raw_path)
+        path = repo_path(raw_path)
+        if not path.exists():
+            errors.append(f"{label}.path does not exist: {raw_path}")
+            payload = None
+        else:
+            try:
+                payload = load_json(path)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{label}.path is not valid JSON: {exc}")
+                payload = None
+    else:
+        payload = None
+
+    generator = artifact.get("generator")
+    if isinstance(generator, str) and not repo_path(generator).exists():
+        errors.append(f"{label}.generator does not exist: {generator}")
+
+    if artifact.get("direct_edit_allowed") is not False:
+        errors.append(f"{label}.direct_edit_allowed must be false for generated artifacts")
+
+    provenance_mode = artifact.get("provenance_mode")
+    if provenance_mode not in PROVENANCE_MODES:
+        errors.append(f"{label}.provenance_mode must be one of {sorted(PROVENANCE_MODES)}")
+
+    trust = artifact.get("trust")
+    if trust not in KNOWN_TRUST:
+        errors.append(f"{label}.trust {trust!r} is not a known trust value")
+
+    forbidden_claims = artifact.get("forbidden_claims")
+    if not isinstance(forbidden_claims, list) or not forbidden_claims:
+        errors.append(f"{label}.forbidden_claims must be a nonempty list")
+    else:
+        for phrase in forbidden_claims:
+            if not isinstance(phrase, str) or not phrase.strip():
+                errors.append(f"{label}.forbidden_claims entries must be nonempty strings")
+
+    if payload is not None:
+        errors.extend(validate_json_payload(artifact, payload, label))
+    return errors
+
+
+def validate_json_payload(artifact: dict[str, Any], payload: Any, label: str) -> list[str]:
+    errors: list[str] = []
+    expected_type = artifact.get("json_top_level_type")
+    expected_python_type = JSON_TOP_LEVEL_TYPES.get(expected_type)
+    if expected_python_type is None:
+        errors.append(f"{label}.json_top_level_type must be one of {sorted(JSON_TOP_LEVEL_TYPES)}")
+    elif not isinstance(payload, expected_python_type):
+        errors.append(f"{label}.path top level is not {expected_type}")
+
+    if artifact.get("provenance_mode") == "embedded":
+        if not isinstance(payload, dict) or not isinstance(payload.get("provenance"), dict):
+            errors.append(f"{label}.path must contain an embedded provenance object")
+
+    expected_json = artifact.get("expected_json", {})
+    if expected_json is None:
+        expected_json = {}
+    if not isinstance(expected_json, dict):
+        errors.append(f"{label}.expected_json must be a mapping when present")
+        return errors
+
+    for dotted_key, expected in expected_json.items():
+        try:
+            actual = dotted_get(payload, str(dotted_key))
+        except KeyError:
+            errors.append(f"{label}.path is missing expected JSON key {dotted_key!r}")
+            continue
+        if actual != expected:
+            errors.append(f"{label}.path {dotted_key!r} is {actual!r}, expected {expected!r}")
+    return errors
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = args.manifest
+    if not manifest.is_absolute():
+        manifest = REPO_ROOT / manifest
+    try:
+        payload = load_manifest(manifest)
+        errors = validate_manifest(payload)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        errors = [str(exc)]
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print(f"artifact provenance manifest is valid: {manifest.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -2,9 +2,12 @@
 """Check top-level status text for stale or overclaiming contradictions."""
 from __future__ import annotations
 
+import argparse
 import re
 import sys
+from datetime import date, datetime
 from pathlib import Path
+from typing import Sequence
 
 try:
     import yaml
@@ -95,6 +98,12 @@ def require_string_field(mapping: object, key: str, label: str) -> str:
     return value
 
 
+def parse_iso_date(value: str, label: str) -> date:
+    if not DATE_RE.fullmatch(value):
+        fail(f"{label} should be YYYY-MM-DD")
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
 def require_pattern(label: str, text: str, pattern: re.Pattern[str], detail: str) -> None:
     if not pattern.search(text):
         fail(f"{label} should state {detail}")
@@ -118,7 +127,7 @@ def stale_line_is_archived(lines: list[str], index: int) -> bool:
     return any(marker in window for marker in ARCHIVAL_MARKERS)
 
 
-def validate_metadata() -> None:
+def validate_metadata(max_official_status_age_days: int | None = None) -> None:
     path = ROOT / "metadata" / "erdos97.yaml"
     if not path.exists():
         fail("metadata/erdos97.yaml is missing")
@@ -127,6 +136,14 @@ def validate_metadata() -> None:
     official_status = metadata_value(metadata, ("problem", "official_status"))
     if not isinstance(official_status, str) or official_status.lower() != "falsifiable/open":
         fail("metadata official_status should be falsifiable/open")
+    official = metadata_value(metadata, ("problem",))
+    if not isinstance(official, dict):
+        fail("metadata problem should be a mapping")
+    parse_iso_date(
+        require_string_field(official, "official_page_last_edited", "metadata problem"),
+        "metadata problem.official_page_last_edited",
+    )
+    validate_official_status_freshness(official, max_official_status_age_days)
     require_pattern(
         "metadata local_repo.overall_claim",
         str(metadata_value(metadata, ("local_repo", "overall_claim"))),
@@ -148,6 +165,30 @@ def validate_metadata() -> None:
             fail(f"metadata trust_policy.{key} should be true")
 
     validate_nearby_literature(metadata)
+
+
+def validate_official_status_freshness(
+    official: dict[str, object],
+    max_age_days: int | None,
+    today: date | None = None,
+) -> None:
+    checked = parse_iso_date(
+        require_string_field(official, "official_status_last_checked", "metadata problem"),
+        "metadata problem.official_status_last_checked",
+    )
+    if max_age_days is None:
+        return
+    if max_age_days < 0:
+        fail("--max-official-status-age-days should be nonnegative")
+    today = today or date.today()
+    age_days = (today - checked).days
+    if age_days < 0:
+        fail("metadata problem.official_status_last_checked is in the future")
+    if age_days > max_age_days:
+        fail(
+            "metadata problem.official_status_last_checked is "
+            f"{age_days} days old, above the {max_age_days}-day limit"
+        )
 
 
 def validate_nearby_literature(metadata: dict[str, object]) -> None:
@@ -205,8 +246,23 @@ def validate_archived_synthesis() -> None:
             fail(f"unarchived stale n=8 Open wording at {synthesis}:{i + 1}")
 
 
-def main() -> None:
-    validate_metadata()
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-official-status-age-days",
+        type=int,
+        default=None,
+        help=(
+            "Fail if metadata problem.official_status_last_checked is older "
+            "than this many days. Intended for artifact-audit or release paths."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    validate_metadata(args.max_official_status_age_days)
     validate_top_level_status()
     validate_archived_synthesis()
 

--- a/scripts/check_text_clean.py
+++ b/scripts/check_text_clean.py
@@ -88,7 +88,11 @@ def tracked_files() -> list[Path]:
 
 
 def is_text_target(path: Path) -> bool:
-    return path.suffix in TEXT_SUFFIXES or path.name.startswith("LICENSE")
+    return (
+        path.suffix in TEXT_SUFFIXES
+        or path.name == "Makefile"
+        or path.name.startswith("LICENSE")
+    )
 
 
 def line_col(text: str, index: int) -> tuple[int, int]:

--- a/scripts/independent_check_n8_artifacts.py
+++ b/scripts/independent_check_n8_artifacts.py
@@ -237,6 +237,16 @@ def check_all(root: Path) -> dict[str, Any]:
             "does not claim a general proof of Erdos Problem #97 or a "
             "standalone public theorem."
         ),
+        "does_not_check": [
+            "full independent regeneration of the n=8 incidence enumeration",
+            "independent external mathematical review",
+            "general Erdos Problem #97 proof",
+            "counterexample to Erdos Problem #97",
+        ],
+        "dependencies_imported": [
+            "scripts/analyze_n8_exact_survivors.py",
+            "scripts/independent_check_n8_incidence_json.py",
+        ],
     }
 
 

--- a/scripts/interval_verify_candidate.py
+++ b/scripts/interval_verify_candidate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Conservatively interval-check a saved Erdos #97 numerical candidate."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from erdos97.interval_verify import verify_interval_json
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("json_path")
+    parser.add_argument("--eq-bound", type=float, default=1e-8)
+    parser.add_argument("--coord-abs-radius", type=float, default=1e-12)
+    parser.add_argument("--coord-rel-radius", type=float, default=1e-12)
+    parser.add_argument("--check", action="store_true", help="exit nonzero unless the candidate is certified")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = verify_interval_json(
+        args.json_path,
+        eq_bound=args.eq_bound,
+        coord_abs_radius=args.coord_abs_radius,
+        coord_rel_radius=args.coord_rel_radius,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.check and not result["ok"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -94,7 +94,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
 
 
 def utc_now() -> str:
-    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def sha256_bytes(data: bytes) -> str:

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Run the slower artifact audit commands and record reproducibility metadata."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class AuditCommand:
+    """One artifact-audit command and its claim scope."""
+
+    ident: str
+    command: tuple[str, ...]
+    claim_scope: str
+
+
+AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
+    AuditCommand(
+        ident="n8_artifact_alignment",
+        command=("python", "scripts/independent_check_n8_artifacts.py", "--check", "--json"),
+        claim_scope="Repo-local n <= 8 artifact alignment and exact-obstruction audit; not a general proof.",
+    ),
+    AuditCommand(
+        ident="n8_incidence_enumeration",
+        command=("python", "scripts/enumerate_n8_incidence.py", "--summary"),
+        claim_scope="Repo-local n=8 finite selected-witness incidence enumeration.",
+    ),
+    AuditCommand(
+        ident="n8_exact_survivors",
+        command=("python", "scripts/analyze_n8_exact_survivors.py", "--check", "--json"),
+        claim_scope="Repo-local n=8 exact survivor obstruction audit pending external review.",
+    ),
+    AuditCommand(
+        ident="round2_certificates",
+        command=("python", "scripts/check_round2_certificates.py"),
+        claim_scope="Fixed-pattern and fixed-order round-two certificate regression checks only.",
+    ),
+    AuditCommand(
+        ident="c19_fixed_order_compact_kalmanson",
+        command=(
+            "python",
+            "scripts/check_kalmanson_certificate.py",
+            "data/certificates/round2/c19_kalmanson_known_order_two_unsat.json",
+            "--summary-json",
+        ),
+        claim_scope="Exact obstruction for one fixed C19_skew cyclic order only.",
+    ),
+    AuditCommand(
+        ident="c13_fixed_order_compact_kalmanson",
+        command=(
+            "python",
+            "scripts/check_kalmanson_certificate.py",
+            "data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json",
+            "--summary-json",
+        ),
+        claim_scope="Exact obstruction for one fixed C13 selected-witness cyclic order only.",
+    ),
+    AuditCommand(
+        ident="c13_all_orders_fixed_pattern",
+        command=(
+            "python",
+            "scripts/check_kalmanson_two_order_search.py",
+            "--name",
+            "C13_sidon_1_2_4_10",
+            "--n",
+            "13",
+            "--offsets",
+            "1,2,4,10",
+            "--assert-obstructed",
+            "--assert-c13-expected",
+            "--json",
+        ),
+        claim_scope="All-order obstruction for one fixed abstract C13 selected-witness pattern only.",
+    ),
+    AuditCommand(
+        ident="n9_vertex_circle_review_pending",
+        command=("python", "scripts/check_n9_vertex_circle_exhaustive.py", "--assert-expected", "--json"),
+        claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",
+    ),
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_git(args: Sequence[str]) -> str | None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def command_text(command: Sequence[str]) -> str:
+    return " ".join(command)
+
+
+def run_audit_command(command: AuditCommand, output_dir: Path) -> dict[str, Any]:
+    command_dir = output_dir / "commands"
+    command_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = command_dir / f"{command.ident}.stdout"
+    stderr_path = command_dir / f"{command.ident}.stderr"
+
+    started_at = utc_now()
+    start = time.perf_counter()
+    result = subprocess.run(
+        command.command,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    elapsed_seconds = time.perf_counter() - start
+    finished_at = utc_now()
+
+    stdout_path.write_bytes(result.stdout)
+    stderr_path.write_bytes(result.stderr)
+    combined_output = result.stdout + result.stderr
+
+    return {
+        "id": command.ident,
+        "command": command_text(command.command),
+        "claim_scope": command.claim_scope,
+        "started_at_utc": started_at,
+        "finished_at_utc": finished_at,
+        "elapsed_seconds": round(elapsed_seconds, 6),
+        "exit_code": result.returncode,
+        "stdout_path": stdout_path.relative_to(output_dir).as_posix(),
+        "stderr_path": stderr_path.relative_to(output_dir).as_posix(),
+        "stdout_sha256": sha256_bytes(result.stdout),
+        "stderr_sha256": sha256_bytes(result.stderr),
+        "combined_output_sha256": sha256_bytes(combined_output),
+        "stdout_bytes": len(result.stdout),
+        "stderr_bytes": len(result.stderr),
+    }
+
+
+def build_summary(output_dir: Path, commands: Sequence[AuditCommand]) -> dict[str, Any]:
+    started_at = utc_now()
+    command_results = [run_audit_command(command, output_dir) for command in commands]
+    finished_at = utc_now()
+    dependency_snapshot = REPO_ROOT / "requirements-lock.txt"
+
+    return {
+        "type": "erdos97_artifact_audit_run_v1",
+        "claim_scope": (
+            "Artifact audit for repo-local finite-case and fixed-pattern/fixed-order "
+            "certificates; passing does not prove Erdos Problem #97."
+        ),
+        "does_not_claim": [
+            "general proof of Erdos Problem #97",
+            "counterexample to Erdos Problem #97",
+            "official/global status change",
+            "independent external mathematical review",
+        ],
+        "started_at_utc": started_at,
+        "finished_at_utc": finished_at,
+        "verified": all(record["exit_code"] == 0 for record in command_results),
+        "repo": {
+            "commit": run_git(("rev-parse", "HEAD")),
+            "status_porcelain": run_git(("status", "--porcelain")),
+        },
+        "python": {
+            "executable": sys.executable,
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "dependency_snapshot": {
+            "path": dependency_snapshot.relative_to(REPO_ROOT).as_posix(),
+            "sha256": sha256_file(dependency_snapshot),
+        },
+        "commands": command_results,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifact-audit-results"),
+        help="Directory for summary.json and per-command stdout/stderr files.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    output_dir = args.output_dir
+    if not output_dir.is_absolute():
+        output_dir = REPO_ROOT / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = build_summary(output_dir, AUDIT_COMMANDS)
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["verified"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/interval_verify.py
+++ b/src/erdos97/interval_verify.py
@@ -1,0 +1,351 @@
+"""Conservative interval checks for saved numerical candidates.
+
+The floating path certifies residual bounds, not exact equalities. Exact
+acceptance is reserved for rational-coordinate inputs under
+``coordinates_exact``.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+from erdos97.search import (
+    Pattern,
+    independent_diagnostics,
+    normalize_points,
+    polygon_area2,
+    validate_candidate_shape,
+)
+
+
+@dataclass(frozen=True)
+class Interval:
+    lo: float
+    hi: float
+
+    def __post_init__(self) -> None:
+        if self.lo > self.hi:
+            raise ValueError(f"empty interval [{self.lo}, {self.hi}]")
+
+    def __add__(self, other: Interval) -> Interval:
+        return Interval(down(self.lo + other.lo), up(self.hi + other.hi))
+
+    def __sub__(self, other: Interval) -> Interval:
+        return Interval(down(self.lo - other.hi), up(self.hi - other.lo))
+
+    def __mul__(self, other: Interval) -> Interval:
+        products = (
+            self.lo * other.lo,
+            self.lo * other.hi,
+            self.hi * other.lo,
+            self.hi * other.hi,
+        )
+        return Interval(down(min(products)), up(max(products)))
+
+    def square(self) -> Interval:
+        if self.lo <= 0.0 <= self.hi:
+            return Interval(0.0, up(max(self.lo * self.lo, self.hi * self.hi)))
+        values = (self.lo * self.lo, self.hi * self.hi)
+        return Interval(down(min(values)), up(max(values)))
+
+    def scaled(self, factor: float) -> Interval:
+        if factor >= 0:
+            return Interval(down(factor * self.lo), up(factor * self.hi))
+        return Interval(down(factor * self.hi), up(factor * self.lo))
+
+    def contains_zero(self) -> bool:
+        return self.lo <= 0.0 <= self.hi
+
+    def abs_upper(self) -> float:
+        return max(abs(self.lo), abs(self.hi))
+
+    def to_json(self) -> list[float]:
+        return [float(self.lo), float(self.hi)]
+
+
+def down(value: float) -> float:
+    return math.nextafter(float(value), -math.inf)
+
+
+def up(value: float) -> float:
+    return math.nextafter(float(value), math.inf)
+
+
+def load_candidate(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def parse_pattern(data: dict[str, Any]) -> Pattern:
+    return [[int(j) for j in row] for row in data["S"]]
+
+
+def parse_float_coordinates(data: dict[str, Any]) -> np.ndarray:
+    coordinates = data.get("coordinates", data.get("coordinates_float"))
+    if coordinates is None:
+        raise KeyError("candidate JSON must contain coordinates or coordinates_float")
+    return np.array(coordinates, dtype=float)
+
+
+def parse_exact_coordinates(data: dict[str, Any]) -> list[list[Fraction]] | None:
+    raw = data.get("coordinates_exact")
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise ValueError("coordinates_exact must be a list")
+    parsed: list[list[Fraction]] = []
+    for row in raw:
+        if not isinstance(row, list) or len(row) != 2:
+            raise ValueError("coordinates_exact entries must be coordinate pairs")
+        parsed.append([Fraction(str(row[0])), Fraction(str(row[1]))])
+    return parsed
+
+
+def coordinate_intervals(
+    coordinates: np.ndarray,
+    *,
+    abs_radius: float,
+    rel_radius: float,
+) -> list[list[Interval]]:
+    intervals: list[list[Interval]] = []
+    for row in coordinates:
+        interval_row: list[Interval] = []
+        for value in row:
+            radius = abs_radius + rel_radius * abs(float(value))
+            interval_row.append(Interval(down(float(value) - radius), up(float(value) + radius)))
+        intervals.append(interval_row)
+    return intervals
+
+
+def interval_sqdist(points: list[list[Interval]], i: int, j: int) -> Interval:
+    dx = points[i][0] - points[j][0]
+    dy = points[i][1] - points[j][1]
+    return dx.square() + dy.square()
+
+
+def interval_cross(
+    points: list[list[Interval]],
+    a: int,
+    b: int,
+    c: int,
+) -> Interval:
+    edge_x = points[b][0] - points[a][0]
+    edge_y = points[b][1] - points[a][1]
+    vertex_x = points[c][0] - points[a][0]
+    vertex_y = points[c][1] - points[a][1]
+    return (edge_x * vertex_y) - (edge_y * vertex_x)
+
+
+def convexity_interval_bounds(points: list[list[Interval]], sign: float) -> dict[str, Any]:
+    n = len(points)
+    margins: list[Interval] = []
+    for i in range(n):
+        for j in range(n):
+            if j == i or j == (i + 1) % n:
+                continue
+            margins.append(interval_cross(points, i, (i + 1) % n, j).scaled(sign))
+    if not margins:
+        return {"certified": False, "min_interval": [float("-inf"), float("-inf")]}
+    min_lo = min(margin.lo for margin in margins)
+    min_hi = min(margin.hi for margin in margins)
+    return {
+        "certified": min_lo > 0.0,
+        "min_interval": [float(min_lo), float(min_hi)],
+    }
+
+
+def residual_intervals(points: list[list[Interval]], S: Pattern) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for i, row in enumerate(S):
+        base = row[0]
+        base_dist = interval_sqdist(points, i, base)
+        for target in row[1:]:
+            residual = interval_sqdist(points, i, target) - base_dist
+            records.append(
+                {
+                    "center": i,
+                    "base": base,
+                    "target": target,
+                    "interval": residual.to_json(),
+                    "abs_upper": residual.abs_upper(),
+                    "contains_zero": residual.contains_zero(),
+                }
+            )
+    return records
+
+
+def exact_sqdist(points: list[list[Fraction]], i: int, j: int) -> Fraction:
+    dx = points[i][0] - points[j][0]
+    dy = points[i][1] - points[j][1]
+    return dx * dx + dy * dy
+
+
+def exact_cross(points: list[list[Fraction]], a: int, b: int, c: int) -> Fraction:
+    edge_x = points[b][0] - points[a][0]
+    edge_y = points[b][1] - points[a][1]
+    vertex_x = points[c][0] - points[a][0]
+    vertex_y = points[c][1] - points[a][1]
+    return edge_x * vertex_y - edge_y * vertex_x
+
+
+def exact_verification(points: list[list[Fraction]], S: Pattern) -> dict[str, Any]:
+    n = len(points)
+    area2 = sum(
+        points[i][0] * points[(i + 1) % n][1] - points[i][1] * points[(i + 1) % n][0]
+        for i in range(n)
+    )
+    sign = Fraction(-1 if area2 < 0 else 1)
+    margins = [
+        sign * exact_cross(points, i, (i + 1) % n, j)
+        for i in range(n)
+        for j in range(n)
+        if j != i and j != (i + 1) % n
+    ]
+    residuals = [
+        exact_sqdist(points, i, target) - exact_sqdist(points, i, row[0])
+        for i, row in enumerate(S)
+        for target in row[1:]
+    ]
+    min_pair = min(
+        exact_sqdist(points, i, j)
+        for i in range(n)
+        for j in range(i + 1, n)
+    )
+    convexity_certified = bool(margins) and min(margins) > 0
+    distance_equalities_certified = all(residual == 0 for residual in residuals)
+    accepted = convexity_certified and distance_equalities_certified and min_pair > 0
+    return {
+        "exact_mode": True,
+        "convexity_certified": convexity_certified,
+        "distance_equalities_certified": distance_equalities_certified,
+        "min_exact_convexity_margin": str(min(margins)) if margins else None,
+        "max_abs_exact_residual": str(max((abs(value) for value in residuals), default=Fraction(0))),
+        "failure_mode": "exact_algebraic_candidate_accepted" if accepted else "exact_algebraic_rejected",
+    }
+
+
+def classify_float_result(
+    *,
+    validation_errors: Sequence[str],
+    convexity_certified: bool,
+    distance_equalities_certified: bool,
+    definite_nonzero_residuals: int,
+    claimed_success: bool,
+) -> str:
+    if validation_errors:
+        return "malformed"
+    if convexity_certified and distance_equalities_certified:
+        return "interval_certified_candidate_at_tolerance"
+    if convexity_certified and definite_nonzero_residuals:
+        if claimed_success:
+            return "floating_near_miss"
+        return "interval_convexity_certified_equality_uncertified"
+    if convexity_certified:
+        return "interval_convexity_certified_equality_uncertified"
+    return "uncertified"
+
+
+def verify_interval_json(
+    path: str | Path,
+    *,
+    eq_bound: float = 1e-8,
+    coord_abs_radius: float = 1e-12,
+    coord_rel_radius: float = 1e-12,
+) -> dict[str, Any]:
+    data = load_candidate(path)
+    try:
+        S = parse_pattern(data)
+        raw_coordinates = parse_float_coordinates(data)
+    except (KeyError, TypeError, ValueError) as exc:
+        return {
+            "ok": False,
+            "failure_mode": "malformed",
+            "validation_errors": [str(exc)],
+            "claim_strength": "MALFORMED_INPUT",
+        }
+
+    validation_errors = validate_candidate_shape(raw_coordinates, S)
+    if validation_errors:
+        return {
+            "ok": False,
+            "failure_mode": "malformed",
+            "validation_errors": validation_errors,
+            "claim_strength": "MALFORMED_INPUT",
+        }
+
+    exact_coordinates = parse_exact_coordinates(data)
+    if exact_coordinates is not None:
+        exact = exact_verification(exact_coordinates, S)
+        return {
+            "ok": exact["failure_mode"] == "exact_algebraic_candidate_accepted",
+            "validation_errors": [],
+            "eq_bound": eq_bound,
+            "claim_strength": (
+                "EXACT_OR_ALGEBRAIC_CANDIDATE_ACCEPTED_PENDING_REVIEW"
+                if exact["failure_mode"] == "exact_algebraic_candidate_accepted"
+                else "EXACT_OR_ALGEBRAIC_INPUT_REJECTED"
+            ),
+            **exact,
+        }
+
+    coordinates = normalize_points(raw_coordinates)
+    diagnostics = independent_diagnostics(coordinates, S)
+    points = coordinate_intervals(
+        coordinates,
+        abs_radius=coord_abs_radius,
+        rel_radius=coord_rel_radius,
+    )
+    sign = -1.0 if polygon_area2(coordinates) < 0 else 1.0
+    convexity = convexity_interval_bounds(points, sign)
+    residuals = residual_intervals(points, S)
+    max_abs_residual_bound = max((record["abs_upper"] for record in residuals), default=0.0)
+    definite_nonzero = sum(1 for record in residuals if not record["contains_zero"])
+    distance_equalities_certified = bool(residuals) and max_abs_residual_bound <= eq_bound
+    failure_mode = classify_float_result(
+        validation_errors=[],
+        convexity_certified=bool(convexity["certified"]),
+        distance_equalities_certified=distance_equalities_certified,
+        definite_nonzero_residuals=definite_nonzero,
+        claimed_success=bool(data.get("success") is True),
+    )
+    ok = failure_mode == "interval_certified_candidate_at_tolerance"
+    return {
+        "ok": ok,
+        "failure_mode": failure_mode,
+        "validation_errors": [],
+        "eq_bound": eq_bound,
+        "coordinate_interval": {
+            "abs_radius": coord_abs_radius,
+            "rel_radius": coord_rel_radius,
+            "normalization": "search.normalize_points applied before interval bounds",
+        },
+        "convexity_certified": bool(convexity["certified"]),
+        "convexity_margin_interval": convexity["min_interval"],
+        "distance_equalities_certified": distance_equalities_certified,
+        "residual_bounds": {
+            "max_abs_residual_bound": max_abs_residual_bound,
+            "definite_nonzero_residuals": definite_nonzero,
+            "residual_count": len(residuals),
+        },
+        "claim_strength": (
+            "INTERVAL_BOUNDED_NUMERICAL_CANDIDATE"
+            if ok
+            else "NUMERICAL_EVIDENCE_OR_NEAR_MISS_NOT_A_COUNTEREXAMPLE"
+        ),
+        "does_not_claim": [
+            "general proof of Erdos Problem #97",
+            "counterexample to Erdos Problem #97",
+            "exact equality from floating residuals alone",
+        ],
+        "float_diagnostics": {
+            "max_spread": diagnostics["max_spread"],
+            "max_rel_spread": diagnostics["max_rel_spread"],
+            "convexity_margin": diagnostics["convexity_margin"],
+            "min_pair_distance": diagnostics["min_pair_distance"],
+        },
+    }

--- a/src/erdos97/interval_verify.py
+++ b/src/erdos97/interval_verify.py
@@ -106,6 +106,10 @@ def parse_exact_coordinates(data: dict[str, Any]) -> list[list[Fraction]] | None
     return parsed
 
 
+def exact_coordinates_to_float(points: list[list[Fraction]]) -> np.ndarray:
+    return np.array([[float(x), float(y)] for x, y in points], dtype=float)
+
+
 def coordinate_intervals(
     coordinates: np.ndarray,
     *,
@@ -260,7 +264,12 @@ def verify_interval_json(
     data = load_candidate(path)
     try:
         S = parse_pattern(data)
-        raw_coordinates = parse_float_coordinates(data)
+        exact_coordinates = parse_exact_coordinates(data)
+        raw_coordinates = (
+            exact_coordinates_to_float(exact_coordinates)
+            if exact_coordinates is not None
+            else parse_float_coordinates(data)
+        )
     except (KeyError, TypeError, ValueError) as exc:
         return {
             "ok": False,
@@ -278,13 +287,16 @@ def verify_interval_json(
             "claim_strength": "MALFORMED_INPUT",
         }
 
-    exact_coordinates = parse_exact_coordinates(data)
     if exact_coordinates is not None:
         exact = exact_verification(exact_coordinates, S)
         return {
             "ok": exact["failure_mode"] == "exact_algebraic_candidate_accepted",
             "validation_errors": [],
             "eq_bound": eq_bound,
+            "does_not_claim": [
+                "general proof of Erdos Problem #97",
+                "counterexample without independent review",
+            ],
             "claim_strength": (
                 "EXACT_OR_ALGEBRAIC_CANDIDATE_ACCEPTED_PENDING_REVIEW"
                 if exact["failure_mode"] == "exact_algebraic_candidate_accepted"

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.check_artifact_provenance import load_manifest, validate_manifest
+
+
+def test_generated_artifact_manifest_is_valid() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    manifest = repo / "metadata" / "generated_artifacts.yaml"
+
+    errors = validate_manifest(load_manifest(manifest))
+
+    assert errors == []
+
+
+def test_manifest_rejects_mismatched_expected_json(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    artifact.write_text(json.dumps({"status": "BAD"}), encoding="utf-8")
+    generator.write_text("print('ok')\n", encoding="utf-8")
+    manifest = {
+        "schema": "erdos97.generated_artifacts.v1",
+        "claim_scope": "test manifest only",
+        "artifacts": [
+            {
+                "id": "sample",
+                "path": str(artifact),
+                "kind": "test",
+                "generator": str(generator),
+                "command": f"python {generator}",
+                "direct_edit_allowed": False,
+                "provenance_mode": "manifest_only_legacy",
+                "trust": "EXACT_OBSTRUCTION",
+                "claim_scope": "test artifact only",
+                "json_top_level_type": "object",
+                "expected_json": {"status": "GOOD"},
+                "forbidden_claims": ["general proof"],
+            }
+        ],
+    }
+
+    errors = validate_manifest(manifest)
+
+    assert any("'status' is 'BAD', expected 'GOOD'" in error for error in errors)

--- a/tests/test_check_status_consistency.py
+++ b/tests/test_check_status_consistency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import date
 from pathlib import Path
 
 
@@ -67,3 +68,29 @@ trust_policy:
 
     assert checker.metadata_value(parsed, ("problem", "official_status")) == "falsifiable/open"
     assert checker.metadata_value(parsed, ("trust_policy", "no_overclaiming")) is True
+
+
+def test_official_status_freshness_is_opt_in() -> None:
+    checker = load_checker()
+    official = {
+        "official_page_last_edited": "2025-10-27",
+        "official_status_last_checked": "2026-04-30",
+    }
+
+    checker.validate_official_status_freshness(official, None, today=date(2026, 8, 1))
+    checker.validate_official_status_freshness(official, 10, today=date(2026, 5, 4))
+
+
+def test_official_status_freshness_can_fail() -> None:
+    checker = load_checker()
+    official = {
+        "official_page_last_edited": "2025-10-27",
+        "official_status_last_checked": "2026-04-30",
+    }
+
+    try:
+        checker.validate_official_status_freshness(official, 10, today=date(2026, 5, 20))
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:  # pragma: no cover
+        raise AssertionError("freshness check should fail")

--- a/tests/test_interval_verify.py
+++ b/tests/test_interval_verify.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from erdos97.interval_verify import verify_interval_json
+
+
+ROOT = Path(__file__).resolve().parents[1]
+B12 = ROOT / "data" / "runs" / "best_B12_slsqp_m1e-6.json"
+
+
+def write_candidate(path: Path, coordinates: list[list[float]], rows: list[list[int]], **extra: object) -> None:
+    payload = {"coordinates": coordinates, "S": rows, **extra}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_b12_near_miss_is_not_interval_certified() -> None:
+    result = verify_interval_json(B12)
+
+    assert result["ok"] is False
+    assert result["failure_mode"] == "floating_near_miss"
+    assert result["convexity_certified"] is True
+    assert result["distance_equalities_certified"] is False
+    assert result["residual_bounds"]["definite_nonzero_residuals"] > 0
+    assert "counterexample to Erdos Problem #97" in result["does_not_claim"]
+
+
+def test_malformed_candidate_is_reported(tmp_path: Path) -> None:
+    candidate = tmp_path / "bad.json"
+    write_candidate(candidate, [[0.0, 0.0], [1.0, 0.0]], [[1, 1, 1, 1], [0, 0, 0, 0]])
+
+    result = verify_interval_json(candidate)
+
+    assert result["ok"] is False
+    assert result["failure_mode"] == "malformed"
+    assert result["claim_strength"] == "MALFORMED_INPUT"
+    assert result["validation_errors"]
+
+
+def test_convex_float_without_equalities_is_not_certified(tmp_path: Path) -> None:
+    candidate = tmp_path / "c9.json"
+    n = 9
+    coordinates = [
+        [float(np.cos(2.0 * np.pi * i / n)), float(np.sin(2.0 * np.pi * i / n))]
+        for i in range(n)
+    ]
+    rows = [
+        sorted((i + offset) % n for offset in (-4, -2, 2, 4))
+        for i in range(n)
+    ]
+    write_candidate(candidate, coordinates, rows)
+
+    result = verify_interval_json(candidate)
+
+    assert result["ok"] is False
+    assert result["failure_mode"] == "interval_convexity_certified_equality_uncertified"
+    assert result["convexity_certified"] is True
+    assert result["distance_equalities_certified"] is False
+
+
+def test_interval_verify_cli_check_rejects_b12() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/interval_verify_candidate.py", str(B12), "--check"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["failure_mode"] == "floating_near_miss"

--- a/tests/test_interval_verify.py
+++ b/tests/test_interval_verify.py
@@ -42,6 +42,28 @@ def test_malformed_candidate_is_reported(tmp_path: Path) -> None:
     assert result["validation_errors"]
 
 
+def test_exact_coordinates_do_not_require_float_coordinates(tmp_path: Path) -> None:
+    candidate = tmp_path / "exact.json"
+    n = 9
+    payload = {
+        "coordinates_exact": [
+            [str(i), str(i * i)]
+            for i in range(n)
+        ],
+        "S": [
+            sorted((i + offset) % n for offset in (-4, -2, 2, 4))
+            for i in range(n)
+        ],
+    }
+    candidate.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = verify_interval_json(candidate)
+
+    assert result["ok"] is False
+    assert result["failure_mode"] == "exact_algebraic_rejected"
+    assert result["claim_strength"] == "EXACT_OR_ALGEBRAIC_INPUT_REJECTED"
+
+
 def test_convex_float_without_equalities_is_not_certified(tmp_path: Path) -> None:
     candidate = tmp_path / "c9.json"
     n = 9

--- a/tests/test_n8_artifact_audit.py
+++ b/tests/test_n8_artifact_audit.py
@@ -28,6 +28,11 @@ def test_independent_n8_artifact_audit_entrypoint() -> None:
         summary["overall_status"]
         == "n8_artifacts_verified_repo_local_pending_external_review"
     )
+    assert "full independent regeneration" in summary["does_not_check"][0]
+    assert summary["dependencies_imported"] == [
+        "scripts/analyze_n8_exact_survivors.py",
+        "scripts/independent_check_n8_incidence_json.py",
+    ]
     assert summary["survivor_json"]["record_count"] == 15
     assert summary["completeness_artifact"]["canonical_class_count"] == 15
     exact = summary["exact_obstruction_artifacts"]

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from scripts.run_artifact_audit import AuditCommand, run_audit_command, sha256_bytes
+
+
+def test_sha256_bytes_is_stable() -> None:
+    assert sha256_bytes(b"erdos97\n") == "d804cace0801472174f9f279439ba930de0123adced9367f0df1dcc8dc996d4b"
+
+
+def test_run_audit_command_records_metadata(tmp_path: Path) -> None:
+    command = AuditCommand(
+        ident="smoke",
+        command=(sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'ok\\n')"),
+        claim_scope="test command only",
+    )
+
+    record = run_audit_command(command, tmp_path)
+
+    assert record["id"] == "smoke"
+    assert record["exit_code"] == 0
+    assert record["claim_scope"] == "test command only"
+    assert record["stdout_bytes"] == len(b"ok\n")
+    assert (tmp_path / record["stdout_path"]).read_bytes() == b"ok\n"
+    assert (tmp_path / record["stderr_path"]).read_bytes() == b""
+    assert len(record["combined_output_sha256"]) == 64


### PR DESCRIPTION
## Summary

- Sync Codex/README/reviewer command guidance around fast checks, artifact checks, and audit metadata.
- Add a Makefile, scheduled/manual artifact audit workflow, audit runner, generated-artifact manifest, and provenance checker.
- Add a conservative interval verifier CLI that rejects the saved B12 near-miss rather than certifying it as a counterexample.
- Add a Codex-ready backlog for the live open issues and clarify n=8 artifact-audit scope.

## Scope discipline

This PR does not claim a general proof or counterexample for Erdos Problem #97. It keeps the official/global status falsifiable/open, keeps `n <= 8` repo-local pending external review, and labels C13/C19/n9 artifacts by their narrower scopes.

## Verification

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_status_consistency.py --max-official-status-age-days 90`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/run_artifact_audit.py --output-dir artifact-audit-results`
- `python scripts/interval_verify_candidate.py data/runs/best_B12_slsqp_m1e-6.json`
- `python -m pytest -q` (`205 passed, 16 deselected`)

Note: `metadata/erdos97.yaml` official-status dates were not updated; that should happen only after a same-session manual recheck of the official page.