### PR TITLE
Add C19 Z3 clause diagnostic

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -37,6 +37,9 @@ Expected artifacts:
 - a reproducible diagnostic script or update to an existing report generator;
 - a checked JSON or Markdown report summarizing support groups, smaller
   dependencies, or negative results.
+- optional all-order Z3 clause-template diagnostics such as
+  `reports/c19_kalmanson_z3_clause_diagnostics.json`, kept separate from the
+  underlying SMT replay certificate.
 
 Acceptance criteria:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,10 +47,11 @@ put detailed reconciliation in the canonical synthesis.
   Kalmanson/Farkas certificate for the registered non-natural C13 Sidon order.
 - [`kalmanson-certificate-diagnostics.md`](kalmanson-certificate-diagnostics.md):
   deterministic support diagnostics for the checked C13 and C19 fixed-order
-  Kalmanson/Farkas certificates.
+  Kalmanson/Farkas certificates, plus the C19 all-order Z3 clause-template
+  diagnostic.
 - [`kalmanson-two-order-search.md`](kalmanson-two-order-search.md): exact
   all-cyclic-order two-inequality Kalmanson obstruction for the fixed C13 Sidon
-  pattern.
+  and C19 skew patterns.
 - [`c13-kalmanson-order-pilot.md`](c13-kalmanson-order-pilot.md): bounded
   C13 fixed-order Kalmanson pilot over seven explicit cyclic orders; not an
   all-order search.

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -88,6 +88,33 @@ support, and this report does not derive one certificate from the other. It is
 only a fixed-order support diagnostic. The separate all-order `C19_skew` Z3
 artifact remains separate, and no global Erdos Problem #97 status changes here.
 
+## C19 Z3 Clause-Template Diagnostic
+
+The all-order C19 Z3 certificate has a separate clause-template diagnostic:
+
+```text
+reports/c19_kalmanson_z3_clause_diagnostics.json
+```
+
+Regenerate and compare it to the stored report with:
+
+```bash
+python scripts/analyze_kalmanson_z3_clauses.py \
+  --assert-expected \
+  --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
+```
+
+The report replays
+`data/certificates/c19_skew_all_orders_kalmanson_z3.json` before summarizing
+its 7,981 forbidden ordered-quadrilateral clauses. It records clause validation
+counts, inverse-pair kind counts, selected-distance quotient table counts,
+translation-template coverage, label-overlap shapes, and label-0
+rotation-quotient literal counts.
+
+This is an inspection aid for the already checked fixed abstract `C19_skew`
+all-order certificate. It is not an independent proof, not a statement about
+all C19-like patterns, and not a proof of Erdos Problem #97.
+
 ## Interpretation
 
 Safe claim:

--- a/docs/kalmanson-two-order-search.md
+++ b/docs/kalmanson-two-order-search.md
@@ -70,6 +70,32 @@ row vectors are exact inverses after selected-distance quotienting. The verifier
 checks every clause against the inverse-vector table and then asks Z3 to prove
 that the accumulated exact cyclic-order constraints are unsatisfiable.
 
+The companion clause-template diagnostic is:
+
+```text
+reports/c19_kalmanson_z3_clause_diagnostics.json
+```
+
+Regenerate and check it with:
+
+```bash
+python scripts/analyze_kalmanson_z3_clauses.py \
+  --assert-expected \
+  --out reports/c19_kalmanson_z3_clause_diagnostics.json
+
+python scripts/analyze_kalmanson_z3_clauses.py \
+  --assert-expected \
+  --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
+```
+
+The diagnostic first replays the source Z3 certificate, then summarizes the
+7,981 stored clauses by inverse-pair kind, selected-distance quotient table
+size, simultaneous cyclic-translation families, modular ordered-quad steps,
+label overlap, and label-0 rotation-quotient literals. It is a structural
+inspection aid for the fixed abstract `C19_skew` certificate only. It does not
+add a proof, search new cyclic orders, transfer the obstruction to any other
+pattern, or update the global Erdos #97 status.
+
 ## Reproduction
 
 Regenerate the artifact:

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -112,6 +112,37 @@ artifacts:
       - all sparse patterns are impossible
       - general proof of Erdos Problem #97
 
+  - id: c19_z3_clause_diagnostic
+    path: reports/c19_kalmanson_z3_clause_diagnostics.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/analyze_kalmanson_z3_clauses.py
+    command: python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --out reports/c19_kalmanson_z3_clause_diagnostics.json
+    checker: scripts/analyze_kalmanson_z3_clauses.py
+    check_command: python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: EXACT_CERTIFICATE_DIAGNOSTIC
+    claim_scope: Structural diagnostic for the checked C19_skew all-order Z3 Kalmanson certificate only.
+    json_top_level_type: object
+    expected_json:
+      type: c19_kalmanson_z3_clause_diagnostics_v1
+      trust: EXACT_CERTIFICATE_DIAGNOSTIC
+      status: ALL_ORDER_C19_Z3_CLAUSE_DIAGNOSTIC_ONLY
+      source_certificate.pattern.name: C19_skew
+      source_certificate.status: EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION
+      clause_validation_summary.solver_replay_result: unsat
+      template_summary.clause_count: 7981
+      template_summary.translation_family_count: 1946
+      distance_quotient_table_summary.unique_inverse_vector_pairs_used_by_stored_clauses: 285
+      provenance.command: python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --out reports/c19_kalmanson_z3_clause_diagnostics.json
+    forbidden_claims:
+      - C19_skew proves Erdos Problem #97
+      - all C19-like patterns are impossible
+      - all sparse patterns are impossible
+      - this closes the frontier
+      - this diagnostic is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: c19_compact_vs_legacy_diagnostic
     path: reports/c19_kalmanson_compact_vs_legacy.json
     kind: certificate_diagnostic_artifact

--- a/reports/c19_kalmanson_z3_clause_diagnostics.json
+++ b/reports/c19_kalmanson_z3_clause_diagnostics.json
@@ -1,0 +1,720 @@
+{
+  "claim_scope": "Structural diagnostic for the checked C19_skew all-order Z3 Kalmanson certificate only; not a proof of Erdos Problem #97.",
+  "clause_shape_summary": {
+    "left_right_shared_label_count_distribution": {
+      "2": 7310,
+      "3": 671
+    },
+    "raw_unique_precedence_literal_count_distribution": {
+      "5": 799,
+      "6": 7182
+    },
+    "union_label_count_distribution": {
+      "5": 671,
+      "6": 7310
+    }
+  },
+  "clause_validation_summary": {
+    "lexicographically_sorted": true,
+    "parsed_clause_count": 7981,
+    "solver_replay_result": "unsat",
+    "source_forbidden_clause_count": 7981,
+    "unique_clause_count": 7981,
+    "verified_status": "EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION",
+    "verified_trust": "SMT_EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN"
+  },
+  "distance_quotient_table_summary": {
+    "inverse_vector_pair_count": 11172,
+    "ordered_quad_table_size": 93024,
+    "selected_distance_class_count": 114,
+    "selected_distance_class_size_histogram": {
+      "1": 95,
+      "4": 19
+    },
+    "unique_inverse_vector_pairs_used_by_stored_clauses": 285,
+    "vector_id_count": 22344,
+    "vector_id_note": "Vector-id counts are deterministic for the current table builder, but individual ids are not a mathematical invariant."
+  },
+  "interpretation_note": "This report makes the stored C19_skew Z3 clause set easier to inspect. It does not add clauses, search new cyclic orders, or transfer the obstruction to any other selected-witness pattern.",
+  "label_frequencies": [
+    {
+      "clause_touch_count": 1530,
+      "label": 0,
+      "ordered_quad_occurrences": 1934
+    },
+    {
+      "clause_touch_count": 2822,
+      "label": 1,
+      "ordered_quad_occurrences": 3824
+    },
+    {
+      "clause_touch_count": 2496,
+      "label": 2,
+      "ordered_quad_occurrences": 3387
+    },
+    {
+      "clause_touch_count": 2403,
+      "label": 3,
+      "ordered_quad_occurrences": 3193
+    },
+    {
+      "clause_touch_count": 2646,
+      "label": 4,
+      "ordered_quad_occurrences": 3572
+    },
+    {
+      "clause_touch_count": 2377,
+      "label": 5,
+      "ordered_quad_occurrences": 3222
+    },
+    {
+      "clause_touch_count": 2553,
+      "label": 6,
+      "ordered_quad_occurrences": 3479
+    },
+    {
+      "clause_touch_count": 2643,
+      "label": 7,
+      "ordered_quad_occurrences": 3599
+    },
+    {
+      "clause_touch_count": 2305,
+      "label": 8,
+      "ordered_quad_occurrences": 3118
+    },
+    {
+      "clause_touch_count": 2585,
+      "label": 9,
+      "ordered_quad_occurrences": 3510
+    },
+    {
+      "clause_touch_count": 2636,
+      "label": 10,
+      "ordered_quad_occurrences": 3560
+    },
+    {
+      "clause_touch_count": 2224,
+      "label": 11,
+      "ordered_quad_occurrences": 3012
+    },
+    {
+      "clause_touch_count": 2561,
+      "label": 12,
+      "ordered_quad_occurrences": 3511
+    },
+    {
+      "clause_touch_count": 2603,
+      "label": 13,
+      "ordered_quad_occurrences": 3570
+    },
+    {
+      "clause_touch_count": 2352,
+      "label": 14,
+      "ordered_quad_occurrences": 3151
+    },
+    {
+      "clause_touch_count": 2626,
+      "label": 15,
+      "ordered_quad_occurrences": 3570
+    },
+    {
+      "clause_touch_count": 2451,
+      "label": 16,
+      "ordered_quad_occurrences": 3280
+    },
+    {
+      "clause_touch_count": 2464,
+      "label": 17,
+      "ordered_quad_occurrences": 3392
+    },
+    {
+      "clause_touch_count": 2938,
+      "label": 18,
+      "ordered_quad_occurrences": 3964
+    }
+  ],
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "The source certificate is replayed with Z3 before clause templates are summarized.",
+    "Translation families quotient simultaneous cyclic relabeling only; reversal is not quotiented.",
+    "Template frequencies are diagnostic search guidance, not a statement about all C19-like patterns."
+  ],
+  "provenance": {
+    "command": "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --out reports/c19_kalmanson_z3_clause_diagnostics.json",
+    "generator": "scripts/analyze_kalmanson_z3_clauses.py"
+  },
+  "rotation_quotient_literal_summary": {
+    "effective_literal_count_distribution": {
+      "4": 404,
+      "5": 1126,
+      "6": 6451
+    },
+    "effective_unique_literal_count_distribution": {
+      "3": 15,
+      "4": 466,
+      "5": 1734,
+      "6": 5766
+    },
+    "label0_non_first_occurrences": 0,
+    "label0_positions_inside_ordered_quads": {
+      "0": 1934
+    },
+    "quads_containing_label0_per_clause": {
+      "0": 6451,
+      "1": 1126,
+      "2": 404
+    }
+  },
+  "source_certificate": {
+    "conflict_cap": 1024,
+    "forbidden_clause_count": 7981,
+    "iterations": 142,
+    "path": "data/certificates/c19_skew_all_orders_kalmanson_z3.json",
+    "pattern": {
+      "circulant_offsets": [
+        -8,
+        -3,
+        5,
+        9
+      ],
+      "n": 19,
+      "name": "C19_skew"
+    },
+    "reversal_quotient": "none",
+    "rotation_quotient": "The cyclic order is represented with label 0 at position 0.",
+    "smt_solver": "z3",
+    "solver_result": "unsat",
+    "status": "EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION",
+    "trust": "SMT_EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
+    "type": "kalmanson_two_order_z3_refinement_v1"
+  },
+  "status": "ALL_ORDER_C19_Z3_CLAUSE_DIAGNOSTIC_ONLY",
+  "template_summary": {
+    "clause_count": 7981,
+    "inverse_kind_pair_distribution": [
+      {
+        "count": 1928,
+        "kind_pairs": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          }
+        ]
+      },
+      {
+        "count": 2061,
+        "kind_pairs": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ]
+      },
+      {
+        "count": 2092,
+        "kind_pairs": [
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          }
+        ]
+      },
+      {
+        "count": 1900,
+        "kind_pairs": [
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ]
+      }
+    ],
+    "label_clause_touch_max": 2938,
+    "label_clause_touch_min": 1530,
+    "label_ordered_quad_occurrence_max": 3964,
+    "label_ordered_quad_occurrence_min": 1934,
+    "matched_vector_support_size_distribution": {
+      "2": 7780,
+      "4": 201
+    },
+    "matches_per_clause_distribution": {
+      "1": 7981
+    },
+    "ordered_quad_count": 7535,
+    "ordered_quad_step_pattern_count": 576,
+    "ordered_quad_step_signature_count": 1946,
+    "shared_label_count_distribution": {
+      "2": 7310,
+      "3": 671
+    },
+    "translation_family_count": 1946,
+    "translation_family_coverage_histogram": {
+      "1": 198,
+      "10": 22,
+      "11": 18,
+      "12": 1,
+      "14": 2,
+      "2": 305,
+      "3": 354,
+      "4": 358,
+      "5": 266,
+      "6": 206,
+      "7": 109,
+      "8": 71,
+      "9": 36
+    }
+  },
+  "top_ordered_quad_step_patterns": [
+    {
+      "count": 62,
+      "ordered_quad_steps": [
+        11,
+        11,
+        11,
+        5
+      ]
+    },
+    {
+      "count": 60,
+      "ordered_quad_steps": [
+        5,
+        11,
+        16,
+        6
+      ]
+    },
+    {
+      "count": 57,
+      "ordered_quad_steps": [
+        11,
+        3,
+        11,
+        13
+      ]
+    },
+    {
+      "count": 57,
+      "ordered_quad_steps": [
+        11,
+        11,
+        5,
+        11
+      ]
+    },
+    {
+      "count": 55,
+      "ordered_quad_steps": [
+        8,
+        8,
+        8,
+        14
+      ]
+    },
+    {
+      "count": 55,
+      "ordered_quad_steps": [
+        11,
+        5,
+        11,
+        11
+      ]
+    },
+    {
+      "count": 53,
+      "ordered_quad_steps": [
+        6,
+        16,
+        11,
+        5
+      ]
+    },
+    {
+      "count": 53,
+      "ordered_quad_steps": [
+        12,
+        16,
+        14,
+        15
+      ]
+    },
+    {
+      "count": 52,
+      "ordered_quad_steps": [
+        3,
+        8,
+        14,
+        13
+      ]
+    },
+    {
+      "count": 51,
+      "ordered_quad_steps": [
+        13,
+        3,
+        8,
+        14
+      ]
+    },
+    {
+      "count": 51,
+      "ordered_quad_steps": [
+        15,
+        14,
+        15,
+        13
+      ]
+    },
+    {
+      "count": 50,
+      "ordered_quad_steps": [
+        14,
+        8,
+        8,
+        8
+      ]
+    }
+  ],
+  "top_ordered_quads": [
+    {
+      "count": 9,
+      "ordered_quad": [
+        0,
+        10,
+        8,
+        13
+      ]
+    },
+    {
+      "count": 9,
+      "ordered_quad": [
+        0,
+        11,
+        16,
+        8
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        0,
+        6,
+        3,
+        14
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        0,
+        8,
+        3,
+        11
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        0,
+        8,
+        10,
+        17
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        0,
+        11,
+        3,
+        8
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        0,
+        11,
+        16,
+        7
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        0,
+        13,
+        10,
+        8
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        1,
+        9,
+        11,
+        16
+      ]
+    },
+    {
+      "count": 8,
+      "ordered_quad": [
+        13,
+        18,
+        10,
+        2
+      ]
+    },
+    {
+      "count": 7,
+      "ordered_quad": [
+        0,
+        2,
+        11,
+        5
+      ]
+    },
+    {
+      "count": 7,
+      "ordered_quad": [
+        0,
+        4,
+        5,
+        9
+      ]
+    }
+  ],
+  "top_translation_families": [
+    {
+      "canonical_clause": "0,5,16,13|10,0,5,13",
+      "count": 14,
+      "ordered_quad_step_signature": [
+        [
+          5,
+          11,
+          16,
+          6
+        ],
+        [
+          9,
+          5,
+          8,
+          16
+        ]
+      ],
+      "step_signature_count": 14
+    },
+    {
+      "canonical_clause": "0,9,14,6|0,14,6,3",
+      "count": 14,
+      "ordered_quad_step_signature": [
+        [
+          9,
+          5,
+          11,
+          13
+        ],
+        [
+          14,
+          11,
+          16,
+          16
+        ]
+      ],
+      "step_signature_count": 14
+    },
+    {
+      "canonical_clause": "0,10,16,5|0,13,10,5",
+      "count": 12,
+      "ordered_quad_step_signature": [
+        [
+          10,
+          6,
+          8,
+          14
+        ],
+        [
+          13,
+          16,
+          14,
+          14
+        ]
+      ],
+      "step_signature_count": 12
+    },
+    {
+      "canonical_clause": "0,10,13,5|0,13,16,5",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          10,
+          3,
+          11,
+          14
+        ],
+        [
+          13,
+          3,
+          8,
+          14
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,10,5,16|10,5,13,16",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          10,
+          14,
+          11,
+          3
+        ],
+        [
+          14,
+          8,
+          3,
+          13
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,11,16,6|3,0,11,6",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          11,
+          5,
+          9,
+          13
+        ],
+        [
+          16,
+          11,
+          14,
+          16
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,13,3,8|0,16,13,8",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          13,
+          9,
+          5,
+          11
+        ],
+        [
+          16,
+          16,
+          14,
+          11
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,16,3,8|16,13,3,8",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          16,
+          6,
+          5,
+          11
+        ],
+        [
+          16,
+          9,
+          5,
+          8
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,3,11,16|3,11,6,16",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          3,
+          8,
+          5,
+          3
+        ],
+        [
+          8,
+          14,
+          10,
+          6
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,3,11,6|0,11,6,16",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          3,
+          8,
+          14,
+          13
+        ],
+        [
+          11,
+          14,
+          10,
+          3
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,3,13,8|16,0,13,8",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          3,
+          10,
+          14,
+          11
+        ],
+        [
+          3,
+          13,
+          14,
+          8
+        ]
+      ],
+      "step_signature_count": 11
+    },
+    {
+      "canonical_clause": "0,3,6,11|0,6,16,11",
+      "count": 11,
+      "ordered_quad_step_signature": [
+        [
+          3,
+          3,
+          5,
+          8
+        ],
+        [
+          6,
+          10,
+          14,
+          8
+        ]
+      ],
+      "step_signature_count": 11
+    }
+  ],
+  "trust": "EXACT_CERTIFICATE_DIAGNOSTIC",
+  "type": "c19_kalmanson_z3_clause_diagnostics_v1"
+}

--- a/scripts/analyze_kalmanson_z3_clauses.py
+++ b/scripts/analyze_kalmanson_z3_clauses.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""Analyze clause templates in the checked C19 all-order Z3 certificate.
+
+This diagnostic replays the stored C19_skew all-order Kalmanson SMT
+certificate, then summarizes the exact forbidden ordered-quadrilateral clauses
+by translation families, modular step patterns, kind pairs, label overlap, and
+label frequencies.
+
+It is a structural diagnostic for one already-checked fixed abstract selected
+witness pattern. It does not prove Erdos Problem #97.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_kalmanson_certificate import build_distance_classes  # noqa: E402
+from check_kalmanson_two_order_search import KINDS, _sparse_vector  # noqa: E402
+from check_kalmanson_two_order_z3 import (  # noqa: E402
+    Clause,
+    Quad,
+    _clause_key,
+    _json_clause,
+    _parse_clause,
+    _prepare_vector_tables,
+    verify_certificate,
+)
+
+
+DEFAULT_CERTIFICATE = ROOT / "data" / "certificates" / "c19_skew_all_orders_kalmanson_z3.json"
+DEFAULT_ARTIFACT = ROOT / "reports" / "c19_kalmanson_z3_clause_diagnostics.json"
+DEFAULT_COMMAND = (
+    "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected "
+    "--out reports/c19_kalmanson_z3_clause_diagnostics.json"
+)
+EXPECTED_TYPE = "c19_kalmanson_z3_clause_diagnostics_v1"
+EXPECTED_STATUS = "ALL_ORDER_C19_Z3_CLAUSE_DIAGNOSTIC_ONLY"
+EXPECTED_TRUST = "EXACT_CERTIFICATE_DIAGNOSTIC"
+
+
+def relative_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(ROOT.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def quad_steps(quad: Quad, n: int) -> tuple[int, int, int, int]:
+    """Return ordered modular label steps around a quadrilateral."""
+
+    return tuple((quad[(idx + 1) % 4] - quad[idx]) % n for idx in range(4))  # type: ignore[return-value]
+
+
+def shift_quad(quad: Quad, shift: int, n: int) -> Quad:
+    return tuple((label + shift) % n for label in quad)  # type: ignore[return-value]
+
+
+def translation_family(clause: Clause, n: int) -> Clause:
+    """Canonicalize a clause under simultaneous cyclic label translation."""
+
+    return min(
+        _clause_key(shift_quad(clause[0], shift, n), shift_quad(clause[1], shift, n))
+        for shift in range(n)
+    )
+
+
+def clause_step_signature(clause: Clause, n: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    return tuple(sorted((quad_steps(clause[0], n), quad_steps(clause[1], n))))  # type: ignore[return-value]
+
+
+def inverse_kind_pairs(
+    clause: Clause,
+    quad_ids: Mapping[Quad, tuple[int, int]],
+    inverse_id: Sequence[int],
+) -> tuple[tuple[str, str], ...]:
+    """Return kind-name pairs that make this clause a valid inverse pair."""
+
+    left_ids = quad_ids[clause[0]]
+    right_ids = quad_ids[clause[1]]
+    pairs: list[tuple[str, str]] = []
+    for left_kind, left_vector_id in enumerate(left_ids):
+        for right_kind, right_vector_id in enumerate(right_ids):
+            if inverse_id[left_vector_id] == right_vector_id:
+                pairs.append((KINDS[left_kind], KINDS[right_kind]))
+    return tuple(sorted(pairs))
+
+
+def inverse_vector_matches(
+    clause: Clause,
+    quad_ids: Mapping[Quad, tuple[int, int]],
+    inverse_id: Sequence[int],
+) -> tuple[tuple[int, int], ...]:
+    """Return vector-id pairs that justify the clause."""
+
+    left_ids = quad_ids[clause[0]]
+    right_ids = quad_ids[clause[1]]
+    matches = []
+    for left_vector_id in left_ids:
+        for right_vector_id in right_ids:
+            if inverse_id[left_vector_id] == right_vector_id:
+                matches.append((left_vector_id, right_vector_id))
+    return tuple(sorted(matches))
+
+
+def clause_literals(clause: Clause) -> list[tuple[int, int]]:
+    literals = []
+    for quad in clause:
+        literals.extend(
+            [
+                (quad[0], quad[1]),
+                (quad[1], quad[2]),
+                (quad[2], quad[3]),
+            ]
+        )
+    return literals
+
+
+def vector_support_sizes(
+    n: int,
+    offsets: Sequence[int],
+    quad_ids: Mapping[Quad, tuple[int, int]],
+) -> dict[int, int]:
+    """Return sparse support sizes for all vector ids in the quad table."""
+
+    classes = dict(build_distance_classes(n, offsets))
+    support_sizes: dict[int, int] = {}
+    for quad, ids in quad_ids.items():
+        for kind_idx, vector_id in enumerate(ids):
+            if vector_id not in support_sizes:
+                support_sizes[vector_id] = len(_sparse_vector(classes, KINDS[kind_idx], quad))
+    return support_sizes
+
+
+def distance_quotient_summary(
+    n: int,
+    offsets: Sequence[int],
+    quad_ids: Mapping[Quad, tuple[int, int]],
+    inverse_id: Sequence[int],
+    used_vector_pairs: set[tuple[int, int]],
+) -> dict[str, object]:
+    """Return compact counts for the selected-distance quotient vector table."""
+
+    classes = dict(build_distance_classes(n, offsets))
+    class_sizes = Counter(classes.values())
+    class_size_histogram = Counter(class_sizes.values())
+    inverse_pair_count = sum(
+        1 for vector_id, inverse in enumerate(inverse_id) if inverse >= 0 and vector_id < inverse
+    )
+    return {
+        "ordered_quad_table_size": len(quad_ids),
+        "vector_id_count": len(inverse_id),
+        "inverse_vector_pair_count": inverse_pair_count,
+        "selected_distance_class_count": len(set(classes.values())),
+        "selected_distance_class_size_histogram": {
+            str(size): class_size_histogram[size] for size in sorted(class_size_histogram)
+        },
+        "unique_inverse_vector_pairs_used_by_stored_clauses": len(used_vector_pairs),
+        "vector_id_note": (
+            "Vector-id counts are deterministic for the current table builder, "
+            "but individual ids are not a mathematical invariant."
+        ),
+    }
+
+
+def top_translation_families(
+    family_counts: Counter[Clause],
+    step_counts: Counter[tuple[tuple[int, ...], tuple[int, ...]]],
+    *,
+    n: int,
+    top: int,
+) -> list[dict[str, object]]:
+    rows = []
+    for family, count in sorted(
+        family_counts.items(),
+        key=lambda item: (-item[1], _json_clause(item[0])),
+    )[:top]:
+        step_signature = clause_step_signature(family, n)
+        rows.append(
+            {
+                "canonical_clause": _json_clause(family),
+                "count": count,
+                "ordered_quad_step_signature": [list(steps) for steps in step_signature],
+                "step_signature_count": step_counts[step_signature],
+            }
+        )
+    return rows
+
+
+def top_quad_steps(
+    step_counts: Counter[tuple[int, int, int, int]],
+    *,
+    top: int,
+) -> list[dict[str, object]]:
+    return [
+        {"ordered_quad_steps": list(steps), "count": count}
+        for steps, count in sorted(step_counts.items(), key=lambda item: (-item[1], item[0]))[:top]
+    ]
+
+
+def top_ordered_quads(
+    quad_counts: Counter[Quad],
+    *,
+    top: int,
+) -> list[dict[str, object]]:
+    return [
+        {"ordered_quad": list(quad), "count": count}
+        for quad, count in sorted(quad_counts.items(), key=lambda item: (-item[1], item[0]))[:top]
+    ]
+
+
+def diagnostic_payload(
+    certificate: Path = DEFAULT_CERTIFICATE,
+    *,
+    top: int = 12,
+) -> dict[str, object]:
+    """Return the deterministic C19 Z3 clause diagnostic payload."""
+
+    raw_payload = load_json(certificate)
+    verified = verify_certificate(raw_payload)
+    pattern = verified["pattern"]
+    if not isinstance(pattern, dict):
+        raise AssertionError("verified pattern must be an object")
+    n = int(pattern["n"])
+    offsets = [int(offset) for offset in pattern["circulant_offsets"]]  # type: ignore[index]
+    quad_ids, inverse_id = _prepare_vector_tables(n, offsets)
+    clauses = [_parse_clause(item) for item in raw_payload["forbidden_order_pairs"]]
+    if len(set(clauses)) != len(clauses):
+        raise AssertionError("duplicate forbidden clauses in source certificate")
+    support_sizes = vector_support_sizes(n, offsets, quad_ids)
+
+    family_counts: Counter[Clause] = Counter()
+    step_signature_counts: Counter[tuple[tuple[int, ...], tuple[int, ...]]] = Counter()
+    quad_step_counts: Counter[tuple[int, int, int, int]] = Counter()
+    quad_counts: Counter[Quad] = Counter()
+    kind_pair_counts: Counter[tuple[tuple[str, str], ...]] = Counter()
+    matches_per_clause_counts: Counter[int] = Counter()
+    matched_vector_support_counts: Counter[int] = Counter()
+    shared_label_counts: Counter[int] = Counter()
+    union_label_counts: Counter[int] = Counter()
+    quads_with_label0_counts: Counter[int] = Counter()
+    label0_position_counts: Counter[int] = Counter()
+    effective_literal_counts: Counter[int] = Counter()
+    effective_unique_literal_counts: Counter[int] = Counter()
+    raw_unique_literal_counts: Counter[int] = Counter()
+    label_occurrences: Counter[int] = Counter()
+    label_clause_touches: Counter[int] = Counter()
+    used_vector_pairs: set[tuple[int, int]] = set()
+
+    for clause in clauses:
+        family_counts[translation_family(clause, n)] += 1
+        step_signature_counts[clause_step_signature(clause, n)] += 1
+        kind_matches = inverse_kind_pairs(clause, quad_ids, inverse_id)
+        vector_matches = inverse_vector_matches(clause, quad_ids, inverse_id)
+        kind_pair_counts[kind_matches] += 1
+        matches_per_clause_counts[len(vector_matches)] += 1
+        for left_vector_id, right_vector_id in vector_matches:
+            used_vector_pairs.add(tuple(sorted((left_vector_id, right_vector_id))))
+            matched_vector_support_counts[support_sizes[left_vector_id]] += 1
+        shared_label_counts[len(set(clause[0]) & set(clause[1]))] += 1
+        union_label_counts[len(set(clause[0]) | set(clause[1]))] += 1
+        quads_with_label0_counts[sum(1 for quad in clause if 0 in quad)] += 1
+        for quad in clause:
+            for idx, label in enumerate(quad):
+                if label == 0:
+                    label0_position_counts[idx] += 1
+        literals = clause_literals(clause)
+        effective_literals = [literal for literal in literals if literal[0] != 0]
+        effective_literal_counts[len(effective_literals)] += 1
+        effective_unique_literal_counts[len(set(effective_literals))] += 1
+        raw_unique_literal_counts[len(set(literals))] += 1
+        for quad in clause:
+            quad_counts[quad] += 1
+            quad_step_counts[quad_steps(quad, n)] += 1
+            label_occurrences.update(quad)
+        label_clause_touches.update(set(clause[0]) | set(clause[1]))
+
+    label_frequencies = [
+        {
+            "label": label,
+            "ordered_quad_occurrences": label_occurrences[label],
+            "clause_touch_count": label_clause_touches[label],
+        }
+        for label in range(n)
+    ]
+    return {
+        "type": EXPECTED_TYPE,
+        "trust": EXPECTED_TRUST,
+        "status": EXPECTED_STATUS,
+        "claim_scope": (
+            "Structural diagnostic for the checked C19_skew all-order Z3 "
+            "Kalmanson certificate only; not a proof of Erdos Problem #97."
+        ),
+        "notes": [
+            "No general proof of Erdos Problem #97 is claimed.",
+            "No counterexample is claimed.",
+            "The source certificate is replayed with Z3 before clause templates are summarized.",
+            "Translation families quotient simultaneous cyclic relabeling only; reversal is not quotiented.",
+            "Template frequencies are diagnostic search guidance, not a statement about all C19-like patterns.",
+        ],
+        "source_certificate": {
+            "path": relative_path(certificate),
+            "type": raw_payload.get("type"),
+            "pattern": verified["pattern"],
+            "status": verified["status"],
+            "trust": verified["trust"],
+            "solver_result": verified["solver_result"],
+            "smt_solver": raw_payload.get("smt_solver"),
+            "iterations": raw_payload.get("iterations"),
+            "conflict_cap": raw_payload.get("conflict_cap"),
+            "forbidden_clause_count": verified["forbidden_clause_count"],
+            "rotation_quotient": raw_payload.get("rotation_quotient"),
+            "reversal_quotient": raw_payload.get("reversal_quotient"),
+        },
+        "clause_validation_summary": {
+            "source_forbidden_clause_count": raw_payload.get("forbidden_clause_count"),
+            "parsed_clause_count": len(clauses),
+            "unique_clause_count": len(set(clauses)),
+            "lexicographically_sorted": clauses == sorted(clauses),
+            "solver_replay_result": verified["solver_result"],
+            "verified_status": verified["status"],
+            "verified_trust": verified["trust"],
+        },
+        "distance_quotient_table_summary": distance_quotient_summary(
+            n,
+            offsets,
+            quad_ids,
+            inverse_id,
+            used_vector_pairs,
+        ),
+        "template_summary": {
+            "clause_count": len(clauses),
+            "translation_family_count": len(family_counts),
+            "translation_family_coverage_histogram": {
+                str(count): frequency
+                for count, frequency in sorted(Counter(family_counts.values()).items())
+            },
+            "ordered_quad_step_signature_count": len(step_signature_counts),
+            "ordered_quad_step_pattern_count": len(quad_step_counts),
+            "ordered_quad_count": len(quad_counts),
+            "shared_label_count_distribution": {
+                str(key): shared_label_counts[key] for key in sorted(shared_label_counts)
+            },
+            "matches_per_clause_distribution": {
+                str(key): matches_per_clause_counts[key] for key in sorted(matches_per_clause_counts)
+            },
+            "matched_vector_support_size_distribution": {
+                str(key): matched_vector_support_counts[key]
+                for key in sorted(matched_vector_support_counts)
+            },
+            "inverse_kind_pair_distribution": [
+                {
+                    "kind_pairs": [
+                        {"left_kind": left, "right_kind": right}
+                        for left, right in kind_pairs
+                    ],
+                    "count": kind_pair_counts[kind_pairs],
+                }
+                for kind_pairs in sorted(kind_pair_counts)
+            ],
+            "label_ordered_quad_occurrence_min": min(label_occurrences.values()),
+            "label_ordered_quad_occurrence_max": max(label_occurrences.values()),
+            "label_clause_touch_min": min(label_clause_touches.values()),
+            "label_clause_touch_max": max(label_clause_touches.values()),
+        },
+        "rotation_quotient_literal_summary": {
+            "quads_containing_label0_per_clause": {
+                str(key): quads_with_label0_counts[key] for key in sorted(quads_with_label0_counts)
+            },
+            "label0_positions_inside_ordered_quads": {
+                str(key): label0_position_counts[key] for key in sorted(label0_position_counts)
+            },
+            "label0_non_first_occurrences": sum(
+                count for position, count in label0_position_counts.items() if position != 0
+            ),
+            "effective_literal_count_distribution": {
+                str(key): effective_literal_counts[key] for key in sorted(effective_literal_counts)
+            },
+            "effective_unique_literal_count_distribution": {
+                str(key): effective_unique_literal_counts[key]
+                for key in sorted(effective_unique_literal_counts)
+            },
+        },
+        "clause_shape_summary": {
+            "union_label_count_distribution": {
+                str(key): union_label_counts[key] for key in sorted(union_label_counts)
+            },
+            "left_right_shared_label_count_distribution": {
+                str(key): shared_label_counts[key] for key in sorted(shared_label_counts)
+            },
+            "raw_unique_precedence_literal_count_distribution": {
+                str(key): raw_unique_literal_counts[key] for key in sorted(raw_unique_literal_counts)
+            },
+        },
+        "label_frequencies": label_frequencies,
+        "top_translation_families": top_translation_families(
+            family_counts,
+            step_signature_counts,
+            n=n,
+            top=top,
+        ),
+        "top_ordered_quad_step_patterns": top_quad_steps(quad_step_counts, top=top),
+        "top_ordered_quads": top_ordered_quads(quad_counts, top=top),
+        "interpretation_note": (
+            "This report makes the stored C19_skew Z3 clause set easier to inspect. "
+            "It does not add clauses, search new cyclic orders, or transfer the "
+            "obstruction to any other selected-witness pattern."
+        ),
+        "provenance": {
+            "generator": "scripts/analyze_kalmanson_z3_clauses.py",
+            "command": DEFAULT_COMMAND,
+        },
+    }
+
+
+def assert_expected(payload: Mapping[str, object]) -> None:
+    expected_top = {
+        "type": EXPECTED_TYPE,
+        "trust": EXPECTED_TRUST,
+        "status": EXPECTED_STATUS,
+        "claim_scope": (
+            "Structural diagnostic for the checked C19_skew all-order Z3 "
+            "Kalmanson certificate only; not a proof of Erdos Problem #97."
+        ),
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} is {payload.get(key)!r}, expected {expected!r}")
+
+    source = payload.get("source_certificate")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_certificate must be an object")
+    expected_source = {
+        "path": "data/certificates/c19_skew_all_orders_kalmanson_z3.json",
+        "type": "kalmanson_two_order_z3_refinement_v1",
+        "status": "EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION",
+        "trust": "SMT_EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
+        "solver_result": "unsat",
+        "smt_solver": "z3",
+        "iterations": 142,
+        "conflict_cap": 1024,
+        "forbidden_clause_count": 7981,
+    }
+    for key, expected in expected_source.items():
+        if source.get(key) != expected:
+            raise AssertionError(
+                f"source_certificate[{key!r}] is {source.get(key)!r}, expected {expected!r}"
+            )
+    if source.get("pattern") != {
+        "name": "C19_skew",
+        "n": 19,
+        "circulant_offsets": [-8, -3, 5, 9],
+    }:
+        raise AssertionError(f"unexpected source pattern: {source.get('pattern')!r}")
+
+    validation = payload.get("clause_validation_summary")
+    if not isinstance(validation, Mapping):
+        raise AssertionError("clause_validation_summary must be an object")
+    expected_validation = {
+        "source_forbidden_clause_count": 7981,
+        "parsed_clause_count": 7981,
+        "unique_clause_count": 7981,
+        "lexicographically_sorted": True,
+        "solver_replay_result": "unsat",
+        "verified_status": "EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION",
+        "verified_trust": "SMT_EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
+    }
+    for key, expected in expected_validation.items():
+        if validation.get(key) != expected:
+            raise AssertionError(
+                f"clause_validation_summary[{key!r}] is {validation.get(key)!r}, expected {expected!r}"
+            )
+
+    distance_summary = payload.get("distance_quotient_table_summary")
+    if not isinstance(distance_summary, Mapping):
+        raise AssertionError("distance_quotient_table_summary must be an object")
+    expected_distance_summary = {
+        "ordered_quad_table_size": 93024,
+        "vector_id_count": 22344,
+        "inverse_vector_pair_count": 11172,
+        "selected_distance_class_count": 114,
+        "selected_distance_class_size_histogram": {"1": 95, "4": 19},
+        "unique_inverse_vector_pairs_used_by_stored_clauses": 285,
+    }
+    for key, expected in expected_distance_summary.items():
+        if distance_summary.get(key) != expected:
+            raise AssertionError(
+                f"distance_quotient_table_summary[{key!r}] is {distance_summary.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+
+    summary = payload.get("template_summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("template_summary must be an object")
+    expected_summary = {
+        "clause_count": 7981,
+        "translation_family_count": 1946,
+        "translation_family_coverage_histogram": {
+            "1": 198,
+            "2": 305,
+            "3": 354,
+            "4": 358,
+            "5": 266,
+            "6": 206,
+            "7": 109,
+            "8": 71,
+            "9": 36,
+            "10": 22,
+            "11": 18,
+            "12": 1,
+            "14": 2,
+        },
+        "ordered_quad_step_signature_count": 1946,
+        "ordered_quad_step_pattern_count": 576,
+        "ordered_quad_count": 7535,
+        "shared_label_count_distribution": {"2": 7310, "3": 671},
+        "matches_per_clause_distribution": {"1": 7981},
+        "matched_vector_support_size_distribution": {"2": 7780, "4": 201},
+        "label_ordered_quad_occurrence_min": 1934,
+        "label_ordered_quad_occurrence_max": 3964,
+        "label_clause_touch_min": 1530,
+        "label_clause_touch_max": 2938,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"template_summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    expected_kind_counts = {
+        ("K1_diag_gt_sides", "K1_diag_gt_sides"): 1928,
+        ("K1_diag_gt_sides", "K2_diag_gt_other"): 2061,
+        ("K2_diag_gt_other", "K1_diag_gt_sides"): 2092,
+        ("K2_diag_gt_other", "K2_diag_gt_other"): 1900,
+    }
+    observed_kind_counts: dict[tuple[str, str], int] = {}
+    rows = summary.get("inverse_kind_pair_distribution")
+    if not isinstance(rows, list):
+        raise AssertionError("inverse_kind_pair_distribution must be a list")
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise AssertionError("inverse kind-pair rows must be objects")
+        pairs = row.get("kind_pairs")
+        if not isinstance(pairs, list) or len(pairs) != 1 or not isinstance(pairs[0], Mapping):
+            raise AssertionError(f"unexpected kind_pairs row: {row!r}")
+        pair = pairs[0]
+        observed_kind_counts[(str(pair["left_kind"]), str(pair["right_kind"]))] = int(row["count"])
+    if observed_kind_counts != expected_kind_counts:
+        raise AssertionError(f"unexpected kind-pair distribution: {observed_kind_counts!r}")
+
+    rotation = payload.get("rotation_quotient_literal_summary")
+    if not isinstance(rotation, Mapping):
+        raise AssertionError("rotation_quotient_literal_summary must be an object")
+    expected_rotation = {
+        "quads_containing_label0_per_clause": {"0": 6451, "1": 1126, "2": 404},
+        "label0_positions_inside_ordered_quads": {"0": 1934},
+        "label0_non_first_occurrences": 0,
+        "effective_literal_count_distribution": {"4": 404, "5": 1126, "6": 6451},
+        "effective_unique_literal_count_distribution": {
+            "3": 15,
+            "4": 466,
+            "5": 1734,
+            "6": 5766,
+        },
+    }
+    for key, expected in expected_rotation.items():
+        if rotation.get(key) != expected:
+            raise AssertionError(
+                f"rotation_quotient_literal_summary[{key!r}] is {rotation.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+
+    shape = payload.get("clause_shape_summary")
+    if not isinstance(shape, Mapping):
+        raise AssertionError("clause_shape_summary must be an object")
+    expected_shape = {
+        "union_label_count_distribution": {"5": 671, "6": 7310},
+        "left_right_shared_label_count_distribution": {"2": 7310, "3": 671},
+        "raw_unique_precedence_literal_count_distribution": {"5": 799, "6": 7182},
+    }
+    for key, expected in expected_shape.items():
+        if shape.get(key) != expected:
+            raise AssertionError(
+                f"clause_shape_summary[{key!r}] is {shape.get(key)!r}, expected {expected!r}"
+            )
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping) or provenance.get("command") != DEFAULT_COMMAND:
+        raise AssertionError("provenance command changed")
+    notes = payload.get("notes")
+    if not isinstance(notes, list) or "No general proof of Erdos Problem #97 is claimed." not in notes:
+        raise AssertionError("nonclaiming notes changed")
+
+
+def check_artifact(path: Path, payload: Mapping[str, object]) -> None:
+    artifact = load_json(path)
+    if artifact != payload:
+        raise AssertionError(f"{relative_path(path)} does not match regenerated diagnostic payload")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--certificate", type=Path, default=DEFAULT_CERTIFICATE)
+    parser.add_argument("--out", type=Path, help="write generated JSON to this path")
+    parser.add_argument("--check-artifact", type=Path, help="compare generated JSON to this stored artifact")
+    parser.add_argument("--top", type=int, default=12, help="number of top diagnostic rows to retain")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.top <= 0:
+        raise SystemExit("--top must be positive")
+    certificate = args.certificate if args.certificate.is_absolute() else ROOT / args.certificate
+    payload = diagnostic_payload(certificate, top=args.top)
+    if args.assert_expected:
+        assert_expected(payload)
+    if args.check_artifact:
+        artifact = args.check_artifact if args.check_artifact.is_absolute() else ROOT / args.check_artifact
+        check_artifact(artifact, payload)
+    if args.out:
+        out = args.out if args.out.is_absolute() else ROOT / args.out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["template_summary"]  # type: ignore[index]
+        print("C19 Z3 clause-template diagnostic")
+        print(f"clauses: {summary['clause_count']}")  # type: ignore[index]
+        print(f"translation families: {summary['translation_family_count']}")  # type: ignore[index]
+        print(f"ordered quad step patterns: {summary['ordered_quad_step_pattern_count']}")  # type: ignore[index]
+        if args.assert_expected:
+            print("OK: C19 Z3 clause-template diagnostic matches expected values")
+        if args.check_artifact:
+            print(f"OK: {relative_path(args.check_artifact)} matches regenerated payload")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -59,6 +59,28 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope="Exact obstruction for one fixed C19_skew cyclic order only.",
     ),
     AuditCommand(
+        ident="c19_all_orders_kalmanson_z3",
+        command=(
+            "python",
+            "scripts/check_kalmanson_two_order_z3.py",
+            "--certificate",
+            "data/certificates/c19_skew_all_orders_kalmanson_z3.json",
+            "--assert-unsat",
+        ),
+        claim_scope="All-order obstruction for one fixed abstract C19_skew selected-witness pattern only.",
+    ),
+    AuditCommand(
+        ident="c19_z3_clause_diagnostic",
+        command=(
+            "python",
+            "scripts/analyze_kalmanson_z3_clauses.py",
+            "--assert-expected",
+            "--check-artifact",
+            "reports/c19_kalmanson_z3_clause_diagnostics.json",
+        ),
+        claim_scope="Structural diagnostic for the C19_skew all-order Z3 clauses only.",
+    ),
+    AuditCommand(
         ident="c13_fixed_order_compact_kalmanson",
         command=(
             "python",

--- a/tests/test_kalmanson_z3_clause_diagnostics.py
+++ b/tests/test_kalmanson_z3_clause_diagnostics.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.analyze_kalmanson_z3_clauses import (
+    DEFAULT_ARTIFACT,
+    assert_expected,
+    check_artifact,
+    diagnostic_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_c19_z3_clause_diagnostic_matches_artifact() -> None:
+    payload = diagnostic_payload()
+
+    assert_expected(payload)
+    check_artifact(DEFAULT_ARTIFACT, payload)
+    assert payload["source_certificate"]["pattern"] == {
+        "circulant_offsets": [-8, -3, 5, 9],
+        "n": 19,
+        "name": "C19_skew",
+    }
+    assert payload["template_summary"]["clause_count"] == 7981
+    assert payload["template_summary"]["translation_family_count"] == 1946
+    assert payload["template_summary"]["ordered_quad_step_pattern_count"] == 576
+    assert payload["template_summary"]["shared_label_count_distribution"] == {
+        "2": 7310,
+        "3": 671,
+    }
+    assert payload["clause_validation_summary"]["lexicographically_sorted"] is True
+    assert payload["template_summary"]["matches_per_clause_distribution"] == {"1": 7981}
+    assert payload["template_summary"]["matched_vector_support_size_distribution"] == {
+        "2": 7780,
+        "4": 201,
+    }
+    assert payload["distance_quotient_table_summary"][
+        "unique_inverse_vector_pairs_used_by_stored_clauses"
+    ] == 285
+    assert payload["rotation_quotient_literal_summary"][
+        "label0_non_first_occurrences"
+    ] == 0
+    assert payload["clause_shape_summary"]["union_label_count_distribution"] == {
+        "5": 671,
+        "6": 7310,
+    }
+
+
+def test_c19_z3_clause_diagnostic_rejects_tampered_counts() -> None:
+    payload = diagnostic_payload()
+    payload["template_summary"]["translation_family_count"] = 1947
+
+    try:
+        assert_expected(payload)
+    except AssertionError as exc:
+        assert "translation_family_count" in str(exc)
+    else:  # pragma: no cover - defensive assertion shape
+        raise AssertionError("tampered diagnostic unexpectedly passed")
+
+
+def test_c19_z3_clause_diagnostic_rejects_tampered_provenance() -> None:
+    payload = diagnostic_payload()
+    payload["provenance"]["command"] = "python scripts/analyze_kalmanson_z3_clauses.py"
+
+    try:
+        assert_expected(payload)
+    except AssertionError as exc:
+        assert "provenance" in str(exc)
+    else:  # pragma: no cover - defensive assertion shape
+        raise AssertionError("tampered provenance unexpectedly passed")
+
+
+def test_c19_z3_clause_diagnostic_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/analyze_kalmanson_z3_clauses.py",
+            "--assert-expected",
+            "--check-artifact",
+            "reports/c19_kalmanson_z3_clause_diagnostics.json",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["trust"] == "EXACT_CERTIFICATE_DIAGNOSTIC"
+    assert payload["status"] == "ALL_ORDER_C19_Z3_CLAUSE_DIAGNOSTIC_ONLY"

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -28,9 +28,19 @@ def test_run_audit_command_records_metadata(tmp_path: Path) -> None:
     assert len(record["combined_output_sha256"]) == 64
 
 
-def test_audit_commands_include_n9_base_apex_ledgers() -> None:
+def test_audit_commands_include_registered_followup_checkers() -> None:
     command_texts = {command_text(command.command) for command in AUDIT_COMMANDS}
 
+    assert (
+        "python scripts/check_kalmanson_two_order_z3.py --certificate "
+        "data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat"
+        in command_texts
+    )
+    assert (
+        "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json"
+        in command_texts
+    )
     assert (
         "python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json"
         in command_texts


### PR DESCRIPTION
## Summary
- add a generated C19 all-order Z3 clause-template diagnostic report
- add a replaying generator/checker that validates the source SMT certificate before summarizing clause templates, inverse-pair kinds, label-0 quotient literals, and distance-quotient table counts
- register the report in generated-artifact provenance and artifact audit coverage, with docs and tests

## Scope
This is a structural diagnostic for the checked fixed abstract `C19_skew` all-order Kalmanson Z3 certificate. It does not add clauses, search new cyclic orders, transfer the obstruction to other patterns, prove Erdos #97, claim a counterexample, or update global status.

## Validation
- `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json --json`
- `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- raw artifact tier because `make` is unavailable in this shell:
  - `python scripts/independent_check_n8_artifacts.py --check --json`
  - `python scripts/enumerate_n8_incidence.py --summary`
  - `python scripts/analyze_n8_exact_survivors.py --check --json`
  - `python scripts/check_round2_certificates.py`
  - `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
  - `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
  - `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json`
  - `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
  - `python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json`
  - `python scripts/check_n9_base_apex_escape_budget.py --check --json`
  - `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic`