### PR TITLE
[codex] fix reproducibility audit hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.vscode/
+.idea/
+*.swp
 build/
 dist/
 *.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 PYTHON ?= python
 
-.PHONY: verify-fast verify-n8 verify-kalmanson verify-n9-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-n8 verify-kalmanson verify-n9-review verify-artifacts audit-artifacts verify-all
 
-verify-fast:
+verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
 	$(PYTHON) scripts/check_status_consistency.py
 	$(PYTHON) scripts/check_artifact_provenance.py
 	git diff --check
 	$(PYTHON) -m ruff check .
+
+verify-fast: verify-lint
 	$(PYTHON) -m pytest -q
 
 verify-n8:
@@ -27,6 +29,7 @@ verify-n9-review:
 verify-artifacts: verify-n8 verify-kalmanson verify-n9-review
 
 audit-artifacts:
+	$(PYTHON) scripts/check_status_consistency.py --max-official-status-age-days 90
 	$(PYTHON) scripts/check_artifact_provenance.py
 	$(PYTHON) scripts/run_artifact_audit.py --output-dir artifact-audit-results
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ pip install -e .[dev]
 make verify-fast
 ```
 
+`make verify-lint` runs the sub-minute text/status/provenance/ruff tier
+without pytest. The default pytest configuration excludes tests marked
+`artifact`, `slow`, or `exhaustive`; run `python -m pytest -q -m ""` when you
+intentionally want the full marker set.
+
 If `make` is not available, run the fast tier directly:
 
 ```bash
@@ -272,21 +277,24 @@ make verify-artifacts
 
 The manual/scheduled artifact-audit workflow runs the same artifact commands
 with command, commit, Python version, dependency snapshot, elapsed-time, and
-output-hash metadata:
+output-hash metadata. It also includes the dated official-status consistency
+check:
 
 ```bash
-python scripts/check_status_consistency.py --max-official-status-age-days 90
 make audit-artifacts
 ```
 
 Equivalent raw commands:
 
 ```bash
+python scripts/check_status_consistency.py --max-official-status-age-days 90
+python scripts/check_artifact_provenance.py
 python scripts/independent_check_n8_artifacts.py --check --json
-python scripts/check_round2_certificates.py
 python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
+python scripts/check_round2_certificates.py
 python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 ```
@@ -361,6 +369,8 @@ If you use this repository, please cite it using [`CITATION.cff`](CITATION.cff).
 - Run `make verify-fast` or the equivalent raw fast-tier commands.
 - Run `make verify-artifacts` before finite-case, certificate, or public
   theorem-style updates, or record why a command could not be run.
+- Run `make audit-artifacts` for audit metadata; it includes the dated
+  official-status consistency check.
 - Run `python scripts/check_text_clean.py`.
 - Run `python scripts/check_status_consistency.py`.
 - Confirm this README still says no general proof and no counterexample are claimed.

--- a/data/certificates/c13_sidon_all_orders_kalmanson_two_search.json
+++ b/data/certificates/c13_sidon_all_orders_kalmanson_two_search.json
@@ -1,6 +1,5 @@
 {
   "branches_pruned_by_completed_two_certificate": 6192576,
-  "elapsed_seconds": 79.183565,
   "max_surviving_prefix": [
     0,
     1,

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -28,12 +28,13 @@ Acceptance standard: a written review should identify every accepted lemma and
 any exact gap. If the note survives review, keep it as the main human-readable
 small-case proof route, with the computational pipeline as an audit appendix.
 
-## Priority 2 - build an independent n=8 checker
+## Priority 2 - audit and extend the n=8 checker
 
-Build a minimal checker for the `n=8` finite artifact that treats the checked-in
-JSON and certificate data as inputs, not as generated truth. It should avoid
-reusing the current canonicalization and algebra-helper code except where the
-input format forces it.
+Audit the current checker, and extend it toward a more independent `n=8`
+finite-artifact check that treats the checked-in JSON and certificate data as
+inputs, not as generated truth. Any extension should avoid reusing the current
+canonicalization and algebra-helper code except where the input format forces
+it.
 
 Suggested inputs:
 

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -47,21 +47,30 @@ make verify-artifacts
 For CI-style audit metadata, run:
 
 ```bash
-python scripts/check_status_consistency.py --max-official-status-age-days 90
 make audit-artifacts
 ```
+
+The `audit-artifacts` target includes the dated official-status consistency
+check, so this audit path is stricter than the default fast tier.
 
 Equivalent raw commands:
 
 ```bash
+python scripts/check_status_consistency.py --max-official-status-age-days 90
+python scripts/check_artifact_provenance.py
 python scripts/independent_check_n8_artifacts.py --check --json
 python scripts/enumerate_n8_incidence.py --summary
 python scripts/analyze_n8_exact_survivors.py --check --json
 python scripts/check_round2_certificates.py
 python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
+python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 ```
+
+The default pytest configuration excludes tests marked `artifact`, `slow`, or
+`exhaustive`. Use `python -m pytest -q -m ""` when intentionally replaying the
+full marker set.
 
 For a version-matched reproduction run, replace `pip install -e .[dev]` with:
 
@@ -108,6 +117,8 @@ invariants:
 9. `docs/review-priorities.md`
 
 ## Review target A - `n=7`
+
+Primary reference: `docs/n7-fano-enumeration.md`.
 
 Check:
 

--- a/scripts/analyze_n9_vertex_circle_local_cores.py
+++ b/scripts/analyze_n9_vertex_circle_local_cores.py
@@ -17,6 +17,7 @@ from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
     assert_expected_local_core_counts,
     local_core_summary,
 )
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
 
@@ -48,7 +49,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: local core counts verified")
         if args.write:
-            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/analyze_n9_vertex_circle_motif_families.py
+++ b/scripts/analyze_n9_vertex_circle_motif_families.py
@@ -17,6 +17,7 @@ from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
     assert_expected_motif_family_counts,
     motif_family_summary,
 )
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_motif_families.json"
 
@@ -59,7 +60,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: motif-family counts verified")
         if args.write:
-            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/analyze_n9_vertex_circle_obstruction_shapes.py
+++ b/scripts/analyze_n9_vertex_circle_obstruction_shapes.py
@@ -17,6 +17,7 @@ from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
     assert_expected_counts,
     obstruction_shape_summary,
 )
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_obstruction_shapes.json"
 
@@ -56,7 +57,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: obstruction shape counts verified")
         if args.write:
-            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/check_kalmanson_two_order_search.py
+++ b/scripts/check_kalmanson_two_order_search.py
@@ -16,7 +16,6 @@ import argparse
 import itertools
 import json
 import sys
-import time
 from collections import Counter
 from pathlib import Path
 from typing import Sequence
@@ -32,7 +31,7 @@ from check_kalmanson_certificate import (  # noqa: E402
     build_distance_classes,
     inequality_terms,
 )
-from find_kalmanson_certificate import parse_int_list  # noqa: E402
+from kalmanson_order_utils import parse_int_list  # noqa: E402
 
 KINDS = ("K1_diag_gt_sides", "K2_diag_gt_other")
 
@@ -96,7 +95,6 @@ def search_avoiding_order(
     if node_limit is not None and node_limit <= 0:
         raise ValueError("node_limit must be positive when supplied")
 
-    started = time.perf_counter()
     quad_ids, inverse_id = _prepare_vector_tables(n, offsets)
     counts = [0] * len(inverse_id)
     nodes_visited = 0
@@ -144,7 +142,6 @@ def search_avoiding_order(
         return None
 
     survivor = dfs([0], list(range(1, n)))
-    elapsed = time.perf_counter() - started
     if survivor is not None:
         status = "FOUND_ORDER_WITHOUT_TWO_INEQUALITY_KALMANSON_CERTIFICATE"
         trust = "EXACT_COUNTEREXAMPLE_TO_THIS_FILTER_ONLY"
@@ -175,7 +172,6 @@ def search_avoiding_order(
         "max_surviving_prefix_depth": len(max_surviving_prefix),
         "max_surviving_prefix": max_surviving_prefix,
         "survivor_order": survivor,
-        "elapsed_seconds": elapsed,
         "semantics": (
             "If status is EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION, "
             "every cyclic order of this fixed abstract pattern contains some "
@@ -232,9 +228,7 @@ def main() -> int:
         assert_c13_expected(payload)
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)
-        stored = dict(payload)
-        stored["elapsed_seconds"] = round(float(stored["elapsed_seconds"]), 6)
-        args.out.write_text(json.dumps(stored, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:

--- a/scripts/check_n9_incidence_frontier.py
+++ b/scripts/check_n9_incidence_frontier.py
@@ -14,6 +14,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.n9_incidence_frontier import run_bounded_scan  # noqa: E402
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_incidence_frontier_bounded.json"
 
@@ -76,7 +77,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: bounded n=9 frontier expectations verified")
         if args.write:
-            print(f"wrote {Path(args.out).relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/check_n9_vertex_circle_exhaustive.py
+++ b/scripts/check_n9_vertex_circle_exhaustive.py
@@ -19,6 +19,7 @@ from erdos97.n9_vertex_circle_exhaustive import (  # noqa: E402
     exhaustive_search,
     summary_payload,
 )
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_exhaustive.json"
 
@@ -100,7 +101,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: n=9 vertex-circle exhaustive counts verified")
         if args.write:
-            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/check_phi4_frontier_scan.py
+++ b/scripts/check_phi4_frontier_scan.py
@@ -20,6 +20,7 @@ from erdos97.phi4_frontier import (  # noqa: E402
     scan_payload,
     sparse_order_cases_from_payload,
 )
+from erdos97.path_display import display_path  # noqa: E402
 from erdos97.search import built_in_patterns  # noqa: E402
 
 DEFAULT_SPARSE_ORDERS = ROOT / "data" / "certificates" / "sparse_order_survivors.json"
@@ -124,7 +125,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: phi4 frontier scan expectations verified")
         if args.write:
-            print(f"wrote {Path(args.out).relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/check_sparse_order_survivors.py
+++ b/scripts/check_sparse_order_survivors.py
@@ -190,15 +190,21 @@ def kalmanson_status(
             "obstructed": False,
         }
 
-    result = check_certificate_file(path)
     certificate = json.loads(path.read_text(encoding="utf-8"))
-    if result.pattern != pattern.name:
-        raise ValueError(f"{path} pattern {result.pattern} does not match {pattern.name}")
-    if result.n != pattern.n:
-        raise ValueError(f"{path} n {result.n} does not match {pattern.n}")
+    certificate_pattern = certificate.get("pattern", {})
+    if not isinstance(certificate_pattern, dict):
+        raise ValueError(f"{path} pattern metadata should be an object")
+    if certificate_pattern.get("name") != pattern.name:
+        raise ValueError(f"{path} pattern {certificate_pattern.get('name')} does not match {pattern.name}")
+    if certificate_pattern.get("n") != pattern.n:
+        raise ValueError(f"{path} n {certificate_pattern.get('n')} does not match {pattern.n}")
+    certificate_offsets = certificate_pattern.get("circulant_offsets")
+    if normalize_offsets(certificate_offsets, pattern.n) != circulant_offsets(pattern):
+        raise ValueError(f"{path} circulant offsets do not match registered {case}")
     if certificate.get("cyclic_order") != order:
         raise ValueError(f"{path} cyclic order does not match registered {case}")
 
+    result = check_certificate_file(path)
     return {
         "status": result.status,
         "obstructed": result.zero_sum_verified,
@@ -211,6 +217,21 @@ def kalmanson_status(
         "max_weight": result.max_weight,
         "claim_strength": result.claim_strength,
     }
+
+
+def circulant_offsets(pattern: PatternInfo) -> list[int]:
+    row0 = sorted(int(witness) % pattern.n for witness in pattern.S[0])
+    for center, witnesses in enumerate(pattern.S):
+        offsets = sorted((int(witness) - center) % pattern.n for witness in witnesses)
+        if offsets != row0:
+            raise ValueError(f"{pattern.name} is not a circulant row pattern")
+    return row0
+
+
+def normalize_offsets(raw_offsets: object, n: int) -> list[int]:
+    if not isinstance(raw_offsets, list):
+        raise ValueError("circulant_offsets should be a list")
+    return sorted(int(offset) % n for offset in raw_offsets)
 
 
 def registered_rows(patterns: dict[str, PatternInfo]) -> list[dict[str, object]]:

--- a/scripts/compare_n9_vertex_circle_frontier.py
+++ b/scripts/compare_n9_vertex_circle_frontier.py
@@ -17,6 +17,7 @@ from erdos97.n9_vertex_circle_frontier_comparison import (  # noqa: E402
     assert_expected_frontier_comparison,
     frontier_comparison_summary,
 )
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_frontier_comparison.json"
 
@@ -51,7 +52,7 @@ def main() -> int:
         if args.assert_expected:
             print("OK: frontier comparison counts verified")
         if args.write:
-            print(f"wrote {Path(args.out).resolve().relative_to(ROOT)}")
+            print(f"wrote {display_path(args.out, ROOT)}")
     return 0
 
 

--- a/scripts/find_kalmanson_certificate.py
+++ b/scripts/find_kalmanson_certificate.py
@@ -9,54 +9,23 @@ Kalmanson distance inequalities.
 from __future__ import annotations
 
 import argparse
-import itertools
 import json
 import math
 from pathlib import Path
-from typing import NamedTuple, Sequence
+from typing import Sequence
 
 import numpy as np
 import sympy as sp
 from scipy.optimize import linprog
 
-from check_kalmanson_certificate import (
-    build_distance_classes,
-    check_certificate_dict,
-    inequality_terms,
+from check_kalmanson_certificate import check_certificate_dict
+from kalmanson_order_utils import (
+    InequalityRow,
+    KINDS as KINDS,
+    all_kalmanson_rows,
+    certificate_payload,
+    parse_int_list,
 )
-
-
-KINDS = ("K1_diag_gt_sides", "K2_diag_gt_other")
-
-
-class InequalityRow(NamedTuple):
-    kind: str
-    quad: tuple[int, int, int, int]
-    vector: tuple[int, ...]
-
-
-def parse_int_list(raw: str) -> list[int]:
-    try:
-        return [int(item.strip()) for item in raw.split(",") if item.strip()]
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError(f"invalid comma-separated integer list: {raw}") from exc
-
-
-def all_kalmanson_rows(
-    n: int,
-    offsets: Sequence[int],
-    order: Sequence[int],
-) -> list[InequalityRow]:
-    classes = build_distance_classes(n, offsets)
-    class_count = len(set(classes.values()))
-    rows: list[InequalityRow] = []
-    for quad in itertools.combinations(order, 4):
-        for kind in KINDS:
-            vector = [0] * class_count
-            for pair, coeff in inequality_terms(kind, quad):
-                vector[classes[pair]] += coeff
-            rows.append(InequalityRow(kind, tuple(int(v) for v in quad), tuple(vector)))
-    return rows
 
 
 def lp_support(rows: Sequence[InequalityRow], tol: float) -> list[int] | None:
@@ -102,56 +71,6 @@ def exact_positive_weights(
     for weight in weights:
         divisor = math.gcd(divisor, abs(weight))
     return [weight // divisor for weight in weights]
-
-
-def certificate_payload(
-    name: str,
-    n: int,
-    offsets: Sequence[int],
-    order: Sequence[int],
-    rows: Sequence[InequalityRow],
-    support: Sequence[int],
-    weights: Sequence[int],
-) -> dict[str, object]:
-    inequalities = [
-        {
-            "weight": int(weight),
-            "quad": list(rows[idx].quad),
-            "kind": rows[idx].kind,
-        }
-        for idx, weight in zip(support, weights)
-    ]
-    return {
-        "certificate_type": "kalmanson_strict_inequality_farkas",
-        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
-        "pattern": {
-            "name": name,
-            "n": n,
-            "circulant_offsets": [int(offset) for offset in offsets],
-        },
-        "cyclic_order": [int(label) for label in order],
-        "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
-        "distance_equalities": (
-            "for each row i, all distances d(i,w), w in S_i, are identified"
-        ),
-        "inequality_lemma": (
-            "for every convex quadrilateral a,b,c,d in cyclic order, "
-            "d(a,c)+d(b,d)>d(a,b)+d(c,d) and "
-            "d(a,c)+d(b,d)>d(a,d)+d(b,c)"
-        ),
-        "certificate_logic": (
-            "the listed positive integer combination of Kalmanson strict "
-            "inequalities has zero total coefficient after quotienting by "
-            "selected-distance equalities, giving 0 > 0"
-        ),
-        "num_inequalities": len(inequalities),
-        "weight_sum": int(sum(weights)),
-        "inequalities": inequalities,
-        "claim_strength": (
-            "Exact obstruction for this fixed selected-witness pattern and "
-            "fixed cyclic order only; not an abstract all-order obstruction."
-        ),
-    }
 
 
 def find_certificate(

--- a/scripts/find_kalmanson_two_certificate.py
+++ b/scripts/find_kalmanson_two_certificate.py
@@ -29,7 +29,7 @@ from check_kalmanson_certificate import (  # noqa: E402
     build_distance_classes,
     check_certificate_dict,
 )
-from find_kalmanson_certificate import (  # noqa: E402
+from kalmanson_order_utils import (  # noqa: E402
     InequalityRow,
     all_kalmanson_rows,
     certificate_payload,

--- a/scripts/kalmanson_order_utils.py
+++ b/scripts/kalmanson_order_utils.py
@@ -1,0 +1,92 @@
+"""Lightweight helpers for Kalmanson order/certificate scripts."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from typing import NamedTuple, Sequence
+
+from check_kalmanson_certificate import build_distance_classes, inequality_terms
+
+
+KINDS = ("K1_diag_gt_sides", "K2_diag_gt_other")
+
+
+class InequalityRow(NamedTuple):
+    kind: str
+    quad: tuple[int, int, int, int]
+    vector: tuple[int, ...]
+
+
+def parse_int_list(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated integer list: {raw}") from exc
+
+
+def all_kalmanson_rows(
+    n: int,
+    offsets: Sequence[int],
+    order: Sequence[int],
+) -> list[InequalityRow]:
+    classes = build_distance_classes(n, offsets)
+    class_count = len(set(classes.values()))
+    rows: list[InequalityRow] = []
+    for quad in itertools.combinations(order, 4):
+        for kind in KINDS:
+            vector = [0] * class_count
+            for pair, coeff in inequality_terms(kind, quad):
+                vector[classes[pair]] += coeff
+            rows.append(InequalityRow(kind, tuple(int(v) for v in quad), tuple(vector)))
+    return rows
+
+
+def certificate_payload(
+    name: str,
+    n: int,
+    offsets: Sequence[int],
+    order: Sequence[int],
+    rows: Sequence[InequalityRow],
+    support: Sequence[int],
+    weights: Sequence[int],
+) -> dict[str, object]:
+    inequalities = [
+        {
+            "weight": int(weight),
+            "quad": list(rows[idx].quad),
+            "kind": rows[idx].kind,
+        }
+        for idx, weight in zip(support, weights)
+    ]
+    return {
+        "certificate_type": "kalmanson_strict_inequality_farkas",
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+        "pattern": {
+            "name": name,
+            "n": n,
+            "circulant_offsets": [int(offset) for offset in offsets],
+        },
+        "cyclic_order": [int(label) for label in order],
+        "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+        "distance_equalities": (
+            "for each row i, all distances d(i,w), w in S_i, are identified"
+        ),
+        "inequality_lemma": (
+            "for every convex quadrilateral a,b,c,d in cyclic order, "
+            "d(a,c)+d(b,d)>d(a,b)+d(c,d) and "
+            "d(a,c)+d(b,d)>d(a,d)+d(b,c)"
+        ),
+        "certificate_logic": (
+            "the listed positive integer combination of Kalmanson strict "
+            "inequalities has zero total coefficient after quotienting by "
+            "selected-distance equalities, giving 0 > 0"
+        ),
+        "num_inequalities": len(inequalities),
+        "weight_sum": int(sum(weights)),
+        "inequalities": inequalities,
+        "claim_strength": (
+            "Exact obstruction for this fixed selected-witness pattern and "
+            "fixed cyclic order only; not an abstract all-order obstruction."
+        ),
+    }

--- a/src/erdos97/path_display.py
+++ b/src/erdos97/path_display.py
@@ -1,0 +1,16 @@
+"""Small CLI path-display helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def display_path(path: str | Path, root: str | Path) -> str:
+    """Return a stable display path without requiring ``path`` to sit under ``root``."""
+
+    resolved = Path(path).resolve()
+    resolved_root = Path(root).resolve()
+    try:
+        return resolved.relative_to(resolved_root).as_posix()
+    except ValueError:
+        return str(resolved)

--- a/tests/test_kalmanson_two_order_search.py
+++ b/tests/test_kalmanson_two_order_search.py
@@ -26,6 +26,7 @@ def test_c13_all_orders_kalmanson_two_search_artifact() -> None:
     assert payload["branches_pruned_by_completed_two_certificate"] == 6192576
     assert payload["max_surviving_prefix_depth"] == 11
     assert payload["survivor_order"] is None
+    assert "elapsed_seconds" not in payload
     assert "does not prove Erdos Problem #97" in payload["semantics"]
 
 
@@ -39,6 +40,32 @@ def test_kalmanson_two_order_search_cli_help() -> None:
     )
 
     assert "Search cyclic orders" in result.stdout
+
+
+def test_kalmanson_two_order_search_json_is_deterministic_shape() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_kalmanson_two_order_search.py",
+            "--name",
+            "toy",
+            "--n",
+            "5",
+            "--offsets",
+            "1,2,3,4",
+            "--node-limit",
+            "1",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert "elapsed_seconds" not in payload
+    assert payload["status"] == "UNKNOWN_NODE_LIMIT_REACHED"
 
 
 @pytest.mark.slow

--- a/tests/test_path_display.py
+++ b/tests/test_path_display.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.path_display import display_path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_display_path_prefers_repo_relative_inside_root(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    out = root / "data" / "artifact.json"
+
+    assert display_path(out, root) == "data/artifact.json"
+
+
+def test_display_path_allows_outputs_outside_root(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    out = tmp_path / "elsewhere" / "artifact.json"
+
+    assert display_path(out, root) == str(out.resolve())
+
+
+def test_write_cli_reports_outside_repo_path_without_crashing(tmp_path: Path) -> None:
+    out = tmp_path / "phi4_frontier_scan.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_phi4_frontier_scan.py",
+            "--no-builtins",
+            "--no-sparse-orders",
+            "--write",
+            "--out",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert out.exists()
+    assert f"wrote {out.resolve()}" in result.stdout

--- a/tests/test_phi4_frontier.py
+++ b/tests/test_phi4_frontier.py
@@ -14,9 +14,11 @@ from erdos97.phi4_frontier import (
 )
 from erdos97.search import built_in_patterns
 
+ROOT = Path(__file__).resolve().parents[1]
+
 
 def sparse_order_payload() -> dict[str, object]:
-    path = Path("data/certificates/sparse_order_survivors.json")
+    path = ROOT / "data" / "certificates" / "sparse_order_survivors.json"
     loaded = json.loads(path.read_text(encoding="utf-8"))
     assert isinstance(loaded, dict)
     return loaded

--- a/tests/test_sparse_order_survivors.py
+++ b/tests/test_sparse_order_survivors.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_sparse_order_survivors as sparse_orders  # noqa: E402
 
 
 def test_registered_sparse_order_survivors_match_artifact() -> None:
@@ -43,3 +50,22 @@ def test_registered_sparse_order_survivors_match_artifact() -> None:
     assert c19["kalmanson_certificate"]["positive_inequalities"] == 2
     assert c19["kalmanson_certificate"]["max_weight"] == 1
     assert c19["sparse_frontier"]["trivial_empty_radius_choice_exists"] is True
+
+
+def test_kalmanson_status_rejects_offset_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = ROOT / "data" / "certificates" / "c13_sidon_order_survivor_kalmanson_two_unsat.json"
+    tampered = tmp_path / "tampered_certificate.json"
+    shutil.copyfile(source, tampered)
+    payload = json.loads(tampered.read_text(encoding="utf-8"))
+    payload["pattern"]["circulant_offsets"] = [1, 2, 4, 9]
+    tampered.write_text(json.dumps(payload), encoding="utf-8")
+
+    case = "C13_sidon_1_2_4_10:sample_full_filter_survivor"
+    monkeypatch.setitem(sparse_orders.KALMANSON_CERTIFICATES, case, tampered)
+    pattern = sparse_orders.built_in_patterns()["C13_sidon_1_2_4_10"]
+    order = sparse_orders.REGISTERED_ORDERS["C13_sidon_1_2_4_10"][
+        "sample_full_filter_survivor"
+    ]
+
+    with pytest.raises(ValueError, match="circulant offsets"):
+        sparse_orders.kalmanson_status(case, pattern, order)


### PR DESCRIPTION
## Summary

- remove nondeterministic elapsed timing from the C13 all-order Kalmanson JSON output and checked artifact
- add safe repo-relative/absolute write-path reporting for artifact-writing CLIs
- move lightweight Kalmanson order helpers out of the LP finder import path and tighten sparse-order certificate identity checks
- align audit docs/Makefile targets and add focused regression tests

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- raw audit equivalent: `python scripts/check_status_consistency.py --max-official-status-age-days 90`, `python scripts/check_artifact_provenance.py`, `python scripts/run_artifact_audit.py --output-dir artifact-audit-results`

No mathematical claim strength is changed: no general proof and no counterexample are claimed.