### PR TITLE
Add fragile-cover essential matching check

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -326,12 +326,15 @@ not a contradiction.
 ### Minimal fragile-cover bridge
 
 Every minimal counterexample admits a partial fragile-cover witness system:
-some exact critical 4-tie rows cover all vertices, and each vertex is assigned
-to a fragile center whose exact 4-tie contains it.
+some exact critical 4-tie rows cover all vertices, each vertex is assigned to
+a fragile center whose exact 4-tie contains it, and every retained fragile row
+is assigned at least one vertex.
 
 This follows by applying the minimal-counterexample critical-tie lemma to each
-deleted vertex and retaining one copy of each resulting exact 4-tie. The rows
-also satisfy the two-circle cap and the radical-axis crossing rule for
+deleted vertex and retaining one copy of each resulting exact 4-tie. The row
+usage condition is equivalently a matching from retained fragile centers to
+distinct vertices they cover. The rows also satisfy the two-circle cap and the
+radical-axis crossing rule for
 two-overlaps. This is a necessary bridge theorem only; the block-6 abstract
 family checked by `scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok`
 shows that fragile-cover hypergraph constraints alone are too weak to prove

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -28,6 +28,7 @@ consisting of some centers `y` and exact 4-sets `F_y`, with:
 - `|F_y| = 4`;
 - the sets `F_y` cover every vertex of `P`;
 - there is a witness map `pi: V -> {fragile centers}` with `x in F_{pi(x)}`.
+- every retained fragile center is used by at least one vertex under `pi`.
 
 ## Lemma
 
@@ -47,9 +48,10 @@ after deleting `x` it would still have size at least `4`. Thus `x` belongs to
 a unique exact 4-tie at `y`.
 
 Do this for every vertex `x`. If several vertices choose the same center and
-the same exact 4-tie, keep one copy. The retained exact 4-ties cover all
-vertices by construction, giving the desired partial witness system and
-witness map.
+the same exact 4-tie, keep one copy. Every retained row has at least one
+generating vertex, so the retained rows can be matched to distinct covered
+vertices. The retained exact 4-ties cover all vertices by construction, giving
+the desired partial witness system and witness map.
 
 ## Immediate Geometric Constraints
 
@@ -63,7 +65,8 @@ satisfies the usual exact selected-witness constraints:
 
 These are exactly the checks implemented by
 `src/erdos97/fragile_hypergraph.py` and exposed through
-`scripts/check_fragile_hypergraph.py`.
+`scripts/check_fragile_hypergraph.py`. The checker also reports the row-use
+matching condition above as `essential_cover_ok`.
 
 ## What This Does Not Prove
 

--- a/src/erdos97/fragile_hypergraph.py
+++ b/src/erdos97/fragile_hypergraph.py
@@ -27,12 +27,15 @@ class FragileHypergraphCheck:
     uniformity_ok: bool
     pairwise_intersection_ok: bool
     crossing_ok: bool
+    essential_cover_ok: bool
     witness_map_ok: bool | None
     cover_missing: list[int]
     self_exclusion_violations: list[int]
     uniformity_violations: list[dict[str, object]]
     pairwise_intersection_violations: list[dict[str, object]]
     crossing_violations: list[dict[str, object]]
+    essential_matching: dict[int, int]
+    essential_matching_unmatched_centers: list[int]
     witness_map_violations: list[dict[str, object]]
 
     @property
@@ -44,6 +47,7 @@ class FragileHypergraphCheck:
             and self.uniformity_ok
             and self.pairwise_intersection_ok
             and self.crossing_ok
+            and self.essential_cover_ok
             and witness_ok
         )
 
@@ -79,6 +83,42 @@ def canonical_witness_map(n: int, rows: Mapping[int, Sequence[int]]) -> WitnessM
     return witnesses
 
 
+def essential_row_matching(
+    n: int,
+    rows: Mapping[int, Sequence[int]],
+) -> tuple[dict[int, int], list[int]]:
+    """Match each fragile row to a distinct vertex it covers, when possible.
+
+    Minimality supplies a deleted vertex for every retained fragile row.  After
+    duplicate rows are removed, those generating vertices are distinct, so a
+    fragile-cover system from a minimal counterexample has this matching.
+    """
+
+    _validate_labels(n, rows)
+    centers = sorted(rows)
+    vertex_to_center: dict[int, int] = {}
+
+    def augment(center: int, seen: set[int]) -> bool:
+        for vertex in sorted(set(rows[center])):
+            if vertex in seen:
+                continue
+            seen.add(vertex)
+            current = vertex_to_center.get(vertex)
+            if current is None or augment(current, seen):
+                vertex_to_center[vertex] = center
+                return True
+        return False
+
+    for center in centers:
+        augment(center, set())
+
+    center_to_vertex = {
+        center: vertex for vertex, center in sorted(vertex_to_center.items())
+    }
+    unmatched = [center for center in centers if center not in center_to_vertex]
+    return center_to_vertex, unmatched
+
+
 def check_fragile_hypergraph(
     n: int,
     rows: Mapping[int, Sequence[int]],
@@ -97,6 +137,10 @@ def check_fragile_hypergraph(
 
     cover = covered_vertices(normalized_rows)
     cover_missing = [vertex for vertex in range(n) if vertex not in cover]
+    essential_matching, essential_unmatched = essential_row_matching(
+        n,
+        normalized_rows,
+    )
 
     self_exclusion_violations = [
         center for center, row in normalized_rows.items() if center in row
@@ -145,6 +189,7 @@ def check_fragile_hypergraph(
         witness_map_ok = None
     else:
         witness_map_ok = True
+        used_centers: set[int] = set()
         for vertex in range(n):
             if vertex not in witness_map:
                 witness_map_ok = False
@@ -171,6 +216,18 @@ def check_fragile_hypergraph(
                         "reason": "witness center does not cover vertex",
                     }
                 )
+            else:
+                used_centers.add(center)
+        unused_centers = sorted(set(centers) - used_centers)
+        if unused_centers:
+            witness_map_ok = False
+            for center in unused_centers:
+                witness_map_violations.append(
+                    {
+                        "center": center,
+                        "reason": "fragile center is not assigned any vertex",
+                    }
+                )
 
     return FragileHypergraphCheck(
         n=n,
@@ -180,12 +237,15 @@ def check_fragile_hypergraph(
         uniformity_ok=not uniformity_violations,
         pairwise_intersection_ok=not pairwise_intersection_violations,
         crossing_ok=not crossing_violations,
+        essential_cover_ok=not essential_unmatched,
         witness_map_ok=witness_map_ok,
         cover_missing=cover_missing,
         self_exclusion_violations=self_exclusion_violations,
         uniformity_violations=uniformity_violations,
         pairwise_intersection_violations=pairwise_intersection_violations,
         crossing_violations=crossing_violations,
+        essential_matching=essential_matching,
+        essential_matching_unmatched_centers=essential_unmatched,
         witness_map_violations=witness_map_violations,
     )
 
@@ -225,12 +285,20 @@ def check_to_json(result: FragileHypergraphCheck) -> dict[str, object]:
         "uniformity_ok": result.uniformity_ok,
         "pairwise_intersection_ok": result.pairwise_intersection_ok,
         "crossing_ok": result.crossing_ok,
+        "essential_cover_ok": result.essential_cover_ok,
         "witness_map_ok": result.witness_map_ok,
         "cover_missing": result.cover_missing,
         "self_exclusion_violations": result.self_exclusion_violations,
         "uniformity_violations": result.uniformity_violations,
         "pairwise_intersection_violations": result.pairwise_intersection_violations,
         "crossing_violations": result.crossing_violations,
+        "essential_matching": {
+            str(center): vertex
+            for center, vertex in sorted(result.essential_matching.items())
+        },
+        "essential_matching_unmatched_centers": (
+            result.essential_matching_unmatched_centers
+        ),
         "witness_map_violations": result.witness_map_violations,
     }
 

--- a/tests/test_fragile_hypergraph.py
+++ b/tests/test_fragile_hypergraph.py
@@ -4,6 +4,7 @@ from erdos97.fragile_hypergraph import (
     block6_family,
     canonical_witness_map,
     check_fragile_hypergraph,
+    essential_row_matching,
 )
 
 
@@ -14,6 +15,7 @@ def test_block6_family_satisfies_fragile_hypergraph_axioms() -> None:
     result = check_fragile_hypergraph(n, rows, witness_map=witness_map)
 
     assert result.ok
+    assert result.essential_cover_ok
     assert result.fragile_centers == [0, 3, 6, 9]
     assert witness_map[0] == 3
     assert witness_map[5] == 3
@@ -54,3 +56,52 @@ def test_witness_map_must_choose_a_covering_fragile_center() -> None:
         "center": 0,
         "reason": "witness center does not cover vertex",
     } in result.witness_map_violations
+
+
+def test_witness_map_must_use_every_fragile_center() -> None:
+    rows = {
+        0: [1, 2, 3, 4],
+        1: [0, 5, 6, 7],
+        2: [0, 1, 3, 5],
+    }
+    witness_map = {
+        0: 1,
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 1,
+        6: 1,
+        7: 1,
+    }
+
+    result = check_fragile_hypergraph(8, rows, witness_map=witness_map)
+
+    assert not result.ok
+    assert result.witness_map_ok is False
+    assert {
+        "center": 2,
+        "reason": "fragile center is not assigned any vertex",
+    } in result.witness_map_violations
+
+
+def test_essential_row_matching_detects_hall_defect() -> None:
+    rows = {
+        0: [1, 2, 3, 4],
+        1: [2, 3, 4, 5],
+        2: [3, 4, 5, 6],
+        3: [4, 5, 6, 7],
+        4: [0, 5, 6, 7],
+        5: [0, 1, 6, 7],
+        6: [0, 1, 2, 7],
+        7: [0, 1, 2, 3],
+        8: [0, 1, 2, 3],
+    }
+
+    matching, unmatched = essential_row_matching(9, rows)
+    result = check_fragile_hypergraph(9, rows)
+
+    assert len(matching) == 8
+    assert unmatched
+    assert not result.essential_cover_ok
+    assert result.essential_matching_unmatched_centers == unmatched


### PR DESCRIPTION
## Summary
- add an essential row-use matching check to the fragile-cover hypergraph verifier
- require supplied witness maps to use every retained fragile center at least once
- document the matching condition as a necessary minimal-counterexample bridge refinement

## Verification
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_fragile_hypergraph.py -q`
- `python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json`
- `python -m pytest -q`

This remains a necessary-condition bridge only; it does not claim a general proof or counterexample.