### PR TITLE
[codex] Add quotient-cone certificate tooling

### DIFF
--- a/scripts/check_quotient_cone_certificate.py
+++ b/scripts/check_quotient_cone_certificate.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Check exact quotient-cone certificates.
+
+The accepted certificate format includes either generalized ``strict_rows`` or
+legacy Kalmanson ``inequalities``. Legacy Kalmanson certificates are replayed as
+the zero-sum special case of the quotient-cone condition.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import (  # noqa: E402
+    check_quotient_cone_certificate,
+    footprint_summary,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("certificates", nargs="+", type=Path)
+    parser.add_argument("--summary-json", action="store_true")
+    parser.add_argument("--footprint-json", action="store_true")
+    args = parser.parse_args(argv)
+
+    payloads: list[dict[str, object]] = []
+    for path in args.certificates:
+        cert = json.loads(path.read_text(encoding="utf-8"))
+        if args.footprint_json:
+            payload = footprint_summary(cert)
+            payload["path"] = path.as_posix()
+        else:
+            result = check_quotient_cone_certificate(cert)
+            payload = {**result.__dict__, "path": path.as_posix()}
+        payloads.append(payload)
+
+    if args.summary_json or args.footprint_json:
+        output: object = payloads[0] if len(payloads) == 1 else payloads
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 0
+
+    for payload in payloads:
+        print("quotient-cone certificate OK")
+        print(f"path={payload['path']}")
+        print(f"pattern={payload['pattern']} n={payload['n']}")
+        print(f"strict rows={payload['strict_rows']}")
+        print(f"distance classes={payload['distance_classes']}")
+        print(f"weight sum={payload.get('weight_sum', '-')}")
+        print(f"combined nonzero coefficients={payload['combined_nonzero_coefficient_count']}")
+        print(f"zero sum={payload['zero_sum_verified']}")
+        print(f"nonpositive sum={payload['nonpositive_sum_verified']}")
+        print("claim strength: fixed selected-witness pattern plus fixed cyclic order only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_quotient_cone_footprint_cover.py
+++ b/scripts/check_quotient_cone_footprint_cover.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Check whether one fixed-order certificate footprint covers all cyclic orders.
+
+The probe takes the ordered quadrilateral footprint of a Kalmanson-style
+certificate and asks Z3 whether every cyclic order contains one translated
+copy, optionally in either orientation. For a circulant selected-witness
+pattern, such a copy would replay the same fixed-order certificate after
+relabeling.
+
+This is only a single-footprint coverage diagnostic. SAT means the footprint
+family misses at least one cyclic order. UNSAT would prove only that this
+specific footprint family covers every cyclic order of the fixed abstract
+pattern; it would not prove Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from z3 import Distinct, Int, Or, Solver, sat, unsat
+except ImportError as exc:  # pragma: no cover - depends on optional dev dep
+    raise SystemExit("z3-solver is required for this checker") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import (  # noqa: E402
+    selected_rows_from_certificate,
+    strict_items_from_certificate,
+)
+
+Quad = tuple[int, int, int, int]
+
+
+def ordered_kalmanson_quads(cert: dict[str, object]) -> list[Quad]:
+    quads: list[Quad] = []
+    for item in strict_items_from_certificate(cert):
+        if "quad" not in item:
+            raise ValueError("footprint cover currently requires Kalmanson quad rows")
+        quad = tuple(int(label) for label in item["quad"])  # type: ignore[index]
+        if len(quad) != 4 or len(set(quad)) != 4:
+            raise ValueError(f"bad Kalmanson quad: {quad}")
+        quads.append(quad)  # type: ignore[arg-type]
+    return sorted(set(quads))
+
+
+def _transform_quad(quad: Quad, n: int, shift: int, reverse: bool) -> Quad:
+    shifted = tuple((label + shift) % n for label in quad)
+    if reverse:
+        shifted = tuple(reversed(shifted))
+    return shifted  # type: ignore[return-value]
+
+
+def _not_in_cyclic_order(positions: Sequence[object], quad: Quad) -> object:
+    return Or(
+        positions[quad[0]] > positions[quad[1]],
+        positions[quad[1]] > positions[quad[2]],
+        positions[quad[2]] > positions[quad[3]],
+    )
+
+
+def _order_from_model(model: object, positions: Sequence[object], n: int) -> list[int]:
+    return sorted(
+        range(n),
+        key=lambda label: model.evaluate(positions[label], model_completion=True).as_long(),
+    )
+
+
+def check_footprint_cover(
+    cert: dict[str, object],
+    *,
+    include_reversal: bool,
+    random_seed: int,
+    timeout_ms: int,
+) -> dict[str, object]:
+    pattern = cert.get("pattern")
+    if not isinstance(pattern, dict):
+        raise ValueError("certificate pattern must be an object")
+    if "circulant_offsets" not in pattern:
+        raise ValueError("footprint translations require a circulant certificate pattern")
+    pattern_name, rows = selected_rows_from_certificate(cert)
+    n = len(rows)
+    quads = ordered_kalmanson_quads(cert)
+
+    positions = [Int(f"p{label}") for label in range(n)]
+    solver = Solver()
+    solver.set("random_seed", random_seed)
+    solver.set("timeout", timeout_ms)
+    solver.add(positions[0] == 0)
+    solver.add(Distinct(positions))
+    for position in positions:
+        solver.add(position >= 0, position < n)
+
+    orientations = (False, True) if include_reversal else (False,)
+    motif_count = 0
+    for shift in range(n):
+        for reverse in orientations:
+            motif_count += 1
+            transformed = sorted(
+                {_transform_quad(quad, n, shift, reverse) for quad in quads}
+            )
+            solver.add(Or(*[_not_in_cyclic_order(positions, quad) for quad in transformed]))
+
+    solver_result = solver.check()
+    payload: dict[str, object] = {
+        "type": "quotient_cone_footprint_cover_probe_v1",
+        "pattern": pattern_name,
+        "n": n,
+        "certificate_rows": len(strict_items_from_certificate(cert)),
+        "unique_order_quads": len(quads),
+        "motifs_tested": motif_count,
+        "include_reversal": include_reversal,
+        "rotation_quotient": "label 0 fixed at position 0",
+        "solver": "z3",
+        "solver_result": str(solver_result),
+        "semantics": (
+            "SAT means some cyclic order avoids every translated/oriented copy "
+            "of this one fixed-order certificate footprint. UNSAT would be an "
+            "all-order result only for this footprint family."
+        ),
+    }
+    if solver_result == sat:
+        payload["candidate_order"] = _order_from_model(solver.model(), positions, n)
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("certificate", type=Path)
+    parser.add_argument("--no-reversal", action="store_true")
+    parser.add_argument("--random-seed", type=int, default=17)
+    parser.add_argument("--timeout-ms", type=int, default=60000)
+    parser.add_argument("--assert-sat", action="store_true")
+    parser.add_argument("--assert-unsat", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    cert = json.loads(args.certificate.read_text(encoding="utf-8"))
+    payload = check_footprint_cover(
+        cert,
+        include_reversal=not args.no_reversal,
+        random_seed=args.random_seed,
+        timeout_ms=args.timeout_ms,
+    )
+    if args.assert_sat and payload["solver_result"] != str(sat):
+        raise AssertionError(f"expected SAT footprint miss, got {payload['solver_result']}")
+    if args.assert_unsat and payload["solver_result"] != str(unsat):
+        raise AssertionError(f"expected UNSAT footprint cover, got {payload['solver_result']}")
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            f"{payload['pattern']} footprint-cover {payload['solver_result']} "
+            f"motifs={payload['motifs_tested']} unique_quads={payload['unique_order_quads']}"
+        )
+        if "candidate_order" in payload:
+            print("candidate_order=" + ",".join(str(v) for v in payload["candidate_order"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mine_quotient_cone_footprints.py
+++ b/scripts/mine_quotient_cone_footprints.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Mine compact equality-footprints from checked quotient-cone certificates.
+
+This first-pass miner intentionally starts from existing fixed-order
+certificates. It extracts the selected-distance quotient support that a
+certificate actually uses, which is the reusable object needed before trying
+larger all-order searches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import footprint_summary  # noqa: E402
+
+
+C29_CERTIFICATE = (
+    ROOT / "data" / "certificates" / "c29_sidon_fixed_order_kalmanson_165_unsat.json"
+)
+
+
+def _display_path(path: Path) -> str:
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "certificates",
+        nargs="*",
+        type=Path,
+        help="certificate JSON paths; defaults to the recorded C29 fixed-order certificate",
+    )
+    parser.add_argument("--out", type=Path, help="write JSON footprint payload")
+    parser.add_argument("--assert-c29", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    paths = args.certificates or [C29_CERTIFICATE]
+    footprints = []
+    for path in paths:
+        cert = json.loads(path.read_text(encoding="utf-8"))
+        item = footprint_summary(cert)
+        item["path"] = _display_path(path)
+        footprints.append(item)
+
+    if args.assert_c29:
+        by_pattern = {str(item["pattern"]): item for item in footprints}
+        c29 = by_pattern.get("C29_sidon_1_3_7_15")
+        if c29 is None:
+            raise AssertionError("C29_sidon_1_3_7_15 footprint missing")
+        if c29["strict_rows"] != 165:
+            raise AssertionError("unexpected C29 strict-row count")
+        if c29["distance_classes"] != 319:
+            raise AssertionError("unexpected C29 distance-class count")
+        if c29["zero_sum_verified"] is not True:
+            raise AssertionError("C29 footprint did not replay as zero-sum certificate")
+
+    payload: object
+    payload = footprints[0] if len(footprints) == 1 else {
+        "type": "quotient_cone_footprint_collection_v1",
+        "footprints": footprints,
+    }
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            "pattern  n  rows  classes  touched-classes  touched-centers  "
+            "zero-sum  source-counts"
+        )
+        for item in footprints:
+            print(
+                f"{item['pattern']}  {item['n']}  {item['strict_rows']}  "
+                f"{item['distance_classes']}  "
+                f"{item['touched_distance_class_count']}  "
+                f"{item['touched_selected_center_count']}  "
+                f"{item['zero_sum_verified']}  {item['source_counts']}"
+            )
+        if args.assert_c29:
+            print("OK: C29 quotient-cone footprint expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/quotient_cone.py
+++ b/src/erdos97/quotient_cone.py
@@ -1,0 +1,445 @@
+"""Exact quotient-cone certificates for selected-witness patterns.
+
+This module generalizes the existing fixed-order Kalmanson/Farkas checker.
+It works with arbitrary selected-witness rows, quotients ordinary pair-distance
+variables by the selected equalities, and verifies strict linear inequality
+certificates whose reduced coefficient vector is coordinatewise nonpositive.
+
+The checker is finite exact bookkeeping. A valid certificate obstructs only the
+encoded selected-witness system in the encoded cyclic order.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from erdos97.stuck_sets import validate_selected_pattern
+
+Pair = tuple[int, int]
+Term = tuple[Pair, int]
+Pattern = Sequence[Sequence[int]]
+
+KALMANSON_KINDS = ("K1_diag_gt_sides", "K2_diag_gt_other")
+
+
+@dataclass(frozen=True)
+class DistanceQuotient:
+    """Selected-distance quotient over unordered pair variables."""
+
+    n: int
+    pair_class: Mapping[Pair, int]
+    class_members: tuple[tuple[Pair, ...], ...]
+
+    @property
+    def class_count(self) -> int:
+        return len(self.class_members)
+
+
+@dataclass(frozen=True)
+class StrictRow:
+    """One strict linear inequality row after selected-distance quotienting."""
+
+    source: str
+    vector: tuple[int, ...]
+    terms: tuple[Term, ...]
+    metadata: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class QuotientConeCheckResult:
+    """Summary of one exact quotient-cone certificate check."""
+
+    pattern: str
+    n: int
+    status: str
+    strict_rows: int
+    distance_classes: int
+    weight_sum: int
+    max_weight: int
+    coefficient_positive_count: int
+    coefficient_negative_count: int
+    coefficient_zero_count: int
+    combined_nonzero_coefficient_count: int
+    zero_sum_verified: bool
+    nonpositive_sum_verified: bool
+    claim_strength: str
+
+
+class UnionFind:
+    """Deterministic union-find over unordered pairs."""
+
+    def __init__(self, items: Iterable[Pair]) -> None:
+        self.parent = {item: item for item in items}
+
+    def find(self, item: Pair) -> Pair:
+        parent = self.parent[item]
+        if parent != item:
+            self.parent[item] = self.find(parent)
+        return self.parent[item]
+
+    def union(self, left: Pair, right: Pair) -> None:
+        root_left = self.find(left)
+        root_right = self.find(right)
+        if root_left == root_right:
+            return
+        if root_right < root_left:
+            root_left, root_right = root_right, root_left
+        self.parent[root_right] = root_left
+
+
+def pair(left: int, right: int) -> Pair:
+    """Return a normalized unordered pair."""
+
+    if left == right:
+        raise ValueError(f"loop pair is not allowed: ({left}, {right})")
+    return (left, right) if left < right else (right, left)
+
+
+def rows_from_circulant_offsets(n: int, offsets: Sequence[int]) -> list[list[int]]:
+    """Return selected rows from a circulant offset rule."""
+
+    rows: list[list[int]] = []
+    residues = [int(offset) % n for offset in offsets]
+    for center in range(n):
+        row = sorted((center + residue) % n for residue in residues)
+        rows.append(row)
+    validate_selected_pattern(rows)
+    return rows
+
+
+def selected_distance_quotient(rows: Pattern) -> DistanceQuotient:
+    """Build the quotient by selected row equalities."""
+
+    validate_selected_pattern(rows)
+    n = len(rows)
+    all_pairs = [pair(left, right) for left, right in combinations(range(n), 2)]
+    uf = UnionFind(all_pairs)
+    for center, witnesses in enumerate(rows):
+        base = pair(center, int(witnesses[0]))
+        for witness in witnesses[1:]:
+            uf.union(base, pair(center, int(witness)))
+
+    root_index: MutableMapping[Pair, int] = {}
+    pair_class: dict[Pair, int] = {}
+    members: dict[int, list[Pair]] = {}
+    for item in all_pairs:
+        root = uf.find(item)
+        class_index = root_index.setdefault(root, len(root_index))
+        pair_class[item] = class_index
+        members.setdefault(class_index, []).append(item)
+    class_members = tuple(tuple(members[idx]) for idx in range(len(members)))
+    return DistanceQuotient(
+        n=n,
+        pair_class=pair_class,
+        class_members=class_members,
+    )
+
+
+def vector_from_terms(quotient: DistanceQuotient, terms: Sequence[Term]) -> tuple[int, ...]:
+    """Reduce pair-coefficient terms to the selected-distance quotient."""
+
+    vector = [0] * quotient.class_count
+    for raw_pair, coefficient in terms:
+        vector[quotient.pair_class[pair(*raw_pair)]] += int(coefficient)
+    return tuple(vector)
+
+
+def kalmanson_terms(kind: str, quad: Sequence[int]) -> tuple[Term, ...]:
+    """Return coefficient terms for one strict Kalmanson inequality.
+
+    For vertices ``a,b,c,d`` in cyclic order:
+
+    - ``K1_diag_gt_sides``: ``d(a,c)+d(b,d)>d(a,b)+d(c,d)``
+    - ``K2_diag_gt_other``: ``d(a,c)+d(b,d)>d(a,d)+d(b,c)``
+    """
+
+    if len(quad) != 4 or len(set(quad)) != 4:
+        raise ValueError(f"Kalmanson row needs four distinct vertices, got {quad!r}")
+    a, b, c, d = (int(label) for label in quad)
+    if kind == "K1_diag_gt_sides":
+        return (
+            (pair(a, c), +1),
+            (pair(b, d), +1),
+            (pair(a, b), -1),
+            (pair(c, d), -1),
+        )
+    if kind == "K2_diag_gt_other":
+        return (
+            (pair(a, c), +1),
+            (pair(b, d), +1),
+            (pair(a, d), -1),
+            (pair(b, c), -1),
+        )
+    raise ValueError(f"unknown Kalmanson kind: {kind}")
+
+
+def kalmanson_row(
+    quotient: DistanceQuotient,
+    kind: str,
+    quad: Sequence[int],
+) -> StrictRow:
+    """Return one reduced Kalmanson strict row."""
+
+    terms = kalmanson_terms(kind, quad)
+    return StrictRow(
+        source="kalmanson",
+        vector=vector_from_terms(quotient, terms),
+        terms=terms,
+        metadata={"kind": kind, "quad": [int(label) for label in quad]},
+    )
+
+
+def altman_gap_row(
+    quotient: DistanceQuotient,
+    order: Sequence[int],
+    gap_order: int,
+) -> StrictRow:
+    """Return the strict Altman gap row ``U_{k+1} - U_k > 0``.
+
+    The coefficient convention intentionally matches
+    :mod:`erdos97.altman_diagonal_sums`: for each cyclic chord order, we sum
+    over all starting vertices in the supplied cyclic order.
+    """
+
+    n = quotient.n
+    if not 1 <= gap_order < n // 2:
+        raise ValueError(f"gap_order must be in [1,{n // 2 - 1}], got {gap_order}")
+    _validate_order(order, n)
+    terms: list[Term] = []
+    for idx, source in enumerate(order):
+        left_target = order[(idx + gap_order) % n]
+        right_target = order[(idx + gap_order + 1) % n]
+        terms.append((pair(source, right_target), +1))
+        terms.append((pair(source, left_target), -1))
+    return StrictRow(
+        source="altman_gap",
+        vector=vector_from_terms(quotient, terms),
+        terms=tuple(terms),
+        metadata={"gap_order": gap_order},
+    )
+
+
+def strict_row_from_certificate_item(
+    quotient: DistanceQuotient,
+    order: Sequence[int],
+    item: Mapping[str, object],
+) -> StrictRow:
+    """Parse one strict row item from the generalized certificate format."""
+
+    source = str(item.get("source", ""))
+    if source in ("", "kalmanson") and "quad" in item:
+        kind = str(item["kind"])
+        quad = [int(label) for label in item["quad"]]  # type: ignore[index]
+        _validate_quad_order(quad, order)
+        return kalmanson_row(quotient, kind, quad)
+    if source == "altman_gap":
+        return altman_gap_row(quotient, order, int(item["gap_order"]))
+    raise ValueError(f"unsupported strict row item: {item!r}")
+
+
+def selected_rows_from_certificate(cert: Mapping[str, object]) -> tuple[str, list[list[int]]]:
+    """Extract selected rows from a generalized or legacy certificate."""
+
+    pattern = cert.get("pattern")
+    if not isinstance(pattern, Mapping):
+        raise ValueError("certificate pattern must be an object")
+    name = str(pattern.get("name", cert.get("pattern_name", "<unnamed>")))
+    if "selected_rows" in pattern:
+        rows = [[int(label) for label in row] for row in pattern["selected_rows"]]  # type: ignore[index]
+        validate_selected_pattern(rows)
+        return name, rows
+    if "rows" in pattern:
+        rows = [[int(label) for label in row] for row in pattern["rows"]]  # type: ignore[index]
+        validate_selected_pattern(rows)
+        return name, rows
+    if "circulant_offsets" in pattern:
+        n = int(pattern["n"])
+        offsets = [int(offset) for offset in pattern["circulant_offsets"]]  # type: ignore[index]
+        return name, rows_from_circulant_offsets(n, offsets)
+    raise ValueError("certificate pattern must include selected_rows, rows, or circulant_offsets")
+
+
+def strict_items_from_certificate(cert: Mapping[str, object]) -> list[Mapping[str, object]]:
+    """Return strict row items from generalized or legacy certificate shapes."""
+
+    if "strict_rows" in cert:
+        items = cert["strict_rows"]
+    elif "inequalities" in cert:
+        items = cert["inequalities"]
+    else:
+        raise ValueError("certificate must include strict_rows or inequalities")
+    if not isinstance(items, list):
+        raise ValueError("strict row collection must be a list")
+    if not all(isinstance(item, Mapping) for item in items):
+        raise ValueError("every strict row item must be an object")
+    return list(items)
+
+
+def check_quotient_cone_certificate(
+    cert: Mapping[str, object],
+) -> QuotientConeCheckResult:
+    """Verify an exact quotient-cone certificate.
+
+    A certificate is valid when a nonzero nonnegative integer combination of
+    strict rows reduces to a coordinatewise nonpositive vector after selected
+    equalities are quotiented. Since all ordinary distances are nonnegative,
+    this contradicts the strict positivity of the same combination.
+    """
+
+    pattern_name, rows = selected_rows_from_certificate(cert)
+    n = len(rows)
+    order = [int(label) for label in cert["cyclic_order"]]  # type: ignore[index]
+    _validate_order(order, n)
+    quotient = selected_distance_quotient(rows)
+
+    total = [0] * quotient.class_count
+    strict_count = 0
+    weight_sum = 0
+    max_weight = 0
+    for item in strict_items_from_certificate(cert):
+        weight = int(item["weight"])
+        if weight <= 0:
+            raise ValueError(f"strict row weight must be positive, got {weight}")
+        strict_row = strict_row_from_certificate_item(quotient, order, item)
+        strict_count += 1
+        weight_sum += weight
+        max_weight = max(max_weight, weight)
+        for idx, coefficient in enumerate(strict_row.vector):
+            total[idx] += weight * coefficient
+
+    if strict_count == 0:
+        raise ValueError("certificate has no strict rows")
+    if "num_inequalities" in cert and int(cert["num_inequalities"]) != strict_count:
+        raise ValueError("stored num_inequalities does not match listed strict rows")
+    if "weight_sum" in cert and int(cert["weight_sum"]) != weight_sum:
+        raise ValueError("stored weight_sum does not match listed weights")
+
+    if any(value > 0 for value in total):
+        positive = {idx: value for idx, value in enumerate(total) if value > 0}
+        raise AssertionError(f"combined coefficient vector is not nonpositive: {positive}")
+
+    positive_count = sum(1 for value in total if value > 0)
+    negative_count = sum(1 for value in total if value < 0)
+    zero_count = len(total) - positive_count - negative_count
+    combined_nonzero_count = sum(1 for value in total if value != 0)
+    zero_sum = all(value == 0 for value in total)
+    return QuotientConeCheckResult(
+        pattern=pattern_name,
+        n=n,
+        status=str(
+            cert.get(
+                "status",
+                "EXACT_QUOTIENT_CONE_OBSTRUCTION_FOR_FIXED_PATTERN_AND_ORDER",
+            )
+        ),
+        strict_rows=strict_count,
+        distance_classes=quotient.class_count,
+        weight_sum=weight_sum,
+        max_weight=max_weight,
+        coefficient_positive_count=positive_count,
+        coefficient_negative_count=negative_count,
+        coefficient_zero_count=zero_count,
+        combined_nonzero_coefficient_count=combined_nonzero_count,
+        zero_sum_verified=zero_sum,
+        nonpositive_sum_verified=True,
+        claim_strength=str(
+            cert.get(
+                "claim_strength",
+                "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only.",
+            )
+        ),
+    )
+
+
+def footprint_summary(cert: Mapping[str, object]) -> dict[str, object]:
+    """Return a compact equality-footprint summary for a certificate."""
+
+    pattern_name, rows = selected_rows_from_certificate(cert)
+    n = len(rows)
+    order = [int(label) for label in cert["cyclic_order"]]  # type: ignore[index]
+    _validate_order(order, n)
+    quotient = selected_distance_quotient(rows)
+    items = strict_items_from_certificate(cert)
+
+    source_counts: Counter[str] = Counter()
+    kind_counts: Counter[str] = Counter()
+    label_counts: Counter[int] = Counter()
+    touched_classes: set[int] = set()
+    touched_pairs: set[Pair] = set()
+    row_centers: set[int] = set()
+    for item in items:
+        strict_row = strict_row_from_certificate_item(quotient, order, item)
+        source_counts[strict_row.source] += 1
+        if "kind" in strict_row.metadata:
+            kind_counts[str(strict_row.metadata["kind"])] += 1
+        for raw_pair, _coefficient in strict_row.terms:
+            normalized = pair(*raw_pair)
+            touched_pairs.add(normalized)
+            touched_classes.add(quotient.pair_class[normalized])
+            label_counts.update(normalized)
+            row_centers.update(_selected_centers_for_pair(rows, normalized))
+
+    class_sizes = [len(members) for members in quotient.class_members]
+    touched_class_sizes = [
+        len(quotient.class_members[class_idx])
+        for class_idx in sorted(touched_classes)
+    ]
+    check = check_quotient_cone_certificate(cert)
+    return {
+        "type": "quotient_cone_equality_footprint_v1",
+        "pattern": pattern_name,
+        "n": n,
+        "strict_rows": len(items),
+        "distance_classes": quotient.class_count,
+        "source_counts": dict(sorted(source_counts.items())),
+        "kind_counts": dict(sorted(kind_counts.items())),
+        "label_support_size": len(label_counts),
+        "label_support": sorted(label_counts),
+        "touched_pair_count": len(touched_pairs),
+        "touched_distance_class_count": len(touched_classes),
+        "touched_selected_center_count": len(row_centers),
+        "touched_selected_centers": sorted(row_centers),
+        "distance_class_size_histogram": _histogram(class_sizes),
+        "touched_class_size_histogram": _histogram(touched_class_sizes),
+        "zero_sum_verified": check.zero_sum_verified,
+        "nonpositive_sum_verified": check.nonpositive_sum_verified,
+        "claim_strength": check.claim_strength,
+        "semantics": (
+            "Footprint only: this records which quotient classes and selected "
+            "rows a checked fixed-order certificate uses. It is not an "
+            "all-order obstruction and not a counterexample."
+        ),
+    }
+
+
+def _selected_centers_for_pair(rows: Pattern, target_pair: Pair) -> list[int]:
+    left, right = target_pair
+    centers = []
+    for center, witnesses in enumerate(rows):
+        witness_set = set(witnesses)
+        if left in witness_set and right in witness_set:
+            centers.append(center)
+    return centers
+
+
+def _histogram(values: Sequence[int]) -> dict[str, int]:
+    return {str(key): count for key, count in sorted(Counter(values).items())}
+
+
+def _validate_order(order: Sequence[int], n: int) -> None:
+    if len(order) != n or set(order) != set(range(n)):
+        missing = sorted(set(range(n)) - set(order))
+        extra = sorted(set(order) - set(range(n)))
+        raise ValueError(f"cyclic order is not a permutation; missing={missing}, extra={extra}")
+
+
+def _validate_quad_order(quad: Sequence[int], order: Sequence[int]) -> None:
+    position = {label: idx for idx, label in enumerate(order)}
+    if any(label not in position for label in quad):
+        raise ValueError(f"quad contains label outside cyclic order: {quad}")
+    positions = [position[label] for label in quad]
+    if positions != sorted(positions):
+        raise ValueError(f"quad is not listed in supplied cyclic order: {quad}")

--- a/tests/test_quotient_cone.py
+++ b/tests/test_quotient_cone.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.quotient_cone import (
+    check_quotient_cone_certificate,
+    footprint_summary,
+)
+from erdos97.search import built_in_patterns
+
+ROOT = Path(__file__).resolve().parents[1]
+C19_COMPACT = (
+    ROOT / "data" / "certificates" / "round2" / "c19_kalmanson_known_order_two_unsat.json"
+)
+C29 = ROOT / "data" / "certificates" / "c29_sidon_fixed_order_kalmanson_165_unsat.json"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_quotient_cone_replays_compact_c19_certificate() -> None:
+    result = check_quotient_cone_certificate(_load_json(C19_COMPACT))
+
+    assert result.pattern == "C19_skew"
+    assert result.n == 19
+    assert result.strict_rows == 2
+    assert result.distance_classes == 114
+    assert result.weight_sum == 2
+    assert result.max_weight == 1
+    assert result.combined_nonzero_coefficient_count == 0
+    assert result.zero_sum_verified is True
+    assert result.nonpositive_sum_verified is True
+
+
+def test_quotient_cone_replays_c29_fixed_order_certificate() -> None:
+    result = check_quotient_cone_certificate(_load_json(C29))
+
+    assert result.pattern == "C29_sidon_1_3_7_15"
+    assert result.n == 29
+    assert result.strict_rows == 165
+    assert result.distance_classes == 319
+    assert result.weight_sum == 504300794
+    assert result.max_weight == 15835921
+    assert result.combined_nonzero_coefficient_count == 0
+    assert result.zero_sum_verified is True
+    assert result.nonpositive_sum_verified is True
+    assert "not a proof of Erdos Problem #97" in result.claim_strength
+
+
+def test_c29_quotient_cone_footprint_records_used_support() -> None:
+    footprint = footprint_summary(_load_json(C29))
+
+    assert footprint["type"] == "quotient_cone_equality_footprint_v1"
+    assert footprint["pattern"] == "C29_sidon_1_3_7_15"
+    assert footprint["strict_rows"] == 165
+    assert footprint["distance_classes"] == 319
+    assert footprint["source_counts"] == {"kalmanson": 165}
+    assert footprint["kind_counts"] == {
+        "K1_diag_gt_sides": 65,
+        "K2_diag_gt_other": 100,
+    }
+    assert footprint["label_support_size"] == 29
+    assert footprint["label_support"] == list(range(29))
+    assert footprint["touched_pair_count"] == 236
+    assert footprint["touched_distance_class_count"] == 166
+    assert footprint["touched_selected_center_count"] == 29
+    assert footprint["distance_class_size_histogram"] == {"1": 290, "4": 29}
+    assert footprint["touched_class_size_histogram"] == {"1": 137, "4": 29}
+    assert footprint["zero_sum_verified"] is True
+    assert "not an all-order obstruction" in str(footprint["semantics"])
+
+
+def test_generalized_altman_gap_rows_share_the_quotient_cone_checker() -> None:
+    pattern = built_in_patterns()["C29_sidon_1_3_7_15"]
+    cert = {
+        "pattern": {"name": pattern.name, "selected_rows": pattern.S},
+        "cyclic_order": list(range(pattern.n)),
+        "strict_rows": [
+            {"source": "altman_gap", "gap_order": 1, "weight": 1},
+            {"source": "altman_gap", "gap_order": 2, "weight": 1},
+        ],
+    }
+
+    result = check_quotient_cone_certificate(cert)
+
+    assert result.pattern == "C29_sidon_1_3_7_15"
+    assert result.strict_rows == 2
+    assert result.distance_classes == 319
+    assert result.weight_sum == 2
+    assert result.max_weight == 1
+    assert result.combined_nonzero_coefficient_count == 0
+    assert result.zero_sum_verified is True
+
+
+def test_quotient_cone_checker_cli_outputs_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_quotient_cone_certificate.py",
+            str(C29),
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    summary = json.loads(result.stdout)
+
+    assert summary["pattern"] == "C29_sidon_1_3_7_15"
+    assert summary["strict_rows"] == 165
+    assert summary["distance_classes"] == 319
+    assert summary["combined_nonzero_coefficient_count"] == 0
+    assert summary["zero_sum_verified"] is True
+
+
+def test_quotient_cone_footprint_miner_cli_asserts_c29() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/mine_quotient_cone_footprints.py",
+            "--assert-c29",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    summary = json.loads(result.stdout)
+
+    assert summary["pattern"] == "C29_sidon_1_3_7_15"
+    assert summary["strict_rows"] == 165
+    assert summary["distance_classes"] == 319
+    assert summary["touched_distance_class_count"] == 166
+    assert summary["zero_sum_verified"] is True
+
+
+def test_quotient_cone_footprint_cover_probe_finds_c29_miss() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_quotient_cone_footprint_cover.py",
+            str(C29),
+            "--assert-sat",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    summary = json.loads(result.stdout)
+
+    assert summary["pattern"] == "C29_sidon_1_3_7_15"
+    assert summary["solver_result"] == "sat"
+    assert summary["certificate_rows"] == 165
+    assert summary["unique_order_quads"] == 165
+    assert summary["motifs_tested"] == 58
+    assert len(summary["candidate_order"]) == 29


### PR DESCRIPTION
## Summary

Adds exact quotient-cone tooling for selected-witness certificate replay and footprint inspection:

- verifies generalized strict-row certificates after selected-distance quotienting
- replays existing fixed-order Kalmanson certificates as the zero-sum special case
- mines the C29 certificate footprint and checks whether one translated/oriented footprint family covers all cyclic orders
- adds regression coverage for C19, C29, generalized Altman-gap rows, and the footprint-cover SAT miss

## Claim Scope

This is tooling and diagnostics only. It does not claim a proof of Erdos Problem #97, an all-order C29 obstruction, or a counterexample.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`255 passed, 19 deselected`)