### PR TITLE
Wire n10 singleton draft into artifact checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: verify-lint verify-fast verify-n8 verify-kalmanson verify-n9-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-n8 verify-kalmanson verify-n9-review verify-n10-review verify-artifacts audit-artifacts verify-all
 
 verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
@@ -27,7 +27,10 @@ verify-kalmanson:
 verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 
-verify-artifacts: verify-n8 verify-kalmanson verify-n9-review
+verify-n10-review:
+	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+
+verify-artifacts: verify-n8 verify-kalmanson verify-n9-review verify-n10-review
 
 audit-artifacts:
 	$(PYTHON) scripts/check_status_consistency.py --max-official-status-age-days 90

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
 ```
 
 Useful exploratory commands:

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -51,6 +51,7 @@ python scripts/analyze_n8_exact_survivors.py --check --json \
   --check-compatible-orders-data data/incidence/n8_compatible_orders.json \
   --check-exact-analysis-data certificates/n8_exact_analysis.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
 ```
 
 The independent incidence JSON checker validates the 15 stored survivor
@@ -77,3 +78,8 @@ The `n=9` vertex-circle exhaustive checker is review-pending. It is faster than
 the fresh `n=8` incidence enumeration on the current machine, but it is still a
 full replay and should be reviewed before it changes the source-of-truth local
 finite-case status.
+
+The `n=10` singleton-slice checker is a draft review-pending artifact check.
+The command above validates the imported counts and reruns row0 singleton `0`
+with the repo-native generic checker; it is not a full repo-native replay of
+all 126 singleton slices and does not promote `n=10`.

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -90,6 +90,19 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=("python", "scripts/check_n9_vertex_circle_exhaustive.py", "--assert-expected", "--json"),
         claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",
     ),
+    AuditCommand(
+        ident="n10_vertex_circle_singleton_draft",
+        command=(
+            "python",
+            "scripts/check_n10_vertex_circle_singletons.py",
+            "--assert-expected",
+            "--spot-check-generic",
+        ),
+        claim_scope=(
+            "Draft review-pending n=10 singleton-slice artifact spot-check; "
+            "not a source-of-truth finite-case result or official/global status update."
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

- Add `verify-n10-review` and include the draft n10 singleton-slice check in `verify-artifacts`.
- Add the same n10 draft check to the artifact audit command list with explicit non-promotion scope.
- Document the command in the README and reproduction log, including that it is not a full repo-native replay and does not promote `n=10`.

## Verification

- `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic`
- `python -m pytest tests/test_n10_vertex_circle_singletons.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`260 passed, 19 deselected`)

`make verify-n10-review` could not be run in the local PowerShell environment because `make` is not installed; the target's underlying command was run directly and passed.

## Review

A read-only review agent checked the diff for overclaiming, Make/audit wiring, docs drift, and promotion risk. No findings. Residual risk: this remains a draft n10 artifact spot-check, not a source-of-truth finite-case result and not a global status update.