### PR TITLE
Add n9 row-Ptolemy product filter

### DIFF
--- a/data/certificates/n9_row_ptolemy_product_cancellations.json
+++ b/data/certificates/n9_row_ptolemy_product_cancellations.json
@@ -1,0 +1,16265 @@
+{
+  "claim_scope": "Focused n=9 row-Ptolemy product-cancellation bookkeeping for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.",
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "filter": {
+    "cancellation_conclusion": "d03*d12 = 0",
+    "fixed_order_requirement": "The row witness cyclic order must be supplied or certified; the selected-distance quotient alone is not an orderless abstract-incidence obstruction.",
+    "historical_alias": "F15 row-Ptolemy symmetric quad",
+    "name": "row_ptolemy_product_cancel",
+    "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+    "trigger": "d02=d23 and d13=d01 for row witnesses w0,w1,w2,w3"
+  },
+  "hit_records": [
+    {
+      "assignment_index": 1,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                3
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                3
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            5,
+            8,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            5,
+            8,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 11,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            5,
+            6,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            5,
+            6,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            8,
+            2,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            8,
+            2,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 13,
+      "certificate_count": 12,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F09",
+      "family_orbit_size": 6,
+      "selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 22,
+      "certificate_count": 18,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F13",
+      "family_orbit_size": 2,
+      "selected_rows": [
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 23,
+      "certificate_count": 12,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F09",
+      "family_orbit_size": 6,
+      "selected_rows": [
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 30,
+      "certificate_count": 12,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F09",
+      "family_orbit_size": 6,
+      "selected_rows": [
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 42,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            2,
+            5,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            2,
+            5,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            8,
+            0,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            8,
+            0,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  8
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 49,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            5,
+            8,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                5,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            6,
+            7,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  6,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                5,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            6,
+            7,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  6,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            0,
+            3,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            0,
+            3,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 66,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            3,
+            6,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            3,
+            6,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            8,
+            2,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            0,
+            1,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            0,
+            1,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 83,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            4,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            4,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  5
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 84,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            7,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  7,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            7,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  7,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                5,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  6,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 85,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            3,
+            4,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            3,
+            4,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            6,
+            0,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            6,
+            0,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 95,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                5,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            5,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                5,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            5,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          5,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 105,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            2,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            2,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 108,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                3
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            1,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  2
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                3
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            1,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  2
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 121,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                2
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            0,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                2
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            0,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          6
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 131,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            8,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                3
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            8,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 133,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            3,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            3,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 139,
+      "certificate_count": 12,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            4,
+            7,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            7,
+            1,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F09",
+      "family_orbit_size": 6,
+      "selected_rows": [
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 142,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                6,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            6,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  6,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                6,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            6,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  6,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          1,
+          6,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 148,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            4,
+            7,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            4,
+            7,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            0,
+            3,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                2
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  2
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                2
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  2
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          2,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 149,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                5
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            4,
+            5,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            4,
+            5,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  4,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                4
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            7,
+            1,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            7,
+            1,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 158,
+      "certificate_count": 6,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            6,
+            0,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                6,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                8
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            7,
+            8,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  7,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                6,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            7,
+            8,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  6
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  7,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                7
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 28,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "distance_class": 0,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F02",
+      "family_orbit_size": 18,
+      "selected_rows": [
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          7
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 165,
+      "certificate_count": 12,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F09",
+      "family_orbit_size": 6,
+      "selected_rows": [
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 173,
+      "certificate_count": 18,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                4,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                1
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 2,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 3,
+                "name": "d03",
+                "pair": [
+                  1,
+                  4
+                ]
+              },
+              {
+                "distance_class": 2,
+                "name": "d12",
+                "pair": [
+                  0,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                4
+              ],
+              "right": "d23",
+              "right_pair": [
+                3,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 5,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            7,
+            0,
+            3,
+            4
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 8,
+                "name": "d03",
+                "pair": [
+                  4,
+                  7
+                ]
+              },
+              {
+                "distance_class": 1,
+                "name": "d12",
+                "pair": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                6,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 8,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 4,
+                "name": "d03",
+                "pair": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "distance_class": 7,
+                "name": "d12",
+                "pair": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F13",
+      "family_orbit_size": 2,
+      "selected_rows": [
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 174,
+      "certificate_count": 12,
+      "certificates": [
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                2,
+                4
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                7,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 0,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 6,
+                "name": "d03",
+                "pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "distance_class": 8,
+                "name": "d12",
+                "pair": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                3,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                0,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 1,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 1,
+                "name": "d03",
+                "pair": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "distance_class": 9,
+                "name": "d12",
+                "pair": [
+                  5,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                5,
+                7
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                7
+              ],
+              "right": "d23",
+              "right_pair": [
+                1,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 3,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 5,
+                "name": "d03",
+                "pair": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "distance_class": 4,
+                "name": "d12",
+                "pair": [
+                  1,
+                  7
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                6,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                3,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                2,
+                3
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 4,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 7,
+                "name": "d03",
+                "pair": [
+                  3,
+                  6
+                ]
+              },
+              {
+                "distance_class": 6,
+                "name": "d12",
+                "pair": [
+                  2,
+                  8
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                4,
+                8
+              ],
+              "right": "d01",
+              "right_pair": [
+                1,
+                8
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                1,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                4,
+                5
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 6,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            8,
+            1,
+            4,
+            5
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 9,
+                "name": "d03",
+                "pair": [
+                  5,
+                  8
+                ]
+              },
+              {
+                "distance_class": 3,
+                "name": "d12",
+                "pair": [
+                  1,
+                  4
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "cancelled_product": "d01*d23",
+          "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+          "forced_equalities": [
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d02",
+              "left_pair": [
+                0,
+                5
+              ],
+              "right": "d01",
+              "right_pair": [
+                0,
+                2
+              ]
+            },
+            {
+              "class_member_count": 27,
+              "distance_class": 0,
+              "left": "d13",
+              "left_pair": [
+                2,
+                6
+              ],
+              "right": "d23",
+              "right_pair": [
+                5,
+                6
+              ]
+            }
+          ],
+          "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+          "row": 7,
+          "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+          "type": "row_ptolemy_product_cancellation",
+          "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+          "witness_order": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "zero_product": {
+            "expression": "d03*d12",
+            "factors": [
+              {
+                "distance_class": 2,
+                "name": "d03",
+                "pair": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "distance_class": 5,
+                "name": "d12",
+                "pair": [
+                  2,
+                  5
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "family_id": "F09",
+      "family_orbit_size": 6,
+      "selected_rows": [
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "vertex_circle_status": "self_edge"
+    }
+  ],
+  "hit_summary": {
+    "certificate_count_by_center": {
+      "0": 24,
+      "1": 24,
+      "2": 24,
+      "3": 24,
+      "4": 24,
+      "5": 24,
+      "6": 24,
+      "7": 24,
+      "8": 24
+    },
+    "certificates_per_hit_assignment_counts": {
+      "12": 6,
+      "18": 2,
+      "6": 18
+    },
+    "hit_assignment_count": 26,
+    "hit_assignment_vertex_circle_status_counts": {
+      "self_edge": 26
+    },
+    "hit_certificate_count": 216,
+    "hit_family_count": 3,
+    "hit_family_counts": [
+      {
+        "family_id": "F02",
+        "family_orbit_size": 18,
+        "hit_assignment_count": 18
+      },
+      {
+        "family_id": "F09",
+        "family_orbit_size": 6,
+        "hit_assignment_count": 6
+      },
+      {
+        "family_id": "F13",
+        "family_orbit_size": 2,
+        "hit_assignment_count": 2
+      }
+    ]
+  },
+  "interpretation": [
+    "Each recorded hit is an exact obstruction for one fixed selected-witness assignment under the natural cyclic order.",
+    "The proof uses Ptolemy on a row witness circle plus exact selected-distance quotient equalities.",
+    "The filter kills 26 of the 184 n=9 pre-vertex-circle assignments, covering 3 of the 16 deterministic dihedral family labels.",
+    "For this n=9 frontier, every hit is also a vertex-circle self-edge case; this diagnostic does not dominate or replace the vertex-circle checker.",
+    "The row order must be supplied or certified. This is not an orderless abstract-incidence obstruction.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --out data/certificates/n9_row_ptolemy_product_cancellations.json",
+    "generator": "scripts/analyze_n9_row_ptolemy_product_cancellations.py"
+  },
+  "schema": "erdos97.n9_row_ptolemy_product_cancellations.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_exhaustive.json",
+      "role": "review-pending source frontier count target"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_motif_families.json",
+      "role": "deterministic family-id convention used for F02/F09/F13 labels"
+    },
+    {
+      "path": "data/runs/2026-05-05/new_obstructions.md",
+      "role": "archived exploratory memo for the historical F15 alias"
+    }
+  ],
+  "source_frontier": {
+    "assignment_count": 184,
+    "description": "Complete n=9 assignments after pair/crossing/count filters and before vertex-circle obstruction.",
+    "dihedral_family_count": 16,
+    "nodes_visited": 100817,
+    "row0_choices": 70
+  },
+  "status": "EXPLORATORY_LEDGER_ONLY",
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+  "witness_size": 4
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`ptolemy-order-nlp.md`](ptolemy-order-nlp.md): numerical nonlinear
   diagnostic adding Ptolemy inequalities for cyclic quadrilaterals; records a
   relaxation miss on the registered sparse orders.
+- [`row-ptolemy-product-filter.md`](row-ptolemy-product-filter.md): exact
+  row-circle Ptolemy product-cancellation filter for fixed row orders, plus a
+  non-promoting n=9 frontier sweep.
 - [`two-orbit-radius-propagation.md`](two-orbit-radius-propagation.md): exact
   obstruction for a half-step two-orbit near-regular ansatz.
 - [`minimum-radius-filter.md`](minimum-radius-filter.md): weak exact

--- a/docs/row-ptolemy-product-filter.md
+++ b/docs/row-ptolemy-product-filter.md
@@ -1,0 +1,64 @@
+# Row-Ptolemy Product Filter
+
+Status: `EXACT_OBSTRUCTION` for fixed selected-witness patterns with a supplied
+or certified row witness order. The generated n=9 sweep is exploratory
+bookkeeping only; it is not a proof of `n=9`, not a counterexample, not a
+geometric realizability test, and not a global status update.
+
+## Lemma
+
+Let one selected row have center `i` and four distinct witnesses
+`w0,w1,w2,w3` in cyclic order around `i`. Because the witnesses lie on the
+circle centered at `i`, Ptolemy's theorem gives
+
+```text
+d02*d13 = d01*d23 + d03*d12,
+```
+
+where `dab` denotes the Euclidean distance `|w_a w_b|`.
+
+If the selected-distance quotient forces
+
+```text
+d02 = d23
+d13 = d01
+```
+
+then substituting into Ptolemy cancels the left product with the first product
+on the right, leaving `d03*d12 = 0`. That is impossible for distinct vertices
+in a strictly convex polygon. Thus the fixed selected-witness pattern is
+obstructed under the supplied row order.
+
+The row order is part of the hypothesis. The selected-distance quotient alone
+does not determine which witness pairs are sides and diagonals in Ptolemy, so
+this is not an orderless abstract-incidence obstruction unless all compatible
+orders have been checked separately.
+
+## n=9 Sweep
+
+The artifact
+`data/certificates/n9_row_ptolemy_product_cancellations.json` applies the
+filter to the 184 complete `n=9` selected-witness assignments that survive the
+pair/crossing/count filters before the vertex-circle filter.
+
+It records:
+
+- `26` hit assignments out of `184`;
+- `216` row-local certificates after checking all cyclic rotations of the row
+  Ptolemy cancellation;
+- `3` deterministic dihedral family labels: `F02`, `F09`, and `F13`;
+- all hits are vertex-circle `self_edge` cases in the current n=9 frontier.
+
+This gives an independent Ptolemy-equality certificate for those fixed-order
+assignments, but it does not dominate or replace the vertex-circle checker and
+does not prove the full `n=9` finite case.
+
+## Reproduction
+
+```bash
+python scripts/analyze_n9_row_ptolemy_product_cancellations.py \
+  --assert-expected \
+  --out data/certificates/n9_row_ptolemy_product_cancellations.json
+
+python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
+```

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -403,6 +403,41 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_row_ptolemy_product_cancellations
+    path: data/certificates/n9_row_ptolemy_product_cancellations.json
+    kind: exploratory_ledger_artifact
+    generator: scripts/analyze_n9_row_ptolemy_product_cancellations.py
+    command: python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --out data/certificates/n9_row_ptolemy_product_cancellations.json
+    checker: scripts/check_n9_row_ptolemy_product_cancellations.py
+    check_command: python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Focused n=9 row-Ptolemy product-cancellation bookkeeping for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_row_ptolemy_product_cancellations.v1
+      status: EXPLORATORY_LEDGER_ONLY
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      claim_scope: Focused n=9 row-Ptolemy product-cancellation bookkeeping for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
+      n: 9
+      witness_size: 4
+      source_frontier.assignment_count: 184
+      source_frontier.nodes_visited: 100817
+      source_frontier.dihedral_family_count: 16
+      hit_summary.hit_assignment_count: 26
+      hit_summary.hit_certificate_count: 216
+      hit_summary.hit_family_count: 3
+      provenance.command: python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --out data/certificates/n9_row_ptolemy_product_cancellations.json
+    forbidden_claims:
+      - n=9 is proved
+      - orderless abstract-incidence obstruction
+      - geometric realizability count
+      - counterexample
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact

--- a/scripts/analyze_n9_row_ptolemy_product_cancellations.py
+++ b/scripts/analyze_n9_row_ptolemy_product_cancellations.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate the n=9 row-Ptolemy product-cancellation artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_row_ptolemy_product_cancellations import (  # noqa: E402
+    assert_expected_counts,
+    row_ptolemy_product_cancellation_report,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_OUT = (
+    ROOT / "data" / "certificates" / "n9_row_ptolemy_product_cancellations.json"
+)
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def load_json(path: Path) -> object:
+    """Load JSON from a path."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print generated JSON")
+    parser.add_argument("--out", type=Path, help="write generated JSON to this path")
+    parser.add_argument(
+        "--check-artifact",
+        type=Path,
+        help="compare generated JSON with an existing artifact",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = row_ptolemy_product_cancellation_report()
+    if args.assert_expected:
+        assert_expected_counts(payload)
+
+    if args.check_artifact is not None:
+        artifact = (
+            args.check_artifact
+            if args.check_artifact.is_absolute()
+            else ROOT / args.check_artifact
+        )
+        checked = load_json(artifact)
+        if checked != payload:
+            print(
+                f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",
+                file=sys.stderr,
+            )
+            return 1
+
+    if args.out is not None:
+        out = args.out if args.out.is_absolute() else ROOT / args.out
+        write_json(payload, out)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif args.check_artifact is not None:
+        print("OK: n=9 row-Ptolemy product-cancellation artifact is current")
+    elif args.out is not None:
+        print(f"wrote {display_path(out, ROOT)}")
+    else:
+        source = payload["source_frontier"]
+        summary = payload["hit_summary"]
+        print("n=9 row-Ptolemy product-cancellation diagnostic")
+        print(f"source assignments: {source['assignment_count']}")
+        print(f"hit assignments: {summary['hit_assignment_count']}")
+        print(f"hit certificates: {summary['hit_certificate_count']}")
+        print(f"hit families: {summary['hit_family_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_n9_row_ptolemy_product_cancellations.py
+++ b/scripts/check_n9_row_ptolemy_product_cancellations.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Validate the n=9 row-Ptolemy product-cancellation artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_row_ptolemy_product_cancellations import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    row_ptolemy_product_cancellation_report,
+)
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_row_ptolemy_product_cancellations.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "cyclic_order",
+    "filter",
+    "hit_records",
+    "hit_summary",
+    "interpretation",
+    "n",
+    "provenance",
+    "schema",
+    "source_artifacts",
+    "source_frontier",
+    "status",
+    "trust",
+    "witness_size",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _validate_claim_scope(errors: list[str], claim_scope: Any) -> None:
+    expect_equal(errors, "claim_scope", claim_scope, CLAIM_SCOPE)
+    if not isinstance(claim_scope, str):
+        errors.append("claim_scope must be a string")
+        return
+    lowered = claim_scope.lower()
+    for phrase in (
+        "not a proof",
+        "not a counterexample",
+        "not a geometric realizability test",
+        "not a global status update",
+    ):
+        if phrase not in lowered:
+            errors.append(f"claim_scope must include {phrase!r}")
+
+
+def _validate_interpretation(errors: list[str], interpretation: Any) -> None:
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+        return
+    required = (
+        "No proof of the n=9 case is claimed.",
+        "The row order must be supplied or certified. This is not an orderless abstract-incidence obstruction.",
+    )
+    for phrase in required:
+        if phrase not in interpretation:
+            errors.append(f"interpretation must include {phrase!r}")
+
+
+def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
+    """Return validation errors for a loaded cancellation artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    top_level_keys = set(payload)
+    if top_level_keys != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, "
+            f"got {sorted(top_level_keys)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "n": 9,
+        "witness_size": 4,
+        "cyclic_order": list(range(9)),
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    _validate_claim_scope(errors, payload.get("claim_scope"))
+    _validate_interpretation(errors, payload.get("interpretation"))
+    expect_equal(errors, "provenance", payload.get("provenance"), PROVENANCE)
+
+    source = payload.get("source_frontier")
+    if isinstance(source, dict):
+        expect_equal(errors, "source assignment count", source.get("assignment_count"), 184)
+        expect_equal(errors, "source nodes", source.get("nodes_visited"), 100817)
+        expect_equal(errors, "source families", source.get("dihedral_family_count"), 16)
+    else:
+        errors.append("source_frontier must be an object")
+
+    summary = payload.get("hit_summary")
+    if isinstance(summary, dict):
+        expect_equal(errors, "hit assignment count", summary.get("hit_assignment_count"), 26)
+        expect_equal(errors, "hit certificate count", summary.get("hit_certificate_count"), 216)
+        expect_equal(errors, "hit family count", summary.get("hit_family_count"), 3)
+        expect_equal(
+            errors,
+            "hit status counts",
+            summary.get("hit_assignment_vertex_circle_status_counts"),
+            {"self_edge": 26},
+        )
+    else:
+        errors.append("hit_summary must be an object")
+
+    if recompute:
+        try:
+            expected_payload = row_ptolemy_product_cancellation_report()
+        except (AssertionError, ValueError) as exc:
+            errors.append(f"recomputed row-Ptolemy report failed: {exc}")
+        else:
+            expect_equal(
+                errors,
+                "row-Ptolemy product-cancellation payload",
+                payload,
+                expected_payload,
+            )
+    return errors
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repo-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    source = object_payload.get("source_frontier", {})
+    hit_summary = object_payload.get("hit_summary", {})
+    return {
+        "ok": not errors,
+        "artifact": display_path(path),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "source_assignment_count": (
+            source.get("assignment_count") if isinstance(source, dict) else None
+        ),
+        "hit_assignment_count": (
+            hit_summary.get("hit_assignment_count")
+            if isinstance(hit_summary, dict)
+            else None
+        ),
+        "hit_certificate_count": (
+            hit_summary.get("hit_certificate_count")
+            if isinstance(hit_summary, dict)
+            else None
+        ),
+        "hit_family_count": (
+            hit_summary.get("hit_family_count") if isinstance(hit_summary, dict) else None
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="fail if validation fails")
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 row-Ptolemy product-cancellation artifact")
+        print(f"artifact: {summary['artifact']}")
+        print(f"source assignments: {summary['source_assignment_count']}")
+        print(f"hit assignments: {summary['hit_assignment_count']}")
+        print(f"hit certificates: {summary['hit_certificate_count']}")
+        print(f"hit families: {summary['hit_family_count']}")
+        if args.check:
+            print("OK: row-Ptolemy product-cancellation checks passed")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -150,6 +150,20 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_row_ptolemy_product_cancellations",
+        command=(
+            "python",
+            "scripts/check_n9_row_ptolemy_product_cancellations.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused n=9 row-Ptolemy product-cancellation bookkeeping for "
+            "fixed row order; not a proof of n=9, counterexample, geometric "
+            "realizability test, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/src/erdos97/incidence_filters.py
+++ b/src/erdos97/incidence_filters.py
@@ -341,6 +341,174 @@ def phi4_rectangle_trap_certificates(
     return out
 
 
+def _row_witness_order(
+    order: Sequence[int],
+    center: int,
+    witnesses: Sequence[int],
+) -> list[int]:
+    """Return witnesses in boundary order around a convex-hull vertex."""
+    positions = _positions(order)
+    if center not in positions:
+        raise ValueError(f"center {center} is missing from cyclic order")
+    missing = [witness for witness in witnesses if witness not in positions]
+    if missing:
+        raise ValueError(f"witness {missing[0]} is missing from cyclic order")
+    n = len(order)
+    center_pos = positions[center]
+    return sorted(witnesses, key=lambda witness: (positions[witness] - center_pos) % n)
+
+
+def _selected_distance_pair_classes(
+    S: Sequence[Sequence[int]],
+) -> tuple[dict[Chord, int], tuple[tuple[Chord, ...], ...]]:
+    n = len(S)
+    all_pairs = [normalize_chord(left, right) for left, right in combinations(range(n), 2)]
+    parent = {item: item for item in all_pairs}
+
+    def find(item: Chord) -> Chord:
+        while parent[item] != item:
+            parent[item] = parent[parent[item]]
+            item = parent[item]
+        return item
+
+    def union(left: Chord, right: Chord) -> None:
+        root_left = find(left)
+        root_right = find(right)
+        if root_left == root_right:
+            return
+        if root_right < root_left:
+            root_left, root_right = root_right, root_left
+        parent[root_right] = root_left
+
+    for center, row in enumerate(S):
+        if len(row) != 4:
+            raise ValueError(f"row {center} has length {len(row)}, expected 4")
+        if center in row:
+            raise ValueError(f"row {center} selects itself")
+        if len(set(row)) != 4:
+            raise ValueError(f"row {center} has repeated witnesses")
+        base = normalize_chord(center, int(row[0]))
+        for witness in row[1:]:
+            union(base, normalize_chord(center, int(witness)))
+
+    root_index: dict[Chord, int] = {}
+    pair_class: dict[Chord, int] = {}
+    members: dict[int, list[Chord]] = {}
+    for item in all_pairs:
+        root = find(item)
+        class_index = root_index.setdefault(root, len(root_index))
+        pair_class[item] = class_index
+        members.setdefault(class_index, []).append(item)
+    return pair_class, tuple(tuple(members[idx]) for idx in range(len(members)))
+
+
+def row_ptolemy_product_cancellation_certificates(
+    S: Sequence[Sequence[int]],
+    order: Sequence[int] | None = None,
+) -> list[dict[str, object]]:
+    """
+    Return row-Ptolemy product-cancellation obstruction certificates.
+
+    For row witnesses ``w0,w1,w2,w3`` in the supplied/certified row order,
+    Ptolemy gives ``d02*d13 = d01*d23 + d03*d12``. If selected-distance
+    quotienting forces ``d02=d23`` and ``d13=d01``, then the equality forces
+    ``d03*d12=0``. Distinct strictly convex vertices have positive distances,
+    so the fixed selected-witness pattern and order are obstructed.
+    """
+    n = len(S)
+    if order is None:
+        order = list(range(n))
+    if len(order) != n:
+        raise ValueError(f"cyclic order has length {len(order)}, expected {n}")
+
+    pair_class, class_members = _selected_distance_pair_classes(S)
+    out: list[dict[str, object]] = []
+    for center, row in enumerate(S):
+        witnesses = _row_witness_order(order, center, row)
+        w0, w1, w2, w3 = witnesses
+        pairs = {
+            "d01": normalize_chord(w0, w1),
+            "d02": normalize_chord(w0, w2),
+            "d03": normalize_chord(w0, w3),
+            "d12": normalize_chord(w1, w2),
+            "d13": normalize_chord(w1, w3),
+            "d23": normalize_chord(w2, w3),
+        }
+        classes = {name: pair_class[item] for name, item in pairs.items()}
+        variants = (
+            (
+                "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+                (("d02", "d23"), ("d13", "d01")),
+                "d01*d23",
+                ("d03", "d12"),
+            ),
+            (
+                "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+                (("d02", "d01"), ("d13", "d23")),
+                "d01*d23",
+                ("d03", "d12"),
+            ),
+            (
+                "cancel_d03_d12_via_d02_eq_d12_and_d13_eq_d03",
+                (("d02", "d12"), ("d13", "d03")),
+                "d03*d12",
+                ("d01", "d23"),
+            ),
+            (
+                "cancel_d03_d12_via_d02_eq_d03_and_d13_eq_d12",
+                (("d02", "d03"), ("d13", "d12")),
+                "d03*d12",
+                ("d01", "d23"),
+            ),
+        )
+        for variant, equalities, cancelled_product, zero_factors in variants:
+            if any(classes[left] != classes[right] for left, right in equalities):
+                continue
+            out.append(
+                {
+                    "type": "row_ptolemy_product_cancellation",
+                    "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+                    "variant": variant,
+                    "row": int(center),
+                    "witness_order": [int(label) for label in witnesses],
+                    "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+                    "cancelled_product": cancelled_product,
+                    "forced_equalities": [
+                        {
+                            "left": left,
+                            "left_pair": _json_chord(pairs[left]),
+                            "right": right,
+                            "right_pair": _json_chord(pairs[right]),
+                            "distance_class": int(classes[left]),
+                            "class_member_count": len(class_members[classes[left]]),
+                        }
+                        for left, right in equalities
+                    ],
+                    "zero_product": {
+                        "expression": "*".join(zero_factors),
+                        "factors": [
+                            {
+                                "name": factor,
+                                "pair": _json_chord(pairs[factor]),
+                                "distance_class": int(classes[factor]),
+                            }
+                            for factor in zero_factors
+                        ],
+                    },
+                    "contradiction": (
+                        "Ptolemy cancellation forces a product of two "
+                        "ordinary distances to be zero, but distinct strictly "
+                        "convex vertices have positive Euclidean distances."
+                    ),
+                    "scope": (
+                        "Exact obstruction for this fixed selected-witness row "
+                        "under the supplied/certified row order only."
+                    ),
+                }
+            )
+    return out
+
+
 def mutual_phi_pairs(S: Sequence[Sequence[int]]) -> list[tuple[Chord, Chord]]:
     """Return unordered reciprocal pairs (e,f) with phi(e)=f and phi(f)=e."""
     phis = phi_map(S)

--- a/src/erdos97/n9_row_ptolemy_product_cancellations.py
+++ b/src/erdos97/n9_row_ptolemy_product_cancellations.py
@@ -1,0 +1,261 @@
+"""n=9 row-Ptolemy product-cancellation diagnostics.
+
+This module sweeps the 184 complete n=9 selected-witness assignments that
+survive the pair/crossing/count filters before vertex-circle obstruction. It
+records where a fixed-row-order Ptolemy cancellation gives an independent exact
+obstruction. It does not prove the n=9 case and does not claim a
+counterexample.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.incidence_filters import row_ptolemy_product_cancellation_certificates
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    _rows_from_assignment,
+    canonical_dihedral_rows,
+    pre_vertex_circle_assignments,
+)
+
+SCHEMA = "erdos97.n9_row_ptolemy_product_cancellations.v1"
+STATUS = "EXPLORATORY_LEDGER_ONLY"
+TRUST = "FINITE_BOOKKEEPING_NOT_A_PROOF"
+CLAIM_SCOPE = (
+    "Focused n=9 row-Ptolemy product-cancellation bookkeeping for the "
+    "fixed natural cyclic order; not a proof of n=9, not a counterexample, "
+    "not a geometric realizability test, and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/analyze_n9_row_ptolemy_product_cancellations.py",
+    "command": (
+        "python scripts/analyze_n9_row_ptolemy_product_cancellations.py "
+        "--assert-expected --out "
+        "data/certificates/n9_row_ptolemy_product_cancellations.json"
+    ),
+}
+
+EXPECTED_PRE_VERTEX_CIRCLE_NODES = 100_817
+EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS = 184
+EXPECTED_HIT_ASSIGNMENTS = 26
+EXPECTED_HIT_CERTIFICATES = 216
+EXPECTED_HIT_FAMILIES = 3
+EXPECTED_HIT_ASSIGNMENT_STATUS_COUNTS = {"self_edge": 26}
+EXPECTED_HIT_FAMILY_COUNTS = {"F02": 18, "F09": 6, "F13": 2}
+EXPECTED_CERTIFICATE_COUNT_BY_CENTER = {str(center): 24 for center in range(n9.N)}
+EXPECTED_CERTIFICATES_PER_HIT_ASSIGNMENT = {"6": 18, "12": 6, "18": 2}
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _family_labels(
+    rows_by_assignment: Sequence[Sequence[Sequence[int]]],
+) -> tuple[dict[tuple[tuple[int, ...], ...], str], dict[str, int]]:
+    families: dict[tuple[tuple[int, ...], ...], int] = defaultdict(int)
+    for rows in rows_by_assignment:
+        families[canonical_dihedral_rows(rows)] += 1
+
+    key_to_family: dict[tuple[tuple[int, ...], ...], str] = {}
+    family_orbit_sizes: dict[str, int] = {}
+    for family_index, (family_key, orbit_size) in enumerate(
+        sorted(families.items()),
+        start=1,
+    ):
+        family_id = f"F{family_index:02d}"
+        key_to_family[family_key] = family_id
+        family_orbit_sizes[family_id] = int(orbit_size)
+    return key_to_family, family_orbit_sizes
+
+
+def _hit_record(
+    assignment_index: int,
+    rows: Sequence[Sequence[int]],
+    family_id: str,
+    family_orbit_size: int,
+    status: str,
+    certificates: Sequence[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "assignment_index": int(assignment_index),
+        "family_id": family_id,
+        "family_orbit_size": int(family_orbit_size),
+        "vertex_circle_status": status,
+        "selected_rows": [[int(label) for label in row] for row in rows],
+        "certificate_count": len(certificates),
+        "certificates": list(certificates),
+    }
+
+
+def row_ptolemy_product_cancellation_report() -> dict[str, object]:
+    """Return the stable n=9 row-Ptolemy product-cancellation artifact."""
+
+    assignments, nodes = pre_vertex_circle_assignments()
+    rows_by_assignment = [_rows_from_assignment(assign) for assign in assignments]
+    family_labels, family_orbit_sizes = _family_labels(rows_by_assignment)
+
+    hit_records: list[dict[str, object]] = []
+    status_counts: Counter[str] = Counter()
+    family_hit_counts: Counter[str] = Counter()
+    certificate_count_by_center: Counter[int] = Counter()
+    certificates_per_hit: Counter[int] = Counter()
+    total_certificates = 0
+
+    for assignment_index, (assign, rows) in enumerate(
+        zip(assignments, rows_by_assignment),
+    ):
+        certificates = row_ptolemy_product_cancellation_certificates(
+            rows,
+            n9.ORDER,
+        )
+        if not certificates:
+            continue
+
+        family_key = canonical_dihedral_rows(rows)
+        family_id = family_labels[family_key]
+        status = n9.vertex_circle_status(assign)
+        status_counts[status] += 1
+        family_hit_counts[family_id] += 1
+        certificates_per_hit[len(certificates)] += 1
+        total_certificates += len(certificates)
+        for certificate in certificates:
+            certificate_count_by_center[int(certificate["row"])] += 1
+        hit_records.append(
+            _hit_record(
+                assignment_index,
+                rows,
+                family_id,
+                family_orbit_sizes[family_id],
+                status,
+                certificates,
+            )
+        )
+
+    hit_family_rows = [
+        {
+            "family_id": family_id,
+            "hit_assignment_count": int(family_hit_counts[family_id]),
+            "family_orbit_size": int(family_orbit_sizes[family_id]),
+        }
+        for family_id in sorted(family_hit_counts)
+    ]
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "witness_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "source_frontier": {
+            "description": (
+                "Complete n=9 assignments after pair/crossing/count filters "
+                "and before vertex-circle obstruction."
+            ),
+            "row0_choices": len(n9.OPTIONS[0]),
+            "nodes_visited": int(nodes),
+            "assignment_count": len(assignments),
+            "dihedral_family_count": len(family_orbit_sizes),
+        },
+        "filter": {
+            "name": "row_ptolemy_product_cancel",
+            "historical_alias": "F15 row-Ptolemy symmetric quad",
+            "fixed_order_requirement": (
+                "The row witness cyclic order must be supplied or certified; "
+                "the selected-distance quotient alone is not an orderless "
+                "abstract-incidence obstruction."
+            ),
+            "trigger": "d02=d23 and d13=d01 for row witnesses w0,w1,w2,w3",
+            "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+            "cancellation_conclusion": "d03*d12 = 0",
+        },
+        "hit_summary": {
+            "hit_assignment_count": len(hit_records),
+            "hit_certificate_count": int(total_certificates),
+            "hit_family_count": len(family_hit_counts),
+            "hit_assignment_vertex_circle_status_counts": dict(
+                sorted(status_counts.items()),
+            ),
+            "hit_family_counts": hit_family_rows,
+            "certificate_count_by_center": _json_counter(certificate_count_by_center),
+            "certificates_per_hit_assignment_counts": _json_counter(
+                certificates_per_hit,
+            ),
+        },
+        "hit_records": hit_records,
+        "interpretation": [
+            "Each recorded hit is an exact obstruction for one fixed selected-witness assignment under the natural cyclic order.",
+            "The proof uses Ptolemy on a row witness circle plus exact selected-distance quotient equalities.",
+            "The filter kills 26 of the 184 n=9 pre-vertex-circle assignments, covering 3 of the 16 deterministic dihedral family labels.",
+            "For this n=9 frontier, every hit is also a vertex-circle self-edge case; this diagnostic does not dominate or replace the vertex-circle checker.",
+            "The row order must be supplied or certified. This is not an orderless abstract-incidence obstruction.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": [
+            {
+                "path": "data/certificates/n9_vertex_circle_exhaustive.json",
+                "role": "review-pending source frontier count target",
+            },
+            {
+                "path": "data/certificates/n9_vertex_circle_motif_families.json",
+                "role": "deterministic family-id convention used for F02/F09/F13 labels",
+            },
+            {
+                "path": "data/runs/2026-05-05/new_obstructions.md",
+                "role": "archived exploratory memo for the historical F15 alias",
+            },
+        ],
+        "provenance": PROVENANCE,
+    }
+    assert_expected_counts(payload)
+    return payload
+
+
+def assert_expected_counts(payload: dict[str, object]) -> None:
+    """Assert stable headline counts for the n=9 cancellation report."""
+
+    source = payload["source_frontier"]
+    summary = payload["hit_summary"]
+    if not isinstance(source, dict) or not isinstance(summary, dict):
+        raise AssertionError("malformed row-Ptolemy product-cancellation payload")
+
+    if source["nodes_visited"] != EXPECTED_PRE_VERTEX_CIRCLE_NODES:
+        raise AssertionError(f"unexpected source nodes: {source['nodes_visited']}")
+    if source["assignment_count"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError(
+            f"unexpected source assignments: {source['assignment_count']}",
+        )
+    if summary["hit_assignment_count"] != EXPECTED_HIT_ASSIGNMENTS:
+        raise AssertionError(
+            f"unexpected hit assignments: {summary['hit_assignment_count']}",
+        )
+    if summary["hit_certificate_count"] != EXPECTED_HIT_CERTIFICATES:
+        raise AssertionError(
+            f"unexpected hit certificates: {summary['hit_certificate_count']}",
+        )
+    if summary["hit_family_count"] != EXPECTED_HIT_FAMILIES:
+        raise AssertionError(f"unexpected hit families: {summary['hit_family_count']}")
+    if (
+        summary["hit_assignment_vertex_circle_status_counts"]
+        != EXPECTED_HIT_ASSIGNMENT_STATUS_COUNTS
+    ):
+        raise AssertionError("unexpected hit status counts")
+
+    actual_family_counts = {
+        str(row["family_id"]): int(row["hit_assignment_count"])
+        for row in summary["hit_family_counts"]
+        if isinstance(row, dict)
+    }
+    if actual_family_counts != EXPECTED_HIT_FAMILY_COUNTS:
+        raise AssertionError(f"unexpected hit family counts: {actual_family_counts}")
+    if summary["certificate_count_by_center"] != EXPECTED_CERTIFICATE_COUNT_BY_CENTER:
+        raise AssertionError("unexpected certificate center counts")
+    if (
+        summary["certificates_per_hit_assignment_counts"]
+        != EXPECTED_CERTIFICATES_PER_HIT_ASSIGNMENT
+    ):
+        raise AssertionError("unexpected certificate-per-hit histogram")

--- a/tests/test_incidence_filters.py
+++ b/tests/test_incidence_filters.py
@@ -10,6 +10,7 @@ from erdos97.incidence_filters import (
     phi4_rectangle_trap_certificates,
     phi_directed_4_cycles,
     phi_map,
+    row_ptolemy_product_cancellation_certificates,
 )
 from erdos97.search import built_in_patterns
 
@@ -160,6 +161,31 @@ def test_n9_rectangle_trap_accepts_reversed_cyclic_order() -> None:
 
     assert len(certs) == 1
     assert certs[0]["cyclic_order_orientation"] == "reversed"
+
+
+def test_row_ptolemy_product_cancellation_certificate_on_toy_pattern() -> None:
+    rows = [
+        [1, 2, 3, 4],
+        [0, 2, 3, 4],
+        [1, 3, 4, 5],
+        [1, 2, 4, 5],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+    ]
+
+    certs = row_ptolemy_product_cancellation_certificates(rows, list(range(6)))
+
+    row0_certs = [cert for cert in certs if cert["row"] == 0]
+    assert row0_certs
+    cert = row0_certs[0]
+    assert cert["status"] == "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER"
+    assert cert["witness_order"] == [1, 2, 3, 4]
+    assert cert["ptolemy_identity"] == "d02*d13 = d01*d23 + d03*d12"
+    assert cert["zero_product"]["expression"] == "d03*d12"
+    assert any(
+        cert["variant"] == "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23"
+        for cert in row0_certs
+    )
 
 
 def test_phi4_rectangle_trap_determinant_identity_expands_exactly() -> None:

--- a/tests/test_n9_row_ptolemy_product_cancellations.py
+++ b/tests/test_n9_row_ptolemy_product_cancellations.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_row_ptolemy_product_cancellations import (
+    row_ptolemy_product_cancellation_report,
+)
+from scripts.check_n9_row_ptolemy_product_cancellations import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_row_ptolemy_product_artifact_summary_is_nonclaiming() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert payload["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert payload["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a geometric realizability test" in payload["claim_scope"]
+    assert any(
+        "not an orderless abstract-incidence obstruction" in item
+        for item in payload["interpretation"]
+    )
+    assert payload["source_frontier"]["assignment_count"] == 184
+    assert payload["hit_summary"]["hit_assignment_count"] == 26
+    assert payload["hit_summary"]["hit_certificate_count"] == 216
+    assert payload["hit_summary"]["hit_family_count"] == 3
+
+
+def test_row_ptolemy_product_artifact_records_family_counts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    family_counts = {
+        row["family_id"]: row["hit_assignment_count"]
+        for row in payload["hit_summary"]["hit_family_counts"]
+    }
+
+    assert family_counts == {"F02": 18, "F09": 6, "F13": 2}
+    assert payload["hit_summary"]["hit_assignment_vertex_circle_status_counts"] == {
+        "self_edge": 26,
+    }
+    assert payload["hit_summary"]["certificates_per_hit_assignment_counts"] == {
+        "6": 18,
+        "12": 6,
+        "18": 2,
+    }
+    assert payload["hit_summary"]["certificate_count_by_center"] == {
+        str(center): 24 for center in range(9)
+    }
+
+
+def test_row_ptolemy_product_certificate_shape_is_exact_and_ordered() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    cert = payload["hit_records"][0]["certificates"][0]
+
+    assert cert["type"] == "row_ptolemy_product_cancellation"
+    assert cert["status"] == "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER"
+    assert cert["ptolemy_identity"] == "d02*d13 = d01*d23 + d03*d12"
+    assert cert["zero_product"]["expression"] == "d03*d12"
+    assert "supplied/certified row order" in cert["scope"]
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_row_ptolemy_product_artifact_matches_generator() -> None:
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == row_ptolemy_product_cancellation_report()
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_row_ptolemy_product_checker_passes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["hit_assignment_count"] == 26
+    assert summary["hit_certificate_count"] == 216
+
+
+def test_row_ptolemy_product_checker_rejects_tampered_provenance() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["provenance"]["command"] = (
+        "python scripts/analyze_n9_row_ptolemy_product_cancellations.py"
+    )
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("provenance" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_unknown_top_level_key() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["unchecked_schema_drift"] = {"ok": False}
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("top-level keys" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_tampered_count() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["hit_summary"]["hit_assignment_count"] = 27
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("hit assignment count" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_row_ptolemy_product_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_row_ptolemy_product_cancellations.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["hit_certificate_count"] == 216

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -51,3 +51,7 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert "python scripts/check_n9_d3_escape_slice.py --check --json" in command_texts
+    assert (
+        "python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary
- add an exact row-Ptolemy product-cancellation helper for fixed/certified row orders
- add a generated `n=9` frontier artifact recording 26 hit assignments and 216 row-local certificates across deterministic families `F02`, `F09`, and `F13`
- add generator/checker CLIs, provenance/audit registration, docs, and focused tests

## Scope
This is fixed-order exploratory bookkeeping for the review-pending `n=9` pre-vertex-circle frontier. It is not an orderless abstract-incidence obstruction, not a proof of `n=9`, not a counterexample, not a geometric realizability test, not a replacement for the vertex-circle checker, and not a global status update.

## Review Notes
- Implementation review found and we fixed a cyclic-row-rotation false-negative: the helper now checks all row-Ptolemy product-cancellation variants.
- Claim-hygiene review found no issues after the fixed-row-order caveat was made explicit.
- Provenance/readiness review found no issues after the artifact count updated to 216 certificates.

## Validation
- `python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --out data/certificates/n9_row_ptolemy_product_cancellations.json`
- `python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
- `python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --check-artifact data/certificates/n9_row_ptolemy_product_cancellations.json`
- `python -m pytest tests/test_n9_row_ptolemy_product_cancellations.py tests/test_incidence_filters.py tests/test_run_artifact_audit.py -q`
- `python -m pytest tests/test_n9_row_ptolemy_product_cancellations.py -q -m "artifact or exhaustive or not artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- artifact tier:
  - `python scripts/independent_check_n8_artifacts.py --check --json`
  - `python scripts/enumerate_n8_incidence.py --summary`
  - `python scripts/analyze_n8_exact_survivors.py --check --json`
  - `python scripts/check_round2_certificates.py`
  - `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
  - `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
  - `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`