### PR TITLE
Add minimal fragile-cover bridge note

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and [`docs/round2/kalmanson_distance_filter.md`](docs/round2/kalmanson_distance_filter.md).
 - For the weak exact minimum-radius short-chord filter, read
   [`docs/minimum-radius-filter.md`](docs/minimum-radius-filter.md).
+- For a partial bridge theorem from minimality to fragile-cover witness
+  systems, read
+  [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -104,6 +104,18 @@ turn `2*pi`.
 This note does not alter the global status of Erdos Problem #97 and does not
 replace the existing machine-checked `n=8` finite-case artifact.
 
+### Minimal fragile-cover bridge
+
+Status: `LEMMA` / partial bridge theorem.
+
+Every minimal counterexample admits a partial fragile-cover witness system:
+for each deleted vertex `x`, minimality produces a remaining center `y` whose
+unique exact 4-tie contains `x`; retaining these exact 4-ties gives a cover of
+all vertices by fragile rows. The rows satisfy the two-circle cap and the
+radical-axis crossing rule for two-overlaps. This is a necessary structural
+bridge only, not a contradiction and not the open ear-orderable bridge. See
+`docs/minimal-fragile-cover-bridge.md`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -38,6 +38,12 @@ equal-distance algebra kills the other 14. See
 External independent review remains recommended before public theorem-style
 claims.
 
+For the general bridge problem, minimality now gives a small proved foothold:
+every minimal counterexample admits a partial fragile-cover witness system made
+from exact critical 4-ties. This is necessary structure only; the block-6
+abstract family shows that fragile-cover hypergraph constraints alone are too
+weak. See `docs/minimal-fragile-cover-bridge.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -323,6 +323,20 @@ size at least 4 after deletion. Thus `x` lies in a unique critical 4-tie at
 This is structural information about minimal counterexamples; by itself it is
 not a contradiction.
 
+### Minimal fragile-cover bridge
+
+Every minimal counterexample admits a partial fragile-cover witness system:
+some exact critical 4-tie rows cover all vertices, and each vertex is assigned
+to a fragile center whose exact 4-tie contains it.
+
+This follows by applying the minimal-counterexample critical-tie lemma to each
+deleted vertex and retaining one copy of each resulting exact 4-tie. The rows
+also satisfy the two-circle cap and the radical-axis crossing rule for
+two-overlaps. This is a necessary bridge theorem only; the block-6 abstract
+family checked by `scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok`
+shows that fragile-cover hypergraph constraints alone are too weak to prove
+the problem. See `docs/minimal-fragile-cover-bridge.md`.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`minimum-radius-filter.md`](minimum-radius-filter.md): weak exact
   minimum-radius short-chord filter; records why it does not kill `C19_skew`
   by itself.
+- [`minimal-fragile-cover-bridge.md`](minimal-fragile-cover-bridge.md):
+  partial bridge theorem showing that every minimal counterexample admits a
+  fragile-cover witness system; also records why this is not sufficient.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -1,0 +1,103 @@
+# Minimal Fragile-Cover Bridge
+
+Status: `LEMMA` / partial bridge theorem. No general proof of Erdos Problem #97
+is claimed. No counterexample is claimed.
+
+This note records a modest bridge theorem that is actually proved, in contrast
+to the open ear-orderable bridge. It converts minimality of a hypothetical
+counterexample into a covering family of exact critical 4-ties.
+
+## Definitions
+
+Let `P` be a strictly convex counterexample with the minimum possible number of
+vertices, if any counterexample exists.
+
+For a center `y`, call a distance class `C_y(r)` **critical** if
+
+```text
+|C_y(r)| = 4.
+```
+
+It is critical for a vertex `x in C_y(r)` when deleting `x` makes `y` good,
+meaning that no distance class of size at least `4` remains at `y`.
+
+A **fragile-cover witness system** is a partial selected-witness system
+consisting of some centers `y` and exact 4-sets `F_y`, with:
+
+- `y notin F_y`;
+- `|F_y| = 4`;
+- the sets `F_y` cover every vertex of `P`;
+- there is a witness map `pi: V -> {fragile centers}` with `x in F_{pi(x)}`.
+
+## Lemma
+
+Every minimal counterexample admits a fragile-cover witness system.
+
+## Proof
+
+Fix a vertex `x` of a minimal counterexample `P`, and delete it. By minimality,
+the remaining polygon is not a counterexample, so some remaining vertex `y`
+has `E(y) <= 3` after deletion.
+
+In the original polygon, every distance class at `y` of size at least `4` must
+contain `x`; otherwise that class would still have size at least `4` after
+deleting `x`. Since `x` lies at one distance from `y`, there is at most one
+such class. Its size is exactly `4`, because if it had size at least `5`, then
+after deleting `x` it would still have size at least `4`. Thus `x` belongs to
+a unique exact 4-tie at `y`.
+
+Do this for every vertex `x`. If several vertices choose the same center and
+the same exact 4-tie, keep one copy. The retained exact 4-ties cover all
+vertices by construction, giving the desired partial witness system and
+witness map.
+
+## Immediate Geometric Constraints
+
+Any fragile-cover witness system coming from a minimal counterexample also
+satisfies the usual exact selected-witness constraints:
+
+- Two fragile rows intersect in at most two vertices, by the two-circle cap.
+- If two fragile rows `F_a` and `F_b` intersect in exactly `{u,v}`, then the
+  source chord `{a,b}` crosses the witness chord `{u,v}` in the cyclic order,
+  by the radical-axis crossing/bisection lemma.
+
+These are exactly the checks implemented by
+`src/erdos97/fragile_hypergraph.py` and exposed through
+`scripts/check_fragile_hypergraph.py`.
+
+## What This Does Not Prove
+
+The bridge is necessary, not sufficient. The checked block-6 family passes the
+abstract fragile-cover constraints:
+
+```bash
+python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json
+```
+
+For each six-vertex block with local labels `b,...,b+5`, the rows are:
+
+```text
+b   -> {b+1,b+2,b+3,b+4}
+b+3 -> {b,b+2,b+4,b+5}
+```
+
+The two fragile rows in a block cover the six vertices, intersect in
+`{b+2,b+4}`, and satisfy the cyclic crossing rule. Disjoint copies preserve
+the same abstract checks. Therefore pure fragile-cover hypergraph constraints
+cannot prove Erdos #97.
+
+## Research Use
+
+This bridge is still useful because it gives a necessary finite object for any
+minimal counterexample:
+
+1. Search pipelines can require at least one cover by exact critical 4-tie
+   rows, rather than arbitrary selected rows alone.
+2. Stuck-set and ear-orderability failures should be analyzed together with
+   a witness map `pi`, not only as full fixed-row patterns.
+3. The next bridge target is to add a genuinely geometric constraint to the
+   fragile cover: for example, dependency-cycle restrictions, critical-radius
+   ordering, or row-circle exact constraints on the fragile rows.
+
+This is a foothold toward a bridge theorem, not the central ear-orderable
+bridge itself.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -178,6 +178,26 @@ benchmarks for the larger frontier:
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 
+## Priority 8b - strengthen the fragile-cover bridge
+
+Target: `docs/minimal-fragile-cover-bridge.md` and
+`src/erdos97/fragile_hypergraph.py`.
+
+Minimality proves that every minimal counterexample has a fragile-cover
+witness system, but the block-6 abstract family shows the current hypergraph
+axioms are too weak. The next useful bridge work is to add a geometric
+condition that the block-6 family does not automatically satisfy:
+
+- dependency-cycle restrictions for the witness map `pi`;
+- critical-radius ordering or deletion-dependency inequalities;
+- exact row-circle constraints on the fragile rows;
+- interaction between fragile-cover rows and stuck-set/ear-orderability
+  failures.
+
+Acceptance standard: a strengthened bridge should be stated as a necessary
+condition for minimal counterexamples and should reject at least one abstract
+fragile-cover family that passes the current pairwise/crossing checks.
+
 ## Priority 9 - strengthen only productive filters
 
 The minimum-radius short-chord filter in `docs/minimum-radius-filter.md` is a

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -117,6 +117,11 @@ local_repo:
       status: "one fixed order survives current lightweight filters and is a stress test for stronger exactification"
       artifact: "data/certificates/c25_c29_sparse_frontier_probe.json"
       claim_scope: "fixed-order diagnostic only; surviving filters is not evidence of geometric realizability"
+  notable_bridge_lemmas:
+    - name: "minimal_fragile_cover_bridge"
+      status: "proved necessary structure for a minimal counterexample"
+      document: "docs/minimal-fragile-cover-bridge.md"
+      claim_scope: "partial bridge theorem only; not a contradiction, not the open ear-orderable bridge, and not a proof of Erdos #97"
   best_numerical_object: "B12_3x4_danzer_lift near-miss; rejected as proof/counterexample."
   main_entry_points:
     - "STATE.md"
@@ -127,6 +132,7 @@ local_repo:
     - "docs/n8-geometric-proof.md"
     - "docs/round2/round2_merged_report.md"
     - "docs/phi4-rectangle-trap.md"
+    - "docs/minimal-fragile-cover-bridge.md"
     - "docs/reproduction-log.md"
     - "docs/verification-contract.md"
 


### PR DESCRIPTION
## Summary

- add a proof-facing note for the minimal fragile-cover bridge theorem
- record the lemma in the claims/results ledgers, README, index, metadata, and review priorities
- point the next bridge work at strengthening fragile-cover constraints beyond the current block-6 abstract family

This is a partial bridge theorem only. It does not prove Erdos #97, does not claim a counterexample, and does not settle the open ear-orderable bridge.

## Verification

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python -m pytest tests/test_fragile_hypergraph.py -q`