### PR TITLE
Add fragile full-extension bridge check

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -112,9 +112,12 @@ Every minimal counterexample admits a partial fragile-cover witness system:
 for each deleted vertex `x`, minimality produces a remaining center `y` whose
 unique exact 4-tie contains `x`; retaining these exact 4-ties gives a cover of
 all vertices by fragile rows. The rows satisfy the two-circle cap and the
-radical-axis crossing rule for two-overlaps. This is a necessary structural
-bridge only, not a contradiction and not the open ear-orderable bridge. See
-`docs/minimal-fragile-cover-bridge.md`.
+radical-axis crossing rule for two-overlaps, and they must extend to a full
+selected-witness incidence system because every vertex in the original
+counterexample is bad. The optional full-extension checker rejects the single
+block-6 fragile cover but still permits two disjoint blocks, so this is a
+necessary structural bridge only, not a contradiction and not the open
+ear-orderable bridge. See `docs/minimal-fragile-cover-bridge.md`.
 
 ### Fixed-pattern exact obstructions
 

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -333,8 +333,11 @@ is assigned at least one vertex.
 This follows by applying the minimal-counterexample critical-tie lemma to each
 deleted vertex and retaining one copy of each resulting exact 4-tie. The row
 usage condition is equivalently a matching from retained fragile centers to
-distinct vertices they cover. The rows also satisfy the two-circle cap and the
-radical-axis crossing rule for
+distinct vertices they cover. Since every vertex in a counterexample is bad,
+the retained fragile rows can also be extended to a full selected-witness
+incidence system by choosing one 4-neighbor row at every non-fragile center and
+using the retained critical row at each fragile center. The rows also satisfy
+the two-circle cap and the radical-axis crossing rule for
 two-overlaps. This is a necessary bridge theorem only; the block-6 abstract
 family checked by `scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok`
 shows that fragile-cover hypergraph constraints alone are too weak to prove

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -53,6 +53,14 @@ generating vertex, so the retained rows can be matched to distinct covered
 vertices. The retained exact 4-ties cover all vertices by construction, giving
 the desired partial witness system and witness map.
 
+There is one more incidence-level consequence. Since every vertex of the
+original polygon is bad, choose one selected 4-neighbor row at every
+non-fragile center. At a retained fragile center, use its critical row: because
+that row is used by some deleted vertex, the critical-tie proof shows it is the
+unique distance class of size at least `4` at that center. Thus every minimal
+counterexample also gives a full selected-witness incidence system extending
+the fragile rows.
+
 ## Immediate Geometric Constraints
 
 Any fragile-cover witness system coming from a minimal counterexample also
@@ -67,6 +75,17 @@ These are exactly the checks implemented by
 `src/erdos97/fragile_hypergraph.py` and exposed through
 `scripts/check_fragile_hypergraph.py`. The checker also reports the row-use
 matching condition above as `essential_cover_ok`.
+
+The same script can optionally test the full-row extension condition:
+
+```bash
+python scripts/check_fragile_hypergraph.py --blocks 1 --check-full-extension --json
+```
+
+This searches for a full selected-witness incidence system extending the
+fragile rows, subject to self-exclusion, four-uniformity, the two-circle cap,
+and the two-overlap crossing rule. Passing this extension check is still not a
+Euclidean realization certificate.
 
 ## What This Does Not Prove
 
@@ -88,6 +107,12 @@ The two fragile rows in a block cover the six vertices, intersect in
 `{b+2,b+4}`, and satisfy the cyclic crossing rule. Disjoint copies preserve
 the same abstract checks. Therefore pure fragile-cover hypergraph constraints
 cannot prove Erdos #97.
+
+The full-extension diagnostic rejects the single six-vertex block: it cannot be
+extended to full selected rows satisfying the pair and crossing constraints.
+However, two disjoint blocks still pass the full-extension diagnostic. Thus
+full-row extendability is a real strengthening, but it is still far from a
+proof.
 
 ## Research Use
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -185,8 +185,10 @@ Target: `docs/minimal-fragile-cover-bridge.md` and
 
 Minimality proves that every minimal counterexample has a fragile-cover
 witness system, but the block-6 abstract family shows the current hypergraph
-axioms are too weak. The next useful bridge work is to add a geometric
-condition that the block-6 family does not automatically satisfy:
+axioms are too weak. The current checker now also has an optional full-row
+extension diagnostic: it rejects the single six-vertex block but still permits
+two disjoint blocks. The next useful bridge work is to add a geometric
+condition that the surviving multi-block family does not automatically satisfy:
 
 - dependency-cycle restrictions for the witness map `pi`;
 - critical-radius ordering or deletion-dependency inequalities;

--- a/scripts/check_fragile_hypergraph.py
+++ b/scripts/check_fragile_hypergraph.py
@@ -18,6 +18,8 @@ from erdos97.fragile_hypergraph import (  # noqa: E402
     canonical_witness_map,
     check_fragile_hypergraph,
     check_to_json,
+    full_extension_to_json,
+    full_selected_extension,
 )
 
 
@@ -26,6 +28,22 @@ def main() -> int:
     parser.add_argument("--blocks", type=int, default=2, help="number of six-vertex blocks")
     parser.add_argument("--json", action="store_true", help="print JSON instead of a summary")
     parser.add_argument("--assert-ok", action="store_true", help="assert the checks pass")
+    parser.add_argument(
+        "--check-full-extension",
+        action="store_true",
+        help="also search for a full selected-witness incidence extension",
+    )
+    parser.add_argument(
+        "--assert-full-extension",
+        action="store_true",
+        help="assert the optional full-extension check passes",
+    )
+    parser.add_argument(
+        "--max-extension-nodes",
+        type=int,
+        default=100_000,
+        help="maximum backtracking nodes for --check-full-extension",
+    )
     parser.add_argument("--write-certificate", help="write JSON result to this path")
     args = parser.parse_args()
 
@@ -43,9 +61,19 @@ def main() -> int:
             "realization or counterexample"
         ),
     }
+    extension = None
+    if args.check_full_extension or args.assert_full_extension:
+        extension = full_selected_extension(
+            n,
+            rows,
+            max_nodes=args.max_extension_nodes,
+        )
+        payload["full_selected_extension"] = full_extension_to_json(extension)
 
     if args.assert_ok and not result.ok:
         raise AssertionError("expected block6 fragile hypergraph checks to pass")
+    if args.assert_full_extension and (extension is None or not extension.ok):
+        raise AssertionError("expected a full selected-witness extension")
 
     if args.write_certificate:
         path = Path(args.write_certificate)
@@ -62,8 +90,18 @@ def main() -> int:
         status = "PASS" if result.ok else "FAIL"
         print("family  blocks  n  fragile centers  result")
         print(f"block6  {args.blocks}  {n}  {len(rows)}  {status}")
+        if extension is not None:
+            extension_status = "PASS" if extension.ok else "FAIL"
+            print(
+                "full selected extension: "
+                f"{extension_status} ({extension.nodes_visited} nodes)"
+            )
+            if extension.failure_reason:
+                print(f"extension reason: {extension.failure_reason}")
         if args.assert_ok:
             print("OK: fragile hypergraph expectation verified")
+        if args.assert_full_extension:
+            print("OK: full selected-witness extension verified")
     return 0
 
 

--- a/src/erdos97/fragile_hypergraph.py
+++ b/src/erdos97/fragile_hypergraph.py
@@ -52,6 +52,18 @@ class FragileHypergraphCheck:
         )
 
 
+@dataclass(frozen=True)
+class FullSelectedExtensionCheck:
+    n: int
+    fixed_centers: list[int]
+    ok: bool
+    search_exhausted: bool
+    nodes_visited: int
+    max_nodes: int
+    full_rows: Rows | None
+    failure_reason: str | None
+
+
 def _validate_labels(n: int, rows: Mapping[int, Sequence[int]]) -> None:
     if n <= 0:
         raise ValueError(f"n must be positive, got {n}")
@@ -117,6 +129,152 @@ def essential_row_matching(
     }
     unmatched = [center for center in centers if center not in center_to_vertex]
     return center_to_vertex, unmatched
+
+
+def _normalize_rows(rows: Mapping[int, Sequence[int]]) -> Rows:
+    return {int(center): sorted({int(v) for v in row}) for center, row in rows.items()}
+
+
+def _selected_pair_ok(
+    left: int,
+    left_row: Sequence[int],
+    right: int,
+    right_row: Sequence[int],
+    order: Sequence[int],
+) -> bool:
+    inter = sorted(set(left_row) & set(right_row))
+    if len(inter) > 2:
+        return False
+    if len(inter) == 2:
+        source = normalize_chord(left, right)
+        target = normalize_chord(inter[0], inter[1])
+        return chords_cross_in_order(source, target, order)
+    return True
+
+
+def full_selected_extension(
+    n: int,
+    rows: Mapping[int, Sequence[int]],
+    order: Sequence[int] | None = None,
+    max_nodes: int = 100_000,
+) -> FullSelectedExtensionCheck:
+    """Try to extend fragile rows to a full selected-witness incidence system.
+
+    Any counterexample has at least one selected four-neighbor row at every
+    center. If a fragile center is used by the minimality bridge, its retained
+    critical row is the unique size-at-least-four class at that center, so the
+    full selected system can be chosen to extend the fragile rows.
+
+    This remains an incidence/order necessary condition only: an extension is
+    not a Euclidean realization certificate.
+    """
+
+    _validate_labels(n, rows)
+    if order is None:
+        order = list(range(n))
+    if sorted(order) != list(range(n)):
+        raise ValueError("order must be a permutation of range(n)")
+    if max_nodes <= 0:
+        raise ValueError(f"max_nodes must be positive, got {max_nodes}")
+
+    fixed_rows = _normalize_rows(rows)
+    centers = list(range(n))
+
+    for center, row in fixed_rows.items():
+        if len(row) != 4:
+            return FullSelectedExtensionCheck(
+                n=n,
+                fixed_centers=sorted(fixed_rows),
+                ok=False,
+                search_exhausted=True,
+                nodes_visited=0,
+                max_nodes=max_nodes,
+                full_rows=None,
+                failure_reason=f"fixed row {center} is not a four-set",
+            )
+        if center in row:
+            return FullSelectedExtensionCheck(
+                n=n,
+                fixed_centers=sorted(fixed_rows),
+                ok=False,
+                search_exhausted=True,
+                nodes_visited=0,
+                max_nodes=max_nodes,
+                full_rows=None,
+                failure_reason=f"fixed row {center} contains its center",
+            )
+
+    candidates: dict[int, list[tuple[int, ...]]] = {}
+    for center in centers:
+        if center in fixed_rows:
+            candidates[center] = [tuple(fixed_rows[center])]
+        else:
+            labels = [label for label in centers if label != center]
+            candidates[center] = [tuple(row) for row in combinations(labels, 4)]
+
+    assigned: dict[int, tuple[int, ...]] = {}
+    nodes_visited = 0
+    hit_limit = False
+
+    def candidate_ok(center: int, row: Sequence[int]) -> bool:
+        return all(
+            _selected_pair_ok(center, row, other, other_row, order)
+            for other, other_row in assigned.items()
+        )
+
+    def choose_center() -> tuple[int | None, list[tuple[int, ...]]]:
+        best_center: int | None = None
+        best_candidates: list[tuple[int, ...]] = []
+        for center in centers:
+            if center in assigned:
+                continue
+            viable = [row for row in candidates[center] if candidate_ok(center, row)]
+            if best_center is None or len(viable) < len(best_candidates):
+                best_center = center
+                best_candidates = viable
+            if not viable:
+                break
+        return best_center, best_candidates
+
+    def search() -> bool:
+        nonlocal hit_limit, nodes_visited
+        if len(assigned) == n:
+            return True
+        if nodes_visited >= max_nodes:
+            hit_limit = True
+            return False
+        center, viable = choose_center()
+        if center is None:
+            return True
+        for row in viable:
+            nodes_visited += 1
+            assigned[center] = row
+            if search():
+                return True
+            del assigned[center]
+            if hit_limit:
+                return False
+        return False
+
+    ok = search()
+    full_rows = (
+        {center: list(row) for center, row in sorted(assigned.items())}
+        if ok
+        else None
+    )
+    failure_reason = None
+    if not ok:
+        failure_reason = "node limit reached" if hit_limit else "no extension exists"
+    return FullSelectedExtensionCheck(
+        n=n,
+        fixed_centers=sorted(fixed_rows),
+        ok=ok,
+        search_exhausted=not hit_limit,
+        nodes_visited=nodes_visited,
+        max_nodes=max_nodes,
+        full_rows=full_rows,
+        failure_reason=failure_reason,
+    )
 
 
 def check_fragile_hypergraph(
@@ -300,6 +458,25 @@ def check_to_json(result: FragileHypergraphCheck) -> dict[str, object]:
             result.essential_matching_unmatched_centers
         ),
         "witness_map_violations": result.witness_map_violations,
+    }
+
+
+def full_extension_to_json(result: FullSelectedExtensionCheck) -> dict[str, object]:
+    """Return a JSON-serializable full-extension check result."""
+    return {
+        "type": "fragile_full_selected_extension_check",
+        "n": result.n,
+        "fixed_centers": result.fixed_centers,
+        "ok": result.ok,
+        "search_exhausted": result.search_exhausted,
+        "nodes_visited": result.nodes_visited,
+        "max_nodes": result.max_nodes,
+        "failure_reason": result.failure_reason,
+        "full_rows": (
+            {str(center): row for center, row in sorted(result.full_rows.items())}
+            if result.full_rows is not None
+            else None
+        ),
     }
 
 

--- a/tests/test_fragile_hypergraph.py
+++ b/tests/test_fragile_hypergraph.py
@@ -5,6 +5,7 @@ from erdos97.fragile_hypergraph import (
     canonical_witness_map,
     check_fragile_hypergraph,
     essential_row_matching,
+    full_selected_extension,
 )
 
 
@@ -105,3 +106,26 @@ def test_essential_row_matching_detects_hall_defect() -> None:
     assert unmatched
     assert not result.essential_cover_ok
     assert result.essential_matching_unmatched_centers == unmatched
+
+
+def test_single_block6_has_no_full_selected_extension() -> None:
+    n, rows = block6_family(1)
+
+    extension = full_selected_extension(n, rows)
+
+    assert not extension.ok
+    assert extension.search_exhausted
+    assert extension.failure_reason == "no extension exists"
+
+
+def test_two_block6_still_has_full_selected_extension() -> None:
+    n, rows = block6_family(2)
+
+    extension = full_selected_extension(n, rows)
+
+    assert extension.ok
+    assert extension.full_rows is not None
+    assert extension.full_rows[0] == rows[0]
+    assert extension.full_rows[3] == rows[3]
+    assert extension.full_rows[6] == rows[6]
+    assert extension.full_rows[9] == rows[9]


### PR DESCRIPTION
## Summary
- add a bounded full selected-witness extension checker for fragile-cover rows
- expose the diagnostic through `scripts/check_fragile_hypergraph.py`
- document the necessary extension condition and its calibrated block-6 behavior

## Verification
- `python -m pytest tests/test_fragile_hypergraph.py -q`
- `python scripts/check_fragile_hypergraph.py --blocks 1 --check-full-extension --json`
- `python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --assert-full-extension --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

This is a necessary bridge refinement only. It rejects the single block-6 fragile cover but still permits two disjoint blocks, so it does not claim a proof or counterexample.