### PR TITLE
Add SymPy-free n=8 obstruction cross-check

### DIFF
--- a/docs/n8-independent-obstruction.md
+++ b/docs/n8-independent-obstruction.md
@@ -1,0 +1,103 @@
+# n=8 Independent SymPy-Free Obstruction Recheck
+
+Status: `REPO_LOCAL_INDEPENDENT_CROSS_CHECK_PENDING_EXTERNAL_REVIEW`.
+
+This note records a SymPy-free cross-check of the `n=8` obstruction
+certificates documented in `docs/n8-exact-survivors.md`.  The cross-check
+is repo-local and does not turn the `n <= 8` finite-case result into a
+public theorem-style claim.
+
+## Goal
+
+The existing `n=8` obstruction artifact (see
+`docs/n8-exact-survivors.md`) uses SymPy for rational linear-span checks
+and Groebner-basis substitution chains.  This note records an
+independent reproduction of as much of that obstruction set as is
+feasible in pure-Python rational arithmetic, with no SymPy import and
+no shared code path.
+
+The independent verifier is intended as a defensive cross-check: if a
+SymPy bug or a regression in `scripts/analyze_n8_exact_survivors.py`
+were to affect the existing checker, this independent verifier would
+still flag mismatches in the parts it covers.
+
+## Method
+
+The verifier in `src/erdos97/n8_independent_obstruction.py`
+reimplements the obstruction tests using only the Python standard
+library and `fractions.Fraction` for exact rational arithmetic:
+
+- A from-scratch sparse multivariate polynomial type
+  (`dict[monomial_tuple, Fraction]`).
+- A from-scratch sparse Gauss-Jordan rank routine over `QQ`.
+- An independent cyclic-order enumeration loop with its own
+  forced-perpendicularity bipartite-coloring step.
+- An auxiliary squared-distance / Cayley-Menger linear stage that
+  treats `PB` and `ED` equations as linear identities in the 28
+  squared-distance variables `d_{ij}` and reports the resulting rank
+  and free-variable count for each class.
+
+The Cartesian gauge matches the existing checker
+(`p_0 = (0, 0)`, `p_1 = (1, 0)`, twelve free coordinates
+`x_2, y_2, ..., x_7, y_7`).  Each phi-edge `(i, j) -> (a, b)`
+contributes both forms of the perpendicular-bisector polynomial: the
+dot-product form `(p_i - p_j) . (p_a - p_b)` and the bisector
+determinant form `det(p_j - p_i, p_a + p_b - 2 p_i)`.
+
+## Coverage
+
+| class | independent kill | mechanism |
+| ---: | :--- | :--- |
+| 0  | yes | `y_2 in PB span` |
+| 1  | yes | `y_2 in PB span` |
+| 2  | yes | `y_2 in PB span` |
+| 3  | no  | requires Groebner substitution chain |
+| 4  | no  | requires Groebner substitution chain |
+| 5  | no  | requires Groebner substitution chain |
+| 6  | yes | `y_2 in PB span` |
+| 7  | yes | `y_2 in PB span` |
+| 8  | yes | `y_2 in PB span` |
+| 9  | yes | `y_2 in PB span` |
+| 10 | yes | `y_2 in PB span` |
+| 11 | yes | `y_2 in PB span` |
+| 12 | yes | cyclic-order kill |
+| 13 | yes | `y_2 in PB span` |
+| 14 | no  | requires Groebner substitution chain |
+
+The independent verifier kills 11 of 15 reconstructed classes.  The
+remaining four classes (3, 4, 5, 14) require nonlinear substitution
+chains that go beyond the Q-linear span of the PB polynomials.  They
+are explicitly out of scope here and remain covered by the
+SymPy/Groebner-based existing checker.
+
+The independent verifier additionally re-derives the compatible
+cyclic-order count for every class.  All 15 counts match the values
+recorded in `data/incidence/n8_compatible_orders.json` and listed in
+`docs/n8-exact-survivors.md`.  This is a stronger check than a
+single-class kill: it independently reconstructs the full
+forced-perpendicularity bipartite structure for every class.
+
+## Reproduction
+
+```bash
+python scripts/independent_n8_obstruction_recheck.py --check --json
+python -m pytest tests/test_n8_independent_obstruction.py -q
+```
+
+## Remaining gap
+
+The independent verifier does not cover classes 3, 4, 5, 14.  Closing
+that gap would require either implementing multivariate Groebner
+bases over `QQ` from scratch (substantial), or using a fundamentally
+different obstruction route (e.g., interval-arithmetic certified
+nonexistence on the polynomial system, or an SOS/positivstellensatz
+certificate).  These remain on the backlog as conditional follow-ups
+and are not preconditions for the existing repo-local result.
+
+## Provenance
+
+- Implementation: `src/erdos97/n8_independent_obstruction.py`.
+- CLI entrypoint: `scripts/independent_n8_obstruction_recheck.py`.
+- Tests: `tests/test_n8_independent_obstruction.py`.
+- Existing checker (cross-checked against): `scripts/analyze_n8_exact_survivors.py`.
+- Survivor data (input): `data/incidence/n8_reconstructed_15_survivors.json`.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -61,6 +61,17 @@ and exact-analysis artifacts as input data. It is an artifact-consistency and
 exact-obstruction audit entrypoint, not an independent regeneration of the full
 incidence enumeration.
 
+Partial SymPy-free independent cross-check:
+
+```bash
+python scripts/independent_n8_obstruction_recheck.py --check --json
+```
+
+This command independently replays the compatible cyclic-order counts, the
+class `12` cyclic-order kill, and the `y_2`-in-PB-span kill for ten classes
+using pure-Python rational arithmetic. It does not verify the Groebner-based
+classes `3`, `4`, `5`, or `14`.
+
 ## Priority 3 - isolate class 14
 
 Class `14` is the most delicate current survivor obstruction because it uses

--- a/scripts/independent_n8_obstruction_recheck.py
+++ b/scripts/independent_n8_obstruction_recheck.py
@@ -11,7 +11,7 @@ theorem-style claim.
 
 Coverage:
 - Cyclic-order compatible-orbit count for every class (independent
-  enumeration; 11/11 expected counts confirmed).
+  enumeration; 15/15 expected counts confirmed).
 - Cyclic-order kill for class 12.
 - y_2-in-PB-span kill for classes 0, 1, 2, 6, 7, 8, 9, 10, 11, 13.
 - Squared-distance / Cayley-Menger linear diagnostic for every class.

--- a/scripts/independent_n8_obstruction_recheck.py
+++ b/scripts/independent_n8_obstruction_recheck.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Independent SymPy-free recheck of n=8 obstruction certificates.
+
+This script re-verifies as much of the n=8 obstruction-certificate set
+as is feasible in pure-Python rational arithmetic, with no SymPy and
+no shared code path with ``scripts/analyze_n8_exact_survivors.py``.
+
+It is a repo-local cross-check artifact pending external review.  It
+does not turn the ``n <= 8`` finite-case result into a public
+theorem-style claim.
+
+Coverage:
+- Cyclic-order compatible-orbit count for every class (independent
+  enumeration; 11/11 expected counts confirmed).
+- Cyclic-order kill for class 12.
+- y_2-in-PB-span kill for classes 0, 1, 2, 6, 7, 8, 9, 10, 11, 13.
+- Squared-distance / Cayley-Menger linear diagnostic for every class.
+- First-stage linear identities x_3 - x_2, y_3 + y_2 (in the Q-linear
+  span of the PB polynomials; auxiliary cross-reference).
+
+Not covered (require Groebner-basis machinery):
+- Class 3 duplicate-vertex full kill.
+- Class 4 collinearity full kill.
+- Class 5 Groebner contradiction.
+- Class 14 four-branch strict-interior obstruction.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from erdos97 import n8_independent_obstruction as ind
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def survivors_path() -> Path:
+    return repo_root() / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+
+
+def run() -> dict:
+    survivors = json.loads(survivors_path().read_text(encoding="utf-8"))
+    rows_results: list[dict] = []
+    independent_kills: list[int] = []
+    cyclic_count_mismatches: list[dict] = []
+    expected_independent_kill_failures: list[dict] = []
+    for cls in survivors:
+        cid = int(cls["id"])
+        info = ind.verify_class(cid, cls["rows"])
+        expected_count = ind.expected_cyclic_count(cid)
+        if info.cyclic_order_compatible_count != expected_count:
+            cyclic_count_mismatches.append(
+                {
+                    "class_id": cid,
+                    "expected": expected_count,
+                    "actual": info.cyclic_order_compatible_count,
+                }
+            )
+        expected_attr = ind.expected_independent_kill_attribute(cid)
+        if expected_attr is not None:
+            attr_val = bool(getattr(info, expected_attr))
+            if not attr_val:
+                expected_independent_kill_failures.append(
+                    {"class_id": cid, "expected_attribute": expected_attr}
+                )
+        if info.killed_by_some_independent_check:
+            independent_kills.append(cid)
+        rows_results.append(
+            {
+                "class_id": cid,
+                "cyclic_order_compatible_count": info.cyclic_order_compatible_count,
+                "cyclic_order_kill": info.cyclic_order_kill,
+                "y2_in_pb_span": info.y2_in_pb_span,
+                "linear_span_identities": info.linear_span_identities,
+                "squared_distance_rank": info.squared_distance_rank,
+                "squared_distance_free_d_count": info.squared_distance_free_d_count,
+                "killed_by_some_independent_check": (
+                    info.killed_by_some_independent_check
+                ),
+                "expected_independent_kill_attribute": expected_attr,
+            }
+        )
+
+    verified = (
+        not cyclic_count_mismatches
+        and not expected_independent_kill_failures
+        and sorted(independent_kills) == ind.CLASSES_KILLED_INDEPENDENTLY
+    )
+    summary = {
+        "type": "n8_independent_obstruction_recheck_v1",
+        "trust": "REPO_LOCAL_INDEPENDENT_CROSS_CHECK_PENDING_EXTERNAL_REVIEW",
+        "claim_scope": (
+            "Independent SymPy-free cross-check of the n=8 finite-case "
+            "obstruction certificates.  Reverifies cyclic-order counts, "
+            "the cyclic-order kill of class 12, and the y_2-in-PB-span "
+            "kill of ten survivor classes.  Does not reproduce the "
+            "Groebner-basis substitution chains required for classes "
+            "3, 4, 5, and 14."
+        ),
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "Repo-local artifact pending external review.",
+        ],
+        "verified": verified,
+        "classes_killed_independently": sorted(independent_kills),
+        "expected_classes_killed_independently": ind.CLASSES_KILLED_INDEPENDENTLY,
+        "classes_requiring_groebner_machinery": ind.CLASSES_REQUIRING_GROEBNER,
+        "cyclic_count_mismatches": cyclic_count_mismatches,
+        "expected_independent_kill_failures": expected_independent_kill_failures,
+        "per_class": rows_results,
+        "checked_conditions": [
+            "cyclic-order compatible-orbit counts via independent enumeration",
+            "y_2 in Q-linear span of dot+bisector PB polynomials via Fraction Gauss-Jordan",
+            "first-stage linear identities x_3-x_2 and y_3+y_2 in Q-linear span",
+            "squared-distance Gauss-Jordan rank in d-coordinates",
+        ],
+        "does_not_check": [
+            "class 3 duplicate-vertex Groebner substitution chain",
+            "class 4 collinearity Groebner substitution chain",
+            "class 5 Groebner contradiction",
+            "class 14 four-branch strict-interior obstruction",
+            "incidence completeness (the 15 classes themselves)",
+            "general Erdos Problem #97 proof",
+        ],
+    }
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if the cross-check verification fails",
+    )
+    args = parser.parse_args()
+
+    summary = run()
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif summary["verified"]:
+        kills = summary["classes_killed_independently"]
+        groebner = summary["classes_requiring_groebner_machinery"]
+        print(
+            f"verified independent SymPy-free recheck: "
+            f"{len(kills)} of 15 classes killed independently "
+            f"({kills}); "
+            f"{len(groebner)} require Groebner machinery ({groebner})"
+        )
+    else:
+        print("independent recheck reported failures:")
+        for mismatch in summary["cyclic_count_mismatches"]:
+            print(
+                f"- class {mismatch['class_id']}: cyclic-order count "
+                f"{mismatch['actual']} != expected {mismatch['expected']}"
+            )
+        for failure in summary["expected_independent_kill_failures"]:
+            print(
+                f"- class {failure['class_id']}: expected attribute "
+                f"{failure['expected_attribute']} did not verify"
+            )
+
+    if args.check and not summary["verified"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n8_independent_obstruction.py
+++ b/src/erdos97/n8_independent_obstruction.py
@@ -9,14 +9,14 @@ Scope:
 - Independent y2-span linear-span kill (classes 0, 1, 2, 6, 7, 8, 9, 10,
   11, 13) using a from-scratch multivariate polynomial implementation
   and a from-scratch rational Gauss-Jordan rank computation.
-- Independent class 3 duplicate-vertex certificate via rational
-  substitution.
-- Independent class 4 three-collinear-vertices certificate via rational
-  substitution.
+- First-stage linear identities that appear in the class 3 and class 4
+  substitution chains, recorded as diagnostics only.
 - Auxiliary squared-distance / Cayley-Menger linear diagnostic that is
   not by itself a kill but provides an independent structural fingerprint.
 
 NOT covered here (requires Groebner-basis machinery beyond this scope):
+- Class 3 duplicate-vertex full kill.
+- Class 4 collinearity full kill.
 - Class 5 Groebner contradiction.
 - Class 14 four-branch strict-interior obstruction.
 

--- a/src/erdos97/n8_independent_obstruction.py
+++ b/src/erdos97/n8_independent_obstruction.py
@@ -1,0 +1,595 @@
+"""Independent SymPy-free recheck of n=8 obstruction certificates.
+
+This module reimplements the n=8 obstruction checks in pure Python using
+``fractions.Fraction`` for exact rational arithmetic.  It does not import
+SymPy and shares no code with ``scripts/analyze_n8_exact_survivors.py``.
+
+Scope:
+- Independent cyclic-order noncrossing kill (class 12).
+- Independent y2-span linear-span kill (classes 0, 1, 2, 6, 7, 8, 9, 10,
+  11, 13) using a from-scratch multivariate polynomial implementation
+  and a from-scratch rational Gauss-Jordan rank computation.
+- Independent class 3 duplicate-vertex certificate via rational
+  substitution.
+- Independent class 4 three-collinear-vertices certificate via rational
+  substitution.
+- Auxiliary squared-distance / Cayley-Menger linear diagnostic that is
+  not by itself a kill but provides an independent structural fingerprint.
+
+NOT covered here (requires Groebner-basis machinery beyond this scope):
+- Class 5 Groebner contradiction.
+- Class 14 four-branch strict-interior obstruction.
+
+This is a repo-local cross-check artifact only; it does not turn the
+``n <= 8`` finite-case result into a public theorem claim.
+"""
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import combinations, permutations
+from typing import Iterable, Sequence
+
+N = 8
+
+
+# ---------------------------------------------------------------------------
+# Polynomial arithmetic over Q.
+# A polynomial is dict[tuple[int, ...] -> Fraction] where the tuple is a
+# sorted tuple of variable indices (with repeats for higher powers).
+# ---------------------------------------------------------------------------
+
+Polynomial = dict
+
+
+def p_zero() -> Polynomial:
+    return {}
+
+
+def p_const(c: Fraction | int) -> Polynomial:
+    c = Fraction(c)
+    return {(): c} if c != 0 else {}
+
+
+def p_var(idx: int) -> Polynomial:
+    return {(idx,): Fraction(1)}
+
+
+def p_add(a: Polynomial, b: Polynomial) -> Polynomial:
+    out = dict(a)
+    for m, c in b.items():
+        new = out.get(m, Fraction(0)) + c
+        if new == 0:
+            out.pop(m, None)
+        else:
+            out[m] = new
+    return out
+
+
+def p_neg(a: Polynomial) -> Polynomial:
+    return {m: -c for m, c in a.items()}
+
+
+def p_sub(a: Polynomial, b: Polynomial) -> Polynomial:
+    return p_add(a, p_neg(b))
+
+
+def p_scale(a: Polynomial, c: Fraction | int) -> Polynomial:
+    c = Fraction(c)
+    if c == 0:
+        return {}
+    return {m: c * v for m, v in a.items()}
+
+
+def p_mul(a: Polynomial, b: Polynomial) -> Polynomial:
+    out: Polynomial = {}
+    for m1, c1 in a.items():
+        for m2, c2 in b.items():
+            m = tuple(sorted(m1 + m2))
+            new = out.get(m, Fraction(0)) + c1 * c2
+            if new == 0:
+                out.pop(m, None)
+            else:
+                out[m] = new
+    return out
+
+
+def p_substitute(a: Polynomial, var_idx: int, replacement: Polynomial) -> Polynomial:
+    """Substitute every occurrence of variable ``var_idx`` with ``replacement``."""
+    out: Polynomial = {}
+    for monom, coeff in a.items():
+        rest = []
+        power = 0
+        for v in monom:
+            if v == var_idx:
+                power += 1
+            else:
+                rest.append(v)
+        rest_poly: Polynomial = {tuple(sorted(rest)): coeff}
+        if power == 0:
+            term = rest_poly
+        else:
+            r = replacement
+            for _ in range(power - 1):
+                r = p_mul(r, replacement)
+            term = p_mul(rest_poly, r)
+        out = p_add(out, term)
+    return out
+
+
+def p_is_zero(a: Polynomial) -> bool:
+    return not a
+
+
+# ---------------------------------------------------------------------------
+# Cartesian coordinates with gauge p_0 = (0,0), p_1 = (1,0).
+# Variables: x_2, y_2, x_3, y_3, ..., x_7, y_7 (12 variables).
+# ---------------------------------------------------------------------------
+
+
+def x_var(i: int) -> int:
+    if i < 2 or i >= N:
+        raise ValueError(f"x_var: vertex {i} has no x variable")
+    return 2 * (i - 2)
+
+
+def y_var(i: int) -> int:
+    if i < 2 or i >= N:
+        raise ValueError(f"y_var: vertex {i} has no y variable")
+    return 2 * (i - 2) + 1
+
+
+def coord(i: int, axis: int) -> Polynomial:
+    if i == 0:
+        return p_zero()
+    if i == 1:
+        return p_const(1) if axis == 0 else p_zero()
+    return p_var(2 * (i - 2) + axis)
+
+
+def diff_coord(i: int, j: int, axis: int) -> Polynomial:
+    return p_sub(coord(i, axis), coord(j, axis))
+
+
+def pb_dot_polynomial(i: int, j: int, a: int, b: int) -> Polynomial:
+    """``(p_i - p_j) . (p_a - p_b)`` expanded in the gauge variables.
+
+    Encodes the perpendicularity of chord ``ij`` and chord ``ab``.
+    """
+    dxij = diff_coord(i, j, 0)
+    dyij = diff_coord(i, j, 1)
+    dxab = diff_coord(a, b, 0)
+    dyab = diff_coord(a, b, 1)
+    return p_add(p_mul(dxij, dxab), p_mul(dyij, dyab))
+
+
+def pb_bisector_polynomial(i: int, j: int, a: int, b: int) -> Polynomial:
+    """``det(p_j - p_i, p_a + p_b - 2 p_i)`` expanded in the gauge variables.
+
+    Encodes that the midpoint of segment ``ab`` lies on the line through
+    ``i`` and ``j``.  Together with :func:`pb_dot_polynomial` this gives
+    two independent algebraic forms of the perpendicular-bisector
+    condition on each phi-edge.
+    """
+    pjx_minus_pix = diff_coord(j, i, 0)
+    pjy_minus_piy = diff_coord(j, i, 1)
+    midline_x = p_sub(p_add(coord(a, 0), coord(b, 0)), p_scale(coord(i, 0), 2))
+    midline_y = p_sub(p_add(coord(a, 1), coord(b, 1)), p_scale(coord(i, 1), 2))
+    return p_sub(p_mul(pjx_minus_pix, midline_y), p_mul(pjy_minus_piy, midline_x))
+
+
+def pb_polynomials(rows: Sequence[Sequence[int]]) -> list[Polynomial]:
+    """Return both dot and bisector PB polynomials for every phi-edge."""
+    out: list[Polynomial] = []
+    for (i, j), (a, b) in phi_edges(rows):
+        out.append(pb_dot_polynomial(i, j, a, b))
+        out.append(pb_bisector_polynomial(i, j, a, b))
+    return out
+
+
+def ed_polynomial(i: int, base: int, other: int) -> Polynomial:
+    """``|p_i - p_other|^2 - |p_i - p_base|^2``."""
+    other_dx = diff_coord(i, other, 0)
+    other_dy = diff_coord(i, other, 1)
+    base_dx = diff_coord(i, base, 0)
+    base_dy = diff_coord(i, base, 1)
+    return p_sub(
+        p_add(p_mul(other_dx, other_dx), p_mul(other_dy, other_dy)),
+        p_add(p_mul(base_dx, base_dx), p_mul(base_dy, base_dy)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Incidence helpers.
+# ---------------------------------------------------------------------------
+
+
+def witnesses_of(rows: Sequence[Sequence[int]], i: int) -> list[int]:
+    return [j for j, value in enumerate(rows[i]) if value]
+
+
+def phi_edges(rows: Sequence[Sequence[int]]) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    w = [set(witnesses_of(rows, i)) for i in range(N)]
+    edges = []
+    for i in range(N):
+        for j in range(i + 1, N):
+            inter = sorted(w[i] & w[j])
+            if len(inter) == 2:
+                edges.append(((i, j), (inter[0], inter[1])))
+    return edges
+
+
+def chord_pair(a: int, b: int) -> tuple[int, int]:
+    return (a, b) if a < b else (b, a)
+
+
+# ---------------------------------------------------------------------------
+# Rational sparse linear algebra (Gauss-Jordan over Q).
+# ---------------------------------------------------------------------------
+
+
+def gauss_jordan_rref(
+    rows: list[dict[int, Fraction]], num_cols: int
+) -> tuple[list[dict[int, Fraction]], list[tuple[int, int]]]:
+    matrix = [dict(r) for r in rows]
+    pivots: list[tuple[int, int]] = []
+    row = 0
+    for col in range(num_cols):
+        pivot_idx = None
+        for r in range(row, len(matrix)):
+            if matrix[r].get(col, Fraction(0)) != 0:
+                pivot_idx = r
+                break
+        if pivot_idx is None:
+            continue
+        matrix[row], matrix[pivot_idx] = matrix[pivot_idx], matrix[row]
+        pv = matrix[row][col]
+        matrix[row] = {k: v / pv for k, v in matrix[row].items()}
+        for r in range(len(matrix)):
+            if r == row:
+                continue
+            f = matrix[r].get(col, Fraction(0))
+            if f == 0:
+                continue
+            new_row = dict(matrix[r])
+            for k, v in matrix[row].items():
+                nv = new_row.get(k, Fraction(0)) - f * v
+                if nv == 0:
+                    new_row.pop(k, None)
+                else:
+                    new_row[k] = nv
+            matrix[r] = new_row
+        pivots.append((row, col))
+        row += 1
+    return matrix, pivots
+
+
+def rank(rows: list[dict[int, Fraction]], num_cols: int) -> int:
+    _, pivots = gauss_jordan_rref(rows, num_cols)
+    return len(pivots)
+
+
+# ---------------------------------------------------------------------------
+# y2-span check: is the polynomial y_2 in the Q-linear span of the PB
+# polynomials, when each polynomial is viewed as a vector indexed by
+# distinct monomials over the gauge variables (x_2, y_2, ..., x_7, y_7)?
+# ---------------------------------------------------------------------------
+
+
+def _polys_to_matrix(
+    polys: Iterable[Polynomial],
+) -> tuple[list[dict[int, Fraction]], dict[tuple[int, ...], int]]:
+    monomials: set[tuple[int, ...]] = set()
+    polys_list = list(polys)
+    for p in polys_list:
+        monomials.update(p.keys())
+    monomial_order = sorted(monomials)
+    m_index = {m: i for i, m in enumerate(monomial_order)}
+    matrix_rows = [{m_index[m]: c for m, c in p.items()} for p in polys_list]
+    return matrix_rows, m_index
+
+
+def y2_in_pb_span(rows: Sequence[Sequence[int]]) -> bool:
+    pb_polys = pb_polynomials(rows)
+    target = p_var(y_var(2))
+    matrix_rows, m_index = _polys_to_matrix(pb_polys + [target])
+    pb_matrix = matrix_rows[:-1]
+    target_row = matrix_rows[-1]
+    rank_pb = rank(pb_matrix, len(m_index))
+    rank_with = rank(pb_matrix + [target_row], len(m_index))
+    return rank_pb == rank_with
+
+
+# ---------------------------------------------------------------------------
+# Cyclic-order kill (class 12).  Independent enumeration: build the
+# forced-perpendicular bipartite graph from the phi-edges, derive
+# same-color classes, and check that no normalized cyclic order makes
+# every same-color class a noncrossing matching.
+# ---------------------------------------------------------------------------
+
+
+def _normalized_orders() -> Iterable[tuple[int, ...]]:
+    for tail in permutations(range(1, N)):
+        order = (0,) + tail
+        if order[1] < order[-1]:
+            yield order
+
+
+def _crosses(c1: tuple[int, int], c2: tuple[int, int], pos: dict[int, int]) -> bool:
+    a, b = c1
+    c, d = c2
+    if len({a, b, c, d}) < 4:
+        return False
+    pa, pb, pc, pd = pos[a], pos[b], pos[c], pos[d]
+    if pa > pb:
+        pa, pb = pb, pa
+    cin = pa < pc < pb
+    din = pa < pd < pb
+    return cin != din
+
+
+def _forced_perp_color(rows: Sequence[Sequence[int]]) -> tuple[bool, list[list[tuple[int, int]]]]:
+    """Bipartition the forced-perpendicularity graph; return same-color classes."""
+    graph: dict[tuple[int, int], set[tuple[int, int]]] = defaultdict(set)
+    for src, tgt in phi_edges(rows):
+        graph[src].add(tgt)
+        graph[tgt].add(src)
+    chords = [(a, b) for a in range(N) for b in range(a + 1, N)]
+    color: dict[tuple[int, int], int] = {}
+    same_color_classes: list[list[tuple[int, int]]] = []
+    for start in chords:
+        if start in color:
+            continue
+        color[start] = 0
+        component = [start]
+        q = deque([start])
+        bipartite = True
+        while q:
+            u = q.popleft()
+            for v in graph[u]:
+                if v not in color:
+                    color[v] = 1 - color[u]
+                    component.append(v)
+                    q.append(v)
+                elif color[v] == color[u]:
+                    bipartite = False
+        if not bipartite:
+            return False, []
+        bucket: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        for c in component:
+            bucket[color[c]].append(c)
+        for cls in bucket.values():
+            if len(cls) >= 2:
+                same_color_classes.append(sorted(cls))
+    return True, same_color_classes
+
+
+def cyclic_order_kill(rows: Sequence[Sequence[int]]) -> bool:
+    """Return True iff no cyclic order is compatible with the perpendicularity classes."""
+    bipartite, same_color_classes = _forced_perp_color(rows)
+    if not bipartite:
+        return True
+    for order in _normalized_orders():
+        pos = {label: idx for idx, label in enumerate(order)}
+        ok = True
+        for cls in same_color_classes:
+            used: set[int] = set()
+            for a, b in cls:
+                if a in used or b in used:
+                    ok = False
+                    break
+                used.add(a)
+                used.add(b)
+            if not ok:
+                break
+            for left, right in combinations(cls, 2):
+                if _crosses(left, right, pos):
+                    ok = False
+                    break
+            if not ok:
+                break
+        if ok:
+            return False
+    return True
+
+
+def compatible_order_count(rows: Sequence[Sequence[int]]) -> int:
+    bipartite, same_color_classes = _forced_perp_color(rows)
+    if not bipartite:
+        return 0
+    count = 0
+    for order in _normalized_orders():
+        pos = {label: idx for idx, label in enumerate(order)}
+        ok = True
+        for cls in same_color_classes:
+            used: set[int] = set()
+            for a, b in cls:
+                if a in used or b in used:
+                    ok = False
+                    break
+                used.add(a)
+                used.add(b)
+            if not ok:
+                break
+            for left, right in combinations(cls, 2):
+                if _crosses(left, right, pos):
+                    ok = False
+                    break
+            if not ok:
+                break
+        if ok:
+            count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary linear-span identities.
+#
+# The Q-linear span of the PB polynomials (dot and bisector) contains
+# many independent relations beyond y_2.  ``linear_span_identities``
+# probes a fixed list of candidate degree-1 polynomials that would
+# arise as first-stage consequences of the substitution chains in the
+# existing class 3 and class 4 Groebner derivations.  These are
+# diagnostic only -- they are not by themselves a kill for classes 3
+# and 4, since the full obstruction requires nonlinear substitution
+# stages we do not reproduce here.
+# ---------------------------------------------------------------------------
+
+
+def linear_span_identities(rows: Sequence[Sequence[int]]) -> dict[str, bool]:
+    pb_polys = pb_polynomials(rows)
+    candidates: dict[str, Polynomial] = {
+        "y_2": p_var(y_var(2)),
+        "x_3 - x_2": p_sub(p_var(x_var(3)), p_var(x_var(2))),
+        "y_3 + y_2": p_add(p_var(y_var(3)), p_var(y_var(2))),
+        "x_3 + x_2 - 1": p_sub(p_add(p_var(x_var(3)), p_var(x_var(2))), p_const(1)),
+        "2*x_2 - 1": p_sub(p_scale(p_var(x_var(2)), 2), p_const(1)),
+    }
+    matrix_rows, m_index = _polys_to_matrix(pb_polys + list(candidates.values()))
+    pb_matrix = matrix_rows[: len(pb_polys)]
+    base = rank(pb_matrix, len(m_index))
+    out: dict[str, bool] = {}
+    for label, target_row in zip(candidates.keys(), matrix_rows[len(pb_polys):]):
+        out[label] = rank(pb_matrix + [target_row], len(m_index)) == base
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary squared-distance linear analysis.  Solves PB+ED in d-coords
+# (linear over Q) and reports the rank, free variable count, and any
+# forced d_{ij} = d_{kl} identities.  This is a structural diagnostic;
+# it is not by itself a kill for any of the 15 classes.
+# ---------------------------------------------------------------------------
+
+
+CHORDS = [(a, b) for a in range(N) for b in range(a + 1, N)]
+CHORD_INDEX = {c: i for i, c in enumerate(CHORDS)}
+
+
+def _pb_d_eq(i: int, j: int, a: int, b: int) -> dict[int, Fraction]:
+    eq: dict[int, Fraction] = {}
+    for v, sign in [
+        (chord_pair(i, b), 1),
+        (chord_pair(j, a), 1),
+        (chord_pair(i, a), -1),
+        (chord_pair(j, b), -1),
+    ]:
+        idx = CHORD_INDEX[v]
+        eq[idx] = eq.get(idx, Fraction(0)) + Fraction(sign)
+        if eq[idx] == 0:
+            del eq[idx]
+    return eq
+
+
+def _ed_d_eq(i: int, base: int, other: int) -> dict[int, Fraction]:
+    return {
+        CHORD_INDEX[chord_pair(i, other)]: Fraction(1),
+        CHORD_INDEX[chord_pair(i, base)]: Fraction(-1),
+    }
+
+
+def squared_distance_diagnostic(rows: Sequence[Sequence[int]]) -> dict:
+    eqs: list[dict[int, Fraction]] = []
+    for (i, j), (a, b) in phi_edges(rows):
+        eq = _pb_d_eq(i, j, a, b)
+        if eq:
+            eqs.append(eq)
+    for i in range(N):
+        w = witnesses_of(rows, i)
+        base = w[0]
+        for other in w[1:]:
+            eqs.append(_ed_d_eq(i, base, other))
+    matrix, pivots = gauss_jordan_rref(eqs, len(CHORDS))
+    pivot_cols = {col for _, col in pivots}
+    free_cols = [c for c in range(len(CHORDS)) if c not in pivot_cols]
+    forced_zeros: list[tuple[int, int]] = []
+    forced_equalities: list[tuple[tuple[int, int], tuple[int, int]]] = []
+    for row_idx, col in pivots:
+        row_dict = matrix[row_idx]
+        others = {c: -coef for c, coef in row_dict.items() if c != col}
+        if not others:
+            forced_zeros.append(CHORDS[col])
+        elif len(others) == 1:
+            (oc, ocoef) = next(iter(others.items()))
+            if ocoef == 1:
+                forced_equalities.append((CHORDS[col], CHORDS[oc]))
+    return {
+        "rank": len(pivots),
+        "free_d_count": len(free_cols),
+        "forced_zeros": forced_zeros,
+        "forced_equalities": forced_equalities,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aggregate verifier.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IndependentVerification:
+    class_id: int
+    cyclic_order_compatible_count: int
+    cyclic_order_kill: bool
+    y2_in_pb_span: bool
+    linear_span_identities: dict[str, bool]
+    squared_distance_rank: int
+    squared_distance_free_d_count: int
+
+    @property
+    def killed_by_some_independent_check(self) -> bool:
+        return self.cyclic_order_kill or self.y2_in_pb_span
+
+
+_EXPECTED_INDEPENDENT_KILL = {
+    0: "y2_in_pb_span",
+    1: "y2_in_pb_span",
+    2: "y2_in_pb_span",
+    3: None,  # full kill needs Groebner substitution chain
+    4: None,  # full kill needs Groebner substitution chain
+    5: None,  # full kill needs Groebner substitution chain
+    6: "y2_in_pb_span",
+    7: "y2_in_pb_span",
+    8: "y2_in_pb_span",
+    9: "y2_in_pb_span",
+    10: "y2_in_pb_span",
+    11: "y2_in_pb_span",
+    12: "cyclic_order_kill",
+    13: "y2_in_pb_span",
+    14: None,  # full kill needs Groebner substitution chain
+}
+
+_EXPECTED_CYCLIC_COUNTS = {
+    0: 2520, 1: 280, 2: 21, 3: 2520, 4: 280, 5: 4, 6: 280, 7: 50,
+    8: 538, 9: 100, 10: 74, 11: 44, 12: 0, 13: 280, 14: 72,
+}
+
+
+def verify_class(class_id: int, rows: Sequence[Sequence[int]]) -> IndependentVerification:
+    sd = squared_distance_diagnostic(rows)
+    return IndependentVerification(
+        class_id=class_id,
+        cyclic_order_compatible_count=compatible_order_count(rows),
+        cyclic_order_kill=cyclic_order_kill(rows),
+        y2_in_pb_span=y2_in_pb_span(rows),
+        linear_span_identities=linear_span_identities(rows),
+        squared_distance_rank=sd["rank"],
+        squared_distance_free_d_count=sd["free_d_count"],
+    )
+
+
+def expected_independent_kill_attribute(class_id: int) -> str | None:
+    return _EXPECTED_INDEPENDENT_KILL[class_id]
+
+
+def expected_cyclic_count(class_id: int) -> int:
+    return _EXPECTED_CYCLIC_COUNTS[class_id]
+
+
+CLASSES_KILLED_INDEPENDENTLY = sorted(
+    cid for cid, attr in _EXPECTED_INDEPENDENT_KILL.items() if attr is not None
+)
+CLASSES_REQUIRING_GROEBNER = sorted(
+    cid for cid, attr in _EXPECTED_INDEPENDENT_KILL.items() if attr is None
+)

--- a/tests/test_n8_independent_obstruction.py
+++ b/tests/test_n8_independent_obstruction.py
@@ -1,0 +1,138 @@
+"""Tests for the SymPy-free independent n=8 obstruction recheck."""
+from __future__ import annotations
+
+import json
+from fractions import Fraction
+from pathlib import Path
+
+import pytest
+
+from erdos97 import n8_independent_obstruction as ind
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SURVIVOR_PATH = REPO_ROOT / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+
+
+def _survivors() -> list[dict]:
+    return json.loads(SURVIVOR_PATH.read_text())
+
+
+def test_polynomial_arithmetic_basic() -> None:
+    a = ind.p_var(0)
+    b = ind.p_var(1)
+    one = ind.p_const(1)
+    assert ind.p_add(a, b) == {(0,): Fraction(1), (1,): Fraction(1)}
+    assert ind.p_sub(a, a) == {}
+    assert ind.p_mul(a, b) == {(0, 1): Fraction(1)}
+    assert ind.p_mul(a, a) == {(0, 0): Fraction(1)}
+    assert ind.p_add(one, ind.p_neg(one)) == {}
+
+
+def test_pb_dot_polynomial_simple() -> None:
+    poly = ind.pb_dot_polynomial(0, 1, 2, 3)
+    expected = ind.p_sub(ind.p_var(ind.x_var(2)), ind.p_var(ind.x_var(3)))
+    expected = ind.p_neg(expected)
+    assert poly == expected
+
+
+def test_cyclic_counts_match_expected() -> None:
+    for cls in _survivors():
+        cid = cls["id"]
+        actual = ind.compatible_order_count(cls["rows"])
+        assert actual == ind.expected_cyclic_count(cid), (
+            f"class {cid}: cyclic-order count {actual} != expected "
+            f"{ind.expected_cyclic_count(cid)}"
+        )
+
+
+def test_class12_cyclic_order_kill() -> None:
+    rows = next(c["rows"] for c in _survivors() if c["id"] == 12)
+    assert ind.cyclic_order_kill(rows)
+    assert ind.compatible_order_count(rows) == 0
+
+
+def test_y2_span_kills_expected_classes() -> None:
+    expected_y2 = {0, 1, 2, 6, 7, 8, 9, 10, 11, 13}
+    for cls in _survivors():
+        cid = cls["id"]
+        in_span = ind.y2_in_pb_span(cls["rows"])
+        if cid in expected_y2:
+            assert in_span, f"class {cid}: y_2 should be in PB span"
+        elif cid in {3, 4, 5, 14}:
+            assert not in_span, f"class {cid}: y_2 should not be in PB span"
+
+
+def test_classes_independently_killed() -> None:
+    killed = []
+    for cls in _survivors():
+        info = ind.verify_class(cls["id"], cls["rows"])
+        if info.killed_by_some_independent_check:
+            killed.append(cls["id"])
+    assert sorted(killed) == ind.CLASSES_KILLED_INDEPENDENTLY
+    assert sorted(killed) == [0, 1, 2, 6, 7, 8, 9, 10, 11, 12, 13]
+
+
+def test_groebner_required_classes() -> None:
+    assert ind.CLASSES_REQUIRING_GROEBNER == [3, 4, 5, 14]
+
+
+def test_squared_distance_diagnostic_runs() -> None:
+    for cls in _survivors():
+        sd = ind.squared_distance_diagnostic(cls["rows"])
+        assert sd["rank"] >= 0
+        assert sd["free_d_count"] == 28 - sd["rank"]
+        for chord in sd["forced_zeros"]:
+            assert isinstance(chord, tuple) and len(chord) == 2
+
+
+def test_first_stage_linear_identities_for_typical_classes() -> None:
+    """The phi-edge (0,1) <-> (2,3) is shared by most classes; when it
+    is present the linear identities x_3 = x_2 and y_3 = -y_2 lie in
+    the Q-linear span of the PB polynomials."""
+    expected_holds = []
+    expected_skips = []
+    for cls in _survivors():
+        ids = ind.linear_span_identities(cls["rows"])
+        if ids["x_3 - x_2"] and ids["y_3 + y_2"]:
+            expected_holds.append(cls["id"])
+        else:
+            expected_skips.append(cls["id"])
+    # Class 14 has a different incidence pattern that lacks the
+    # (0,1)<->(2,3) phi-edge; first-stage linear identities do not
+    # apply.  Every other class includes the identities.
+    assert expected_skips == [14]
+    assert expected_holds == [c["id"] for c in _survivors() if c["id"] != 14]
+
+
+def test_pb_polynomials_count_doubles_phi_edges() -> None:
+    """Each phi-edge contributes one dot polynomial and one bisector polynomial."""
+    for cls in _survivors():
+        polys = ind.pb_polynomials(cls["rows"])
+        edges = ind.phi_edges(cls["rows"])
+        assert len(polys) == 2 * len(edges)
+
+
+def test_rank_function_basic() -> None:
+    rows = [
+        {0: Fraction(1), 1: Fraction(2)},
+        {0: Fraction(2), 1: Fraction(4)},  # multiple of first
+        {0: Fraction(0), 1: Fraction(1)},
+    ]
+    assert ind.rank(rows, 2) == 2
+
+
+def test_polynomial_substitute() -> None:
+    poly = ind.p_mul(ind.p_var(0), ind.p_var(1))
+    poly = ind.p_add(poly, ind.p_const(3))
+    replaced = ind.p_substitute(poly, 0, ind.p_const(2))
+    assert replaced == {(1,): Fraction(2), (): Fraction(3)}
+
+
+@pytest.mark.parametrize("class_id", sorted({0, 1, 2, 6, 7, 8, 9, 10, 11, 12, 13}))
+def test_each_independently_killed_class(class_id: int) -> None:
+    rows = next(c["rows"] for c in _survivors() if c["id"] == class_id)
+    info = ind.verify_class(class_id, rows)
+    assert info.killed_by_some_independent_check, (
+        f"class {class_id}: expected independent kill"
+    )


### PR DESCRIPTION
## Summary

Independent reproduction of as much of the `n=8` obstruction artifact as is feasible in pure-Python rational arithmetic, with no SymPy import and no shared code path with `scripts/analyze_n8_exact_survivors.py`.

This is option (4) from a discussion on contributing incrementally to the repo: a defensive cross-check artifact that would surface bugs in the existing SymPy-based checker for the parts it covers.

## What's covered

- **Cyclic-order kill (class 12)** — independent enumeration confirms zero compatible orders.
- **Compatible cyclic-order count for every class** — all 15 counts match the existing checker exactly (`2520, 280, 21, 2520, 280, 4, 280, 50, 538, 100, 74, 44, 0, 280, 72`).
- **`y_2`-in-PB-span kill (10 classes: 0, 1, 2, 6, 7, 8, 9, 10, 11, 13)** — independent rational Gauss-Jordan over `fractions.Fraction`.
- **Squared-distance / Cayley-Menger linear diagnostic** — for every class, treats PB and ED equations as linear identities in the 28 squared-distance variables `d_{ij}` and reports rank, free-variable count, and forced equalities. Auxiliary structural fingerprint.
- **First-stage linear identities `x_3 - x_2`, `y_3 + y_2`** — independent linear-span check; holds for every class except class 14 (different incidence pattern).

11 of 15 classes are killed by the independent verifier.

## What's NOT covered

Classes **3, 4, 5, 14** still require the existing SymPy/Groebner-based substitution chains in `scripts/analyze_n8_exact_survivors.py`. The new verifier explicitly documents this scope and emits machine-readable JSON listing the classes it cannot reproduce.

No general proof of Erdős Problem #97 or counterexample is claimed.

## New files

- `src/erdos97/n8_independent_obstruction.py` — pure-stdlib polynomial arithmetic, sparse Gauss-Jordan, cyclic-order enumeration, and verifier.
- `scripts/independent_n8_obstruction_recheck.py` — CLI entry point with `--check` and `--json`.
- `tests/test_n8_independent_obstruction.py` — 23 new tests, all passing.
- `docs/n8-independent-obstruction.md` — documentation with the coverage table and reproduction recipe.

## Test plan

- [x] `python -m pytest tests/test_n8_independent_obstruction.py -q` (23 passed)
- [x] `python -m pytest -q` (241 passed, was 218 before; +23 new tests)
- [x] `python -m ruff check .` (clean)
- [x] `python scripts/check_text_clean.py` (clean)
- [x] `python scripts/check_artifact_provenance.py` (clean)
- [x] `python scripts/check_status_consistency.py` (clean)
- [x] `python scripts/independent_n8_obstruction_recheck.py --check --json` (verified: 11/15 independent kills match expected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEWbqdXY2ZyWX2GYqFe2dq)_