### PR TITLE
Validate interval verifier parameters

### DIFF
--- a/src/erdos97/interval_verify.py
+++ b/src/erdos97/interval_verify.py
@@ -254,6 +254,38 @@ def classify_float_result(
     return "uncertified"
 
 
+def malformed_result(message: str) -> dict[str, Any]:
+    """Return the standard malformed-input result shape."""
+
+    return {
+        "ok": False,
+        "failure_mode": "malformed",
+        "validation_errors": [message],
+        "claim_strength": "MALFORMED_INPUT",
+    }
+
+
+def validate_interval_parameters(
+    *,
+    eq_bound: float,
+    coord_abs_radius: float,
+    coord_rel_radius: float,
+) -> list[str]:
+    """Return validation errors for interval verifier parameters."""
+
+    errors = []
+    for name, value in [
+        ("eq_bound", eq_bound),
+        ("coord_abs_radius", coord_abs_radius),
+        ("coord_rel_radius", coord_rel_radius),
+    ]:
+        if not math.isfinite(value):
+            errors.append(f"{name} must be finite, got {value!r}")
+        elif value < 0.0:
+            errors.append(f"{name} must be nonnegative, got {value!r}")
+    return errors
+
+
 def verify_interval_json(
     path: str | Path,
     *,
@@ -261,6 +293,14 @@ def verify_interval_json(
     coord_abs_radius: float = 1e-12,
     coord_rel_radius: float = 1e-12,
 ) -> dict[str, Any]:
+    parameter_errors = validate_interval_parameters(
+        eq_bound=eq_bound,
+        coord_abs_radius=coord_abs_radius,
+        coord_rel_radius=coord_rel_radius,
+    )
+    if parameter_errors:
+        return malformed_result("; ".join(parameter_errors))
+
     data = load_candidate(path)
     try:
         S = parse_pattern(data)
@@ -271,12 +311,7 @@ def verify_interval_json(
             else parse_float_coordinates(data)
         )
     except (KeyError, TypeError, ValueError) as exc:
-        return {
-            "ok": False,
-            "failure_mode": "malformed",
-            "validation_errors": [str(exc)],
-            "claim_strength": "MALFORMED_INPUT",
-        }
+        return malformed_result(str(exc))
 
     validation_errors = validate_candidate_shape(raw_coordinates, S)
     if validation_errors:

--- a/tests/test_interval_verify.py
+++ b/tests/test_interval_verify.py
@@ -30,6 +30,25 @@ def test_b12_near_miss_is_not_interval_certified() -> None:
     assert "counterexample to Erdos Problem #97" in result["does_not_claim"]
 
 
+def test_negative_interval_parameters_are_malformed() -> None:
+    result = verify_interval_json(B12, coord_abs_radius=-1e-12, coord_rel_radius=0.0)
+
+    assert result["ok"] is False
+    assert result["failure_mode"] == "malformed"
+    assert result["claim_strength"] == "MALFORMED_INPUT"
+    assert "coord_abs_radius must be nonnegative" in result["validation_errors"][0]
+
+
+def test_wider_coordinate_radius_documents_uncertified_convexity() -> None:
+    result = verify_interval_json(B12, coord_abs_radius=1e-6, coord_rel_radius=0.0)
+
+    assert result["ok"] is False
+    assert result["failure_mode"] == "uncertified"
+    assert result["convexity_certified"] is False
+    assert result["claim_strength"] == "NUMERICAL_EVIDENCE_OR_NEAR_MISS_NOT_A_COUNTEREXAMPLE"
+    assert "counterexample to Erdos Problem #97" in result["does_not_claim"]
+
+
 def test_malformed_candidate_is_reported(tmp_path: Path) -> None:
     candidate = tmp_path / "bad.json"
     write_candidate(candidate, [[0.0, 0.0], [1.0, 0.0]], [[1, 1, 1, 1], [0, 0, 0, 0]])
@@ -97,3 +116,26 @@ def test_interval_verify_cli_check_rejects_b12() -> None:
     assert result.returncode == 1
     payload = json.loads(result.stdout)
     assert payload["failure_mode"] == "floating_near_miss"
+
+
+def test_interval_verify_cli_reports_negative_radius_as_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/interval_verify_candidate.py",
+            str(B12),
+            "--coord-abs-radius=-1e-12",
+            "--coord-rel-radius",
+            "0",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["failure_mode"] == "malformed"
+    assert payload["claim_strength"] == "MALFORMED_INPUT"


### PR DESCRIPTION
## Summary

- Add structured malformed-input handling for negative or non-finite interval verifier radii/bounds.
- Preserve the existing no-counterexample posture for widened-radius B12 near misses by documenting the uncertified convexity path in tests.
- Add CLI coverage showing invalid interval parameters are reported as JSON instead of raising an implementation exception.

## Validation

- `python -m pytest tests/test_interval_verify.py tests/test_search_hygiene.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Review

Local review agent found no findings. This PR does not claim a proof or counterexample; malformed inputs remain separated from uncertified numerical near-misses.