### PR TITLE
Add n9 D3 escape slice diagnostic

### DIFF
--- a/data/certificates/n9_base_apex_d3_escape_slice.json
+++ b/data/certificates/n9_base_apex_d3_escape_slice.json
@@ -1,0 +1,2539 @@
+{
+  "capacity_deficit": 3,
+  "claim_scope": "Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.",
+  "coupled_slice": {
+    "common_dihedral_pair_class_count": 18088,
+    "common_dihedral_pair_orbit_size_counts": {
+      "18": 17948,
+      "9": 140
+    },
+    "labelled_profile_escape_pair_count": 324324,
+    "pair_class_count_by_escape_class": [
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 3003
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 1519
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 1519
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 3003
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 3003
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 1519
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 1519
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 3003
+      }
+    ],
+    "pair_class_count_by_profile_multiset": [
+      {
+        "common_dihedral_pair_class_count": 56,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 432,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 432,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 224,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 1520,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 3024,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 512,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 3024,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 4560,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 3792,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "common_dihedral_pair_class_count": 512,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    ],
+    "pair_class_count_by_profile_multiset_and_escape_class": [
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 9,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 5,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 5,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 9,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 9,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 5,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 5,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 9,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 72,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 20,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 20,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 20,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 20,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 36,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 128,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 128,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 128,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 128,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 252,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 504,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 756,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 384,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 384,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 756,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 756,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 384,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 384,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 756,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 630,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 318,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 318,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 630,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 630,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 318,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 318,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 630,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 44,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "common_dihedral_pair_class_count": 84,
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    ]
+  },
+  "escape_slice": {
+    "contradiction_threshold": 3,
+    "dihedral_escape_class_count": 8,
+    "dihedral_escape_orbit_size_counts": {
+      "18": 4,
+      "9": 4
+    },
+    "escape_classes": [
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            3
+          ]
+        },
+        "labelled_placement_count": 18
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "labelled_placement_count": 9
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            3
+          ],
+          "spoiled_length3": [
+            1
+          ]
+        },
+        "labelled_placement_count": 9
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            4
+          ],
+          "spoiled_length3": [
+            5
+          ]
+        },
+        "labelled_placement_count": 18
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            3
+          ],
+          "spoiled_length3": []
+        },
+        "labelled_placement_count": 18
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            1,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "labelled_placement_count": 9
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            4
+          ],
+          "spoiled_length3": []
+        },
+        "labelled_placement_count": 9
+      },
+      {
+        "canonical_escape_placement": {
+          "spoiled_length2": [
+            0,
+            2,
+            5
+          ],
+          "spoiled_length3": []
+        },
+        "labelled_placement_count": 18
+      }
+    ],
+    "labelled_escape_placement_count": 108,
+    "relevant_deficit_count": 3
+  },
+  "interpretation": [
+    "This is the sharp strict-threshold D=3 slice where no leftover budget remains after the minimum relevant escape.",
+    "Profile-excess sequences record labelled vertex excesses only, not actual geometric distance-class realizations.",
+    "Escape placements record length-2/length-3 deficits in the current turn-cover diagnostic only.",
+    "Common-dihedral pair classes couple those two labelled structures under the same cyclic relabeling action.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "profile_slice": {
+    "capacity_deficit": 3,
+    "dihedral_profile_orbit_count": 185,
+    "dihedral_profile_orbit_size_counts": {
+      "18": 150,
+      "3": 2,
+      "9": 33
+    },
+    "labelled_profile_sequence_count": 3003,
+    "profile_multiset_counts": [
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          6
+        ],
+        "labelled_sequence_count": 9
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          5
+        ],
+        "labelled_sequence_count": 72
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          4
+        ],
+        "labelled_sequence_count": 72
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          3,
+          3
+        ],
+        "labelled_sequence_count": 36
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          4
+        ],
+        "labelled_sequence_count": 252
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3
+        ],
+        "labelled_sequence_count": 504
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          2,
+          2,
+          2
+        ],
+        "labelled_sequence_count": 84
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          3
+        ],
+        "labelled_sequence_count": 504
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          2,
+          2
+        ],
+        "labelled_sequence_count": 756
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          2
+        ],
+        "labelled_sequence_count": 630
+      },
+      {
+        "excess_multiset": [
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        "labelled_sequence_count": 84
+      }
+    ],
+    "total_profile_excess": 6,
+    "unlabeled_profile_ledger_count": 11
+  },
+  "provenance": {
+    "command": "python scripts/analyze_n9_d3_escape_slice.py --assert-expected --out data/certificates/n9_base_apex_d3_escape_slice.json",
+    "generator": "scripts/analyze_n9_d3_escape_slice.py"
+  },
+  "relevant_deficit_count": 3,
+  "schema": "erdos97.n9_base_apex_d3_escape_slice.v1",
+  "source_artifacts": {
+    "escape_budget": "data/certificates/n9_base_apex_escape_budget_report.json",
+    "low_excess_ledgers": "data/certificates/n9_base_apex_low_excess_ledgers.json",
+    "selected_baseline_overlay": "data/certificates/n9_selected_baseline_escape_budget_overlay.json"
+  },
+  "status": "EXPLORATORY_LEDGER_ONLY",
+  "total_profile_excess": 6,
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+  "witness_size": 4
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -94,6 +94,10 @@ Expected artifacts:
   compare the escape-budget motif map with the 184 pre-vertex-circle
   selected-witness assignments without treating selected-baseline empty slots
   as actual geometric capacity deficits;
+- optional sharp low-excess slices such as
+  `data/certificates/n9_base_apex_d3_escape_slice.json` that couple the
+  `E=6, D=3, r=3` profile/escape bookkeeping under common dihedral symmetry
+  without claiming the slice is impossible or realizable;
 - checker updates that independently replay generated ledger arithmetic and
   motif counts from stored JSON.
 

--- a/docs/n9-base-apex-frontier.md
+++ b/docs/n9-base-apex-frontier.md
@@ -132,6 +132,16 @@ equal-distance triples or profile excess could fill selected-baseline empty
 capacity slots, so the artifact is only a finite bookkeeping map for where the
 current turn-cover method does and does not bite.
 
+The sharp strict-threshold slice is recorded separately at
+`data/certificates/n9_base_apex_d3_escape_slice.json`. This is the case
+`E=6`, `D=3`, `r=3`, where all three capacity-deficit units are relevant
+length-2/length-3 deficits and there is no leftover budget to park on sides or
+length-4 diagonals. The diagnostic finds 3,003 labelled profile-excess
+sequences, 108 labelled strict escape placements, and 18,088 common-dihedral
+coupled profile/escape classes. These are proof-search fingerprints only: the
+artifact does not say that any coupled class is realizable, nor that the
+`D=3` slice is impossible.
+
 ## Turn-cover diagnostic
 
 Index the length-2 diagonal `{v_i,v_{i+2}}` by `i`. If it is fully saturated,

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -365,6 +365,44 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_base_apex_d3_escape_slice
+    path: data/certificates/n9_base_apex_d3_escape_slice.json
+    kind: exploratory_ledger_artifact
+    generator: scripts/analyze_n9_d3_escape_slice.py
+    command: python scripts/analyze_n9_d3_escape_slice.py --assert-expected --out data/certificates/n9_base_apex_d3_escape_slice.json
+    checker: scripts/check_n9_d3_escape_slice.py
+    check_command: python scripts/check_n9_d3_escape_slice.py --check --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_base_apex_d3_escape_slice.v1
+      status: EXPLORATORY_LEDGER_ONLY
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      claim_scope: Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
+      n: 9
+      witness_size: 4
+      total_profile_excess: 6
+      capacity_deficit: 3
+      relevant_deficit_count: 3
+      profile_slice.labelled_profile_sequence_count: 3003
+      profile_slice.dihedral_profile_orbit_count: 185
+      escape_slice.labelled_escape_placement_count: 108
+      escape_slice.dihedral_escape_class_count: 8
+      coupled_slice.labelled_profile_escape_pair_count: 324324
+      coupled_slice.common_dihedral_pair_class_count: 18088
+      provenance.command: python scripts/analyze_n9_d3_escape_slice.py --assert-expected --out data/certificates/n9_base_apex_d3_escape_slice.json
+    forbidden_claims:
+      - n=9 is proved
+      - D=3,r=3 is impossible
+      - geometric realizability count
+      - counterexample
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact

--- a/scripts/analyze_n9_d3_escape_slice.py
+++ b/scripts/analyze_n9_d3_escape_slice.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate the n=9 D=3 coupled escape-slice artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_d3_escape_slice import (  # noqa: E402
+    assert_expected_counts,
+    d3_escape_slice_report,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_base_apex_d3_escape_slice.json"
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def load_json(path: Path) -> object:
+    """Load JSON from a path."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print generated JSON")
+    parser.add_argument("--out", type=Path, help="write generated JSON to this path")
+    parser.add_argument(
+        "--check-artifact",
+        type=Path,
+        help="compare generated JSON with an existing artifact",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = d3_escape_slice_report()
+    if args.assert_expected:
+        assert_expected_counts(payload)
+
+    if args.check_artifact is not None:
+        artifact = (
+            args.check_artifact
+            if args.check_artifact.is_absolute()
+            else ROOT / args.check_artifact
+        )
+        checked = load_json(artifact)
+        if checked != payload:
+            print(
+                f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",
+                file=sys.stderr,
+            )
+            return 1
+
+    if args.out is not None:
+        out = args.out if args.out.is_absolute() else ROOT / args.out
+        write_json(payload, out)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif args.check_artifact is not None:
+        print("OK: n=9 D=3 escape-slice artifact is current")
+    elif args.out is not None:
+        print(f"wrote {display_path(out, ROOT)}")
+    else:
+        profile = payload["profile_slice"]
+        escape = payload["escape_slice"]
+        coupled = payload["coupled_slice"]
+        print("n=9 D=3 coupled escape-slice diagnostic")
+        print(f"profile sequences: {profile['labelled_profile_sequence_count']}")
+        print(f"escape placements: {escape['labelled_escape_placement_count']}")
+        print(
+            "coupled common-dihedral classes: "
+            f"{coupled['common_dihedral_pair_class_count']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_n9_d3_escape_slice.py
+++ b/scripts/check_n9_d3_escape_slice.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Validate the n=9 D=3 coupled escape-slice artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_d3_escape_slice import d3_escape_slice_report  # noqa: E402
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_base_apex_d3_escape_slice.json"
+EXPECTED_TOP_LEVEL_KEYS = {
+    "capacity_deficit",
+    "claim_scope",
+    "coupled_slice",
+    "escape_slice",
+    "interpretation",
+    "n",
+    "profile_slice",
+    "provenance",
+    "relevant_deficit_count",
+    "schema",
+    "source_artifacts",
+    "status",
+    "total_profile_excess",
+    "trust",
+    "witness_size",
+}
+EXPECTED_CLAIM_SCOPE = (
+    "Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; "
+    "not a proof of n=9, not a counterexample, not a geometric "
+    "realizability test, and not a global status update."
+)
+EXPECTED_PROVENANCE = {
+    "generator": "scripts/analyze_n9_d3_escape_slice.py",
+    "command": (
+        "python scripts/analyze_n9_d3_escape_slice.py --assert-expected "
+        "--out data/certificates/n9_base_apex_d3_escape_slice.json"
+    ),
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
+    """Return validation errors for a loaded D=3 escape-slice artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    top_level_keys = set(payload)
+    if top_level_keys != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(top_level_keys)!r}"
+        )
+
+    expected_meta = {
+        "schema": "erdos97.n9_base_apex_d3_escape_slice.v1",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "n": 9,
+        "witness_size": 4,
+        "total_profile_excess": 6,
+        "capacity_deficit": 3,
+        "relevant_deficit_count": 3,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    claim_scope = payload.get("claim_scope")
+    expect_equal(errors, "claim_scope", claim_scope, EXPECTED_CLAIM_SCOPE)
+    if isinstance(claim_scope, str):
+        lowered = claim_scope.lower()
+        for phrase in (
+            "not a proof",
+            "not a counterexample",
+            "not a geometric realizability test",
+            "not a global status update",
+        ):
+            if phrase not in lowered:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    provenance = payload.get("provenance")
+    expect_equal(errors, "provenance", provenance, EXPECTED_PROVENANCE)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+
+    if recompute:
+        try:
+            expected_payload = d3_escape_slice_report()
+        except (AssertionError, ValueError) as exc:
+            errors.append(f"recomputed D=3 slice failed: {exc}")
+        else:
+            expect_equal(errors, "D=3 escape-slice payload", payload, expected_payload)
+    return errors
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repo-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    profile = object_payload.get("profile_slice", {})
+    escape = object_payload.get("escape_slice", {})
+    coupled = object_payload.get("coupled_slice", {})
+    return {
+        "ok": not errors,
+        "artifact": display_path(path),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "labelled_profile_sequence_count": (
+            profile.get("labelled_profile_sequence_count")
+            if isinstance(profile, dict)
+            else None
+        ),
+        "labelled_escape_placement_count": (
+            escape.get("labelled_escape_placement_count")
+            if isinstance(escape, dict)
+            else None
+        ),
+        "common_dihedral_pair_class_count": (
+            coupled.get("common_dihedral_pair_class_count")
+            if isinstance(coupled, dict)
+            else None
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="fail if validation fails")
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 D=3 escape-slice artifact")
+        print(f"artifact: {summary['artifact']}")
+        print(f"profile sequences: {summary['labelled_profile_sequence_count']}")
+        print(f"escape placements: {summary['labelled_escape_placement_count']}")
+        print(
+            "common-dihedral classes: "
+            f"{summary['common_dihedral_pair_class_count']}"
+        )
+        if args.check:
+            print("OK: D=3 escape-slice checks passed")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -142,6 +142,14 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_base_apex_d3_escape_slice",
+        command=("python", "scripts/check_n9_d3_escape_slice.py", "--check", "--json"),
+        claim_scope=(
+            "Exploratory n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; "
+            "not a proof of n=9, counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/src/erdos97/n9_d3_escape_slice.py
+++ b/src/erdos97/n9_d3_escape_slice.py
@@ -1,0 +1,394 @@
+"""Coupled D=3 escape slice for the n=9 base-apex ledger.
+
+This module is finite diagnostic bookkeeping. It couples the sharp strict
+turn-cover escape budget ``D=3, r=3`` with the labelled profile-excess
+placements of total excess ``E=6``. It does not prove the n=9 case and does
+not claim a counterexample.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from itertools import combinations
+
+from erdos97.n9_base_apex import (
+    canonical_deficit_placement,
+    profile_excess_values,
+    transform_base_index,
+    turn_cover_diagnostic,
+)
+
+N = 9
+WITNESS_SIZE = 4
+TOTAL_PROFILE_EXCESS = 6
+CAPACITY_DEFICIT = 3
+RELEVANT_DEFICIT_COUNT = 3
+CONTRADICTION_THRESHOLD = 3
+
+EXPECTED_PROFILE_SEQUENCE_COUNT = 3003
+EXPECTED_PROFILE_DIHEDRAL_ORBIT_COUNT = 185
+EXPECTED_PROFILE_ORBIT_SIZE_COUNTS = {3: 2, 9: 33, 18: 150}
+EXPECTED_ESCAPE_PLACEMENT_COUNT = 108
+EXPECTED_ESCAPE_DIHEDRAL_CLASS_COUNT = 8
+EXPECTED_ESCAPE_ORBIT_SIZE_COUNTS = {9: 4, 18: 4}
+EXPECTED_LABELLED_COUPLED_PAIR_COUNT = 324_324
+EXPECTED_COMMON_DIHEDRAL_PAIR_CLASS_COUNT = 18_088
+EXPECTED_COMMON_DIHEDRAL_ORBIT_SIZE_COUNTS = {9: 140, 18: 17_948}
+
+
+ProfileSequence = tuple[int, ...]
+EscapePlacement = tuple[tuple[int, ...], tuple[int, ...]]
+CoupledKey = tuple[ProfileSequence, EscapePlacement]
+
+
+def json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    """Return a sorted counter with JSON string keys."""
+
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def profile_sequences(
+    total_profile_excess: int = TOTAL_PROFILE_EXCESS,
+) -> list[ProfileSequence]:
+    """Return labelled profile-excess sequences with the requested total."""
+
+    values = [
+        value
+        for value in profile_excess_values(N, WITNESS_SIZE)
+        if value <= total_profile_excess
+    ]
+    out: list[ProfileSequence] = []
+
+    def search(position: int, remaining: int, current: list[int]) -> None:
+        if position == N:
+            if remaining == 0:
+                out.append(tuple(current))
+            return
+        for value in values:
+            if value > remaining:
+                break
+            current.append(value)
+            search(position + 1, remaining - value, current)
+            current.pop()
+
+    search(0, total_profile_excess, [])
+    return sorted(out)
+
+
+def transform_profile_sequence(
+    sequence: ProfileSequence,
+    *,
+    rotation: int,
+    reflected: bool,
+) -> ProfileSequence:
+    """Transform a labelled profile sequence by a dihedral relabeling."""
+
+    out: list[int | None] = [None] * N
+    for label, value in enumerate(sequence):
+        target = (rotation - label) % N if reflected else (label + rotation) % N
+        out[target] = value
+    if any(value is None for value in out):  # pragma: no cover - defensive
+        raise AssertionError("dihedral map did not produce a complete profile")
+    return tuple(int(value) for value in out if value is not None)
+
+
+def canonical_profile_sequence(sequence: ProfileSequence) -> ProfileSequence:
+    """Return the dihedral-canonical labelled profile sequence."""
+
+    return min(
+        transform_profile_sequence(sequence, rotation=rotation, reflected=reflected)
+        for rotation in range(N)
+        for reflected in (False, True)
+    )
+
+
+def transform_escape_placement(
+    placement: EscapePlacement,
+    *,
+    rotation: int,
+    reflected: bool,
+) -> EscapePlacement:
+    """Transform a length-2/length-3 escape placement by one dihedral map."""
+
+    spoiled2, spoiled3 = placement
+    return (
+        tuple(
+            sorted(
+                transform_base_index(
+                    N,
+                    index,
+                    2,
+                    rotation=rotation,
+                    reflected=reflected,
+                )
+                for index in spoiled2
+            )
+        ),
+        tuple(
+            sorted(
+                transform_base_index(
+                    N,
+                    index,
+                    3,
+                    rotation=rotation,
+                    reflected=reflected,
+                )
+                for index in spoiled3
+            )
+        ),
+    )
+
+
+def escape_placements() -> list[EscapePlacement]:
+    """Return labelled strict-threshold r=3 placements escaping turn cover."""
+
+    placements: list[EscapePlacement] = []
+    for count2 in range(RELEVANT_DEFICIT_COUNT + 1):
+        count3 = RELEVANT_DEFICIT_COUNT - count2
+        for spoiled2 in combinations(range(N), count2):
+            for spoiled3 in combinations(range(N), count3):
+                diagnostic = turn_cover_diagnostic(
+                    spoiled_length2=spoiled2,
+                    spoiled_length3=spoiled3,
+                    contradiction_threshold=CONTRADICTION_THRESHOLD,
+                )
+                if not diagnostic.forces_turn_contradiction:
+                    placements.append((tuple(spoiled2), tuple(spoiled3)))
+    return sorted(placements)
+
+
+def placement_payload(placement: EscapePlacement) -> dict[str, list[int]]:
+    """Return a JSON-shaped escape placement."""
+
+    spoiled2, spoiled3 = placement
+    return {
+        "spoiled_length2": [int(value) for value in spoiled2],
+        "spoiled_length3": [int(value) for value in spoiled3],
+    }
+
+
+def canonical_coupled_pair(
+    profile: ProfileSequence,
+    placement: EscapePlacement,
+) -> CoupledKey:
+    """Return the common-dihedral canonical profile/escape pair."""
+
+    return min(
+        (
+            transform_profile_sequence(
+                profile,
+                rotation=rotation,
+                reflected=reflected,
+            ),
+            transform_escape_placement(
+                placement,
+                rotation=rotation,
+                reflected=reflected,
+            ),
+        )
+        for rotation in range(N)
+        for reflected in (False, True)
+    )
+
+
+def profile_sequence_summary(sequences: list[ProfileSequence]) -> dict[str, object]:
+    """Return labelled and dihedral profile-placement counts."""
+
+    multiset_counts = Counter(tuple(sorted(sequence)) for sequence in sequences)
+    orbit_members: defaultdict[ProfileSequence, list[ProfileSequence]] = defaultdict(list)
+    for sequence in sequences:
+        orbit_members[canonical_profile_sequence(sequence)].append(sequence)
+    return {
+        "total_profile_excess": TOTAL_PROFILE_EXCESS,
+        "capacity_deficit": CAPACITY_DEFICIT,
+        "unlabeled_profile_ledger_count": len(multiset_counts),
+        "labelled_profile_sequence_count": len(sequences),
+        "dihedral_profile_orbit_count": len(orbit_members),
+        "dihedral_profile_orbit_size_counts": json_counter(
+            Counter(len(members) for members in orbit_members.values())
+        ),
+        "profile_multiset_counts": [
+            {
+                "excess_multiset": [int(value) for value in multiset],
+                "labelled_sequence_count": int(count),
+            }
+            for multiset, count in sorted(multiset_counts.items())
+        ],
+    }
+
+
+def escape_placement_summary(placements: list[EscapePlacement]) -> dict[str, object]:
+    """Return labelled and dihedral escape-placement counts."""
+
+    orbit_members: defaultdict[EscapePlacement, list[EscapePlacement]] = defaultdict(list)
+    for placement in placements:
+        orbit_members[
+            canonical_deficit_placement(N, placement[0], placement[1])
+        ].append(placement)
+    return {
+        "contradiction_threshold": CONTRADICTION_THRESHOLD,
+        "relevant_deficit_count": RELEVANT_DEFICIT_COUNT,
+        "labelled_escape_placement_count": len(placements),
+        "dihedral_escape_class_count": len(orbit_members),
+        "dihedral_escape_orbit_size_counts": json_counter(
+            Counter(len(members) for members in orbit_members.values())
+        ),
+        "escape_classes": [
+            {
+                "canonical_escape_placement": placement_payload(placement),
+                "labelled_placement_count": len(orbit_members[placement]),
+            }
+            for placement in sorted(
+                orbit_members,
+                key=lambda item: (len(item[0]), item),
+            )
+        ],
+    }
+
+
+def coupled_slice_summary(
+    sequences: list[ProfileSequence],
+    placements: list[EscapePlacement],
+) -> dict[str, object]:
+    """Return common-dihedral coupled profile/escape summary counts."""
+
+    class_sizes: Counter[CoupledKey] = Counter()
+    for sequence in sequences:
+        for placement in placements:
+            class_sizes[canonical_coupled_pair(sequence, placement)] += 1
+
+    by_profile_multiset: Counter[tuple[int, ...]] = Counter()
+    by_escape_class: Counter[EscapePlacement] = Counter()
+    by_profile_and_escape: Counter[tuple[tuple[int, ...], EscapePlacement]] = Counter()
+    for profile, placement in class_sizes:
+        profile_multiset = tuple(sorted(profile))
+        escape_class = canonical_deficit_placement(N, placement[0], placement[1])
+        by_profile_multiset[profile_multiset] += 1
+        by_escape_class[escape_class] += 1
+        by_profile_and_escape[(profile_multiset, escape_class)] += 1
+
+    return {
+        "labelled_profile_escape_pair_count": len(sequences) * len(placements),
+        "common_dihedral_pair_class_count": len(class_sizes),
+        "common_dihedral_pair_orbit_size_counts": json_counter(
+            Counter(class_sizes.values())
+        ),
+        "pair_class_count_by_profile_multiset": [
+            {
+                "excess_multiset": [int(value) for value in multiset],
+                "common_dihedral_pair_class_count": int(count),
+            }
+            for multiset, count in sorted(by_profile_multiset.items())
+        ],
+        "pair_class_count_by_escape_class": [
+            {
+                "canonical_escape_placement": placement_payload(placement),
+                "common_dihedral_pair_class_count": int(count),
+            }
+            for placement, count in sorted(
+                by_escape_class.items(),
+                key=lambda item: (len(item[0][0]), item[0]),
+            )
+        ],
+        "pair_class_count_by_profile_multiset_and_escape_class": [
+            {
+                "excess_multiset": [int(value) for value in multiset],
+                "canonical_escape_placement": placement_payload(placement),
+                "common_dihedral_pair_class_count": int(count),
+            }
+            for (multiset, placement), count in sorted(
+                by_profile_and_escape.items(),
+                key=lambda item: (item[0][0], len(item[0][1][0]), item[0][1]),
+            )
+        ],
+    }
+
+
+def d3_escape_slice_report() -> dict[str, object]:
+    """Return the generated D=3 coupled escape-slice report."""
+
+    sequences = profile_sequences()
+    placements = escape_placements()
+    payload = {
+        "schema": "erdos97.n9_base_apex_d3_escape_slice.v1",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+        "claim_scope": (
+            "Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; "
+            "not a proof of n=9, not a counterexample, not a geometric "
+            "realizability test, and not a global status update."
+        ),
+        "n": N,
+        "witness_size": WITNESS_SIZE,
+        "total_profile_excess": TOTAL_PROFILE_EXCESS,
+        "capacity_deficit": CAPACITY_DEFICIT,
+        "relevant_deficit_count": RELEVANT_DEFICIT_COUNT,
+        "source_artifacts": {
+            "low_excess_ledgers": "data/certificates/n9_base_apex_low_excess_ledgers.json",
+            "escape_budget": "data/certificates/n9_base_apex_escape_budget_report.json",
+            "selected_baseline_overlay": (
+                "data/certificates/n9_selected_baseline_escape_budget_overlay.json"
+            ),
+        },
+        "profile_slice": profile_sequence_summary(sequences),
+        "escape_slice": escape_placement_summary(placements),
+        "coupled_slice": coupled_slice_summary(sequences, placements),
+        "interpretation": [
+            "This is the sharp strict-threshold D=3 slice where no leftover budget remains after the minimum relevant escape.",
+            "Profile-excess sequences record labelled vertex excesses only, not actual geometric distance-class realizations.",
+            "Escape placements record length-2/length-3 deficits in the current turn-cover diagnostic only.",
+            "Common-dihedral pair classes couple those two labelled structures under the same cyclic relabeling action.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/analyze_n9_d3_escape_slice.py",
+            "command": (
+                "python scripts/analyze_n9_d3_escape_slice.py --assert-expected "
+                "--out data/certificates/n9_base_apex_d3_escape_slice.json"
+            ),
+        },
+    }
+    assert_expected_counts(payload)
+    return payload
+
+
+def assert_expected_counts(payload: dict[str, object]) -> None:
+    """Assert stable expected counts for the D=3 escape-slice report."""
+
+    profile = payload["profile_slice"]
+    escape = payload["escape_slice"]
+    coupled = payload["coupled_slice"]
+    if not isinstance(profile, dict) or not isinstance(escape, dict):
+        raise AssertionError("missing profile or escape slice")
+    if not isinstance(coupled, dict):
+        raise AssertionError("missing coupled slice")
+    if profile["labelled_profile_sequence_count"] != EXPECTED_PROFILE_SEQUENCE_COUNT:
+        raise AssertionError("unexpected profile sequence count")
+    if profile["dihedral_profile_orbit_count"] != EXPECTED_PROFILE_DIHEDRAL_ORBIT_COUNT:
+        raise AssertionError("unexpected profile orbit count")
+    if profile["dihedral_profile_orbit_size_counts"] != json_counter(
+        Counter(EXPECTED_PROFILE_ORBIT_SIZE_COUNTS)
+    ):
+        raise AssertionError("unexpected profile orbit size counts")
+    if escape["labelled_escape_placement_count"] != EXPECTED_ESCAPE_PLACEMENT_COUNT:
+        raise AssertionError("unexpected escape placement count")
+    if escape["dihedral_escape_class_count"] != EXPECTED_ESCAPE_DIHEDRAL_CLASS_COUNT:
+        raise AssertionError("unexpected escape class count")
+    if escape["dihedral_escape_orbit_size_counts"] != json_counter(
+        Counter(EXPECTED_ESCAPE_ORBIT_SIZE_COUNTS)
+    ):
+        raise AssertionError("unexpected escape orbit size counts")
+    if (
+        coupled["labelled_profile_escape_pair_count"]
+        != EXPECTED_LABELLED_COUPLED_PAIR_COUNT
+    ):
+        raise AssertionError("unexpected labelled coupled pair count")
+    if (
+        coupled["common_dihedral_pair_class_count"]
+        != EXPECTED_COMMON_DIHEDRAL_PAIR_CLASS_COUNT
+    ):
+        raise AssertionError("unexpected common-dihedral class count")
+    if coupled["common_dihedral_pair_orbit_size_counts"] != json_counter(
+        Counter(EXPECTED_COMMON_DIHEDRAL_ORBIT_SIZE_COUNTS)
+    ):
+        raise AssertionError("unexpected common-dihedral orbit size counts")

--- a/tests/test_n9_d3_escape_slice.py
+++ b/tests/test_n9_d3_escape_slice.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_d3_escape_slice import d3_escape_slice_report
+from scripts.check_n9_d3_escape_slice import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_d3_escape_slice_artifact_summary_is_nonclaiming() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert payload["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert payload["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a geometric realizability test" in payload["claim_scope"]
+    assert payload["total_profile_excess"] == 6
+    assert payload["capacity_deficit"] == 3
+    assert payload["relevant_deficit_count"] == 3
+    assert payload["profile_slice"]["labelled_profile_sequence_count"] == 3003
+    assert payload["profile_slice"]["dihedral_profile_orbit_count"] == 185
+    assert payload["escape_slice"]["labelled_escape_placement_count"] == 108
+    assert payload["escape_slice"]["dihedral_escape_class_count"] == 8
+    assert payload["coupled_slice"]["labelled_profile_escape_pair_count"] == 324324
+    assert payload["coupled_slice"]["common_dihedral_pair_class_count"] == 18088
+
+
+def test_d3_escape_slice_records_burnside_orbit_size_counts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert payload["profile_slice"]["dihedral_profile_orbit_size_counts"] == {
+        "18": 150,
+        "3": 2,
+        "9": 33,
+    }
+    assert payload["escape_slice"]["dihedral_escape_orbit_size_counts"] == {
+        "18": 4,
+        "9": 4,
+    }
+    assert payload["coupled_slice"]["common_dihedral_pair_orbit_size_counts"] == {
+        "18": 17948,
+        "9": 140,
+    }
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_d3_escape_slice_artifact_matches_generator() -> None:
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == d3_escape_slice_report()
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_d3_escape_slice_checker_passes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["labelled_profile_sequence_count"] == 3003
+    assert summary["common_dihedral_pair_class_count"] == 18088
+
+
+def test_d3_escape_slice_checker_rejects_tampered_provenance() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["provenance"]["command"] = "python scripts/analyze_n9_d3_escape_slice.py"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("provenance" in error for error in errors)
+
+
+def test_d3_escape_slice_checker_rejects_unknown_top_level_key() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["unchecked_schema_drift"] = {"ok": False}
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("top-level keys" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_d3_escape_slice_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_d3_escape_slice.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["common_dihedral_pair_class_count"] == 18088

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -50,3 +50,4 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
         in command_texts
     )
+    assert "python scripts/check_n9_d3_escape_slice.py --check --json" in command_texts


### PR DESCRIPTION
## Summary
- add a generated `n=9` base-apex `D=3,r=3` coupled escape-slice report
- add a generator/checker that couples labelled `E=6` profile-excess sequences with strict minimum relevant escape placements under the same dihedral action
- register the artifact in generated-artifact provenance and artifact-audit coverage, with tests and documentation

## Scope
This is finite bookkeeping for the sharp strict-threshold `D=3` low-excess edge case. It records profile/escape placement fingerprints only. It is not a proof of `n=9`, not a counterexample, not a claim that `D=3,r=3` is impossible, not a geometric realizability test, not an independent review of the vertex-circle checker, and not a global status update.

## Validation
- `python scripts/analyze_n9_d3_escape_slice.py --assert-expected --out data/certificates/n9_base_apex_d3_escape_slice.json`
- `python scripts/check_n9_d3_escape_slice.py --check --json`
- `python scripts/analyze_n9_d3_escape_slice.py --assert-expected --check-artifact data/certificates/n9_base_apex_d3_escape_slice.json`
- `python -m pytest tests/test_n9_d3_escape_slice.py -q -m 'artifact or exhaustive or not artifact'`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- raw artifact tier / adjacent checks:
  - `python scripts/independent_check_n8_artifacts.py --check --json`
  - `python scripts/enumerate_n8_incidence.py --summary`
  - `python scripts/analyze_n8_exact_survivors.py --check --json`
  - `python scripts/check_round2_certificates.py`
  - `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
  - `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
  - `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
  - `python scripts/check_n9_d3_escape_slice.py --check --json`
  - `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic`