### PR TITLE
[codex] Fix pattern catalog status drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ Use these labels consistently:
     └── n8_polynomial_systems.txt
 ```
 
+New generated checked certificates should normally live under
+`data/certificates/`. The top-level `certificates/` directory is retained for
+legacy n=8 artifacts and manual templates whose paths are already referenced by
+docs, tests, and manifests.
+
 ## Quick start
 
 ```bash

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -313,8 +313,9 @@ Interpretation:
 
 The runs do not produce a near-miss counterexample. The equality residual stays
 large in normalized coordinates and is best read as a plateau in the SLSQP basin,
-not as an exact obstruction. The pattern remains an `INCIDENCE_PATTERN`, and the
-run artifacts are `NUMERICAL_EVIDENCE` only. See `docs/sidon-patterns.md` and
+not as an exact obstruction. The fixed abstract pattern is now retired by the
+all-order Kalmanson search; these older run artifacts are
+`NUMERICAL_EVIDENCE` only. See `docs/sidon-patterns.md` and
 `data/runs/C13_sidon_m{1e-3,1e-4,1e-5,1e-6}.json`.
 
 ### B12_3x4_danzer_lift

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -1,6 +1,12 @@
 # Certificates
 
-This directory is for exact or interval certificates.
+This directory is legacy/path-stable space for early exact or interval
+certificates and manual certificate templates.
+
+New generated checked certificates should normally live under
+`data/certificates/`, with provenance recorded in
+`metadata/generated_artifacts.yaml`. The existing n=8 files stay here because
+their historical paths are referenced by docs, tests, and manifests.
 
 The current file `best_B12_certificate_template.json` is only a template produced from a numerical near-miss. It is not a proof certificate.
 

--- a/data/patterns/candidate_patterns.json
+++ b/data/patterns/candidate_patterns.json
@@ -41,8 +41,9 @@
     "n": 19,
     "formula": "offsets {-8,-3,5,9}",
     "type": "skew circulant",
-    "status": "natural-order status: exactly killed by Altman diagonal-order sums; registered non-natural cyclic order [18,10,7,17,6,3,5,9,14,11,2,13,4,16,12,15,0,8,1] killed by exact round-two Kalmanson/Farkas fixed-order certificate; abstract-incidence status across all cyclic orders remains live/unresolved",
-    "trust": "INCIDENCE_PATTERN"
+    "status": "abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance",
+    "trust": "EXACT_OBSTRUCTION",
+    "lifecycle": "retired_all_order_obstruction"
   },
   {
     "rank": 6,
@@ -95,8 +96,9 @@
     "n": 13,
     "formula": "offsets {1,2,4,10} (Singer (13,4,1) planar difference set)",
     "type": "Sidon circulant",
-    "status": "natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: registered non-natural order survives current fixed-order exact filters; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as numerical evidence",
-    "trust": "INCIDENCE_PATTERN"
+    "status": "abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as historical numerical evidence",
+    "trust": "EXACT_OBSTRUCTION",
+    "lifecycle": "retired_all_order_obstruction"
   },
   {
     "rank": 12,
@@ -104,8 +106,9 @@
     "n": 25,
     "formula": "offsets {2,5,9,14}",
     "type": "Sidon circulant",
-    "status": "natural-order status: exactly killed by Altman linear certificate; abstract-incidence status: Sidon sparse-overlap lead, not settled by current filters; D = {2,5,9,14} is Sidon: 12 pairwise differences distinct mod 25; |S_a cap S_b| in {0,1} for every a != b; defined for catalog completeness, not yet run numerically",
-    "trust": "INCIDENCE_PATTERN"
+    "status": "natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the step-7 Kalmanson-filter survivor is exactly killed by vertex-circle and Altman filters; no all-order obstruction for the abstract C25 pattern is claimed; D = {2,5,9,14} is Sidon: 12 pairwise differences distinct mod 25; |S_a cap S_b| in {0,1} for every a != b",
+    "trust": "INCIDENCE_PATTERN",
+    "lifecycle": "fixed_order_diagnostic"
   },
   {
     "rank": 13,
@@ -113,7 +116,8 @@
     "n": 29,
     "formula": "offsets {1,3,7,15}",
     "type": "Sidon circulant",
-    "status": "natural-order status: exactly killed by Altman linear certificate; one recorded non-natural fixed order is exactly killed by a 165-inequality Kalmanson/Farkas certificate; abstract all-order status remains unresolved; D = {1,3,7,15} is Sidon: 12 pairwise differences distinct mod 29; |S_a cap S_b| in {0,1} for every a != b",
-    "trust": "INCIDENCE_PATTERN"
+    "status": "natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the fixed order [0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16] escaped weaker filters but is now exactly killed by the 165-row Kalmanson/Farkas fixed-order certificate; no all-order obstruction for the abstract C29 pattern is claimed; D = {1,3,7,15} is Sidon: 12 pairwise differences distinct mod 29; |S_a cap S_b| in {0,1} for every a != b",
+    "trust": "INCIDENCE_PATTERN",
+    "lifecycle": "fixed_order_diagnostic"
   }
 ]

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -10,7 +10,7 @@ designs only; geometric realization is a separate problem.
 | 1 | `C19_skew` | 19 | offsets `{-8,-3,5,9}` | skew circulant | abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; earlier natural-order Altman and registered non-natural fixed-order Kalmanson certificates retained as provenance |
 | 11 | `C13_sidon_1_2_4_10` | 13 | offsets `{1,2,4,10}` | Sidon circulant | abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; earlier natural-order Altman and registered non-natural fixed-order Kalmanson certificates retained as provenance; SLSQP evidence plateaus at `eq_rms ~ 0.84` under strict convexity margins |
 | 12 | `C25_sidon_2_5_9_14` | 25 | offsets `{2,5,9,14}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: a Kalmanson Z3 probe found the step-7 fixed order `[0,7,14,21,3,10,17,24,6,13,20,2,9,16,23,5,12,19,1,8,15,22,4,11,18]` with no two-inequality Kalmanson inverse-pair obstruction, but that order is exactly killed by vertex-circle and Altman filters |
-| 13 | `C29_sidon_1_3_7_15` | 29 | offsets `{1,3,7,15}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; fixed-order diagnostic: the order `[0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16]` escaped the two-inequality Kalmanson inverse-pair search, metric LP, and global Ptolemy NLP diagnostic, but is now exactly killed by the 165-inequality fixed-order Kalmanson/Farkas certificate; abstract all-order status remains unresolved |
+| 13 | `C29_sidon_1_3_7_15` | 29 | offsets `{1,3,7,15}` | Sidon circulant | natural-order status: exactly killed by Altman linear certificate; fixed-order diagnostic: the order `[0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16]` escaped the two-inequality Kalmanson inverse-pair search, metric LP, and global Ptolemy NLP diagnostic, but is now exactly killed by the 165-row fixed-order Kalmanson/Farkas certificate; no all-order C29 obstruction is claimed |
 
 The ranked abstract-incidence patterns above pass the row-overlap filter
 `|S_i cap S_j| <= 2` before numerical optimization. `C19_skew` and
@@ -18,7 +18,7 @@ The ranked abstract-incidence patterns above pass the row-overlap filter
 two-certificate Kalmanson order methods; see
 `docs/kalmanson-two-order-search.md`. The Sidon natural orders are also exactly
 obstructed by Altman linear certificates. The larger Sidon entries remain
-incidence-pattern leads, not geometric realizability claims. The new C25/C29
+incidence-pattern benchmarks, not geometric realizability claims. The new C25/C29
 probe is recorded in
 `data/certificates/c25_c29_sparse_frontier_probe.json`: it retires the tested
 C25 fixed order as a dead end and records the weaker-filter survival of the

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ put detailed reconciliation in the canonical synthesis.
 - [`stuck-set-miner.md`](stuck-set-miner.md): fixed-selection stuck-set mining
   for the bridge/peeling program.
 - [`stuck-frontier-snapshot.md`](stuck-frontier-snapshot.md): first stuck-set,
-  radius-propagation, and fragile-cover pass over the live sparse frontier.
+  radius-propagation, and fragile-cover pass over sparse frontier benchmarks.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible

--- a/docs/minimum-radius-filter.md
+++ b/docs/minimum-radius-filter.md
@@ -72,8 +72,9 @@ not geometric realizability.
 
 The current built-in candidate patterns all pass the natural-order version of
 this filter; every center remains compatible with being the minimum-radius
-center under this filter alone. This includes the main live abstract-incidence
-pattern `C19_skew`.
+center under this filter alone. This includes the retired sparse benchmark
+pattern `C19_skew`, which is killed only by stronger Kalmanson all-order
+certificates.
 
 For `C19_skew` in the natural order, row `0` has
 
@@ -113,6 +114,12 @@ The search is exact finite combinatorics for the supplied order:
   only an escape from this filter, not evidence for realizability.
 - `UNKNOWN_RADIUS_PROPAGATION_NODE_LIMIT` is reported only when an explicit
   node cap stops the search.
+
+In JSON emitted by `min_radius_filter`, inequality edges are serialized as
+`source -> target`, meaning `r_source < r_target`; the target is the row center.
+The stuck-set miner has a separate diagnostic serializer whose local edge
+direction is `center -> smaller_center`, and it records a normalized
+`radius_propagation_status` field for audit tooling.
 
 Reproduction:
 

--- a/docs/sidon-patterns.md
+++ b/docs/sidon-patterns.md
@@ -140,12 +140,11 @@ numerics are consistent with one.
 
 ## What this is not
 
-- It is not a proof of abstract-order non-realisability. Twenty SLSQP
-  restarts in a particular polar basin do not exhaust the configuration
-  space, and the exact Altman certificate currently applies only to the
-  natural label order.
-- It is not a counterexample to anything. The pattern is INCIDENCE_PATTERN;
-  the run is NUMERICAL_EVIDENCE.
+- It is not the proof of abstract-order non-realisability. The later
+  Kalmanson two-certificate order search supplies that exact obstruction;
+  these numerical runs are retained only as historical diagnostics.
+- It is not a counterexample to anything. The fixed abstract C13 pattern is
+  now an exact fixed-pattern obstruction; the run is NUMERICAL_EVIDENCE.
 - It is not an all-order verdict on `C25_sidon_2_5_9_14` or
   `C29_sidon_1_3_7_15`. Later fixed-order diagnostics killed one C25 order by
   vertex-circle and Altman filters and one C29 order by a full

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -22,7 +22,7 @@ on the three consecutive witness pairs in the supplied cyclic order.
 python scripts/analyze_sparse_frontier.py --frontier --assert-empty-choice
 ```
 
-This prints a compact table and asserts that every live frontier row has at
+This prints a compact table and asserts that every sparse benchmark row has at
 least one uncovered consecutive witness pair in the natural order.
 
 To sample other cyclic orders:
@@ -263,8 +263,8 @@ The `C19` order is:
 ```
 
 These remain adversarial objects for filter development, not counterexamples.
-In particular, the fixed-order Kalmanson kills do not prove either abstract
-incidence pattern impossible across all cyclic orders.
+They are superseded as live leads by the later all-order Kalmanson inverse-pair
+certificates for the fixed abstract C13 and C19 patterns.
 
 ## C25/C29 Frontier Probe
 

--- a/docs/stuck-frontier-snapshot.md
+++ b/docs/stuck-frontier-snapshot.md
@@ -4,7 +4,7 @@ Status: exact fixed-selection diagnostics plus bounded search windows. No
 general proof and no counterexample are claimed.
 
 This note records the first pass of the fixed-selection stuck-set miner on the
-currently live sparse frontier:
+sparse frontier benchmarks that were live when this diagnostic was written:
 
 - `C19_skew`
 - `C13_sidon_1_2_4_10`
@@ -86,6 +86,9 @@ incidence-level covers of sizes `4` and `7`, respectively. `C25` and `C29` have
 no cover through the first nontrivial windows checked, but those are bounded
 negative results only.
 
-The useful conclusion is narrower: the live sparse/Sidon patterns remain a
-good target for a new sparse-overlap exact filter. The current two-overlap,
-minimum-radius, and radius-propagation filters do not see them.
+The useful conclusion is narrower: these sparse/Sidon patterns remain good
+benchmarks for sparse-overlap exact filters. Later Kalmanson certificates retire
+the fixed abstract `C19_skew` and `C13_sidon_1_2_4_10` patterns, and a separate
+fixed-order certificate retires the tested C29 order; the two-overlap,
+minimum-radius, and radius-propagation filters themselves do not see those
+obstructions.

--- a/docs/stuck-set-miner.md
+++ b/docs/stuck-set-miner.md
@@ -32,7 +32,7 @@ The tool separately reports:
 If the search starts above size `4`, or stops before `n` without finding a
 stuck set, the status is `UNKNOWN_TRUNCATED_SEARCH`.
 
-For the first run on the current live sparse/Sidon frontier, see
+For the first run on sparse/Sidon frontier benchmarks, see
 `docs/stuck-frontier-snapshot.md`.
 
 ## Usage
@@ -215,6 +215,12 @@ The implementation therefore searches over the disjunction of possible short
 pairs, one per row. The status `RADIUS_CYCLE_OBSTRUCTED` means every such
 choice forces a strict radius cycle. The status `PASS_ACYCLIC_CHOICE` means the
 pattern survives this necessary filter; it is not evidence of realizability.
+
+This is intentionally serialized as a stuck-set diagnostic:
+`stuck_radius_propagation_short_chord_result`. Its local edge convention is
+`center -> smaller_center`, meaning `r_smaller_center < r_center`. For
+cross-tool comparison, the JSON also records a normalized
+`radius_propagation_status` using the `min_radius_filter` status names.
 
 ## Fragile Cover
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3,6 +3,10 @@ claim_scope: >
   Manifest for generated or generator-owned artifacts. This is provenance and
   edit-policy metadata only; it does not prove Erdos Problem #97 and does not
   claim a counterexample.
+path_convention: >
+  New generated checked artifacts live under data/certificates/. The top-level
+  certificates/ directory is legacy/path-stable space for early n=8 artifacts
+  and manual templates retained at their historical paths.
 
 artifacts:
   - id: n8_reconstructed_survivors
@@ -49,7 +53,7 @@ artifacts:
     claim_scope: Repo-local n=8 compatible cyclic-order audit data.
     json_top_level_type: object
     forbidden_claims:
-      - independent external review
+      - external independent review has been completed
       - general proof of Erdos Problem #97
 
   - id: n8_exact_analysis

--- a/scripts/check_altman_diagonal_sums.py
+++ b/scripts/check_altman_diagonal_sums.py
@@ -31,7 +31,7 @@ EXPECTED: dict[str, dict[str, object]] = {
         "forced_equal_U": [3, 5, 8, 9],
         "altman_contradiction": True,
         "status": "NATURAL_ORDER_EXACT_OBSTRUCTION",
-        "abstract_incidence_status": "LIVE",
+        "abstract_incidence_status": "EXACT_OBSTRUCTION",
     }
 }
 
@@ -51,7 +51,7 @@ def abstract_status_from_ledger(pattern_name: str) -> str:
         return "LIVE"
     if normalized.startswith("survives"):
         return "SURVIVES_CURRENT_FILTERS"
-    if normalized.startswith("killed"):
+    if normalized.startswith("killed") or normalized.startswith("exactly killed"):
         return "EXACT_OBSTRUCTION"
     return abstract_status or "UNTOUCHED"
 

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -29,6 +29,10 @@ JSON_TOP_LEVEL_TYPES = {
     "object": dict,
     "list": list,
 }
+AMBIGUOUS_FORBIDDEN_CLAIMS = {
+    "external independent review",
+    "independent external review",
+}
 
 
 def repo_path(raw_path: str) -> Path:
@@ -141,6 +145,12 @@ def validate_artifact(
         for phrase in forbidden_claims:
             if not isinstance(phrase, str) or not phrase.strip():
                 errors.append(f"{label}.forbidden_claims entries must be nonempty strings")
+                continue
+            if phrase.strip().lower() in AMBIGUOUS_FORBIDDEN_CLAIMS:
+                errors.append(
+                    f"{label}.forbidden_claims entry {phrase!r} is ambiguous; "
+                    "name a false completed-review claim instead"
+                )
 
     if payload is not None:
         errors.extend(validate_json_payload(artifact, payload, label))

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from datetime import date, datetime
@@ -17,6 +18,9 @@ except ImportError:  # pragma: no cover - exercised only without dev dependencie
 ROOT = Path(__file__).resolve().parents[1]
 
 REQUIRED_STATUS_FILES = ["README.md", "STATE.md", "RESULTS.md"]
+PATTERN_CATALOG = ROOT / "data" / "patterns" / "candidate_patterns.json"
+PATTERN_DOC = "docs/candidate-patterns.md"
+ALL_ORDER_PATTERN_NAMES = ("C19_skew", "C13_sidon_1_2_4_10")
 
 NO_OVERCLAIM_RE = re.compile(r"no\s+general\s+proof\s+and\s+no\s+counterexample", re.I)
 OFFICIAL_OPEN_RE = re.compile(r"falsifiable\s*[/ -]\s*open", re.I)
@@ -30,6 +34,15 @@ LOCAL_N8_RE = re.compile(
 REVIEW_RE = re.compile(
     r"(?:independent\s+(?:external\s+)?review|external\s+independent\s+review)"
     r"|(?:before\s+(?:paper-style|public\s+theorem-style|public theorem-style))",
+    re.I,
+)
+ALL_ORDER_OBSTRUCTION_RE = re.compile(
+    r"(?:exactly\s+killed|obstruction)[^.\n;|]*\bacross\s+all\s+cyclic\s+orders\b"
+    r"|\ball-cyclic-order\b",
+    re.I,
+)
+STALE_PATTERN_CATALOG_RE = re.compile(
+    r"\b(?:remains\s+live|live/unresolved|survives\s+current\s+fixed-order\s+exact\s+filters)\b",
     re.I,
 )
 
@@ -78,6 +91,23 @@ def load_metadata(path: Path) -> dict[str, object]:
     if not isinstance(loaded, dict):
         fail("metadata/erdos97.yaml should parse as a mapping")
     return loaded
+
+
+def load_pattern_catalog() -> list[dict[str, object]]:
+    if not PATTERN_CATALOG.exists():
+        fail(f"{PATTERN_CATALOG.relative_to(ROOT)} is missing")
+    try:
+        loaded = json.loads(PATTERN_CATALOG.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"{PATTERN_CATALOG.relative_to(ROOT)} is not valid JSON: {exc}")
+    if not isinstance(loaded, list):
+        fail(f"{PATTERN_CATALOG.relative_to(ROOT)} should parse as a list")
+    rows: list[dict[str, object]] = []
+    for index, row in enumerate(loaded):
+        if not isinstance(row, dict):
+            fail(f"{PATTERN_CATALOG.relative_to(ROOT)}[{index}] should be an object")
+        rows.append(row)
+    return rows
 
 
 def metadata_value(metadata: dict[str, object], path: tuple[str, ...]) -> object:
@@ -165,6 +195,7 @@ def validate_metadata(max_official_status_age_days: int | None = None) -> None:
             fail(f"metadata trust_policy.{key} should be true")
 
     validate_nearby_literature(metadata)
+    validate_pattern_catalog(metadata)
 
 
 def validate_official_status_freshness(
@@ -218,6 +249,53 @@ def validate_nearby_literature(metadata: dict[str, object]) -> None:
         )
         if not has_reference:
             fail(f"{label}.citation should include a non-empty source, doi, or url")
+
+
+def validate_pattern_catalog(metadata: dict[str, object]) -> None:
+    """Keep the machine-readable pattern catalog aligned with canonical status."""
+
+    catalog = load_pattern_catalog()
+    by_name: dict[str, dict[str, object]] = {}
+    for row in catalog:
+        name = row.get("name")
+        if not isinstance(name, str) or not name.strip():
+            fail("data/patterns/candidate_patterns.json entries should have nonempty names")
+        if name in by_name:
+            fail(f"data/patterns/candidate_patterns.json has duplicate pattern {name!r}")
+        by_name[name] = row
+
+    all_order = metadata_value(metadata, ("local_repo", "notable_all_order_obstructions"))
+    if not isinstance(all_order, list):
+        fail("metadata local_repo.notable_all_order_obstructions should be a list")
+    all_order_patterns = {
+        str(item.get("pattern"))
+        for item in all_order
+        if isinstance(item, dict) and isinstance(item.get("pattern"), str)
+    }
+
+    candidate_doc = read_text(PATTERN_DOC)
+    doc_lines = candidate_doc.splitlines()
+    for pattern_name in ALL_ORDER_PATTERN_NAMES:
+        if pattern_name not in all_order_patterns:
+            fail(f"metadata should list {pattern_name} under notable_all_order_obstructions")
+        if pattern_name not in by_name:
+            fail(f"pattern catalog is missing {pattern_name}")
+
+        row = by_name[pattern_name]
+        status = str(row.get("status", ""))
+        trust = str(row.get("trust", ""))
+        if STALE_PATTERN_CATALOG_RE.search(status):
+            fail(f"pattern catalog has stale live/survivor wording for {pattern_name}")
+        if not ALL_ORDER_OBSTRUCTION_RE.search(status):
+            fail(f"pattern catalog should mark {pattern_name} as killed across all cyclic orders")
+        if trust == "INCIDENCE_PATTERN":
+            fail(f"pattern catalog trust for {pattern_name} should not remain INCIDENCE_PATTERN")
+
+        matching_lines = [line for line in doc_lines if f"`{pattern_name}`" in line]
+        if not matching_lines:
+            fail(f"{PATTERN_DOC} is missing {pattern_name}")
+        if not any(ALL_ORDER_OBSTRUCTION_RE.search(line) for line in matching_lines):
+            fail(f"{PATTERN_DOC} should mark {pattern_name} as killed across all cyclic orders")
 
 
 def validate_top_level_status() -> None:

--- a/src/erdos97/min_radius_filter.py
+++ b/src/erdos97/min_radius_filter.py
@@ -516,6 +516,8 @@ def radius_result_to_json(result: RadiusPropagationResult) -> dict[str, object]:
 
     return {
         "type": "radius_propagation_order_result",
+        "status_schema": "min_radius_filter.v1",
+        "edge_direction": "source -> target means r_source < r_target; here target is the row center",
         "pattern": result.pattern,
         "n": int(result.n),
         "order": [int(label) for label in result.order],

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -26,6 +26,7 @@ import dataclasses
 import json
 import math
 import time
+from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
@@ -44,6 +45,9 @@ class PatternInfo:
     family: str = ""
     formula: str = ""
     notes: str = ""
+    status: str = ""
+    trust: str = ""
+    lifecycle: str = ""
     source_pattern_name: str = ""
     cyclic_order: Optional[List[int]] = None
 
@@ -181,9 +185,44 @@ def relabel_pattern_by_cyclic_order(
         notes=(
             f"Relabelled from {pat.name} so supplied cyclic order is natural."
         ),
+        status=pat.status,
+        trust=pat.trust,
+        lifecycle=pat.lifecycle,
         source_pattern_name=pat.name,
         cyclic_order=list(order),
     )
+
+
+def _catalog_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "data" / "patterns" / "candidate_patterns.json"
+
+
+def _apply_catalog_metadata(patterns: Dict[str, PatternInfo]) -> None:
+    """Decorate built-in patterns with source-of-truth catalog metadata when available."""
+
+    path = _catalog_path()
+    try:
+        rows = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("name")
+        if not isinstance(name, str) or name not in patterns:
+            continue
+        pattern = patterns[name]
+        status = row.get("status")
+        trust = row.get("trust")
+        lifecycle = row.get("lifecycle")
+        if isinstance(status, str):
+            pattern.status = status
+        if isinstance(trust, str):
+            pattern.trust = trust
+        if isinstance(lifecycle, str):
+            pattern.lifecycle = lifecycle
 
 
 def built_in_patterns() -> Dict[str, PatternInfo]:
@@ -208,7 +247,9 @@ def built_in_patterns() -> Dict[str, PatternInfo]:
     pats.append(circulant_pattern(13, [1, 2, 4, 10], "C13_sidon_1_2_4_10"))
     pats.append(circulant_pattern(25, [2, 5, 9, 14], "C25_sidon_2_5_9_14"))
     pats.append(circulant_pattern(29, [1, 3, 7, 15], "C29_sidon_1_3_7_15"))
-    return {p.name: p for p in pats}
+    by_name = {p.name: p for p in pats}
+    _apply_catalog_metadata(by_name)
+    return by_name
 
 
 # -------------------------- geometry and diagnostics -------------------------
@@ -943,6 +984,15 @@ def main() -> None:
         for p in pats.values():
             stats = incidence_obstruction_stats(p.S)
             print(f"{p.name}: n={p.n}, family={p.family}, formula={p.formula}")
+            metadata = []
+            if p.trust:
+                metadata.append(f"trust={p.trust}")
+            if p.lifecycle:
+                metadata.append(f"lifecycle={p.lifecycle}")
+            if metadata:
+                print(f"  metadata: {', '.join(metadata)}")
+            if p.status:
+                print(f"  status: {p.status}")
             print(f"  stats: max_common={stats['max_common_selected_neighbors']}, indeg=[{stats['indegree_min']},{stats['indegree_max']}], cluster_gap_mean={stats['max_cluster_gap_mean']:.2f}")
         return
 

--- a/src/erdos97/stuck_sets.py
+++ b/src/erdos97/stuck_sets.py
@@ -108,7 +108,15 @@ class RadiusChoice:
 
 
 @dataclass(frozen=True)
-class RadiusPropagationResult:
+class StuckRadiusPropagationResult:
+    """Stuck-set radius diagnostic.
+
+    This intentionally uses center -> smaller-center edges, the reverse of the
+    min_radius_filter JSON convention. Cycle existence is unchanged by a global
+    reversal, but the serializer exposes both the local and normalized status
+    vocabulary to keep downstream artifacts auditable.
+    """
+
     n: int
     order: list[int]
     status: str
@@ -117,6 +125,9 @@ class RadiusPropagationResult:
     node_limit: int
     acyclic_choice: list[RadiusChoice] | None
     choices_by_center: list[list[RadiusChoice]]
+
+
+RadiusPropagationResult = StuckRadiusPropagationResult
 
 
 @dataclass(frozen=True)
@@ -437,7 +448,7 @@ def radius_propagation_obstruction(
     S: Pattern,
     order: Sequence[int] | None = None,
     node_limit: int = 100_000,
-) -> RadiusPropagationResult:
+) -> StuckRadiusPropagationResult:
     """Search for an acyclic assignment of short-chord radius inequalities.
 
     A strict directed cycle among selected radii is impossible.  The filter is
@@ -522,7 +533,7 @@ def radius_propagation_obstruction(
         obstructed = True
         acyclic_choice = None
 
-    return RadiusPropagationResult(
+    return StuckRadiusPropagationResult(
         n=n,
         order=order,
         status=status,
@@ -534,14 +545,25 @@ def radius_propagation_obstruction(
     )
 
 
-def radius_result_to_json(result: RadiusPropagationResult) -> dict[str, object]:
+def _normalized_radius_status(status: str) -> str:
+    return {
+        "PASS_ACYCLIC_CHOICE": "PASS_RADIUS_PROPAGATION",
+        "UNKNOWN_NODE_LIMIT": "UNKNOWN_RADIUS_PROPAGATION_NODE_LIMIT",
+        "RADIUS_CYCLE_OBSTRUCTED": "EXACT_RADIUS_PROPAGATION_OBSTRUCTION",
+    }.get(status, status)
+
+
+def radius_result_to_json(result: StuckRadiusPropagationResult) -> dict[str, object]:
     """Return a JSON-serializable radius propagation result."""
 
     return {
-        "type": "radius_propagation_short_chord_result",
+        "type": "stuck_radius_propagation_short_chord_result",
+        "status_schema": "stuck_sets.v1",
+        "edge_direction": "center -> smaller_center means r_smaller_center < r_center",
         "n": result.n,
         "order": result.order,
         "status": result.status,
+        "radius_propagation_status": _normalized_radius_status(result.status),
         "obstructed": result.obstructed,
         "explored_nodes": result.explored_nodes,
         "node_limit": result.node_limit,
@@ -749,6 +771,8 @@ def radius_choice_optimization_to_json(
 
     return {
         "type": "radius_choice_edge_optimization_result",
+        "status_schema": "stuck_sets.radius_choice_optimization.v1",
+        "edge_direction": "center -> smaller_center means r_smaller_center < r_center",
         "n": result.n,
         "order": result.order,
         "objective": result.objective,

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -44,3 +44,33 @@ def test_manifest_rejects_mismatched_expected_json(tmp_path: Path) -> None:
     errors = validate_manifest(manifest)
 
     assert any("'status' is 'BAD', expected 'GOOD'" in error for error in errors)
+
+
+def test_manifest_rejects_ambiguous_review_forbidden_claim(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    artifact.write_text(json.dumps({"status": "GOOD"}), encoding="utf-8")
+    generator.write_text("print('ok')\n", encoding="utf-8")
+    manifest = {
+        "schema": "erdos97.generated_artifacts.v1",
+        "claim_scope": "test manifest only",
+        "artifacts": [
+            {
+                "id": "sample",
+                "path": str(artifact),
+                "kind": "test",
+                "generator": str(generator),
+                "command": f"python {generator}",
+                "direct_edit_allowed": False,
+                "provenance_mode": "manifest_only_legacy",
+                "trust": "EXACT_OBSTRUCTION",
+                "claim_scope": "test artifact only",
+                "json_top_level_type": "object",
+                "forbidden_claims": ["independent external review"],
+            }
+        ],
+    }
+
+    errors = validate_manifest(manifest)
+
+    assert any("ambiguous" in error for error in errors)

--- a/tests/test_check_status_consistency.py
+++ b/tests/test_check_status_consistency.py
@@ -94,3 +94,13 @@ def test_official_status_freshness_can_fail() -> None:
         assert exc.code == 1
     else:  # pragma: no cover
         raise AssertionError("freshness check should fail")
+
+
+def test_pattern_catalog_all_order_status_is_distinct_from_stale_live_wording() -> None:
+    checker = load_checker()
+
+    current = "abstract-incidence status: exactly killed across all cyclic orders by a certificate"
+    stale = "abstract-incidence status across all cyclic orders remains live/unresolved"
+
+    assert checker.ALL_ORDER_OBSTRUCTION_RE.search(current)
+    assert checker.STALE_PATTERN_CATALOG_RE.search(stale)

--- a/tests/test_min_radius_filter.py
+++ b/tests/test_min_radius_filter.py
@@ -4,6 +4,7 @@ from erdos97.min_radius_filter import (
     covered_witness_path_orders,
     minimum_radius_order_obstruction,
     radius_propagation_order_obstruction,
+    radius_result_to_json,
     row_is_order_free_blocked,
     row_has_order_free_empty_gap,
     selected_pair_sources,
@@ -27,6 +28,9 @@ def test_min_radius_filter_kills_all_other_pentagon_pattern() -> None:
     assert propagation.status == "EXACT_RADIUS_PROPAGATION_OBSTRUCTION"
     assert propagation.obstructed is True
     assert propagation.acyclic_choice is None
+    payload = radius_result_to_json(propagation)
+    assert payload["status_schema"] == "min_radius_filter.v1"
+    assert payload["edge_direction"] == "source -> target means r_source < r_target; here target is the row center"
 
 
 def test_min_radius_filter_c19_survives_natural_order() -> None:

--- a/tests/test_sidon_patterns.py
+++ b/tests/test_sidon_patterns.py
@@ -76,6 +76,15 @@ def test_catalog_json_contains_sidon_entries() -> None:
         assert name in names
 
 
+def test_catalog_metadata_decorates_built_in_patterns() -> None:
+    pats = built_in_patterns()
+
+    assert pats["C13_sidon_1_2_4_10"].trust == "EXACT_OBSTRUCTION"
+    assert pats["C13_sidon_1_2_4_10"].lifecycle == "retired_all_order_obstruction"
+    assert "exactly killed across all cyclic orders" in pats["C13_sidon_1_2_4_10"].status
+    assert pats["C29_sidon_1_3_7_15"].lifecycle == "fixed_order_diagnostic"
+
+
 def test_relabel_pattern_by_cyclic_order_preserves_fixed_order_filters() -> None:
     pat = built_in_patterns()["C13_sidon_1_2_4_10"]
     order = [5, 0, 10, 8, 9, 7, 4, 6, 2, 11, 12, 3, 1]

--- a/tests/test_stuck_sets.py
+++ b/tests/test_stuck_sets.py
@@ -10,6 +10,7 @@ from erdos97.stuck_sets import (
     optimize_radius_choice_edges,
     pattern_filter_snapshot,
     radius_propagation_obstruction,
+    radius_result_to_json,
     radius_choice_optimization_to_json,
     result_to_json,
 )
@@ -77,6 +78,7 @@ def test_all_other_pentagon_has_complete_no_stuck_certificate() -> None:
     result = find_minimal_stuck_sets(S)
     shifted = find_minimal_stuck_sets(S, min_size=5)
     radius = radius_propagation_obstruction(S)
+    radius_payload = radius_result_to_json(radius)
     fragile = fragile_cover_snapshot(S)
 
     assert not result.found
@@ -85,6 +87,9 @@ def test_all_other_pentagon_has_complete_no_stuck_certificate() -> None:
     assert shifted.search_complete
     assert shifted.key_peeling_ok is None
     assert radius.obstructed is True
+    assert radius_payload["type"] == "stuck_radius_propagation_short_chord_result"
+    assert radius_payload["radius_propagation_status"] == "EXACT_RADIUS_PROPAGATION_OBSTRUCTION"
+    assert radius_payload["edge_direction"] == "center -> smaller_center means r_smaller_center < r_center"
     assert fragile["cover_stats"]["cover_exists"] is True
     assert fragile["cover_stats"]["min_cover_size"] == 2
 


### PR DESCRIPTION
## Summary

- update `data/patterns/candidate_patterns.json` so C19/C13 match the current all-order obstruction status, and refresh C25/C29 fixed-order diagnostic wording
- add status-consistency checks so the pattern catalog cannot drift from metadata and docs again
- surface pattern catalog `trust`, `status`, and `lifecycle` in `erdos97-search --list-patterns`
- clarify radius-propagation result schemas and certificate directory conventions
- reject ambiguous generated-artifact forbidden-claim wording around independent review

## Root Cause

The canonical prose and metadata had been updated after later Kalmanson certificates, but the machine-readable pattern catalog and a few diagnostic surfaces still used older live/survivor wording.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`251 passed, 19 deselected`)
- `python scripts/check_altman_diagonal_sums.py --json`
- `python -m erdos97.search --list-patterns`