### PR TITLE
Add n9 base-apex escape-budget diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ verify-kalmanson:
 verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
 
 verify-n10-review:
 	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic

--- a/data/certificates/n9_base_apex_escape_budget_report.json
+++ b/data/certificates/n9_base_apex_escape_budget_report.json
@@ -1,0 +1,1202 @@
+{
+  "base_apex_slack": 9,
+  "capacity_deficit_distribution": [
+    {
+      "capacity_deficit": 0,
+      "profile_ledger_count": 29,
+      "total_profile_excess": 9
+    },
+    {
+      "capacity_deficit": 1,
+      "profile_ledger_count": 21,
+      "total_profile_excess": 8
+    },
+    {
+      "capacity_deficit": 2,
+      "profile_ledger_count": 15,
+      "total_profile_excess": 7
+    },
+    {
+      "capacity_deficit": 3,
+      "profile_ledger_count": 11,
+      "total_profile_excess": 6
+    },
+    {
+      "capacity_deficit": 4,
+      "profile_ledger_count": 7,
+      "total_profile_excess": 5
+    },
+    {
+      "capacity_deficit": 5,
+      "profile_ledger_count": 5,
+      "total_profile_excess": 4
+    },
+    {
+      "capacity_deficit": 6,
+      "profile_ledger_count": 3,
+      "total_profile_excess": 3
+    },
+    {
+      "capacity_deficit": 7,
+      "profile_ledger_count": 2,
+      "total_profile_excess": 2
+    },
+    {
+      "capacity_deficit": 8,
+      "profile_ledger_count": 1,
+      "total_profile_excess": 1
+    },
+    {
+      "capacity_deficit": 9,
+      "profile_ledger_count": 1,
+      "total_profile_excess": 0
+    }
+  ],
+  "claim_scope": "Focused n=9 base-apex escape-budget bookkeeping; not a proof of n=9, not a counterexample, and not a global status update.",
+  "interpretation": [
+    "Capacity deficit D is the total unused base-apex capacity in E + D = 9.",
+    "Relevant deficits are only deficits placed on length-2 or length-3 bases.",
+    "Extra budget not spent on relevant deficits is not assigned to sides or length-4 bases here.",
+    "The counts are finite turn-cover escape bookkeeping, not geometric realizability counts.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/explore_n9_base_apex.py --escape-budget-report --out data/certificates/n9_base_apex_escape_budget_report.json",
+    "generator": "scripts/explore_n9_base_apex.py"
+  },
+  "relevant_cyclic_lengths": [
+    2,
+    3
+  ],
+  "schema": "erdos97.n9_base_apex_escape_budget_report.v1",
+  "status": "EXPLORATORY_LEDGER_ONLY",
+  "strict_positive_threshold": {
+    "budget_rows": [
+      {
+        "available_relevant_deficit_counts": [],
+        "can_spoil_turn_cover_with_relevant_deficits": false,
+        "capacity_deficit_budget": 0,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {},
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {},
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {},
+        "minimum_relevant_deficit_count_to_spoil": null,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": null,
+        "unresolved_profile_ledger_count_at_budget": 0
+      },
+      {
+        "available_relevant_deficit_counts": [],
+        "can_spoil_turn_cover_with_relevant_deficits": false,
+        "capacity_deficit_budget": 1,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {},
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {},
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {},
+        "minimum_relevant_deficit_count_to_spoil": null,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": null,
+        "unresolved_profile_ledger_count_at_budget": 0
+      },
+      {
+        "available_relevant_deficit_counts": [],
+        "can_spoil_turn_cover_with_relevant_deficits": false,
+        "capacity_deficit_budget": 2,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {},
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {},
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {},
+        "minimum_relevant_deficit_count_to_spoil": null,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": null,
+        "unresolved_profile_ledger_count_at_budget": 0
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 3,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 0,
+        "unresolved_profile_ledger_count_at_budget": 11
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3,
+          4
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 4,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8,
+          "4": 80
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108,
+          "4": 1278
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          },
+          "4": {
+            "1": 72,
+            "2": 1206
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 1,
+        "unresolved_profile_ledger_count_at_budget": 7
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3,
+          4,
+          5
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 5,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8,
+          "4": 80,
+          "5": 354
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108,
+          "4": 1278,
+          "5": 6030
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          },
+          "4": {
+            "1": 72,
+            "2": 1206
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 2,
+        "unresolved_profile_ledger_count_at_budget": 5
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3,
+          4,
+          5,
+          6
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 6,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8,
+          "4": 80,
+          "5": 354,
+          "6": 951
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108,
+          "4": 1278,
+          "5": 6030,
+          "6": 16449
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          },
+          "4": {
+            "1": 72,
+            "2": 1206
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 3,
+        "unresolved_profile_ledger_count_at_budget": 3
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 7,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8,
+          "4": 80,
+          "5": 354,
+          "6": 951,
+          "7": 1762
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108,
+          "4": 1278,
+          "5": 6030,
+          "6": 16449,
+          "7": 30798
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          },
+          "4": {
+            "1": 72,
+            "2": 1206
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584
+          },
+          "7": {
+            "0": 2088,
+            "1": 15372,
+            "2": 13338
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564,
+          "7": 31824
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 4,
+        "unresolved_profile_ledger_count_at_budget": 2
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 8,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8,
+          "4": 80,
+          "5": 354,
+          "6": 951,
+          "7": 1762,
+          "8": 2478
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108,
+          "4": 1278,
+          "5": 6030,
+          "6": 16449,
+          "7": 30798,
+          "8": 43488
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          },
+          "4": {
+            "1": 72,
+            "2": 1206
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584
+          },
+          "7": {
+            "0": 2088,
+            "1": 15372,
+            "2": 13338
+          },
+          "8": {
+            "0": 7146,
+            "1": 25758,
+            "2": 10584
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564,
+          "7": 31824,
+          "8": 43758
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 5,
+        "unresolved_profile_ledger_count_at_budget": 1
+      },
+      {
+        "available_relevant_deficit_counts": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 9,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "3": 8,
+          "4": 80,
+          "5": 354,
+          "6": 951,
+          "7": 1762,
+          "8": 2478,
+          "9": 2771
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "3": 108,
+          "4": 1278,
+          "5": 6030,
+          "6": 16449,
+          "7": 30798,
+          "8": 43488,
+          "9": 48590
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "3": {
+            "2": 108
+          },
+          "4": {
+            "1": 72,
+            "2": 1206
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584
+          },
+          "7": {
+            "0": 2088,
+            "1": 15372,
+            "2": 13338
+          },
+          "8": {
+            "0": 7146,
+            "1": 25758,
+            "2": 10584
+          },
+          "9": {
+            "0": 14984,
+            "1": 28206,
+            "2": 5400
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 3,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564,
+          "7": 31824,
+          "8": 43758,
+          "9": 48620
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 6,
+        "unresolved_profile_ledger_count_at_budget": 1
+      }
+    ],
+    "contradiction_threshold": 3,
+    "minimum_escape_motif_classes": [
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 18,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 4,
+        "spoiled_length2": [
+          0,
+          2
+        ],
+        "spoiled_length3": [
+          3
+        ]
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 4,
+        "spoiled_length2": [
+          0,
+          2
+        ],
+        "spoiled_length3": [
+          5
+        ]
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 4,
+        "spoiled_length2": [
+          0,
+          3
+        ],
+        "spoiled_length3": [
+          1
+        ]
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 18,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 4,
+        "spoiled_length2": [
+          0,
+          4
+        ],
+        "spoiled_length3": [
+          5
+        ]
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 18,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 4,
+        "spoiled_length2": [
+          0,
+          1,
+          3
+        ],
+        "spoiled_length3": []
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 4,
+        "spoiled_length2": [
+          0,
+          1,
+          5
+        ],
+        "spoiled_length3": []
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 3,
+        "spoiled_length2": [
+          0,
+          2,
+          4
+        ],
+        "spoiled_length3": []
+      },
+      {
+        "contradiction_threshold": 3,
+        "n": 9,
+        "placement_count": 18,
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 2,
+        "remaining_turn_clause_count": 3,
+        "spoiled_length2": [
+          0,
+          2,
+          5
+        ],
+        "spoiled_length3": []
+      }
+    ],
+    "minimum_relevant_deficit_count_to_spoil": 3
+  },
+  "sum_exceeds_threshold": {
+    "budget_rows": [
+      {
+        "available_relevant_deficit_counts": [],
+        "can_spoil_turn_cover_with_relevant_deficits": false,
+        "capacity_deficit_budget": 0,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {},
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {},
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {},
+        "minimum_relevant_deficit_count_to_spoil": null,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": null,
+        "unresolved_profile_ledger_count_at_budget": 0
+      },
+      {
+        "available_relevant_deficit_counts": [],
+        "can_spoil_turn_cover_with_relevant_deficits": false,
+        "capacity_deficit_budget": 1,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {},
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {},
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {},
+        "minimum_relevant_deficit_count_to_spoil": null,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": null,
+        "unresolved_profile_ledger_count_at_budget": 0
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 2,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 0,
+        "unresolved_profile_ledger_count_at_budget": 15
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 3,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 1,
+        "unresolved_profile_ledger_count_at_budget": 11
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3,
+          4
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 4,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44,
+          "4": 179
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672,
+          "4": 2934
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          },
+          "4": {
+            "1": 72,
+            "2": 1206,
+            "3": 1656
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 2,
+        "unresolved_profile_ledger_count_at_budget": 7
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3,
+          4,
+          5
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 5,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44,
+          "4": 179,
+          "5": 500
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672,
+          "4": 2934,
+          "5": 8514
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          },
+          "4": {
+            "1": 72,
+            "2": 1206,
+            "3": 1656
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968,
+            "3": 2484
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 3,
+        "unresolved_profile_ledger_count_at_budget": 5
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 6,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44,
+          "4": 179,
+          "5": 500,
+          "6": 1074
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672,
+          "4": 2934,
+          "5": 8514,
+          "6": 18555
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          },
+          "4": {
+            "1": 72,
+            "2": 1206,
+            "3": 1656
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968,
+            "3": 2484
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584,
+            "3": 2106
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 4,
+        "unresolved_profile_ledger_count_at_budget": 3
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 7,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44,
+          "4": 179,
+          "5": 500,
+          "6": 1074,
+          "7": 1824
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672,
+          "4": 2934,
+          "5": 8514,
+          "6": 18555,
+          "7": 31824
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          },
+          "4": {
+            "1": 72,
+            "2": 1206,
+            "3": 1656
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968,
+            "3": 2484
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584,
+            "3": 2106
+          },
+          "7": {
+            "0": 2088,
+            "1": 15372,
+            "2": 13338,
+            "3": 1026
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564,
+          "7": 31824
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 5,
+        "unresolved_profile_ledger_count_at_budget": 2
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 8,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44,
+          "4": 179,
+          "5": 500,
+          "6": 1074,
+          "7": 1824,
+          "8": 2494
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672,
+          "4": 2934,
+          "5": 8514,
+          "6": 18555,
+          "7": 31824,
+          "8": 43758
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          },
+          "4": {
+            "1": 72,
+            "2": 1206,
+            "3": 1656
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968,
+            "3": 2484
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584,
+            "3": 2106
+          },
+          "7": {
+            "0": 2088,
+            "1": 15372,
+            "2": 13338,
+            "3": 1026
+          },
+          "8": {
+            "0": 7146,
+            "1": 25758,
+            "2": 10584,
+            "3": 270
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564,
+          "7": 31824,
+          "8": 43758
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 6,
+        "unresolved_profile_ledger_count_at_budget": 1
+      },
+      {
+        "available_relevant_deficit_counts": [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        "can_spoil_turn_cover_with_relevant_deficits": true,
+        "capacity_deficit_budget": 9,
+        "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+          "2": 6,
+          "3": 44,
+          "4": 179,
+          "5": 500,
+          "6": 1074,
+          "7": 1824,
+          "8": 2494,
+          "9": 2774
+        },
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+          "2": 72,
+          "3": 672,
+          "4": 2934,
+          "5": 8514,
+          "6": 18555,
+          "7": 31824,
+          "8": 43758,
+          "9": 48620
+        },
+        "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+          "2": {
+            "3": 72
+          },
+          "3": {
+            "2": 108,
+            "3": 564
+          },
+          "4": {
+            "1": 72,
+            "2": 1206,
+            "3": 1656
+          },
+          "5": {
+            "0": 18,
+            "1": 1044,
+            "2": 4968,
+            "3": 2484
+          },
+          "6": {
+            "0": 321,
+            "1": 5544,
+            "2": 10584,
+            "3": 2106
+          },
+          "7": {
+            "0": 2088,
+            "1": 15372,
+            "2": 13338,
+            "3": 1026
+          },
+          "8": {
+            "0": 7146,
+            "1": 25758,
+            "2": 10584,
+            "3": 270
+          },
+          "9": {
+            "0": 14984,
+            "1": 28206,
+            "2": 5400,
+            "3": 30
+          }
+        },
+        "minimum_relevant_deficit_count_to_spoil": 2,
+        "total_relevant_placement_count_by_relevant_deficit": {
+          "0": 1,
+          "1": 18,
+          "2": 153,
+          "3": 816,
+          "4": 3060,
+          "5": 8568,
+          "6": 18564,
+          "7": 31824,
+          "8": 43758,
+          "9": 48620
+        },
+        "unassigned_capacity_after_minimum_relevant_escape": 7,
+        "unresolved_profile_ledger_count_at_budget": 1
+      }
+    ],
+    "contradiction_threshold": 4,
+    "minimum_escape_motif_classes": [
+      {
+        "contradiction_threshold": 4,
+        "n": 9,
+        "placement_count": 18,
+        "relevant_deficit_count": 2,
+        "remaining_minimum_forced_turns": 3,
+        "remaining_turn_clause_count": 6,
+        "spoiled_length2": [
+          0
+        ],
+        "spoiled_length3": [
+          1
+        ]
+      },
+      {
+        "contradiction_threshold": 4,
+        "n": 9,
+        "placement_count": 18,
+        "relevant_deficit_count": 2,
+        "remaining_minimum_forced_turns": 3,
+        "remaining_turn_clause_count": 6,
+        "spoiled_length2": [
+          0
+        ],
+        "spoiled_length3": [
+          3
+        ]
+      },
+      {
+        "contradiction_threshold": 4,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 2,
+        "remaining_minimum_forced_turns": 3,
+        "remaining_turn_clause_count": 6,
+        "spoiled_length2": [
+          0,
+          1
+        ],
+        "spoiled_length3": []
+      },
+      {
+        "contradiction_threshold": 4,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 2,
+        "remaining_minimum_forced_turns": 3,
+        "remaining_turn_clause_count": 5,
+        "spoiled_length2": [
+          0,
+          2
+        ],
+        "spoiled_length3": []
+      },
+      {
+        "contradiction_threshold": 4,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 2,
+        "remaining_minimum_forced_turns": 3,
+        "remaining_turn_clause_count": 5,
+        "spoiled_length2": [
+          0,
+          3
+        ],
+        "spoiled_length3": []
+      },
+      {
+        "contradiction_threshold": 4,
+        "n": 9,
+        "placement_count": 9,
+        "relevant_deficit_count": 2,
+        "remaining_minimum_forced_turns": 3,
+        "remaining_turn_clause_count": 5,
+        "spoiled_length2": [
+          0,
+          4
+        ],
+        "spoiled_length3": []
+      }
+    ],
+    "minimum_relevant_deficit_count_to_spoil": 2
+  },
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+  "witness_size": 4
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -75,6 +75,7 @@ Commands:
 ```bash
 python scripts/explore_n9_base_apex.py
 python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+python scripts/check_n9_base_apex_escape_budget.py --check --json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 ```
 
@@ -82,6 +83,9 @@ Expected artifacts:
 
 - `data/certificates/n9_base_apex_low_excess_ledgers.json`, or an updated
   successor JSON/Markdown report listing which low-excess ledgers remain;
+- optional successor diagnostics such as
+  `data/certificates/n9_base_apex_escape_budget_report.json` that keep escape
+  placement counts separate from geometric realizability;
 - checker updates that independently replay generated ledger arithmetic and
   motif counts from stored JSON.
 

--- a/docs/n9-base-apex-frontier.md
+++ b/docs/n9-base-apex-frontier.md
@@ -88,6 +88,8 @@ python scripts/explore_n9_base_apex.py --turn-cover
 python scripts/explore_n9_base_apex.py --motifs
 python scripts/explore_n9_base_apex.py --low-excess-report --out data/certificates/n9_base_apex_low_excess_ledgers.json
 python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+python scripts/explore_n9_base_apex.py --escape-budget-report --out data/certificates/n9_base_apex_escape_budget_report.json
+python scripts/check_n9_base_apex_escape_budget.py --check --json
 ```
 
 The focused generated report
@@ -97,6 +99,19 @@ the minimum relevant length-2/length-3 deficit motif classes. It is
 `FINITE_BOOKKEEPING_NOT_A_PROOF`, not a claim that `n=9` is closed. The
 checker command independently replays the partition table, ledger arithmetic,
 turn-cover summaries, and minimum escape motif classes from the stored JSON.
+
+The companion generated report
+`data/certificates/n9_base_apex_escape_budget_report.json` records a coarser
+budget map for the same diagnostic. For each capacity-deficit budget `D`, it
+counts how many labelled and dihedral placements of `r <= D` relevant deficits
+on length-2 and length-3 bases can escape the current turn-cover closure. It
+also records the total number `binom(18,r)` of such relevant placements, so the
+escaping counts are visibly scoped to the two cyclic base families used by this
+turn-cover mechanism.
+
+This is still only bookkeeping. The report does not place any remaining budget
+on sides or length-4 diagonals, does not test geometric realizability of the
+escape placements, and does not close `n = 9`.
 
 ## Turn-cover diagnostic
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -261,6 +261,37 @@ artifacts:
       strict_unresolved_profile_ledger_count: 30
     forbidden_claims:
       - n=9 is proved
+      - geometric realizability count
+      - counterexample
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
+  - id: n9_base_apex_escape_budget_report
+    path: data/certificates/n9_base_apex_escape_budget_report.json
+    kind: exploratory_ledger_artifact
+    generator: scripts/explore_n9_base_apex.py
+    command: python scripts/explore_n9_base_apex.py --escape-budget-report --out data/certificates/n9_base_apex_escape_budget_report.json
+    checker: scripts/check_n9_base_apex_escape_budget.py
+    check_command: python scripts/check_n9_base_apex_escape_budget.py --check --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Focused n=9 base-apex escape-budget bookkeeping; not a proof of n=9, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_base_apex_escape_budget_report.v1
+      status: EXPLORATORY_LEDGER_ONLY
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      claim_scope: Focused n=9 base-apex escape-budget bookkeeping; not a proof of n=9, not a counterexample, and not a global status update.
+      n: 9
+      witness_size: 4
+      base_apex_slack: 9
+      provenance.command: python scripts/explore_n9_base_apex.py --escape-budget-report --out data/certificates/n9_base_apex_escape_budget_report.json
+      strict_positive_threshold.minimum_relevant_deficit_count_to_spoil: 3
+      sum_exceeds_threshold.minimum_relevant_deficit_count_to_spoil: 2
+    forbidden_claims:
+      - n=9 is proved
       - official/global status update
       - general proof of Erdos Problem #97
 

--- a/scripts/check_n9_base_apex_escape_budget.py
+++ b/scripts/check_n9_base_apex_escape_budget.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""Independently validate the n=9 base-apex escape-budget artifact."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+import sys
+from collections import Counter
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_base_apex_escape_budget_report.json"
+EXPECTED_TOP_LEVEL_KEYS = {
+    "base_apex_slack",
+    "capacity_deficit_distribution",
+    "claim_scope",
+    "interpretation",
+    "n",
+    "provenance",
+    "relevant_cyclic_lengths",
+    "schema",
+    "status",
+    "strict_positive_threshold",
+    "sum_exceeds_threshold",
+    "trust",
+    "witness_size",
+}
+EXPECTED_CLAIM_SCOPE = (
+    "Focused n=9 base-apex escape-budget bookkeeping; not a proof of n=9, "
+    "not a counterexample, and not a global status update."
+)
+EXPECTED_INTERPRETATION = [
+    "Capacity deficit D is the total unused base-apex capacity in E + D = 9.",
+    "Relevant deficits are only deficits placed on length-2 or length-3 bases.",
+    "Extra budget not spent on relevant deficits is not assigned to sides or length-4 bases here.",
+    "The counts are finite turn-cover escape bookkeeping, not geometric realizability counts.",
+    "No proof of the n=9 case is claimed.",
+]
+EXPECTED_PROVENANCE = {
+    "generator": "scripts/explore_n9_base_apex.py",
+    "command": (
+        "python scripts/explore_n9_base_apex.py --escape-budget-report "
+        "--out data/certificates/n9_base_apex_escape_budget_report.json"
+    ),
+}
+
+
+def binom2(value: int) -> int:
+    """Return binom(value, 2)."""
+
+    if value < 0:
+        raise ValueError(f"value must be nonnegative, got {value}")
+    return value * (value - 1) // 2
+
+
+def integer_partitions(total: int, minimum: int = 1) -> Iterable[tuple[int, ...]]:
+    """Yield nondecreasing positive integer partitions of total."""
+
+    if total < 0:
+        raise ValueError(f"total must be nonnegative, got {total}")
+    if total == 0:
+        yield ()
+        return
+    for first in range(minimum, total + 1):
+        for rest in integer_partitions(total - first, first):
+            yield (first, *rest)
+
+
+def distance_profiles(n: int, witness_size: int) -> list[tuple[int, tuple[int, ...]]]:
+    """Return independently enumerated profile-excess rows."""
+
+    baseline = binom2(witness_size)
+    rows = []
+    for ascending_parts in integer_partitions(n - 1):
+        parts = tuple(reversed(ascending_parts))
+        if max(parts, default=0) < witness_size:
+            continue
+        excess = sum(binom2(part) for part in parts) - baseline
+        rows.append((excess, parts))
+    return sorted(rows, key=lambda row: (row[0], row[1]))
+
+
+def base_apex_slack(n: int, witness_size: int) -> int:
+    """Return the upper-minus-baseline base-apex slack."""
+
+    return n * (n - 2) - binom2(witness_size) * n
+
+
+def excess_distributions(
+    n: int,
+    witness_size: int,
+) -> list[tuple[tuple[int, ...], int, int]]:
+    """Return sorted unlabeled profile-excess distributions within slack."""
+
+    slack = base_apex_slack(n, witness_size)
+    values = [
+        excess
+        for excess, _parts in distance_profiles(n, witness_size)
+        if excess <= slack
+    ]
+    out: list[tuple[tuple[int, ...], int, int]] = []
+
+    def search(start_index: int, slots_left: int, remaining: int, current: list[int]) -> None:
+        if slots_left == 0:
+            total = sum(current)
+            out.append((tuple(current), total, slack - total))
+            return
+        for index in range(start_index, len(values)):
+            value = values[index]
+            if value > remaining:
+                break
+            current.append(value)
+            search(index, slots_left - 1, remaining - value, current)
+            current.pop()
+
+    search(0, n, slack, [])
+    return sorted(out, key=lambda row: (row[1], row[0]))
+
+
+def capacity_deficit_distribution(n: int, witness_size: int) -> list[dict[str, int]]:
+    """Return profile-ledger counts by capacity deficit."""
+
+    slack = base_apex_slack(n, witness_size)
+    counts = Counter(deficit for _excesses, _total, deficit in excess_distributions(n, witness_size))
+    return [
+        {
+            "capacity_deficit": deficit,
+            "total_profile_excess": slack - deficit,
+            "profile_ledger_count": counts[deficit],
+        }
+        for deficit in range(slack + 1)
+    ]
+
+
+def turn_clauses_from_saturation(
+    n: int,
+    saturated_length2: Iterable[int],
+    saturated_length3: Iterable[int],
+) -> tuple[tuple[int, int], ...]:
+    """Return turn-cover clauses forced by length-2 and length-3 saturation."""
+
+    saturated2 = {index % n for index in saturated_length2}
+    saturated3 = {index % n for index in saturated_length3}
+    clauses = []
+    for index in range(n):
+        if index in saturated3 and index in saturated2 and (index + 1) % n in saturated2:
+            clauses.append(((index + 1) % n, (index + 2) % n))
+    return tuple(clauses)
+
+
+def minimum_turn_hitting_set_size(
+    n: int,
+    clauses: Iterable[tuple[int, int]],
+) -> int:
+    """Return the minimum number of turns hitting all two-turn clauses."""
+
+    clause_tuple = tuple(clauses)
+    if not clause_tuple:
+        return 0
+    for size in range(n + 1):
+        for selected in itertools.combinations(range(n), size):
+            selected_set = set(selected)
+            if all(left in selected_set or right in selected_set for left, right in clause_tuple):
+                return size
+    raise RuntimeError("no hitting set found")
+
+
+def turn_cover_diagnostic(
+    n: int,
+    *,
+    spoiled_length2: Iterable[int] = (),
+    spoiled_length3: Iterable[int] = (),
+    contradiction_threshold: int,
+) -> dict[str, Any]:
+    """Return the independent turn-cover diagnostic for spoiled bases."""
+
+    all_indices = set(range(n))
+    saturated_length2 = tuple(sorted(all_indices - {idx % n for idx in spoiled_length2}))
+    saturated_length3 = tuple(sorted(all_indices - {idx % n for idx in spoiled_length3}))
+    clauses = turn_clauses_from_saturation(n, saturated_length2, saturated_length3)
+    minimum_forced_turns = minimum_turn_hitting_set_size(n, clauses)
+    return {
+        "turn_clauses": clauses,
+        "minimum_forced_turns": minimum_forced_turns,
+        "forces_turn_contradiction": minimum_forced_turns >= contradiction_threshold,
+    }
+
+
+@lru_cache(maxsize=None)
+def minimum_capacity_deficit_to_escape_turn_cover(
+    n: int,
+    *,
+    contradiction_threshold: int,
+) -> int:
+    """Return the least relevant deficit escaping the turn-cover diagnostic."""
+
+    masks_by_size: dict[int, list[tuple[int, ...]]] = {size: [] for size in range(n + 1)}
+    for mask in range(1 << n):
+        spoiled = tuple(index for index in range(n) if (mask >> index) & 1)
+        masks_by_size[len(spoiled)].append(spoiled)
+
+    for cost in range(2 * n + 1):
+        for cost2 in range(max(0, cost - n), min(n, cost) + 1):
+            cost3 = cost - cost2
+            for spoiled2 in masks_by_size[cost2]:
+                for spoiled3 in masks_by_size[cost3]:
+                    diagnostic = turn_cover_diagnostic(
+                        n,
+                        spoiled_length2=spoiled2,
+                        spoiled_length3=spoiled3,
+                        contradiction_threshold=contradiction_threshold,
+                    )
+                    if not diagnostic["forces_turn_contradiction"]:
+                        return cost
+    raise RuntimeError("no escaping deficit pattern found")
+
+
+def transform_base_index(
+    n: int,
+    index: int,
+    cyclic_length: int,
+    *,
+    rotation: int,
+    reflected: bool,
+) -> int:
+    """Transform a cyclic base index under a dihedral relabeling."""
+
+    if reflected:
+        return (rotation - index - cyclic_length) % n
+    return (index + rotation) % n
+
+
+def canonical_deficit_placement(
+    n: int,
+    spoiled_length2: Iterable[int],
+    spoiled_length3: Iterable[int],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return a dihedral canonical key for spoiled length-2/length-3 bases."""
+
+    spoiled2 = tuple(spoiled_length2)
+    spoiled3 = tuple(spoiled_length3)
+    keys = []
+    for rotation in range(n):
+        for reflected in (False, True):
+            keys.append(
+                (
+                    tuple(
+                        sorted(
+                            transform_base_index(
+                                n,
+                                index,
+                                2,
+                                rotation=rotation,
+                                reflected=reflected,
+                            )
+                            for index in spoiled2
+                        )
+                    ),
+                    tuple(
+                        sorted(
+                            transform_base_index(
+                                n,
+                                index,
+                                3,
+                                rotation=rotation,
+                                reflected=reflected,
+                            )
+                            for index in spoiled3
+                        )
+                    ),
+                )
+            )
+    return min(keys)
+
+
+def deficit_placement_classes(
+    n: int,
+    *,
+    relevant_deficit_count: int,
+    contradiction_threshold: int,
+) -> list[dict[str, Any]]:
+    """Return escaping deficit-placement classes up to dihedral symmetry."""
+
+    grouped: Counter[tuple[tuple[int, ...], tuple[int, ...]]] = Counter()
+    for count2 in range(max(0, relevant_deficit_count - n), min(n, relevant_deficit_count) + 1):
+        count3 = relevant_deficit_count - count2
+        for spoiled2 in itertools.combinations(range(n), count2):
+            for spoiled3 in itertools.combinations(range(n), count3):
+                diagnostic = turn_cover_diagnostic(
+                    n,
+                    spoiled_length2=spoiled2,
+                    spoiled_length3=spoiled3,
+                    contradiction_threshold=contradiction_threshold,
+                )
+                if diagnostic["forces_turn_contradiction"]:
+                    continue
+                grouped[canonical_deficit_placement(n, spoiled2, spoiled3)] += 1
+
+    out = []
+    for (spoiled2, spoiled3), placement_count in grouped.items():
+        diagnostic = turn_cover_diagnostic(
+            n,
+            spoiled_length2=spoiled2,
+            spoiled_length3=spoiled3,
+            contradiction_threshold=contradiction_threshold,
+        )
+        out.append(
+            {
+                "contradiction_threshold": contradiction_threshold,
+                "n": n,
+                "placement_count": placement_count,
+                "relevant_deficit_count": relevant_deficit_count,
+                "remaining_minimum_forced_turns": diagnostic["minimum_forced_turns"],
+                "remaining_turn_clause_count": len(diagnostic["turn_clauses"]),
+                "spoiled_length2": list(spoiled2),
+                "spoiled_length3": list(spoiled3),
+            }
+        )
+    return sorted(
+        out,
+        key=lambda row: (
+            len(row["spoiled_length2"]),
+            row["spoiled_length2"],
+            row["spoiled_length3"],
+        ),
+    )
+
+
+def escape_relevant_deficit_counts(
+    n: int,
+    *,
+    relevant_deficit_count: int,
+    contradiction_threshold: int,
+) -> dict[str, Any]:
+    """Return aggregate escape counts for a relevant deficit count."""
+
+    classes = deficit_placement_classes(
+        n,
+        relevant_deficit_count=relevant_deficit_count,
+        contradiction_threshold=contradiction_threshold,
+    )
+    remaining_counts: Counter[int] = Counter()
+    for row in classes:
+        remaining_counts[int(row["remaining_minimum_forced_turns"])] += int(row["placement_count"])
+    return {
+        "total_relevant_placement_count": math.comb(2 * n, relevant_deficit_count),
+        "labelled_placement_count": sum(int(row["placement_count"]) for row in classes),
+        "dihedral_class_count": len(classes),
+        "remaining_minimum_forced_turn_count": {
+            str(turns): remaining_counts[turns]
+            for turns in sorted(remaining_counts)
+        },
+    }
+
+
+def budget_rows(
+    n: int,
+    witness_size: int,
+    *,
+    contradiction_threshold: int,
+) -> list[dict[str, Any]]:
+    """Return independently recomputed escape-budget rows."""
+
+    slack = base_apex_slack(n, witness_size)
+    minimum_escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    )
+    unresolved_counts = Counter(
+        deficit
+        for _excesses, _total, deficit in excess_distributions(n, witness_size)
+        if deficit >= minimum_escape
+    )
+    counts_by_relevant_deficit = {
+        relevant_deficit_count: escape_relevant_deficit_counts(
+            n,
+            relevant_deficit_count=relevant_deficit_count,
+            contradiction_threshold=contradiction_threshold,
+        )
+        for relevant_deficit_count in range(slack + 1)
+    }
+
+    rows = []
+    for capacity_budget in range(slack + 1):
+        available_counts = [
+            relevant_deficit_count
+            for relevant_deficit_count in range(capacity_budget + 1)
+            if counts_by_relevant_deficit[relevant_deficit_count]["labelled_placement_count"] > 0
+        ]
+        rows.append(
+            {
+                "available_relevant_deficit_counts": available_counts,
+                "can_spoil_turn_cover_with_relevant_deficits": bool(available_counts),
+                "capacity_deficit_budget": capacity_budget,
+                "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["dihedral_class_count"]
+                    for relevant_deficit_count in available_counts
+                },
+                "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["labelled_placement_count"]
+                    for relevant_deficit_count in available_counts
+                },
+                "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["remaining_minimum_forced_turn_count"]
+                    for relevant_deficit_count in available_counts
+                },
+                "minimum_relevant_deficit_count_to_spoil": (
+                    min(available_counts) if available_counts else None
+                ),
+                "total_relevant_placement_count_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["total_relevant_placement_count"]
+                    for relevant_deficit_count in range(capacity_budget + 1)
+                },
+                "unassigned_capacity_after_minimum_relevant_escape": (
+                    capacity_budget - minimum_escape
+                    if available_counts
+                    else None
+                ),
+                "unresolved_profile_ledger_count_at_budget": unresolved_counts[
+                    capacity_budget
+                ],
+            }
+        )
+    return rows
+
+
+def escape_budget_section(
+    n: int,
+    witness_size: int,
+    *,
+    contradiction_threshold: int,
+) -> dict[str, Any]:
+    """Return one independently recomputed threshold section."""
+
+    minimum_escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    )
+    return {
+        "budget_rows": budget_rows(
+            n,
+            witness_size,
+            contradiction_threshold=contradiction_threshold,
+        ),
+        "contradiction_threshold": contradiction_threshold,
+        "minimum_escape_motif_classes": deficit_placement_classes(
+            n,
+            relevant_deficit_count=minimum_escape,
+            contradiction_threshold=contradiction_threshold,
+        ),
+        "minimum_relevant_deficit_count_to_spoil": minimum_escape,
+    }
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a compact mismatch error."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def validate_payload(payload: Any) -> list[str]:
+    """Return validation errors for a loaded escape-budget artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    top_level_keys = set(payload)
+    if top_level_keys != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(top_level_keys)!r}"
+        )
+
+    expected_meta = {
+        "schema": "erdos97.n9_base_apex_escape_budget_report.v1",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "n": 9,
+        "witness_size": 4,
+        "base_apex_slack": 9,
+        "relevant_cyclic_lengths": [2, 3],
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    n = payload.get("n")
+    witness_size = payload.get("witness_size")
+    if not isinstance(n, int) or not isinstance(witness_size, int):
+        return errors + ["artifact must contain integer n and witness_size"]
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str):
+        errors.append("claim_scope must be a string")
+    else:
+        expect_equal(errors, "claim_scope", claim_scope, EXPECTED_CLAIM_SCOPE)
+        lowered = claim_scope.lower()
+        for phrase in ("not a proof", "not a counterexample", "not a global status update"):
+            if phrase not in lowered:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    interpretation = payload.get("interpretation")
+    expect_equal(errors, "interpretation", interpretation, EXPECTED_INTERPRETATION)
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, dict):
+        errors.append("provenance must be an object")
+    else:
+        expect_equal(errors, "provenance", provenance, EXPECTED_PROVENANCE)
+
+    expect_equal(
+        errors,
+        "capacity_deficit_distribution",
+        payload.get("capacity_deficit_distribution"),
+        capacity_deficit_distribution(n, witness_size),
+    )
+    expect_equal(
+        errors,
+        "strict_positive_threshold",
+        payload.get("strict_positive_threshold"),
+        escape_budget_section(n, witness_size, contradiction_threshold=3),
+    )
+    expect_equal(
+        errors,
+        "sum_exceeds_threshold",
+        payload.get("sum_exceeds_threshold"),
+        escape_budget_section(n, witness_size, contradiction_threshold=4),
+    )
+    return errors
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repo-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    strict = object_payload.get("strict_positive_threshold", {})
+    conservative = object_payload.get("sum_exceeds_threshold", {})
+    return {
+        "ok": not errors,
+        "artifact": display_path(path),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "n": object_payload.get("n"),
+        "witness_size": object_payload.get("witness_size"),
+        "strict_minimum_relevant_deficit_count_to_spoil": (
+            strict.get("minimum_relevant_deficit_count_to_spoil")
+            if isinstance(strict, dict)
+            else None
+        ),
+        "conservative_minimum_relevant_deficit_count_to_spoil": (
+            conservative.get("minimum_relevant_deficit_count_to_spoil")
+            if isinstance(conservative, dict)
+            else None
+        ),
+        "strict_minimum_escape_motif_class_count": (
+            len(strict.get("minimum_escape_motif_classes", []))
+            if isinstance(strict, dict)
+            else None
+        ),
+        "conservative_minimum_escape_motif_class_count": (
+            len(conservative.get("minimum_escape_motif_classes", []))
+            if isinstance(conservative, dict)
+            else None
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="fail if validation fails")
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 base-apex escape-budget artifact")
+        print(f"artifact: {summary['artifact']}")
+        print(
+            "minimum relevant deficits: "
+            f"strict={summary['strict_minimum_relevant_deficit_count_to_spoil']}, "
+            f"conservative={summary['conservative_minimum_relevant_deficit_count_to_spoil']}"
+        )
+        print(
+            "minimum escape motif classes: "
+            f"strict={summary['strict_minimum_escape_motif_class_count']}, "
+            f"conservative={summary['conservative_minimum_escape_motif_class_count']}"
+        )
+        if args.check:
+            print("OK: independent escape-budget checks passed")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/explore_n9_base_apex.py
+++ b/scripts/explore_n9_base_apex.py
@@ -17,6 +17,7 @@ if str(SRC) not in sys.path:
 from erdos97.n9_base_apex import (  # noqa: E402
     distance_profiles,
     deficit_placement_classes,
+    escape_budget_report,
     excess_distributions,
     guaranteed_full_bases,
     ledger_summary,
@@ -37,7 +38,7 @@ def emit_json(payload: object, out: Path | None = None) -> None:
         return
     path = out if out.is_absolute() else ROOT / out
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    path.write_text(text, encoding="utf-8", newline="\n")
 
 
 def main() -> int:
@@ -48,6 +49,11 @@ def main() -> int:
         "--low-excess-report",
         action="store_true",
         help="emit the focused low-excess unresolved-ledger report",
+    )
+    parser.add_argument(
+        "--escape-budget-report",
+        action="store_true",
+        help="emit the focused turn-cover escape-budget report",
     )
     parser.add_argument(
         "--out",
@@ -83,6 +89,9 @@ def main() -> int:
 
     if args.low_excess_report:
         emit_json(low_excess_ledger_report(), args.out)
+        return 0
+    if args.escape_budget_report:
+        emit_json(escape_budget_report(), args.out)
         return 0
 
     payload = ledger_summary()

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -91,6 +91,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",
     ),
     AuditCommand(
+        ident="n9_base_apex_low_excess_ledgers",
+        command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
+        claim_scope=(
+            "Exploratory n=9 base-apex low-excess bookkeeping; "
+            "not a proof of n=9 or official/global status update."
+        ),
+    ),
+    AuditCommand(
+        ident="n9_base_apex_escape_budget",
+        command=("python", "scripts/check_n9_base_apex_escape_budget.py", "--check", "--json"),
+        claim_scope=(
+            "Exploratory n=9 base-apex escape-budget bookkeeping; "
+            "not a proof of n=9, counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/src/erdos97/n9_base_apex.py
+++ b/src/erdos97/n9_base_apex.py
@@ -8,6 +8,7 @@ claim a proof of the n=9 case.
 from __future__ import annotations
 
 import itertools
+import math
 from collections import Counter
 from dataclasses import dataclass
 from functools import lru_cache
@@ -574,6 +575,213 @@ def minimum_escape_motif_summary(
             }
             for row in classes
         ],
+    }
+
+
+@lru_cache(maxsize=None)
+def escape_relevant_deficit_counts(
+    n: int = 9,
+    *,
+    relevant_deficit_count: int,
+    contradiction_threshold: int = 3,
+) -> dict[str, object]:
+    """Count relevant length-2/length-3 deficit placements that escape.
+
+    The count is only over deficits placed on length-2 and length-3 bases,
+    because those are the bases used by the turn-cover diagnostic. A total
+    capacity deficit budget may be larger than this relevant count; any extra
+    deficit is not assigned by this bookkeeping row.
+    """
+
+    classes = deficit_placement_classes(
+        n,
+        relevant_deficit_count=relevant_deficit_count,
+        contradiction_threshold=contradiction_threshold,
+    )
+    remaining_forced_counts: Counter[int] = Counter()
+    for row in classes:
+        remaining_forced_counts[row.remaining_minimum_forced_turns] += row.placement_count
+    return {
+        "total_relevant_placement_count": math.comb(2 * n, relevant_deficit_count),
+        "labelled_placement_count": sum(row.placement_count for row in classes),
+        "dihedral_class_count": len(classes),
+        "remaining_minimum_forced_turn_count": {
+            str(forced_turns): remaining_forced_counts[forced_turns]
+            for forced_turns in sorted(remaining_forced_counts)
+        },
+    }
+
+
+def escape_budget_rows(
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    contradiction_threshold: int = 3,
+) -> list[dict[str, object]]:
+    """Summarize relevant deficit escape counts available under each budget."""
+
+    slack = base_apex_slack(n, witness_size)
+    minimum_escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    ).minimum_capacity_deficit
+    unresolved = profile_ledger_cases(
+        n,
+        witness_size,
+        contradiction_threshold=contradiction_threshold,
+        forced_by_turn_cover=False,
+    )
+    unresolved_counts = Counter(row.capacity_deficit for row in unresolved)
+    counts_by_relevant_deficit = {
+        relevant_deficit_count: escape_relevant_deficit_counts(
+            n,
+            relevant_deficit_count=relevant_deficit_count,
+            contradiction_threshold=contradiction_threshold,
+        )
+        for relevant_deficit_count in range(slack + 1)
+    }
+
+    rows = []
+    for capacity_deficit_budget in range(slack + 1):
+        available_counts = [
+            relevant_deficit_count
+            for relevant_deficit_count in range(capacity_deficit_budget + 1)
+            if counts_by_relevant_deficit[relevant_deficit_count][
+                "labelled_placement_count"
+            ]
+            > 0
+        ]
+        rows.append(
+            {
+                "capacity_deficit_budget": capacity_deficit_budget,
+                "unresolved_profile_ledger_count_at_budget": unresolved_counts[
+                    capacity_deficit_budget
+                ],
+                "can_spoil_turn_cover_with_relevant_deficits": bool(
+                    available_counts
+                ),
+                "unassigned_capacity_after_minimum_relevant_escape": (
+                    capacity_deficit_budget - minimum_escape
+                    if available_counts
+                    else None
+                ),
+                "minimum_relevant_deficit_count_to_spoil": (
+                    min(available_counts) if available_counts else None
+                ),
+                "available_relevant_deficit_counts": available_counts,
+                "escaping_labelled_relevant_placement_count_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["labelled_placement_count"]
+                    for relevant_deficit_count in available_counts
+                },
+                "total_relevant_placement_count_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["total_relevant_placement_count"]
+                    for relevant_deficit_count in range(capacity_deficit_budget + 1)
+                },
+                "escaping_dihedral_relevant_class_count_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["dihedral_class_count"]
+                    for relevant_deficit_count in available_counts
+                },
+                "escaping_remaining_forced_turn_counts_by_relevant_deficit": {
+                    str(relevant_deficit_count): counts_by_relevant_deficit[
+                        relevant_deficit_count
+                    ]["remaining_minimum_forced_turn_count"]
+                    for relevant_deficit_count in available_counts
+                },
+            }
+        )
+    return rows
+
+
+def escape_budget_section(
+    n: int = 9,
+    witness_size: int = 4,
+    *,
+    contradiction_threshold: int = 3,
+) -> dict[str, object]:
+    """Return one threshold section for the escape-budget report."""
+
+    escape = minimum_capacity_deficit_to_escape_turn_cover(
+        n,
+        contradiction_threshold=contradiction_threshold,
+    )
+    return {
+        "contradiction_threshold": contradiction_threshold,
+        "minimum_relevant_deficit_count_to_spoil": (
+            escape.minimum_capacity_deficit
+        ),
+        "budget_rows": escape_budget_rows(
+            n,
+            witness_size,
+            contradiction_threshold=contradiction_threshold,
+        ),
+        "minimum_escape_motif_classes": [
+            deficit_placement_payload(row)
+            for row in deficit_placement_classes(
+                n,
+                relevant_deficit_count=escape.minimum_capacity_deficit,
+                contradiction_threshold=contradiction_threshold,
+            )
+        ],
+    }
+
+
+def escape_budget_report(n: int = 9, witness_size: int = 4) -> dict[str, object]:
+    """Return the focused escape-budget report for n=9 base-apex ledgers."""
+
+    slack = base_apex_slack(n, witness_size)
+    distribution_counts = Counter(
+        row.capacity_deficit for row in excess_distributions(n, witness_size)
+    )
+    return {
+        "schema": "erdos97.n9_base_apex_escape_budget_report.v1",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "claim_scope": (
+            "Focused n=9 base-apex escape-budget bookkeeping; not a proof of "
+            "n=9, not a counterexample, and not a global status update."
+        ),
+        "n": n,
+        "witness_size": witness_size,
+        "base_apex_slack": slack,
+        "relevant_cyclic_lengths": [2, 3],
+        "capacity_deficit_distribution": [
+            {
+                "capacity_deficit": capacity_deficit,
+                "total_profile_excess": slack - capacity_deficit,
+                "profile_ledger_count": distribution_counts[capacity_deficit],
+            }
+            for capacity_deficit in range(slack + 1)
+        ],
+        "strict_positive_threshold": escape_budget_section(
+            n,
+            witness_size,
+            contradiction_threshold=3,
+        ),
+        "sum_exceeds_threshold": escape_budget_section(
+            n,
+            witness_size,
+            contradiction_threshold=4,
+        ),
+        "interpretation": [
+            "Capacity deficit D is the total unused base-apex capacity in E + D = 9.",
+            "Relevant deficits are only deficits placed on length-2 or length-3 bases.",
+            "Extra budget not spent on relevant deficits is not assigned to sides or length-4 bases here.",
+            "The counts are finite turn-cover escape bookkeeping, not geometric realizability counts.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/explore_n9_base_apex.py",
+            "command": (
+                "python scripts/explore_n9_base_apex.py --escape-budget-report "
+                "--out data/certificates/n9_base_apex_escape_budget_report.json"
+            ),
+        },
     }
 
 

--- a/tests/test_n9_base_apex.py
+++ b/tests/test_n9_base_apex.py
@@ -10,6 +10,7 @@ from erdos97.n9_base_apex import (
     cyclic_base_families,
     deficit_placement_classes,
     distance_profiles,
+    escape_budget_report,
     excess_distributions,
     guaranteed_full_bases,
     ledger_summary,
@@ -274,6 +275,59 @@ def test_low_excess_ledger_report_records_unresolved_counts() -> None:
     assert "No proof of the n=9 case is claimed." in report["notes"]
 
 
+def test_escape_budget_report_records_budget_compatible_escape_counts() -> None:
+    report = escape_budget_report()
+
+    assert report["schema"] == "erdos97.n9_base_apex_escape_budget_report.v1"
+    assert report["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert report["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert report["relevant_cyclic_lengths"] == [2, 3]
+    assert report["capacity_deficit_distribution"] == [
+        {"capacity_deficit": 0, "profile_ledger_count": 29, "total_profile_excess": 9},
+        {"capacity_deficit": 1, "profile_ledger_count": 21, "total_profile_excess": 8},
+        {"capacity_deficit": 2, "profile_ledger_count": 15, "total_profile_excess": 7},
+        {"capacity_deficit": 3, "profile_ledger_count": 11, "total_profile_excess": 6},
+        {"capacity_deficit": 4, "profile_ledger_count": 7, "total_profile_excess": 5},
+        {"capacity_deficit": 5, "profile_ledger_count": 5, "total_profile_excess": 4},
+        {"capacity_deficit": 6, "profile_ledger_count": 3, "total_profile_excess": 3},
+        {"capacity_deficit": 7, "profile_ledger_count": 2, "total_profile_excess": 2},
+        {"capacity_deficit": 8, "profile_ledger_count": 1, "total_profile_excess": 1},
+        {"capacity_deficit": 9, "profile_ledger_count": 1, "total_profile_excess": 0},
+    ]
+
+    strict = report["strict_positive_threshold"]
+    strict_rows = strict["budget_rows"]
+    assert strict["minimum_relevant_deficit_count_to_spoil"] == 3
+    assert strict_rows[2]["can_spoil_turn_cover_with_relevant_deficits"] is False
+    assert strict_rows[3]["minimum_relevant_deficit_count_to_spoil"] == 3
+    assert strict_rows[3]["unassigned_capacity_after_minimum_relevant_escape"] == 0
+    assert strict_rows[3]["unresolved_profile_ledger_count_at_budget"] == 11
+    assert strict_rows[3]["total_relevant_placement_count_by_relevant_deficit"]["3"] == 816
+    assert (
+        strict_rows[3]["escaping_labelled_relevant_placement_count_by_relevant_deficit"]["3"]
+        == 108
+    )
+    assert strict_rows[9]["escaping_dihedral_relevant_class_count_by_relevant_deficit"]["9"] == 2771
+    assert (
+        strict_rows[9]["escaping_labelled_relevant_placement_count_by_relevant_deficit"]["9"]
+        == 48590
+    )
+    assert len(strict["minimum_escape_motif_classes"]) == 8
+
+    conservative = report["sum_exceeds_threshold"]
+    conservative_rows = conservative["budget_rows"]
+    assert conservative["minimum_relevant_deficit_count_to_spoil"] == 2
+    assert conservative_rows[1]["can_spoil_turn_cover_with_relevant_deficits"] is False
+    assert conservative_rows[2]["minimum_relevant_deficit_count_to_spoil"] == 2
+    assert conservative_rows[2]["unresolved_profile_ledger_count_at_budget"] == 15
+    assert (
+        conservative_rows[2]["escaping_labelled_relevant_placement_count_by_relevant_deficit"]["2"]
+        == 72
+    )
+    assert len(conservative["minimum_escape_motif_classes"]) == 6
+    assert "No proof of the n=9 case is claimed." in report["interpretation"]
+
+
 def test_checked_low_excess_ledger_artifact_matches_generator() -> None:
     repo = Path(__file__).resolve().parents[1]
     artifact = repo / "data" / "certificates" / "n9_base_apex_low_excess_ledgers.json"
@@ -281,3 +335,12 @@ def test_checked_low_excess_ledger_artifact_matches_generator() -> None:
     payload = json.loads(artifact.read_text(encoding="utf-8"))
 
     assert payload == low_excess_ledger_report()
+
+
+def test_checked_escape_budget_artifact_matches_generator() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    artifact = repo / "data" / "certificates" / "n9_base_apex_escape_budget_report.json"
+
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+
+    assert payload == escape_budget_report()

--- a/tests/test_n9_base_apex_escape_budget.py
+++ b/tests/test_n9_base_apex_escape_budget.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_n9_base_apex_escape_budget import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_escape_budget_artifact_passes_independent_checker() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload)
+
+    assert errors == []
+
+
+def test_escape_budget_checker_summary_is_nonclaiming() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert summary["ok"] is True
+    assert summary["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert summary["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert summary["strict_minimum_relevant_deficit_count_to_spoil"] == 3
+    assert summary["conservative_minimum_relevant_deficit_count_to_spoil"] == 2
+    assert summary["strict_minimum_escape_motif_class_count"] == 8
+    assert summary["conservative_minimum_escape_motif_class_count"] == 6
+
+
+def test_escape_budget_checker_rejects_tampered_escape_count() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["strict_positive_threshold"]["budget_rows"][3][
+        "escaping_labelled_relevant_placement_count_by_relevant_deficit"
+    ]["3"] = 109
+
+    errors = validate_payload(payload)
+
+    assert any("strict_positive_threshold" in error for error in errors)
+
+
+def test_escape_budget_checker_rejects_unknown_top_level_key() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["unchecked_schema_drift"] = {"ok": False}
+
+    errors = validate_payload(payload)
+
+    assert any("top-level keys" in error for error in errors)
+
+
+def test_escape_budget_checker_rejects_tampered_provenance_command() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["provenance"]["command"] = "python scripts/explore_n9_base_apex.py --escape-budget-report"
+
+    errors = validate_payload(payload)
+
+    assert any("provenance" in error for error in errors)
+
+
+def test_escape_budget_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_base_apex_escape_budget.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["strict_minimum_relevant_deficit_count_to_spoil"] == 3

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from scripts.run_artifact_audit import AuditCommand, run_audit_command, sha256_bytes
+from scripts.run_artifact_audit import AUDIT_COMMANDS, AuditCommand, command_text, run_audit_command, sha256_bytes
 
 
 def test_sha256_bytes_is_stable() -> None:
@@ -26,3 +26,13 @@ def test_run_audit_command_records_metadata(tmp_path: Path) -> None:
     assert (tmp_path / record["stdout_path"]).read_bytes() == b"ok\n"
     assert (tmp_path / record["stderr_path"]).read_bytes() == b""
     assert len(record["combined_output_sha256"]) == 64
+
+
+def test_audit_commands_include_n9_base_apex_ledgers() -> None:
+    command_texts = {command_text(command.command) for command in AUDIT_COMMANDS}
+
+    assert (
+        "python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json"
+        in command_texts
+    )
+    assert "python scripts/check_n9_base_apex_escape_budget.py --check --json" in command_texts


### PR DESCRIPTION
## Summary
- add a generated n=9 base-apex escape-budget report for length-2/length-3 turn-cover deficits
- add an independent checker that recomputes partition ledgers, turn-cover escape counts, dihedral classes, and provenance/schema guardrails
- document the diagnostic scope and register it in the generated-artifact manifest and n9 review target

## Scope
This is finite bookkeeping only. It counts relevant length-2/length-3 deficit placements that can escape the current turn-cover diagnostic, and it explicitly does not count geometric realizability, claim a counterexample, close n=9, or update the official/global status.

## Validation
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_n9_base_apex.py tests/test_n9_base_apex_low_excess_ledgers.py tests/test_n9_base_apex_escape_budget.py -q`
- `python -m pytest -q`
- raw artifact tier because `make` is unavailable in this shell:
  - `python scripts/independent_check_n8_artifacts.py --check --json`
  - `python scripts/enumerate_n8_incidence.py --summary`
  - `python scripts/analyze_n8_exact_survivors.py --check --json`
  - `python scripts/check_round2_certificates.py`
  - `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
  - `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
  - `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
  - `python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json`
  - `python scripts/check_n9_base_apex_escape_budget.py --check --json`
  - `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic`