### PR TITLE
Record C25/C29 sparse frontier diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ The follow-up exact order search now kills this fixed C13 Sidon pattern across
 all cyclic orders; see `docs/kalmanson-two-order-search.md`. This does not
 settle the larger sparse frontier or prove Erdos #97.
 
+A later sparse-frontier probe tested the larger Sidon entries
+`C25_sidon_2_5_9_14` and `C29_sidon_1_3_7_15`. The C25 Kalmanson-filter
+survivor is exactly killed by vertex-circle and Altman filters. One fixed C29
+order survives the current lightweight fixed-order exact sweep, the
+two-inequality Kalmanson inverse-pair search, the metric LP diagnostic, and a
+slow global Ptolemy NLP diagnostic; the row-circle Ptolemy diagnostic was too
+slow to complete. This makes the C29 order a stress test for stronger filters,
+not a counterexample candidate. See
+[`data/certificates/c25_c29_sparse_frontier_probe.json`](data/certificates/c25_c29_sparse_frontier_probe.json)
+and [`docs/sparse-frontier-diagnostic.md`](docs/sparse-frontier-diagnostic.md).
+
 The previous best numerical near-miss was `B12_3x4_danzer_lift`. It remains a
 useful degeneration diagnostic, but the fixed selected pattern is now exactly
 killed by the mutual-rhombus midpoint filter. The saved numerical artifact is

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -223,6 +223,25 @@ See `docs/mutual-rhombus-filter.md` and
 `data/certificates/p24_cyclic_crossing_unsat.json`, and
 `data/certificates/p18_vertex_circle_order_unsat.json`.
 
+### Sparse frontier fixed-order diagnostics
+
+Status: `FIXED_ORDER_DIAGNOSTIC`.
+
+The C25/C29 sparse-frontier probe in
+`data/certificates/c25_c29_sparse_frontier_probe.json` records two fixed-order
+stress tests for the larger Sidon entries. For `C25_sidon_2_5_9_14`, the
+Kalmanson Z3 refinement found a step-7 fixed cyclic order with no
+two-inequality Kalmanson inverse-pair obstruction, but the same order is
+exactly killed by vertex-circle and Altman filters.
+
+For `C29_sidon_1_3_7_15`, the refinement found one fixed cyclic order that
+survives the current lightweight fixed-order exact filter sweep and the
+two-inequality Kalmanson inverse-pair search. It also passes the metric-order
+LP and a slow global Ptolemy NLP diagnostic with positive margins. The
+row-circle Ptolemy NLP was too slow to complete interactively. This C29 order
+is a stress test for stronger filters only; it is not evidence of geometric
+realizability and not a counterexample claim.
+
 ## Numerical Attempts
 
 ### C13_sidon_1_2_4_10

--- a/STATE.md
+++ b/STATE.md
@@ -173,7 +173,15 @@ recommended before any structural claim. See
 `docs/sidon-patterns.md` and `data/runs/C13_sidon_m{1e-3,1e-4,1e-5,1e-6}.json`.
 
 The catalog also contains `C25_sidon_2_5_9_14` and `C29_sidon_1_3_7_15`
-as cheap-to-define INCIDENCE_PATTERN entries. They have not been run.
+as cheap-to-define INCIDENCE_PATTERN entries. A 2026-05-05 sparse-frontier
+probe found that a C25 Kalmanson-filter survivor is exactly killed by
+vertex-circle and Altman filters. The same probe found one fixed C29 cyclic
+order that survives the current lightweight fixed-order exact filters, the
+two-inequality Kalmanson inverse-pair search, the metric LP diagnostic, and a
+slow global Ptolemy NLP diagnostic. This C29 order is only a filter stress
+test; it is not a counterexample candidate, and the row-circle Ptolemy
+diagnostic did not complete. See
+`data/certificates/c25_c29_sparse_frontier_probe.json`.
 
 ## Top killed approaches
 

--- a/data/certificates/c25_c29_sparse_frontier_probe.json
+++ b/data/certificates/c25_c29_sparse_frontier_probe.json
@@ -1,0 +1,180 @@
+{
+  "cases": [
+    {
+      "altman_linear_certificate": {
+        "certificate_method": "interval_dominance",
+        "nonzero_gap_orders": [
+          10
+        ],
+        "obstructed": true,
+        "status": "EXACT_ALTMAN_LINEAR_OBSTRUCTION"
+      },
+      "case": "C25_sidon_2_5_9_14:kalmanson_z3_step7_survivor",
+      "conclusion": "dead_end_for_this_order",
+      "direct_kalmanson_inverse_pair_check": {
+        "first_conflict": [],
+        "inverse_pair_conflicts": 0,
+        "rows_seen": 25025
+      },
+      "kalmanson_two_order_z3_probe": {
+        "conflict_cap": 1024,
+        "forbidden_clause_count": 13246,
+        "iterations": 357,
+        "solver_result": "sat",
+        "status": "FOUND_ORDER_WITHOUT_TWO_INEQUALITY_KALMANSON_CERTIFICATE",
+        "trust": "EXACT_COUNTEREXAMPLE_TO_THIS_FILTER_ONLY"
+      },
+      "n": 25,
+      "notes": [
+        "The order escapes the two-inequality Kalmanson inverse-pair filter.",
+        "The same fixed order is exactly killed by the vertex-circle filter and by an Altman linear certificate."
+      ],
+      "order": [
+        0,
+        7,
+        14,
+        21,
+        3,
+        10,
+        17,
+        24,
+        6,
+        13,
+        20,
+        2,
+        9,
+        16,
+        23,
+        5,
+        12,
+        19,
+        1,
+        8,
+        15,
+        22,
+        4,
+        11,
+        18
+      ],
+      "pattern": "C25_sidon_2_5_9_14",
+      "sparse_order_filter_sweep": {
+        "survives_current_exact_filters": false,
+        "survives_pre_kalmanson_filters": false
+      },
+      "vertex_circle": {
+        "cycle": true,
+        "obstructed": true,
+        "self_edge_count": 0,
+        "strict_edge_count": 225
+      }
+    },
+    {
+      "altman_linear_certificate": {
+        "certificate_method": "none",
+        "nonzero_gap_orders": [],
+        "obstructed": false,
+        "status": "NO_EXACT_ALTMAN_LINEAR_CERTIFICATE_FOUND"
+      },
+      "case": "C29_sidon_1_3_7_15:z3_kalmanson_survivor",
+      "conclusion": "fixed_order_stress_test_for_stronger_filters",
+      "direct_kalmanson_inverse_pair_check": {
+        "first_conflict": [],
+        "inverse_pair_conflicts": 0,
+        "rows_seen": 47259
+      },
+      "global_ptolemy_order_nlp": {
+        "linear_inequality_count": 11236,
+        "max_margin": 0.000926019965531504,
+        "optimizer_iterations": 15,
+        "optimizer_success": true,
+        "ptolemy_inequality_count": 23751,
+        "status": "PASS_PTOLEMY_ORDER_NLP_RELAXATION",
+        "trust": "NUMERICAL_NONLINEAR_DIAGNOSTIC"
+      },
+      "kalmanson_two_order_z3_probe": {
+        "conflict_cap": 1024,
+        "forbidden_clause_count": 20274,
+        "iterations": 412,
+        "solver_result": "sat",
+        "status": "FOUND_ORDER_WITHOUT_TWO_INEQUALITY_KALMANSON_CERTIFICATE",
+        "trust": "EXACT_COUNTEREXAMPLE_TO_THIS_FILTER_ONLY"
+      },
+      "metric_order_lp": {
+        "distance_class_count": 319,
+        "max_margin": 0.0012825717948999307,
+        "status": "PASS_METRIC_ORDER_LP_RELAXATION",
+        "total_inequality_count": 11236,
+        "trust": "NUMERICAL_LINEAR_DIAGNOSTIC"
+      },
+      "n": 29,
+      "notes": [
+        "This is a fixed cyclic order that survives the current lightweight exact filter sweep.",
+        "A positive diagnostic margin is not evidence of geometric realizability.",
+        "The row-circle Ptolemy NLP was attempted interactively and was too slow to treat as a completed diagnostic."
+      ],
+      "order": [
+        0,
+        27,
+        11,
+        4,
+        19,
+        5,
+        26,
+        12,
+        6,
+        21,
+        13,
+        28,
+        14,
+        2,
+        20,
+        18,
+        7,
+        24,
+        10,
+        25,
+        17,
+        3,
+        9,
+        15,
+        1,
+        22,
+        8,
+        23,
+        16
+      ],
+      "pattern": "C29_sidon_1_3_7_15",
+      "row_circle_ptolemy_nlp": {
+        "status": "NOT_COMPLETED_TOO_SLOW",
+        "trust": "NO_RESULT"
+      },
+      "sparse_order_filter_sweep": {
+        "survives_current_exact_filters": true,
+        "survives_pre_kalmanson_filters": true
+      },
+      "vertex_circle": {
+        "cycle": false,
+        "obstructed": false,
+        "self_edge_count": 0,
+        "strict_edge_count": 261
+      }
+    }
+  ],
+  "date": "2026-05-05",
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "These are fixed-order diagnostics for sparse/Sidon selected-witness patterns.",
+    "A Kalmanson filter survivor is only a counterexample to that filter, not to the geometric problem."
+  ],
+  "reproduction": {
+    "c25_exact_filter_sweep": "python scripts/check_sparse_order_survivors.py --pattern C25_sidon_2_5_9_14 --order 0,7,14,21,3,10,17,24,6,13,20,2,9,16,23,5,12,19,1,8,15,22,4,11,18 --order-label kalmanson_z3_step7_survivor --json",
+    "c25_kalmanson_probe": "python scripts/check_kalmanson_two_order_z3.py --name C25_sidon_2_5_9_14 --n 25 --offsets=2,5,9,14 --max-iterations 1000 --conflict-cap 1024",
+    "c29_exact_filter_sweep": "python scripts/check_sparse_order_survivors.py --pattern C29_sidon_1_3_7_15 --order 0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16 --order-label z3_kalmanson_survivor --json",
+    "c29_kalmanson_probe": "python scripts/check_kalmanson_two_order_z3.py --name C29_sidon_1_3_7_15 --n 29 --offsets=1,3,7,15 --max-iterations 1000 --conflict-cap 1024",
+    "c29_metric_lp": "python scripts/check_metric_order_lp.py --pattern C29_sidon_1_3_7_15 --order 0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16 --order-label z3_kalmanson_survivor --json",
+    "c29_ptolemy_nlp": "python scripts/check_ptolemy_order_nlp.py --pattern C29_sidon_1_3_7_15 --order 0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16 --order-label z3_kalmanson_survivor --maxiter 500 --json"
+  },
+  "trust": "FIXED_ORDER_DIAGNOSTIC",
+  "type": "c25_c29_sparse_frontier_probe_v1"
+}

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -9,8 +9,8 @@ designs only; geometric realization is a separate problem.
 |---:|---|---:|---|---|---|
 | 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; earlier natural-order Altman and registered non-natural fixed-order Kalmanson certificates retained as provenance |
 | 11 | `C13_sidon_1_2_4_10` | 13 | offsets `{1,2,4,10}` | Sidon circulant | abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; earlier natural-order Altman and registered non-natural fixed-order Kalmanson certificates retained as provenance; SLSQP evidence plateaus at `eq_rms ~ 0.84` under strict convexity margins |
-| 12 | `C25_sidon_2_5_9_14` | 25 | offsets `{2,5,9,14}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; cataloged but not yet run numerically |
-| 13 | `C29_sidon_1_3_7_15` | 29 | offsets `{1,3,7,15}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; cataloged but not yet run numerically |
+| 12 | `C25_sidon_2_5_9_14` | 25 | offsets `{2,5,9,14}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: a Kalmanson Z3 probe found the step-7 fixed order `[0,7,14,21,3,10,17,24,6,13,20,2,9,16,23,5,12,19,1,8,15,22,4,11,18]` with no two-inequality Kalmanson inverse-pair obstruction, but that order is exactly killed by vertex-circle and Altman filters |
+| 13 | `C29_sidon_1_3_7_15` | 29 | offsets `{1,3,7,15}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the fixed order `[0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16]` survives the current lightweight fixed-order exact sweep, the two-inequality Kalmanson inverse-pair search, the metric LP, and a global Ptolemy NLP diagnostic; row-circle Ptolemy was too slow to complete |
 
 The ranked abstract-incidence patterns above pass the row-overlap filter
 `|S_i cap S_j| <= 2` before numerical optimization. `C19_skew` and
@@ -18,9 +18,13 @@ The ranked abstract-incidence patterns above pass the row-overlap filter
 two-certificate Kalmanson order methods; see
 `docs/kalmanson-two-order-search.md`. The Sidon natural orders are also exactly
 obstructed by Altman linear certificates. The larger Sidon entries remain
-incidence-pattern leads, not geometric realizability claims. The minimum-radius
-short-chord filter is also recorded as a weak exact necessary test, but it does
-not by itself kill `C19_skew`; see `docs/minimum-radius-filter.md`.
+incidence-pattern leads, not geometric realizability claims. The new C25/C29
+probe is recorded in
+`data/certificates/c25_c29_sparse_frontier_probe.json`: it retires the tested
+C25 fixed order as a dead end and promotes the tested C29 fixed order only to a
+stress test for stronger filters. The minimum-radius short-chord filter is also
+recorded as a weak exact necessary test, but it does not by itself kill
+`C19_skew`; see `docs/minimum-radius-filter.md`.
 For the first fixed-selection stuck-set/radius/fragile-cover pass over this
 frontier, see `docs/stuck-frontier-snapshot.md`.
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -169,8 +169,12 @@ orders by exact two-inequality Kalmanson inverse-pair methods. Use them as
 benchmarks for the larger frontier:
 
 - classify the inverse-pair templates that prune C13 and C19;
-- test whether the same templates appear in any newly mined sparse incidence
-  patterns;
+- test whether the same templates appear in newly mined sparse incidence
+  patterns, especially the recorded C29 fixed order in
+  `data/certificates/c25_c29_sparse_frontier_probe.json`;
+- make the row-circle Ptolemy diagnostic practical for that C29 order, either
+  by reducing the active set or by extracting a smaller exact certificate
+  target;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -266,6 +266,46 @@ These remain adversarial objects for filter development, not counterexamples.
 In particular, the fixed-order Kalmanson kills do not prove either abstract
 incidence pattern impossible across all cyclic orders.
 
+## C25/C29 Frontier Probe
+
+The later C25/C29 probe is recorded at
+`data/certificates/c25_c29_sparse_frontier_probe.json`. It extends the sparse
+frontier log beyond the retired C13/C19 registered orders, but it does not add
+any proof-facing global claim.
+
+For `C25_sidon_2_5_9_14`, the Kalmanson Z3 refinement found the fixed step-7
+cyclic order
+
+```text
+0,7,14,21,3,10,17,24,6,13,20,2,9,16,23,5,12,19,1,8,15,22,4,11,18
+```
+
+with no two-inequality Kalmanson inverse-pair obstruction. That is only a
+counterexample to the Kalmanson inverse-pair filter. The same order is exactly
+killed by the vertex-circle order filter and by an Altman linear certificate,
+so it is a useful control case rather than a live target.
+
+For `C29_sidon_1_3_7_15`, the same Kalmanson Z3 refinement found the fixed
+cyclic order
+
+```text
+0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16
+```
+
+This order survives the current lightweight fixed-order exact filter sweep:
+crossing, Altman signature and exact linear-certificate checks,
+vertex-circle, minimum-radius, radius propagation, and the two-inequality
+Kalmanson inverse-pair check all fail to obstruct it. It also passes the
+metric-order LP diagnostic with max margin about `0.00128257`. A slow global
+Ptolemy NLP diagnostic printed a positive-margin pass around `0.00092602`, but
+this remains numerical and is not part of the fast verification tier.
+
+The row-circle Ptolemy NLP, which is the next stronger distance-class
+diagnostic, was too slow to complete interactively on this C29 order. That
+makes the order a stress test for either reducing the row-circle active set or
+building a stronger exact filter. It is not evidence of geometric
+realizability.
+
 The first constrained numerical run on the registered `C13` sparse-filter order
 is:
 

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -108,6 +108,15 @@ local_repo:
       certificate: "data/certificates/c13_sidon_all_orders_kalmanson_two_search.json"
       verifier: "scripts/check_kalmanson_two_order_search.py"
       claim_scope: "kills this fixed abstract C13 selected-witness pattern across all cyclic orders; does not prove Erdos #97"
+  notable_frontier_diagnostics:
+    - pattern: "C25_sidon_2_5_9_14"
+      status: "fixed-order Kalmanson-filter survivor killed by vertex-circle and Altman filters"
+      artifact: "data/certificates/c25_c29_sparse_frontier_probe.json"
+      claim_scope: "fixed-order diagnostic only; not a counterexample and not an all-order obstruction for the abstract pattern"
+    - pattern: "C29_sidon_1_3_7_15"
+      status: "one fixed order survives current lightweight filters and is a stress test for stronger exactification"
+      artifact: "data/certificates/c25_c29_sparse_frontier_probe.json"
+      claim_scope: "fixed-order diagnostic only; surviving filters is not evidence of geometric realizability"
   best_numerical_object: "B12_3x4_danzer_lift near-miss; rejected as proof/counterexample."
   main_entry_points:
     - "STATE.md"

--- a/tests/test_c25_c29_sparse_frontier_probe.py
+++ b/tests/test_c25_c29_sparse_frontier_probe.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import itertools
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_sparse_order_survivors as sparse_orders  # noqa: E402
+from check_kalmanson_two_order_search import _prepare_vector_tables  # noqa: E402
+
+
+ARTIFACT = ROOT / "data" / "certificates" / "c25_c29_sparse_frontier_probe.json"
+
+
+def _has_kalmanson_inverse_pair(n: int, offsets: list[int], order: list[int]) -> bool:
+    quad_ids, inverse_id = _prepare_vector_tables(n, offsets)
+    seen: dict[int, tuple[int, tuple[int, int, int, int]]] = {}
+    for quad in itertools.combinations(order, 4):
+        for kind, vector_id in enumerate(quad_ids[quad]):
+            inverse = inverse_id[vector_id]
+            if inverse >= 0 and inverse in seen:
+                return True
+            seen.setdefault(vector_id, (kind, quad))
+    return False
+
+
+def test_c25_c29_sparse_frontier_probe_records_expected_cases() -> None:
+    artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert artifact["type"] == "c25_c29_sparse_frontier_probe_v1"
+    assert artifact["trust"] == "FIXED_ORDER_DIAGNOSTIC"
+
+    by_case = {row["case"]: row for row in artifact["cases"]}
+    assert set(by_case) == {
+        "C25_sidon_2_5_9_14:kalmanson_z3_step7_survivor",
+        "C29_sidon_1_3_7_15:z3_kalmanson_survivor",
+    }
+
+    c25 = by_case["C25_sidon_2_5_9_14:kalmanson_z3_step7_survivor"]
+    assert c25["conclusion"] == "dead_end_for_this_order"
+    assert c25["vertex_circle"]["obstructed"] is True
+    assert c25["altman_linear_certificate"]["obstructed"] is True
+
+    c29 = by_case["C29_sidon_1_3_7_15:z3_kalmanson_survivor"]
+    assert c29["conclusion"] == "fixed_order_stress_test_for_stronger_filters"
+    assert c29["sparse_order_filter_sweep"]["survives_current_exact_filters"] is True
+    assert c29["metric_order_lp"]["status"] == "PASS_METRIC_ORDER_LP_RELAXATION"
+    assert c29["row_circle_ptolemy_nlp"]["status"] == "NOT_COMPLETED_TOO_SLOW"
+
+
+def test_c25_c29_sparse_frontier_probe_matches_exact_filter_sweep() -> None:
+    artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    patterns = sparse_orders.built_in_patterns()
+
+    for row in artifact["cases"]:
+        pattern = patterns[row["pattern"]]
+        observed = sparse_orders.evaluate_order(pattern, row["order"], "artifact")
+
+        assert observed["vertex_circle"]["obstructed"] == row["vertex_circle"][
+            "obstructed"
+        ]
+        assert observed["altman_linear_certificate"]["obstructed"] == row[
+            "altman_linear_certificate"
+        ]["obstructed"]
+        assert observed["survives_pre_kalmanson_filters"] == row[
+            "sparse_order_filter_sweep"
+        ]["survives_pre_kalmanson_filters"]
+
+
+def test_c25_c29_orders_have_no_two_inequality_kalmanson_inverse_pair() -> None:
+    artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    by_pattern = {row["pattern"]: row for row in artifact["cases"]}
+
+    assert not _has_kalmanson_inverse_pair(
+        25,
+        [2, 5, 9, 14],
+        by_pattern["C25_sidon_2_5_9_14"]["order"],
+    )
+    assert not _has_kalmanson_inverse_pair(
+        29,
+        [1, 3, 7, 15],
+        by_pattern["C29_sidon_1_3_7_15"]["order"],
+    )


### PR DESCRIPTION
## Summary

- add a compact C25/C29 sparse-frontier diagnostic artifact
- document that the tested C25 Kalmanson-filter survivor is killed by exact vertex-circle and Altman filters
- record the tested C29 fixed order as a stronger-filter stress test, not a counterexample candidate
- add regression coverage for the artifact and exact-filter sweep consistency

## Verification

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

No general proof of Erdos Problem #97 and no counterexample are claimed.