### PR TITLE
Add n9 selected-baseline escape overlay

### DIFF
--- a/data/certificates/n9_selected_baseline_escape_budget_overlay.json
+++ b/data/certificates/n9_selected_baseline_escape_budget_overlay.json
@@ -1,0 +1,967 @@
+{
+  "accepted_frontier_overlay": {
+    "accepted_frontier_count": 1,
+    "interpretation": "This accepted_frontier row system escapes the selected-baseline turn-cover overlay; accepted_frontier means it passed the bounded frontier filters, not that it is geometrically realizable.",
+    "rows": [
+      [
+        1,
+        2,
+        3,
+        8
+      ],
+      [
+        0,
+        3,
+        4,
+        7
+      ],
+      [
+        1,
+        3,
+        5,
+        6
+      ],
+      [
+        2,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        3,
+        6,
+        8
+      ],
+      [
+        2,
+        4,
+        6,
+        7
+      ],
+      [
+        1,
+        5,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        4,
+        6
+      ],
+      [
+        0,
+        2,
+        5,
+        7
+      ]
+    ],
+    "selected_baseline": {
+      "canonical_relevant_placement": {
+        "spoiled_length2": [
+          0,
+          3,
+          6
+        ],
+        "spoiled_length3": [
+          1,
+          4
+        ]
+      },
+      "deficit_by_cyclic_length": {
+        "1": 0,
+        "2": 3,
+        "3": 2,
+        "4": 4
+      },
+      "overfull_base_count": 0,
+      "saturated_base_count_by_cyclic_length": {
+        "1": 9,
+        "2": 6,
+        "3": 7,
+        "4": 5
+      },
+      "spoiled_base_count_by_cyclic_length": {
+        "1": 0,
+        "2": 3,
+        "3": 2,
+        "4": 4
+      },
+      "spoiled_length2": [
+        0,
+        3,
+        6
+      ],
+      "spoiled_length3": [
+        1,
+        7
+      ],
+      "total_deficit": 9,
+      "usage_by_cyclic_length": {
+        "1": 9,
+        "2": 15,
+        "3": 16,
+        "4": 14
+      }
+    },
+    "source": "data/certificates/n9_incidence_frontier_bounded.json",
+    "turn_cover_overlay": {
+      "remaining_minimum_forced_turns": 1,
+      "remaining_turn_clauses": [
+        [
+          5,
+          6
+        ]
+      ],
+      "strict_positive_forces_turn_cover": false,
+      "sum_exceeds_forces_turn_cover": false
+    },
+    "vertex_circle_status": "self_edge"
+  },
+  "base_apex_slack": 9,
+  "budget_overlay": {
+    "strict_positive_threshold": {
+      "budget_rows": [
+        {
+          "assignment_with_escape_count": 0,
+          "capacity_deficit_budget": 0,
+          "escaping_final_deficit_placement_count": 0,
+          "forced_final_deficit_placement_count": 184,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 184
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "5": 184
+          },
+          "total_final_deficit_placement_count": 184,
+          "universally_forced_assignment_count": 184
+        },
+        {
+          "assignment_with_escape_count": 0,
+          "capacity_deficit_budget": 1,
+          "escaping_final_deficit_placement_count": 0,
+          "forced_final_deficit_placement_count": 1656,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 576,
+            "1": 1080
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "4": 1080,
+            "5": 576
+          },
+          "total_final_deficit_placement_count": 1656,
+          "universally_forced_assignment_count": 184
+        },
+        {
+          "assignment_with_escape_count": 0,
+          "capacity_deficit_budget": 2,
+          "escaping_final_deficit_placement_count": 0,
+          "forced_final_deficit_placement_count": 6624,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 1080,
+            "1": 2448,
+            "2": 3096
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "3": 2124,
+            "4": 3420,
+            "5": 1080
+          },
+          "total_final_deficit_placement_count": 6624,
+          "universally_forced_assignment_count": 184
+        },
+        {
+          "assignment_with_escape_count": 136,
+          "capacity_deficit_budget": 3,
+          "escaping_final_deficit_placement_count": 1746,
+          "forced_final_deficit_placement_count": 13710,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 1176,
+            "1": 4032,
+            "2": 4536,
+            "3": 5712
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "2": 1746,
+            "3": 6594,
+            "4": 5940,
+            "5": 1176
+          },
+          "total_final_deficit_placement_count": 15456,
+          "universally_forced_assignment_count": 48
+        },
+        {
+          "assignment_with_escape_count": 136,
+          "capacity_deficit_budget": 4,
+          "escaping_final_deficit_placement_count": 6138,
+          "forced_final_deficit_placement_count": 17046,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 828,
+            "1": 3744,
+            "2": 6480,
+            "3": 4752,
+            "4": 7380
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "1": 684,
+            "2": 5454,
+            "3": 10152,
+            "4": 6066,
+            "5": 828
+          },
+          "total_final_deficit_placement_count": 23184,
+          "universally_forced_assignment_count": 48
+        },
+        {
+          "assignment_with_escape_count": 140,
+          "capacity_deficit_budget": 5,
+          "escaping_final_deficit_placement_count": 9378,
+          "forced_final_deficit_placement_count": 13806,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 432,
+            "1": 1980,
+            "2": 5400,
+            "3": 5400,
+            "4": 3240,
+            "5": 6732
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 90,
+            "1": 2520,
+            "2": 6768,
+            "3": 9738,
+            "4": 3636,
+            "5": 432
+          },
+          "total_final_deficit_placement_count": 23184,
+          "universally_forced_assignment_count": 44
+        },
+        {
+          "assignment_with_escape_count": 140,
+          "capacity_deficit_budget": 6,
+          "escaping_final_deficit_placement_count": 8172,
+          "forced_final_deficit_placement_count": 7284,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 192,
+            "1": 576,
+            "2": 2520,
+            "3": 3840,
+            "4": 2520,
+            "5": 1584,
+            "6": 4224
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 432,
+            "1": 3024,
+            "2": 4716,
+            "3": 5904,
+            "4": 1188,
+            "5": 192
+          },
+          "total_final_deficit_placement_count": 15456,
+          "universally_forced_assignment_count": 44
+        },
+        {
+          "assignment_with_escape_count": 140,
+          "capacity_deficit_budget": 7,
+          "escaping_final_deficit_placement_count": 4212,
+          "forced_final_deficit_placement_count": 2412,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 72,
+            "1": 72,
+            "2": 648,
+            "3": 1440,
+            "4": 1440,
+            "5": 648,
+            "6": 576,
+            "7": 1728
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 558,
+            "1": 1674,
+            "2": 1980,
+            "3": 2178,
+            "4": 162,
+            "5": 72
+          },
+          "total_final_deficit_placement_count": 6624,
+          "universally_forced_assignment_count": 44
+        },
+        {
+          "assignment_with_escape_count": 140,
+          "capacity_deficit_budget": 8,
+          "escaping_final_deficit_placement_count": 1188,
+          "forced_final_deficit_placement_count": 468,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 18,
+            "2": 72,
+            "3": 288,
+            "4": 360,
+            "5": 288,
+            "6": 72,
+            "7": 144,
+            "8": 414
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 270,
+            "1": 486,
+            "2": 432,
+            "3": 450,
+            "5": 18
+          },
+          "total_final_deficit_placement_count": 1656,
+          "universally_forced_assignment_count": 44
+        },
+        {
+          "assignment_with_escape_count": 140,
+          "capacity_deficit_budget": 9,
+          "escaping_final_deficit_placement_count": 140,
+          "forced_final_deficit_placement_count": 44,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 2,
+            "3": 24,
+            "4": 36,
+            "5": 36,
+            "6": 24,
+            "8": 18,
+            "9": 44
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 50,
+            "1": 54,
+            "2": 36,
+            "3": 42,
+            "5": 2
+          },
+          "total_final_deficit_placement_count": 184,
+          "universally_forced_assignment_count": 44
+        }
+      ],
+      "contradiction_threshold": 3
+    },
+    "sum_exceeds_threshold": {
+      "budget_rows": [
+        {
+          "assignment_with_escape_count": 0,
+          "capacity_deficit_budget": 0,
+          "escaping_final_deficit_placement_count": 0,
+          "forced_final_deficit_placement_count": 184,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 184
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "5": 184
+          },
+          "total_final_deficit_placement_count": 184,
+          "universally_forced_assignment_count": 184
+        },
+        {
+          "assignment_with_escape_count": 0,
+          "capacity_deficit_budget": 1,
+          "escaping_final_deficit_placement_count": 0,
+          "forced_final_deficit_placement_count": 1656,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 576,
+            "1": 1080
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "4": 1080,
+            "5": 576
+          },
+          "total_final_deficit_placement_count": 1656,
+          "universally_forced_assignment_count": 184
+        },
+        {
+          "assignment_with_escape_count": 178,
+          "capacity_deficit_budget": 2,
+          "escaping_final_deficit_placement_count": 2124,
+          "forced_final_deficit_placement_count": 4500,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 1080,
+            "1": 2448,
+            "2": 3096
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "3": 2124,
+            "4": 3420,
+            "5": 1080
+          },
+          "total_final_deficit_placement_count": 6624,
+          "universally_forced_assignment_count": 6
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 3,
+          "escaping_final_deficit_placement_count": 8340,
+          "forced_final_deficit_placement_count": 7116,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 1176,
+            "1": 4032,
+            "2": 4536,
+            "3": 5712
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "2": 1746,
+            "3": 6594,
+            "4": 5940,
+            "5": 1176
+          },
+          "total_final_deficit_placement_count": 15456,
+          "universally_forced_assignment_count": 2
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 4,
+          "escaping_final_deficit_placement_count": 16290,
+          "forced_final_deficit_placement_count": 6894,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 828,
+            "1": 3744,
+            "2": 6480,
+            "3": 4752,
+            "4": 7380
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "1": 684,
+            "2": 5454,
+            "3": 10152,
+            "4": 6066,
+            "5": 828
+          },
+          "total_final_deficit_placement_count": 23184,
+          "universally_forced_assignment_count": 2
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 5,
+          "escaping_final_deficit_placement_count": 19116,
+          "forced_final_deficit_placement_count": 4068,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 432,
+            "1": 1980,
+            "2": 5400,
+            "3": 5400,
+            "4": 3240,
+            "5": 6732
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 90,
+            "1": 2520,
+            "2": 6768,
+            "3": 9738,
+            "4": 3636,
+            "5": 432
+          },
+          "total_final_deficit_placement_count": 23184,
+          "universally_forced_assignment_count": 2
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 6,
+          "escaping_final_deficit_placement_count": 14076,
+          "forced_final_deficit_placement_count": 1380,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 192,
+            "1": 576,
+            "2": 2520,
+            "3": 3840,
+            "4": 2520,
+            "5": 1584,
+            "6": 4224
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 432,
+            "1": 3024,
+            "2": 4716,
+            "3": 5904,
+            "4": 1188,
+            "5": 192
+          },
+          "total_final_deficit_placement_count": 15456,
+          "universally_forced_assignment_count": 2
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 7,
+          "escaping_final_deficit_placement_count": 6390,
+          "forced_final_deficit_placement_count": 234,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 72,
+            "1": 72,
+            "2": 648,
+            "3": 1440,
+            "4": 1440,
+            "5": 648,
+            "6": 576,
+            "7": 1728
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 558,
+            "1": 1674,
+            "2": 1980,
+            "3": 2178,
+            "4": 162,
+            "5": 72
+          },
+          "total_final_deficit_placement_count": 6624,
+          "universally_forced_assignment_count": 2
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 8,
+          "escaping_final_deficit_placement_count": 1638,
+          "forced_final_deficit_placement_count": 18,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 18,
+            "2": 72,
+            "3": 288,
+            "4": 360,
+            "5": 288,
+            "6": 72,
+            "7": 144,
+            "8": 414
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 270,
+            "1": 486,
+            "2": 432,
+            "3": 450,
+            "5": 18
+          },
+          "total_final_deficit_placement_count": 1656,
+          "universally_forced_assignment_count": 2
+        },
+        {
+          "assignment_with_escape_count": 182,
+          "capacity_deficit_budget": 9,
+          "escaping_final_deficit_placement_count": 182,
+          "forced_final_deficit_placement_count": 2,
+          "relevant_deficit_count_by_final_placement": {
+            "0": 2,
+            "3": 24,
+            "4": 36,
+            "5": 36,
+            "6": 24,
+            "8": 18,
+            "9": 44
+          },
+          "remaining_forced_turn_count_by_final_placement": {
+            "0": 50,
+            "1": 54,
+            "2": 36,
+            "3": 42,
+            "5": 2
+          },
+          "total_final_deficit_placement_count": 184,
+          "universally_forced_assignment_count": 2
+        }
+      ],
+      "contradiction_threshold": 4
+    }
+  },
+  "claim_scope": "Focused n=9 selected-baseline escape-budget overlay bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.",
+  "interpretation": [
+    "The selected baseline counts only the 4 chosen witnesses at each center.",
+    "Every pre-vertex-circle selected-witness assignment uses 54 base-apex incidences against cyclic capacity 63, leaving 9 selected-baseline empty capacity units.",
+    "Actual unselected equal-distance triples or profile excess could fill some selected-baseline empty slots, so these counts are not geometric realizability counts.",
+    "A forced row for budget D means every way to leave D selected-baseline empty slots unfilled still triggers the current length-2/length-3 turn-cover contradiction.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json",
+    "generator": "scripts/analyze_n9_selected_baseline_escape_budget_overlay.py"
+  },
+  "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v1",
+  "selected_baseline": {
+    "assignment_count": 184,
+    "cyclic_base_capacity_total": 63,
+    "deficit_vector_count_by_cyclic_length": [
+      {
+        "assignment_count": 2,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 0,
+          "3": 0,
+          "4": 9
+        }
+      },
+      {
+        "assignment_count": 4,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 0,
+          "3": 9,
+          "4": 0
+        }
+      },
+      {
+        "assignment_count": 24,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 3,
+          "3": 0,
+          "4": 6
+        }
+      },
+      {
+        "assignment_count": 36,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 3,
+          "3": 2,
+          "4": 4
+        }
+      },
+      {
+        "assignment_count": 18,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 3,
+          "3": 3,
+          "4": 3
+        }
+      },
+      {
+        "assignment_count": 18,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 5,
+          "3": 4,
+          "4": 0
+        }
+      },
+      {
+        "assignment_count": 6,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 6,
+          "3": 0,
+          "4": 3
+        }
+      },
+      {
+        "assignment_count": 18,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 6,
+          "3": 2,
+          "4": 1
+        }
+      },
+      {
+        "assignment_count": 18,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 7,
+          "3": 2,
+          "4": 0
+        }
+      },
+      {
+        "assignment_count": 4,
+        "deficit_by_cyclic_length": {
+          "1": 0,
+          "2": 9,
+          "3": 0,
+          "4": 0
+        }
+      },
+      {
+        "assignment_count": 18,
+        "deficit_by_cyclic_length": {
+          "1": 1,
+          "2": 2,
+          "3": 2,
+          "4": 4
+        }
+      },
+      {
+        "assignment_count": 18,
+        "deficit_by_cyclic_length": {
+          "1": 1,
+          "2": 3,
+          "3": 1,
+          "4": 4
+        }
+      }
+    ],
+    "dihedral_relevant_placement_class_count": 13,
+    "dihedral_relevant_placement_classes": [
+      {
+        "assignment_count": 2,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [],
+          "spoiled_length3": []
+        },
+        "relevant_deficit_count": 0,
+        "remaining_minimum_forced_turns": 5,
+        "strict_positive_forces_turn_cover": true,
+        "sum_exceeds_forces_turn_cover": true
+      },
+      {
+        "assignment_count": 24,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            3,
+            6
+          ],
+          "spoiled_length3": []
+        },
+        "relevant_deficit_count": 3,
+        "remaining_minimum_forced_turns": 3,
+        "strict_positive_forces_turn_cover": true,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "relevant_deficit_count": 4,
+        "remaining_minimum_forced_turns": 1,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            0,
+            3
+          ]
+        },
+        "relevant_deficit_count": 4,
+        "remaining_minimum_forced_turns": 3,
+        "strict_positive_forces_turn_cover": true,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": [
+            3,
+            5
+          ]
+        },
+        "relevant_deficit_count": 5,
+        "remaining_minimum_forced_turns": 2,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            3,
+            6
+          ],
+          "spoiled_length3": [
+            1,
+            4
+          ]
+        },
+        "relevant_deficit_count": 5,
+        "remaining_minimum_forced_turns": 1,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 6,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3,
+            4,
+            6,
+            7
+          ],
+          "spoiled_length3": []
+        },
+        "relevant_deficit_count": 6,
+        "remaining_minimum_forced_turns": 0,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": [
+            2,
+            4,
+            6
+          ]
+        },
+        "relevant_deficit_count": 6,
+        "remaining_minimum_forced_turns": 2,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3,
+            4,
+            6,
+            7
+          ],
+          "spoiled_length3": [
+            1,
+            5
+          ]
+        },
+        "relevant_deficit_count": 8,
+        "remaining_minimum_forced_turns": 0,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 4,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [],
+          "spoiled_length3": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ]
+        },
+        "relevant_deficit_count": 9,
+        "remaining_minimum_forced_turns": 0,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 4,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "spoiled_length3": []
+        },
+        "relevant_deficit_count": 9,
+        "remaining_minimum_forced_turns": 0,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "spoiled_length3": [
+            5,
+            7
+          ]
+        },
+        "relevant_deficit_count": 9,
+        "remaining_minimum_forced_turns": 0,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      },
+      {
+        "assignment_count": 18,
+        "canonical_relevant_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "spoiled_length3": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        "relevant_deficit_count": 9,
+        "remaining_minimum_forced_turns": 1,
+        "strict_positive_forces_turn_cover": false,
+        "sum_exceeds_forces_turn_cover": false
+      }
+    ],
+    "overfull_assignment_count": 0,
+    "pre_vertex_circle_nodes": 100817,
+    "relevant_deficit_count_distribution": {
+      "0": 2,
+      "3": 24,
+      "4": 36,
+      "5": 36,
+      "6": 24,
+      "8": 18,
+      "9": 44
+    },
+    "remaining_forced_turn_count_distribution": {
+      "0": 50,
+      "1": 54,
+      "2": 36,
+      "3": 42,
+      "5": 2
+    },
+    "selected_baseline_total_deficit_per_assignment": 9,
+    "selected_baseline_usage_per_assignment": 54,
+    "strict_positive_escaping_assignment_count": 140,
+    "strict_positive_forced_assignment_count": 44,
+    "sum_exceeds_escaping_assignment_count": 182,
+    "sum_exceeds_forced_assignment_count": 2
+  },
+  "source_artifacts": {
+    "accepted_frontier": "data/certificates/n9_incidence_frontier_bounded.json",
+    "base_apex_escape_budget": "data/certificates/n9_base_apex_escape_budget_report.json",
+    "pre_vertex_circle_assignments": "data/certificates/n9_vertex_circle_exhaustive.json"
+  },
+  "status": "EXPLORATORY_LEDGER_ONLY",
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+  "witness_size": 4
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -89,6 +89,11 @@ Expected artifacts:
 - optional successor diagnostics such as
   `data/certificates/n9_base_apex_escape_budget_report.json` that keep escape
   placement counts separate from geometric realizability;
+- optional selected-baseline overlays such as
+  `data/certificates/n9_selected_baseline_escape_budget_overlay.json` that
+  compare the escape-budget motif map with the 184 pre-vertex-circle
+  selected-witness assignments without treating selected-baseline empty slots
+  as actual geometric capacity deficits;
 - checker updates that independently replay generated ledger arithmetic and
   motif counts from stored JSON.
 

--- a/docs/n9-base-apex-frontier.md
+++ b/docs/n9-base-apex-frontier.md
@@ -113,6 +113,25 @@ This is still only bookkeeping. The report does not place any remaining budget
 on sides or length-4 diagonals, does not test geometric realizability of the
 escape placements, and does not close `n = 9`.
 
+A later selected-baseline overlay
+`data/certificates/n9_selected_baseline_escape_budget_overlay.json` compares
+the same turn-cover budget against the 184 complete selected-witness
+assignments that survive the pair/crossing/count filters before vertex-circle
+pruning. In those row systems, the selected 4-witness rows use 54 base-apex
+incidences against total cyclic capacity 63, leaving 9 selected-baseline empty
+capacity units in every case. Under the strict threshold, the selected-baseline
+deficits still force the current turn-cover contradiction in 44 of the 184
+assignments; under the conservative threshold, they force it in 2. The one
+`accepted_frontier` row system from
+`data/certificates/n9_incidence_frontier_bounded.json` has selected-baseline
+deficits on length-2 indices `{0,3,6}` and length-3 indices `{1,7}`, leaving
+only one forced turn, so it is a genuine escape for this diagnostic.
+
+This overlay is not a geometric realizability test. Actual unselected
+equal-distance triples or profile excess could fill selected-baseline empty
+capacity slots, so the artifact is only a finite bookkeeping map for where the
+current turn-cover method does and does not bite.
+
 ## Turn-cover diagnostic
 
 Index the length-2 diagonal `{v_i,v_{i+2}}` by `i`. If it is fully saturated,

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -326,6 +326,45 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_selected_baseline_escape_budget_overlay
+    path: data/certificates/n9_selected_baseline_escape_budget_overlay.json
+    kind: exploratory_ledger_artifact
+    generator: scripts/analyze_n9_selected_baseline_escape_budget_overlay.py
+    command: python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json
+    checker: scripts/check_n9_selected_baseline_escape_budget_overlay.py
+    check_command: python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Focused n=9 selected-baseline escape-budget overlay bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_selected_baseline_escape_budget_overlay.v1
+      status: EXPLORATORY_LEDGER_ONLY
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      claim_scope: Focused n=9 selected-baseline escape-budget overlay bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
+      n: 9
+      witness_size: 4
+      base_apex_slack: 9
+      selected_baseline.assignment_count: 184
+      selected_baseline.pre_vertex_circle_nodes: 100817
+      selected_baseline.selected_baseline_total_deficit_per_assignment: 9
+      selected_baseline.overfull_assignment_count: 0
+      selected_baseline.strict_positive_forced_assignment_count: 44
+      selected_baseline.sum_exceeds_forced_assignment_count: 2
+      selected_baseline.dihedral_relevant_placement_class_count: 13
+      accepted_frontier_overlay.selected_baseline.deficit_by_cyclic_length.2: 3
+      accepted_frontier_overlay.selected_baseline.deficit_by_cyclic_length.3: 2
+      accepted_frontier_overlay.turn_cover_overlay.remaining_minimum_forced_turns: 1
+      provenance.command: python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json
+    forbidden_claims:
+      - n=9 is proved
+      - geometric realizability count
+      - counterexample
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact

--- a/scripts/analyze_n9_selected_baseline_escape_budget_overlay.py
+++ b/scripts/analyze_n9_selected_baseline_escape_budget_overlay.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Generate the n=9 selected-baseline escape-budget overlay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_selected_baseline_escape_budget import (  # noqa: E402
+    assert_expected_overlay_counts,
+    selected_baseline_escape_budget_overlay,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_selected_baseline_escape_budget_overlay.json"
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def load_json(path: Path) -> object:
+    """Load a JSON file."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print the generated JSON")
+    parser.add_argument("--out", type=Path, help="write generated JSON to this path")
+    parser.add_argument(
+        "--check-artifact",
+        type=Path,
+        help="compare generated JSON with an existing artifact",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = selected_baseline_escape_budget_overlay()
+    if args.assert_expected:
+        assert_expected_overlay_counts(payload)
+
+    if args.check_artifact is not None:
+        artifact = (
+            args.check_artifact
+            if args.check_artifact.is_absolute()
+            else ROOT / args.check_artifact
+        )
+        checked = load_json(artifact)
+        if checked != payload:
+            print(
+                f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",
+                file=sys.stderr,
+            )
+            return 1
+
+    if args.out is not None:
+        out = args.out if args.out.is_absolute() else ROOT / args.out
+        write_json(payload, out)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif args.check_artifact is not None:
+        print("OK: selected-baseline escape-budget overlay artifact is current")
+    elif args.out is not None:
+        print(f"wrote {display_path(out, ROOT)}")
+    else:
+        selected = payload["selected_baseline"]
+        print("n=9 selected-baseline escape-budget overlay")
+        print(f"assignments: {selected['assignment_count']}")
+        print(
+            "forced assignments: "
+            f"strict={selected['strict_positive_forced_assignment_count']}, "
+            f"conservative={selected['sum_exceeds_forced_assignment_count']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_n9_selected_baseline_escape_budget_overlay.py
+++ b/scripts/check_n9_selected_baseline_escape_budget_overlay.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Validate the n=9 selected-baseline escape-budget overlay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_selected_baseline_escape_budget import (  # noqa: E402
+    selected_baseline_escape_budget_overlay,
+)
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_selected_baseline_escape_budget_overlay.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "accepted_frontier_overlay",
+    "base_apex_slack",
+    "budget_overlay",
+    "claim_scope",
+    "interpretation",
+    "n",
+    "provenance",
+    "schema",
+    "selected_baseline",
+    "source_artifacts",
+    "status",
+    "trust",
+    "witness_size",
+}
+EXPECTED_CLAIM_SCOPE = (
+    "Focused n=9 selected-baseline escape-budget overlay bookkeeping; "
+    "not a proof of n=9, not a counterexample, not a geometric "
+    "realizability test, and not a global status update."
+)
+EXPECTED_PROVENANCE = {
+    "generator": "scripts/analyze_n9_selected_baseline_escape_budget_overlay.py",
+    "command": (
+        "python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py "
+        "--assert-expected --out "
+        "data/certificates/n9_selected_baseline_escape_budget_overlay.json"
+    ),
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def validate_payload(payload: Any) -> list[str]:
+    """Return validation errors for a loaded overlay artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    top_level_keys = set(payload)
+    if top_level_keys != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(top_level_keys)!r}"
+        )
+
+    expected_meta = {
+        "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v1",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "n": 9,
+        "witness_size": 4,
+        "base_apex_slack": 9,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    claim_scope = payload.get("claim_scope")
+    expect_equal(errors, "claim_scope", claim_scope, EXPECTED_CLAIM_SCOPE)
+    if isinstance(claim_scope, str):
+        lowered = claim_scope.lower()
+        for phrase in (
+            "not a proof",
+            "not a counterexample",
+            "not a geometric realizability test",
+            "not a global status update",
+        ):
+            if phrase not in lowered:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    provenance = payload.get("provenance")
+    expect_equal(errors, "provenance", provenance, EXPECTED_PROVENANCE)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+
+    try:
+        expected_payload = selected_baseline_escape_budget_overlay()
+    except (AssertionError, ValueError) as exc:
+        errors.append(f"recomputed overlay failed: {exc}")
+    else:
+        expect_equal(errors, "overlay payload", payload, expected_payload)
+    return errors
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repo-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    selected = object_payload.get("selected_baseline", {})
+    budget = object_payload.get("budget_overlay", {})
+    strict_rows = []
+    conservative_rows = []
+    if isinstance(budget, dict):
+        strict = budget.get("strict_positive_threshold", {})
+        conservative = budget.get("sum_exceeds_threshold", {})
+        if isinstance(strict, dict):
+            strict_rows = strict.get("budget_rows", [])
+        if isinstance(conservative, dict):
+            conservative_rows = conservative.get("budget_rows", [])
+    return {
+        "ok": not errors,
+        "artifact": display_path(path),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "assignment_count": (
+            selected.get("assignment_count") if isinstance(selected, dict) else None
+        ),
+        "strict_selected_baseline_forced_assignment_count": (
+            selected.get("strict_positive_forced_assignment_count")
+            if isinstance(selected, dict)
+            else None
+        ),
+        "conservative_selected_baseline_forced_assignment_count": (
+            selected.get("sum_exceeds_forced_assignment_count")
+            if isinstance(selected, dict)
+            else None
+        ),
+        "strict_budget9_universally_forced_assignment_count": (
+            strict_rows[9]["universally_forced_assignment_count"]
+            if isinstance(strict_rows, list) and len(strict_rows) > 9
+            else None
+        ),
+        "conservative_budget9_universally_forced_assignment_count": (
+            conservative_rows[9]["universally_forced_assignment_count"]
+            if isinstance(conservative_rows, list) and len(conservative_rows) > 9
+            else None
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="fail if validation fails")
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 selected-baseline escape-budget overlay artifact")
+        print(f"artifact: {summary['artifact']}")
+        print(f"assignments: {summary['assignment_count']}")
+        print(
+            "selected-baseline forced assignments: "
+            f"strict={summary['strict_selected_baseline_forced_assignment_count']}, "
+            f"conservative={summary['conservative_selected_baseline_forced_assignment_count']}"
+        )
+        if args.check:
+            print("OK: selected-baseline overlay checks passed")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -129,6 +129,19 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_selected_baseline_escape_budget_overlay",
+        command=(
+            "python",
+            "scripts/check_n9_selected_baseline_escape_budget_overlay.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Exploratory n=9 selected-baseline escape-budget overlay bookkeeping; "
+            "not a proof of n=9, counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/src/erdos97/n9_selected_baseline_escape_budget.py
+++ b/src/erdos97/n9_selected_baseline_escape_budget.py
@@ -1,0 +1,618 @@
+"""Selected-baseline escape-budget overlay for the n=9 base-apex ledger.
+
+This module is diagnostic bookkeeping. It compares the 184 complete n=9
+selected-witness assignments before vertex-circle pruning against the cyclic
+base-capacity ledger used by the base-apex workstream. It does not prove the
+n=9 case and does not claim a counterexample.
+"""
+
+from __future__ import annotations
+
+import math
+import json
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from erdos97.n9_base_apex import (
+    canonical_deficit_placement,
+    turn_cover_diagnostic,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS,
+    EXPECTED_PRE_VERTEX_CIRCLE_NODES,
+    _rows_from_assignment,
+    pre_vertex_circle_assignments,
+)
+from erdos97.vertex_circle_order_filter import vertex_circle_order_obstruction
+
+N = 9
+ROW_SIZE = 4
+BASE_APEX_SLACK = 9
+SELECTED_BASELINE_USAGE = N * math.comb(ROW_SIZE, 2)
+CYCLIC_BASE_CAPACITY_TOTAL = 63
+STRICT_POSITIVE_THRESHOLD = 3
+SUM_EXCEEDS_THRESHOLD = 4
+ROOT = Path(__file__).resolve().parents[2]
+ACCEPTED_FRONTIER_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_incidence_frontier_bounded.json"
+)
+
+EXPECTED_RELEVANT_DEFICIT_DISTRIBUTION = {
+    0: 2,
+    3: 24,
+    4: 36,
+    5: 36,
+    6: 24,
+    8: 18,
+    9: 44,
+}
+EXPECTED_SELECTED_BASELINE_REMAINING_FORCED_TURNS = {
+    0: 50,
+    1: 54,
+    2: 36,
+    3: 42,
+    5: 2,
+}
+EXPECTED_STRICT_FORCED_ASSIGNMENTS = 44
+EXPECTED_CONSERVATIVE_FORCED_ASSIGNMENTS = 2
+EXPECTED_DIHEDRAL_RELEVANT_PLACEMENT_CLASSES = 13
+EXPECTED_STRICT_UNIVERSALLY_FORCED_BY_BUDGET = {
+    0: 184,
+    1: 184,
+    2: 184,
+    3: 48,
+    4: 48,
+    5: 44,
+    6: 44,
+    7: 44,
+    8: 44,
+    9: 44,
+}
+EXPECTED_CONSERVATIVE_UNIVERSALLY_FORCED_BY_BUDGET = {
+    0: 184,
+    1: 184,
+    2: 6,
+    3: 2,
+    4: 2,
+    5: 2,
+    6: 2,
+    7: 2,
+    8: 2,
+    9: 2,
+}
+
+
+def pair(a: int, b: int) -> tuple[int, int]:
+    """Return a normalized unordered pair."""
+
+    return (a, b) if a < b else (b, a)
+
+
+def cyclic_length(a: int, b: int, n: int = N) -> int:
+    """Return the shorter cyclic length of a base."""
+
+    delta = (b - a) % n
+    return min(delta, n - delta)
+
+
+def capacity_for_cyclic_length(cyclic_length_value: int) -> int:
+    """Return the base-apex selected-baseline capacity for one cyclic length."""
+
+    return 1 if cyclic_length_value == 1 else 2
+
+
+def base_index(a: int, b: int, cyclic_length_value: int, n: int = N) -> int:
+    """Return the cyclic base index for a length-2 or length-3 base."""
+
+    if cyclic_length_value not in (2, 3):
+        raise ValueError("base index is only used for length-2 and length-3 bases")
+    return a if (b - a) % n == cyclic_length_value else b
+
+
+def selected_base_usage(rows: Sequence[Sequence[int]]) -> Counter[tuple[int, int]]:
+    """Count selected-witness row usage for each ordinary base."""
+
+    usage: Counter[tuple[int, int]] = Counter()
+    for row in rows:
+        for left_index in range(len(row)):
+            for right_index in range(left_index + 1, len(row)):
+                usage[pair(row[left_index], row[right_index])] += 1
+    return usage
+
+
+def selected_baseline_empty_slots(
+    rows: Sequence[Sequence[int]],
+) -> list[dict[str, int]]:
+    """Return unit empty capacity slots after selected-witness row usage."""
+
+    usage = selected_base_usage(rows)
+    slots: list[dict[str, int]] = []
+    for a in range(N):
+        for b in range(a + 1, N):
+            length = cyclic_length(a, b)
+            gap = capacity_for_cyclic_length(length) - usage[(a, b)]
+            if gap < 0:
+                raise AssertionError(f"selected usage exceeds capacity on base {(a, b)}")
+            for unit in range(gap):
+                row = {
+                    "a": a,
+                    "b": b,
+                    "cyclic_length": length,
+                    "slot": unit,
+                }
+                if length in (2, 3):
+                    row["base_index"] = base_index(a, b, length)
+                slots.append(row)
+    return slots
+
+
+def deficit_summary(rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    """Return selected-baseline capacity summary for one row assignment."""
+
+    usage = selected_base_usage(rows)
+    usage_by_length: Counter[int] = Counter()
+    deficit_by_length: Counter[int] = Counter()
+    saturated_by_length: Counter[int] = Counter()
+    spoiled_by_length: Counter[int] = Counter()
+    overfull_bases = []
+    spoiled_length2 = []
+    spoiled_length3 = []
+    total_deficit = 0
+
+    for a in range(N):
+        for b in range(a + 1, N):
+            length = cyclic_length(a, b)
+            capacity = capacity_for_cyclic_length(length)
+            used = usage[(a, b)]
+            usage_by_length[length] += used
+            if used > capacity:
+                overfull_bases.append(
+                    {
+                        "base": [a, b],
+                        "cyclic_length": length,
+                        "usage": used,
+                        "capacity": capacity,
+                    }
+                )
+                continue
+            gap = capacity - used
+            total_deficit += gap
+            deficit_by_length[length] += gap
+            if gap == 0:
+                saturated_by_length[length] += 1
+            else:
+                spoiled_by_length[length] += 1
+                if length == 2:
+                    spoiled_length2.append(base_index(a, b, length))
+                elif length == 3:
+                    spoiled_length3.append(base_index(a, b, length))
+
+    return {
+        "usage_by_cyclic_length": length_counter_payload(usage_by_length),
+        "deficit_by_cyclic_length": length_counter_payload(deficit_by_length),
+        "saturated_base_count_by_cyclic_length": length_counter_payload(
+            saturated_by_length
+        ),
+        "spoiled_base_count_by_cyclic_length": length_counter_payload(spoiled_by_length),
+        "total_deficit": total_deficit,
+        "overfull_bases": overfull_bases,
+        "spoiled_length2": sorted(spoiled_length2),
+        "spoiled_length3": sorted(spoiled_length3),
+    }
+
+
+def length_counter_payload(counter: Counter[int]) -> dict[str, int]:
+    """Return length keys 1..4 as JSON strings."""
+
+    return {str(length): int(counter[length]) for length in range(1, 5)}
+
+
+def counter_payload(counter: Counter[int]) -> dict[str, int]:
+    """Return a sorted integer-key counter with JSON string keys."""
+
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def placement_key_payload(
+    spoiled_length2: Iterable[int],
+    spoiled_length3: Iterable[int],
+) -> dict[str, list[int]]:
+    """Return a JSON-shaped spoiled-base placement key."""
+
+    return {
+        "spoiled_length2": [int(value) for value in spoiled_length2],
+        "spoiled_length3": [int(value) for value in spoiled_length3],
+    }
+
+
+def budget_overlay_rows(
+    slot_sets: Sequence[Sequence[dict[str, int]]],
+    *,
+    contradiction_threshold: int,
+) -> list[dict[str, object]]:
+    """Summarize all final deficit placements for each capacity budget."""
+
+    rows = []
+    for budget in range(BASE_APEX_SLACK + 1):
+        total_placements = 0
+        forced_placements = 0
+        escaping_placements = 0
+        universally_forced_assignments = 0
+        assignments_with_escape = 0
+        remaining_turn_counts: Counter[int] = Counter()
+        relevant_deficit_counts: Counter[int] = Counter()
+
+        for slots in slot_sets:
+            assignment_forced = True
+            assignment_has_escape = False
+            for chosen_indices in combinations(range(len(slots)), budget):
+                total_placements += 1
+                spoiled2 = sorted(
+                    {
+                        slots[index]["base_index"]
+                        for index in chosen_indices
+                        if slots[index]["cyclic_length"] == 2
+                    }
+                )
+                spoiled3 = sorted(
+                    {
+                        slots[index]["base_index"]
+                        for index in chosen_indices
+                        if slots[index]["cyclic_length"] == 3
+                    }
+                )
+                diagnostic = turn_cover_diagnostic(
+                    spoiled_length2=spoiled2,
+                    spoiled_length3=spoiled3,
+                    contradiction_threshold=contradiction_threshold,
+                )
+                remaining_turn_counts[diagnostic.minimum_forced_turns] += 1
+                relevant_deficit_counts[len(spoiled2) + len(spoiled3)] += 1
+                if diagnostic.forces_turn_contradiction:
+                    forced_placements += 1
+                else:
+                    escaping_placements += 1
+                    assignment_forced = False
+                    assignment_has_escape = True
+            if assignment_forced:
+                universally_forced_assignments += 1
+            if assignment_has_escape:
+                assignments_with_escape += 1
+
+        rows.append(
+            {
+                "capacity_deficit_budget": budget,
+                "total_final_deficit_placement_count": total_placements,
+                "forced_final_deficit_placement_count": forced_placements,
+                "escaping_final_deficit_placement_count": escaping_placements,
+                "universally_forced_assignment_count": universally_forced_assignments,
+                "assignment_with_escape_count": assignments_with_escape,
+                "remaining_forced_turn_count_by_final_placement": counter_payload(
+                    remaining_turn_counts
+                ),
+                "relevant_deficit_count_by_final_placement": counter_payload(
+                    relevant_deficit_counts
+                ),
+            }
+        )
+    return rows
+
+
+def threshold_section(
+    slot_sets: Sequence[Sequence[dict[str, int]]],
+    *,
+    contradiction_threshold: int,
+) -> dict[str, object]:
+    """Return one threshold section for final-budget overlay rows."""
+
+    rows = budget_overlay_rows(
+        slot_sets,
+        contradiction_threshold=contradiction_threshold,
+    )
+    return {
+        "contradiction_threshold": contradiction_threshold,
+        "budget_rows": rows,
+    }
+
+
+def selected_baseline_class_rows(
+    summaries: Sequence[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Return dihedral classes of selected-baseline relevant deficits."""
+
+    classes: Counter[tuple[tuple[int, ...], tuple[int, ...]]] = Counter()
+    minimum_forced_turns: dict[tuple[tuple[int, ...], tuple[int, ...]], int] = {}
+    strict_forced: dict[tuple[tuple[int, ...], tuple[int, ...]], bool] = {}
+    conservative_forced: dict[tuple[tuple[int, ...], tuple[int, ...]], bool] = {}
+
+    for summary in summaries:
+        spoiled2 = tuple(summary["spoiled_length2"])
+        spoiled3 = tuple(summary["spoiled_length3"])
+        key = canonical_deficit_placement(N, spoiled2, spoiled3)
+        diagnostic = turn_cover_diagnostic(
+            spoiled_length2=spoiled2,
+            spoiled_length3=spoiled3,
+            contradiction_threshold=STRICT_POSITIVE_THRESHOLD,
+        )
+        conservative = turn_cover_diagnostic(
+            spoiled_length2=spoiled2,
+            spoiled_length3=spoiled3,
+            contradiction_threshold=SUM_EXCEEDS_THRESHOLD,
+        )
+        classes[key] += 1
+        minimum_forced_turns[key] = diagnostic.minimum_forced_turns
+        strict_forced[key] = diagnostic.forces_turn_contradiction
+        conservative_forced[key] = conservative.forces_turn_contradiction
+
+    return [
+        {
+            "canonical_relevant_placement": placement_key_payload(*key),
+            "assignment_count": int(classes[key]),
+            "relevant_deficit_count": len(key[0]) + len(key[1]),
+            "remaining_minimum_forced_turns": minimum_forced_turns[key],
+            "strict_positive_forces_turn_cover": strict_forced[key],
+            "sum_exceeds_forces_turn_cover": conservative_forced[key],
+        }
+        for key in sorted(classes, key=lambda item: (len(item[0]) + len(item[1]), item))
+    ]
+
+
+def accepted_frontier_overlay() -> dict[str, object]:
+    """Return the selected-baseline overlay for the bounded accepted frontier."""
+
+    artifact = json.loads(ACCEPTED_FRONTIER_ARTIFACT.read_text(encoding="utf-8"))
+    frontiers = artifact["examples"]["accepted_frontier"]
+    if len(frontiers) != 1:
+        raise AssertionError(f"expected one accepted_frontier, got {len(frontiers)}")
+    rows = frontiers[0]["rows"]
+    summary = deficit_summary(rows)
+    spoiled2 = summary["spoiled_length2"]
+    spoiled3 = summary["spoiled_length3"]
+    strict = turn_cover_diagnostic(
+        spoiled_length2=spoiled2,
+        spoiled_length3=spoiled3,
+        contradiction_threshold=STRICT_POSITIVE_THRESHOLD,
+    )
+    conservative = turn_cover_diagnostic(
+        spoiled_length2=spoiled2,
+        spoiled_length3=spoiled3,
+        contradiction_threshold=SUM_EXCEEDS_THRESHOLD,
+    )
+    vc_result = vertex_circle_order_obstruction(rows, list(range(N)), "n9_accepted_frontier")
+    if vc_result.self_edge_conflicts:
+        status = "self_edge"
+    elif vc_result.cycle_edges:
+        status = "strict_cycle"
+    else:
+        status = "ok"
+    return {
+        "source": "data/certificates/n9_incidence_frontier_bounded.json",
+        "accepted_frontier_count": 1,
+        "rows": rows,
+        "vertex_circle_status": status,
+        "selected_baseline": {
+            "usage_by_cyclic_length": summary["usage_by_cyclic_length"],
+            "deficit_by_cyclic_length": summary["deficit_by_cyclic_length"],
+            "saturated_base_count_by_cyclic_length": summary[
+                "saturated_base_count_by_cyclic_length"
+            ],
+            "spoiled_base_count_by_cyclic_length": summary[
+                "spoiled_base_count_by_cyclic_length"
+            ],
+            "total_deficit": summary["total_deficit"],
+            "overfull_base_count": len(summary["overfull_bases"]),
+            "spoiled_length2": spoiled2,
+            "spoiled_length3": spoiled3,
+            "canonical_relevant_placement": placement_key_payload(
+                *canonical_deficit_placement(N, spoiled2, spoiled3)
+            ),
+        },
+        "turn_cover_overlay": {
+            "remaining_turn_clauses": [list(clause) for clause in strict.turn_clauses],
+            "remaining_minimum_forced_turns": strict.minimum_forced_turns,
+            "strict_positive_forces_turn_cover": strict.forces_turn_contradiction,
+            "sum_exceeds_forces_turn_cover": conservative.forces_turn_contradiction,
+        },
+        "interpretation": (
+            "This accepted_frontier row system escapes the selected-baseline "
+            "turn-cover overlay; accepted_frontier means it passed the bounded "
+            "frontier filters, not that it is geometrically realizable."
+        ),
+    }
+
+
+def selected_baseline_escape_budget_overlay() -> dict[str, object]:
+    """Return the generated selected-baseline escape-budget overlay artifact."""
+
+    assignments, nodes = pre_vertex_circle_assignments()
+    summaries = [deficit_summary(_rows_from_assignment(assign)) for assign in assignments]
+    slot_sets = [selected_baseline_empty_slots(_rows_from_assignment(assign)) for assign in assignments]
+
+    relevant_counts: Counter[int] = Counter()
+    remaining_turn_counts: Counter[int] = Counter()
+    strict_forced = 0
+    conservative_forced = 0
+    deficit_vector_counts: Counter[tuple[int, int, int, int]] = Counter()
+    overfull_assignment_count = 0
+
+    for summary in summaries:
+        if summary["overfull_bases"]:
+            overfull_assignment_count += 1
+        spoiled2 = summary["spoiled_length2"]
+        spoiled3 = summary["spoiled_length3"]
+        strict = turn_cover_diagnostic(
+            spoiled_length2=spoiled2,
+            spoiled_length3=spoiled3,
+            contradiction_threshold=STRICT_POSITIVE_THRESHOLD,
+        )
+        conservative = turn_cover_diagnostic(
+            spoiled_length2=spoiled2,
+            spoiled_length3=spoiled3,
+            contradiction_threshold=SUM_EXCEEDS_THRESHOLD,
+        )
+        remaining_turn_counts[strict.minimum_forced_turns] += 1
+        relevant_counts[len(spoiled2) + len(spoiled3)] += 1
+        strict_forced += int(strict.forces_turn_contradiction)
+        conservative_forced += int(conservative.forces_turn_contradiction)
+        deficits = summary["deficit_by_cyclic_length"]
+        deficit_vector_counts[
+            (
+                int(deficits["1"]),
+                int(deficits["2"]),
+                int(deficits["3"]),
+                int(deficits["4"]),
+            )
+        ] += 1
+
+    payload = {
+        "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v1",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "claim_scope": (
+            "Focused n=9 selected-baseline escape-budget overlay bookkeeping; "
+            "not a proof of n=9, not a counterexample, not a geometric "
+            "realizability test, and not a global status update."
+        ),
+        "n": N,
+        "witness_size": ROW_SIZE,
+        "base_apex_slack": BASE_APEX_SLACK,
+        "source_artifacts": {
+            "pre_vertex_circle_assignments": "data/certificates/n9_vertex_circle_exhaustive.json",
+            "base_apex_escape_budget": "data/certificates/n9_base_apex_escape_budget_report.json",
+            "accepted_frontier": "data/certificates/n9_incidence_frontier_bounded.json",
+        },
+        "selected_baseline": {
+            "assignment_count": len(assignments),
+            "pre_vertex_circle_nodes": int(nodes),
+            "selected_baseline_usage_per_assignment": SELECTED_BASELINE_USAGE,
+            "cyclic_base_capacity_total": CYCLIC_BASE_CAPACITY_TOTAL,
+            "selected_baseline_total_deficit_per_assignment": BASE_APEX_SLACK,
+            "overfull_assignment_count": overfull_assignment_count,
+            "deficit_vector_count_by_cyclic_length": [
+                {
+                    "deficit_by_cyclic_length": {
+                        str(length): int(vector[length - 1])
+                        for length in range(1, 5)
+                    },
+                    "assignment_count": int(count),
+                }
+                for vector, count in sorted(deficit_vector_counts.items())
+            ],
+            "relevant_deficit_count_distribution": counter_payload(relevant_counts),
+            "remaining_forced_turn_count_distribution": counter_payload(
+                remaining_turn_counts
+            ),
+            "strict_positive_forced_assignment_count": strict_forced,
+            "strict_positive_escaping_assignment_count": len(assignments) - strict_forced,
+            "sum_exceeds_forced_assignment_count": conservative_forced,
+            "sum_exceeds_escaping_assignment_count": len(assignments)
+            - conservative_forced,
+            "dihedral_relevant_placement_class_count": len(
+                selected_baseline_class_rows(summaries)
+            ),
+            "dihedral_relevant_placement_classes": selected_baseline_class_rows(
+                summaries
+            ),
+        },
+        "budget_overlay": {
+            "strict_positive_threshold": threshold_section(
+                slot_sets,
+                contradiction_threshold=STRICT_POSITIVE_THRESHOLD,
+            ),
+            "sum_exceeds_threshold": threshold_section(
+                slot_sets,
+                contradiction_threshold=SUM_EXCEEDS_THRESHOLD,
+            ),
+        },
+        "accepted_frontier_overlay": accepted_frontier_overlay(),
+        "interpretation": [
+            "The selected baseline counts only the 4 chosen witnesses at each center.",
+            "Every pre-vertex-circle selected-witness assignment uses 54 base-apex incidences against cyclic capacity 63, leaving 9 selected-baseline empty capacity units.",
+            "Actual unselected equal-distance triples or profile excess could fill some selected-baseline empty slots, so these counts are not geometric realizability counts.",
+            "A forced row for budget D means every way to leave D selected-baseline empty slots unfilled still triggers the current length-2/length-3 turn-cover contradiction.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/analyze_n9_selected_baseline_escape_budget_overlay.py",
+            "command": (
+                "python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py "
+                "--assert-expected --out "
+                "data/certificates/n9_selected_baseline_escape_budget_overlay.json"
+            ),
+        },
+    }
+    assert_expected_overlay_counts(payload)
+    return payload
+
+
+def assert_expected_overlay_counts(payload: dict[str, object]) -> None:
+    """Assert stable counts for the selected-baseline overlay."""
+
+    selected = payload["selected_baseline"]
+    if not isinstance(selected, dict):
+        raise AssertionError("missing selected_baseline block")
+    if selected["assignment_count"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError(f"unexpected assignment count: {selected['assignment_count']}")
+    if selected["pre_vertex_circle_nodes"] != EXPECTED_PRE_VERTEX_CIRCLE_NODES:
+        raise AssertionError(f"unexpected node count: {selected['pre_vertex_circle_nodes']}")
+    if (
+        selected["relevant_deficit_count_distribution"]
+        != counter_payload(Counter(EXPECTED_RELEVANT_DEFICIT_DISTRIBUTION))
+    ):
+        raise AssertionError("unexpected relevant deficit distribution")
+    if (
+        selected["remaining_forced_turn_count_distribution"]
+        != counter_payload(Counter(EXPECTED_SELECTED_BASELINE_REMAINING_FORCED_TURNS))
+    ):
+        raise AssertionError("unexpected selected-baseline forced-turn distribution")
+    if (
+        selected["strict_positive_forced_assignment_count"]
+        != EXPECTED_STRICT_FORCED_ASSIGNMENTS
+    ):
+        raise AssertionError("unexpected strict forced assignment count")
+    if (
+        selected["sum_exceeds_forced_assignment_count"]
+        != EXPECTED_CONSERVATIVE_FORCED_ASSIGNMENTS
+    ):
+        raise AssertionError("unexpected conservative forced assignment count")
+    if (
+        selected["dihedral_relevant_placement_class_count"]
+        != EXPECTED_DIHEDRAL_RELEVANT_PLACEMENT_CLASSES
+    ):
+        raise AssertionError("unexpected dihedral placement class count")
+
+    strict = payload["budget_overlay"]["strict_positive_threshold"]
+    conservative = payload["budget_overlay"]["sum_exceeds_threshold"]
+    if not isinstance(strict, dict) or not isinstance(conservative, dict):
+        raise AssertionError("missing threshold blocks")
+    strict_forced = {
+        int(row["capacity_deficit_budget"]): int(row["universally_forced_assignment_count"])
+        for row in strict["budget_rows"]
+    }
+    conservative_forced = {
+        int(row["capacity_deficit_budget"]): int(row["universally_forced_assignment_count"])
+        for row in conservative["budget_rows"]
+    }
+    if strict_forced != EXPECTED_STRICT_UNIVERSALLY_FORCED_BY_BUDGET:
+        raise AssertionError("unexpected strict universal-forcing counts by budget")
+    if conservative_forced != EXPECTED_CONSERVATIVE_UNIVERSALLY_FORCED_BY_BUDGET:
+        raise AssertionError("unexpected conservative universal-forcing counts by budget")
+
+    frontier = payload["accepted_frontier_overlay"]
+    if not isinstance(frontier, dict):
+        raise AssertionError("missing accepted_frontier_overlay block")
+    if frontier["vertex_circle_status"] != "self_edge":
+        raise AssertionError("unexpected accepted-frontier vertex-circle status")
+    frontier_selected = frontier["selected_baseline"]
+    if not isinstance(frontier_selected, dict):
+        raise AssertionError("missing accepted frontier selected-baseline block")
+    if frontier_selected["deficit_by_cyclic_length"] != {"1": 0, "2": 3, "3": 2, "4": 4}:
+        raise AssertionError("unexpected accepted-frontier deficit vector")
+    if frontier_selected["spoiled_length2"] != [0, 3, 6]:
+        raise AssertionError("unexpected accepted-frontier length-2 deficits")
+    if frontier_selected["spoiled_length3"] != [1, 7]:
+        raise AssertionError("unexpected accepted-frontier length-3 deficits")
+    if frontier["turn_cover_overlay"]["remaining_minimum_forced_turns"] != 1:
+        raise AssertionError("unexpected accepted-frontier forced-turn count")

--- a/tests/test_n9_selected_baseline_escape_budget_overlay.py
+++ b/tests/test_n9_selected_baseline_escape_budget_overlay.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_selected_baseline_escape_budget import (
+    selected_baseline_escape_budget_overlay,
+)
+from scripts.check_n9_selected_baseline_escape_budget_overlay import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_selected_baseline_overlay_artifact_summary_is_nonclaiming() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    selected = payload["selected_baseline"]
+    frontier = payload["accepted_frontier_overlay"]
+
+    assert payload["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert payload["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a geometric realizability test" in payload["claim_scope"]
+    assert selected["assignment_count"] == 184
+    assert selected["pre_vertex_circle_nodes"] == 100817
+    assert selected["selected_baseline_total_deficit_per_assignment"] == 9
+    assert selected["overfull_assignment_count"] == 0
+    assert selected["relevant_deficit_count_distribution"] == {
+        "0": 2,
+        "3": 24,
+        "4": 36,
+        "5": 36,
+        "6": 24,
+        "8": 18,
+        "9": 44,
+    }
+    assert selected["strict_positive_forced_assignment_count"] == 44
+    assert selected["sum_exceeds_forced_assignment_count"] == 2
+    assert selected["dihedral_relevant_placement_class_count"] == 13
+    assert frontier["selected_baseline"]["deficit_by_cyclic_length"] == {
+        "1": 0,
+        "2": 3,
+        "3": 2,
+        "4": 4,
+    }
+    assert frontier["turn_cover_overlay"]["remaining_minimum_forced_turns"] == 1
+
+
+def test_selected_baseline_overlay_budget_rows_pin_universal_forcing_counts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    strict_rows = payload["budget_overlay"]["strict_positive_threshold"]["budget_rows"]
+    conservative_rows = payload["budget_overlay"]["sum_exceeds_threshold"]["budget_rows"]
+
+    assert [row["universally_forced_assignment_count"] for row in strict_rows] == [
+        184,
+        184,
+        184,
+        48,
+        48,
+        44,
+        44,
+        44,
+        44,
+        44,
+    ]
+    assert [row["universally_forced_assignment_count"] for row in conservative_rows] == [
+        184,
+        184,
+        6,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+    ]
+    assert strict_rows[9]["escaping_final_deficit_placement_count"] == 140
+    assert conservative_rows[9]["escaping_final_deficit_placement_count"] == 182
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_selected_baseline_overlay_artifact_matches_generator() -> None:
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == selected_baseline_escape_budget_overlay()
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_selected_baseline_overlay_checker_passes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["strict_selected_baseline_forced_assignment_count"] == 44
+    assert summary["conservative_selected_baseline_forced_assignment_count"] == 2
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_selected_baseline_overlay_checker_rejects_tampered_count() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["selected_baseline"]["strict_positive_forced_assignment_count"] = 45
+
+    errors = validate_payload(payload)
+
+    assert any("overlay payload" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_selected_baseline_overlay_checker_rejects_unknown_top_level_key() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["unchecked_schema_drift"] = {"ok": False}
+
+    errors = validate_payload(payload)
+
+    assert any("top-level keys" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_selected_baseline_overlay_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_selected_baseline_escape_budget_overlay.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["assignment_count"] == 184

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -46,3 +46,7 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert "python scripts/check_n9_base_apex_escape_budget.py --check --json" in command_texts
+    assert (
+        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary
- add a generated n=9 selected-baseline escape-budget overlay for the 184 pre-vertex-circle selected-witness assignments
- add a replaying generator/checker that records selected baseline capacity gaps, final deficit-budget placement rows, dihedral relevant-placement classes, and the bounded accepted-frontier escape shape
- register the artifact in generated-artifact provenance and artifact-audit coverage, with tests and documentation

## Scope
This is finite bookkeeping for the n=9 base-apex workstream. It compares selected-witness row usage against cyclic base capacities and the existing length-2/length-3 turn-cover diagnostic. It is not a proof of n=9, not a counterexample, not a geometric realizability test, not an independent review of the vertex-circle checker, and not a global status update.

## Validation
- `python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json`
- `python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json`
- `python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --check-artifact data/certificates/n9_selected_baseline_escape_budget_overlay.json`
- `python -m pytest tests/test_n9_selected_baseline_escape_budget_overlay.py -q -m 'artifact or exhaustive or not artifact'`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- raw artifact tier / adjacent checks:
  - `python scripts/independent_check_n8_artifacts.py --check --json`
  - `python scripts/enumerate_n8_incidence.py --summary`
  - `python scripts/analyze_n8_exact_survivors.py --check --json`
  - `python scripts/check_round2_certificates.py`
  - `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
  - `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
  - `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
  - `python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json`
  - `python scripts/check_n9_base_apex_escape_budget.py --check --json`
  - `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic`