### PR TITLE
Add n9 local-core template diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ verify-kalmanson:
 
 verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
 	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
 

--- a/data/certificates/n9_vertex_circle_core_templates.json
+++ b/data/certificates/n9_vertex_circle_core_templates.json
@@ -1,0 +1,801 @@
+{
+  "claim_scope": "Template diagnostic for the 16 n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "core_size_counts": {
+    "3": 5,
+    "4": 6,
+    "5": 2,
+    "6": 3
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "families": [
+    {
+      "core_size": 3,
+      "family_id": "F01",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 1,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T02"
+    },
+    {
+      "core_size": 6,
+      "family_id": "F02",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 9,
+        "self_edge_shape_counts": [
+          {
+            "count": 4,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 2,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 54,
+      "template_id": "T08"
+    },
+    {
+      "core_size": 6,
+      "family_id": "F03",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 13,
+        "self_edge_shape_counts": [
+          {
+            "count": 5,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 4,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 2,
+            "inner_span": 2,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 54,
+      "template_id": "T09"
+    },
+    {
+      "core_size": 3,
+      "family_id": "F04",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 1,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T02"
+    },
+    {
+      "core_size": 4,
+      "family_id": "F05",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 1,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T03"
+    },
+    {
+      "core_size": 5,
+      "family_id": "F06",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 6,
+        "self_edge_shape_counts": [
+          {
+            "count": 3,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 2,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 45,
+      "template_id": "T07"
+    },
+    {
+      "core_size": 4,
+      "family_id": "F07",
+      "obstruction_summary": {
+        "cycle_length": 3,
+        "cycle_span_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3
+          },
+          {
+            "count": 1,
+            "inner_span": 2,
+            "outer_span": 3
+          }
+        ]
+      },
+      "orbit_size": 6,
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11"
+    },
+    {
+      "core_size": 3,
+      "family_id": "F08",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 1,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T02"
+    },
+    {
+      "core_size": 3,
+      "family_id": "F09",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 2,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 6,
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T01"
+    },
+    {
+      "core_size": 4,
+      "family_id": "F10",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 2,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T05"
+    },
+    {
+      "core_size": 5,
+      "family_id": "F11",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 3,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "self_edge",
+      "strict_edge_count": 45,
+      "template_id": "T06"
+    },
+    {
+      "core_size": 4,
+      "family_id": "F12",
+      "obstruction_summary": {
+        "cycle_length": 2,
+        "cycle_span_counts": [
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 2
+          }
+        ]
+      },
+      "orbit_size": 18,
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10"
+    },
+    {
+      "core_size": 4,
+      "family_id": "F13",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 2,
+        "self_edge_shape_counts": [
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T04"
+    },
+    {
+      "core_size": 3,
+      "family_id": "F14",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 1,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T02"
+    },
+    {
+      "core_size": 4,
+      "family_id": "F15",
+      "obstruction_summary": {
+        "self_edge_conflict_count": 1,
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          }
+        ]
+      },
+      "orbit_size": 2,
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T03"
+    },
+    {
+      "core_size": 6,
+      "family_id": "F16",
+      "obstruction_summary": {
+        "cycle_length": 3,
+        "cycle_span_counts": [
+          {
+            "count": 3,
+            "inner_span": 1,
+            "outer_span": 3
+          }
+        ]
+      },
+      "orbit_size": 2,
+      "status": "strict_cycle",
+      "strict_edge_count": 54,
+      "template_id": "T12"
+    }
+  ],
+  "family_count": 16,
+  "interpretation": [
+    "Templates are replay-derived shape buckets for the compact local cores.",
+    "Template ids are deterministic artifact labels, not intrinsic theorem names.",
+    "Each template covers only the listed n=9 motif-family representatives under the recorded cyclic order.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "max_core_size": 6,
+  "n": 9,
+  "orbit_size_sum": 184,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_core_templates.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_core_templates.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_local_cores.json",
+      "role": "detailed source local-core certificate artifact"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_motif_families.json",
+      "role": "deterministic family-id convention"
+    }
+  ],
+  "source_packet": {
+    "path": "data/certificates/n9_vertex_circle_local_core_packet.json",
+    "schema": "erdos97.n9_vertex_circle_local_core_packet.v1",
+    "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "status_core_size_counts": {
+    "self_edge": {
+      "3": 5,
+      "4": 4,
+      "5": 2,
+      "6": 2
+    },
+    "strict_cycle": {
+      "4": 2,
+      "6": 1
+    }
+  },
+  "status_template_counts": {
+    "self_edge": 9,
+    "strict_cycle": 3
+  },
+  "template_count": 12,
+  "template_family_count_distribution": {
+    "1": 10,
+    "2": 1,
+    "4": 1
+  },
+  "templates": [
+    {
+      "core_size": 3,
+      "families": [
+        "F09"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 6,
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T01",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+    },
+    {
+      "core_size": 3,
+      "families": [
+        "F01",
+        "F04",
+        "F08",
+        "F14"
+      ],
+      "family_count": 4,
+      "orbit_size_sum": 40,
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T02",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+    },
+    {
+      "core_size": 4,
+      "families": [
+        "F05",
+        "F15"
+      ],
+      "family_count": 2,
+      "orbit_size_sum": 20,
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T03",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+    },
+    {
+      "core_size": 4,
+      "families": [
+        "F13"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 2,
+      "self_edge_shape_counts": [
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T04",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2"
+    },
+    {
+      "core_size": 4,
+      "families": [
+        "F10"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18,
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T05",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+    },
+    {
+      "core_size": 5,
+      "families": [
+        "F11"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18,
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 45,
+      "template_id": "T06",
+      "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x1,3:1:0x1,3:1:1x1"
+    },
+    {
+      "core_size": 5,
+      "families": [
+        "F06"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18,
+      "self_edge_shape_counts": [
+        {
+          "count": 3,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 45,
+      "template_id": "T07",
+      "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x3,3:1:0x1,3:1:1x1,3:2:1x1"
+    },
+    {
+      "core_size": 6,
+      "families": [
+        "F02"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18,
+      "self_edge_shape_counts": [
+        {
+          "count": 4,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 54,
+      "template_id": "T08",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+    },
+    {
+      "core_size": 6,
+      "families": [
+        "F03"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18,
+      "self_edge_shape_counts": [
+        {
+          "count": 5,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 4,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "status": "self_edge",
+      "strict_edge_count": 54,
+      "template_id": "T09",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x5,3:1:0x2,3:1:1x4,3:2:1x2"
+    },
+    {
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_span_counts": [
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 2
+        }
+      ],
+      "families": [
+        "F12"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18,
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+    },
+    {
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_span_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3
+        }
+      ],
+      "families": [
+        "F07"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 6,
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=3|spans=2:1x1,3:1x1,3:2x1"
+    },
+    {
+      "core_size": 6,
+      "cycle_length": 3,
+      "cycle_span_counts": [
+        {
+          "count": 3,
+          "inner_span": 1,
+          "outer_span": 3
+        }
+      ],
+      "families": [
+        "F16"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 2,
+      "status": "strict_cycle",
+      "strict_edge_count": 54,
+      "template_id": "T12",
+      "template_key": "strict_cycle|rows=6|strict_edges=54|cycle=3|spans=3:1x3"
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -39,6 +39,14 @@ packet is also available at
 core selected rows for each family and is replayed by
 `scripts/check_n9_vertex_circle_local_core_packet.py`.
 
+The companion template diagnostic
+`data/certificates/n9_vertex_circle_core_templates.json` groups the 16 compact
+cores into 12 replay-derived shape buckets. The buckets record self-edge
+conflict span/shared-endpoint shapes or strict-cycle span shapes, plus the
+family ids covered by each bucket. These template ids are deterministic
+artifact labels only; they are not theorem names and do not promote the n=9
+finite-case status.
+
 ## Certificate Shape
 
 A self-edge core consists of:
@@ -101,10 +109,26 @@ python scripts/check_n9_vertex_circle_local_core_packet.py \
   --json
 ```
 
+Generate and check the local-core template diagnostic:
+
+```bash
+python scripts/check_n9_vertex_circle_core_templates.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_core_templates.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
-python -m pytest tests/test_n9_vertex_circle_local_cores.py -q
+python -m pytest \
+  tests/test_n9_vertex_circle_local_cores.py \
+  tests/test_n9_vertex_circle_core_templates.py \
+  -q
 ```
 
 Replay the 16 local quotient certificates with the small proof-facing kernel:

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -32,7 +32,10 @@ The checked-in artifact is
 
 The local-core follow-up in `docs/n9-vertex-circle-local-cores.md` shows that
 each of the 16 family representatives has a vertex-circle certificate using at
-most 6 selected rows.
+most 6 selected rows. Its template diagnostic groups those 16 local cores into
+12 replay-derived shape buckets: 9 self-edge templates and 3 strict-cycle
+templates. These buckets are review aids for lemma mining; they are not an
+independent n=9 proof path.
 
 ## Loose Obstruction Shapes
 
@@ -66,6 +69,9 @@ quotient-cycle template.
 
 The local-core diagnostic reduces this to a row-local problem: the family
 representatives need only 3 to 6 rows to certify the contradiction.
+The template diagnostic is a first pass at that classification, but it only
+records replay shapes for the listed n=9 representatives. Any reusable lemma
+still needs precise incidence/order hypotheses and separate proof.
 
 The current result still does not solve the global problem. The known
 `C19_skew` order that survives the vertex-circle filter remains a useful

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -279,6 +279,41 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_core_templates
+    path: data/certificates/n9_vertex_circle_core_templates.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_core_templates.py
+    command: python scripts/check_n9_vertex_circle_core_templates.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_core_templates.py
+    check_command: python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Template diagnostic for the 16 n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_core_templates.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Template diagnostic for the 16 n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      family_count: 16
+      orbit_size_sum: 184
+      template_count: 12
+      status_template_counts.self_edge: 9
+      status_template_counts.strict_cycle: 3
+      template_family_count_distribution.1: 10
+      template_family_count_distribution.2: 1
+      template_family_count_distribution.4: 1
+      provenance.command: python scripts/check_n9_vertex_circle_core_templates.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_core_templates.py
+++ b/scripts/check_n9_vertex_circle_core_templates.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""Generate or check n=9 vertex-circle local-core template diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_local_core_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_PACKET,
+    load_artifact,
+    validate_payload as validate_packet_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    LocalCoreReplay,
+    StrictInequality,
+    replay_local_core_bundle,
+)
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_core_templates.json"
+SCHEMA = "erdos97.n9_vertex_circle_core_templates.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Template diagnostic for the 16 n=9 vertex-circle local-core motif "
+    "representatives; not a proof of n=9, not a counterexample, not an "
+    "independent review of the exhaustive checker, and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_core_templates.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_core_templates.py "
+        "--assert-expected --write"
+    ),
+}
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "core_size_counts",
+    "cyclic_order",
+    "families",
+    "family_count",
+    "interpretation",
+    "max_core_size",
+    "n",
+    "orbit_size_sum",
+    "provenance",
+    "row_size",
+    "schema",
+    "source_artifacts",
+    "source_packet",
+    "status",
+    "status_core_size_counts",
+    "status_template_counts",
+    "template_family_count_distribution",
+    "template_count",
+    "templates",
+    "trust",
+}
+EXPECTED_STATUS_TEMPLATE_COUNTS = {"self_edge": 9, "strict_cycle": 3}
+EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION = {"1": 10, "2": 1, "4": 1}
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _edge_span(edge: StrictInequality) -> tuple[int, int]:
+    return (
+        int(edge.outer_interval[1] - edge.outer_interval[0]),
+        int(edge.inner_interval[1] - edge.inner_interval[0]),
+    )
+
+
+def _shared_endpoint_count(edge: StrictInequality) -> int:
+    return len(set(edge.outer_pair) & set(edge.inner_pair))
+
+
+def _shape_rows(counter: Counter[tuple[int, int, int]]) -> list[dict[str, int]]:
+    return [
+        {
+            "outer_span": outer_span,
+            "inner_span": inner_span,
+            "shared_endpoint_count": shared,
+            "count": counter[(outer_span, inner_span, shared)],
+        }
+        for outer_span, inner_span, shared in sorted(counter)
+    ]
+
+
+def _cycle_span_rows(counter: Counter[tuple[int, int]]) -> list[dict[str, int]]:
+    return [
+        {
+            "outer_span": outer_span,
+            "inner_span": inner_span,
+            "count": counter[(outer_span, inner_span)],
+        }
+        for outer_span, inner_span in sorted(counter)
+    ]
+
+
+def _self_edge_template(
+    result: LocalCoreReplay,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    shape_counter = Counter(
+        (
+            *_edge_span(edge),
+            _shared_endpoint_count(edge),
+        )
+        for edge in result.result.self_edge_conflicts
+    )
+    tokens = [
+        f"{row['outer_span']}:{row['inner_span']}:{row['shared_endpoint_count']}x{row['count']}"
+        for row in _shape_rows(shape_counter)
+    ]
+    template_key = (
+        f"self_edge|rows={result.result.selected_row_count}|"
+        f"strict_edges={result.result.strict_edge_count}|conflicts={','.join(tokens)}"
+    )
+    family_obstruction = {
+        "self_edge_conflict_count": len(result.result.self_edge_conflicts),
+        "self_edge_shape_counts": _shape_rows(shape_counter),
+    }
+    template_fields = {
+        "self_edge_shape_counts": _shape_rows(shape_counter),
+    }
+    return template_key, family_obstruction, template_fields
+
+
+def _strict_cycle_template(
+    result: LocalCoreReplay,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    span_counter = Counter(_edge_span(edge) for edge in result.result.cycle_edges)
+    tokens = [
+        f"{row['outer_span']}:{row['inner_span']}x{row['count']}"
+        for row in _cycle_span_rows(span_counter)
+    ]
+    cycle_length = len(result.result.cycle_edges)
+    template_key = (
+        f"strict_cycle|rows={result.result.selected_row_count}|"
+        f"strict_edges={result.result.strict_edge_count}|"
+        f"cycle={cycle_length}|spans={','.join(tokens)}"
+    )
+    family_obstruction = {
+        "cycle_length": cycle_length,
+        "cycle_span_counts": _cycle_span_rows(span_counter),
+    }
+    template_fields = {
+        "cycle_length": cycle_length,
+        "cycle_span_counts": _cycle_span_rows(span_counter),
+    }
+    return template_key, family_obstruction, template_fields
+
+
+def _template_for_replay(
+    replay: LocalCoreReplay,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    if replay.result.status == "self_edge":
+        return _self_edge_template(replay)
+    if replay.result.status == "strict_cycle":
+        return _strict_cycle_template(replay)
+    raise AssertionError(f"unexpected local-core replay status {replay.result.status!r}")
+
+
+def _family_orbit_sizes(families: Sequence[dict[str, Any]]) -> dict[str, int]:
+    return {str(family["family_id"]): int(family["orbit_size"]) for family in families}
+
+
+def core_template_payload(packet: dict[str, Any]) -> dict[str, Any]:
+    """Return the replay-derived template diagnostic for a compact packet."""
+
+    replays = replay_local_core_bundle(packet)
+    raw_families = packet.get("certificates")
+    if not isinstance(raw_families, list):
+        raise ValueError("source packet must contain certificate list")
+    if len(raw_families) != len(replays):
+        raise ValueError("source packet certificate count does not match replay count")
+    orbit_sizes = _family_orbit_sizes(raw_families)
+
+    template_acc: dict[str, dict[str, Any]] = {}
+    family_rows = []
+    for replay in replays:
+        template_key, family_obstruction, template_fields = _template_for_replay(replay)
+        family_id = replay.family_id
+        orbit_size = orbit_sizes[family_id]
+        family_rows.append(
+            {
+                "family_id": family_id,
+                "orbit_size": orbit_size,
+                "status": replay.result.status,
+                "core_size": replay.result.selected_row_count,
+                "strict_edge_count": replay.result.strict_edge_count,
+                "template_key": template_key,
+                "obstruction_summary": family_obstruction,
+            }
+        )
+        template = template_acc.setdefault(
+            template_key,
+            {
+                "template_key": template_key,
+                "status": replay.result.status,
+                "core_size": replay.result.selected_row_count,
+                "strict_edge_count": replay.result.strict_edge_count,
+                "families": [],
+                "family_count": 0,
+                "orbit_size_sum": 0,
+                **template_fields,
+            },
+        )
+        template["families"].append(family_id)
+        template["family_count"] = int(template["family_count"]) + 1
+        template["orbit_size_sum"] = int(template["orbit_size_sum"]) + orbit_size
+
+    templates = []
+    template_id_by_key = {}
+    for idx, key in enumerate(sorted(template_acc), start=1):
+        template_id = f"T{idx:02d}"
+        template = dict(template_acc[key])
+        template["template_id"] = template_id
+        template["families"] = sorted(template["families"])
+        templates.append(template)
+        template_id_by_key[key] = template_id
+
+    families = []
+    for family in sorted(family_rows, key=lambda row: row["family_id"]):
+        row = dict(family)
+        row["template_id"] = template_id_by_key[row.pop("template_key")]
+        families.append(row)
+
+    status_template_counts = Counter(str(template["status"]) for template in templates)
+    family_count_distribution = Counter(int(template["family_count"]) for template in templates)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": packet["n"],
+        "row_size": packet["row_size"],
+        "cyclic_order": packet["cyclic_order"],
+        "family_count": len(families),
+        "orbit_size_sum": sum(int(family["orbit_size"]) for family in families),
+        "template_count": len(templates),
+        "status_template_counts": {
+            status: status_template_counts[status] for status in sorted(status_template_counts)
+        },
+        "template_family_count_distribution": {
+            str(count): family_count_distribution[count] for count in sorted(family_count_distribution)
+        },
+        "core_size_counts": packet["core_size_counts"],
+        "status_core_size_counts": packet["status_core_size_counts"],
+        "max_core_size": packet["max_core_size"],
+        "templates": templates,
+        "families": families,
+        "interpretation": [
+            "Templates are replay-derived shape buckets for the compact local cores.",
+            "Template ids are deterministic artifact labels, not intrinsic theorem names.",
+            "Each template covers only the listed n=9 motif-family representatives under the recorded cyclic order.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_packet": {
+            "path": "data/certificates/n9_vertex_circle_local_core_packet.json",
+            "schema": packet["schema"],
+            "status": packet["status"],
+            "trust": packet["trust"],
+        },
+        "source_artifacts": packet["source_artifacts"],
+        "provenance": PROVENANCE,
+    }
+    assert_expected_core_template_counts(payload)
+    return payload
+
+
+def assert_expected_core_template_counts(payload: dict[str, Any]) -> None:
+    """Assert stable headline counts for the local-core template diagnostic."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["family_count"] != 16:
+        raise AssertionError(f"unexpected family count: {payload['family_count']}")
+    if payload["orbit_size_sum"] != 184:
+        raise AssertionError(f"unexpected orbit-size sum: {payload['orbit_size_sum']}")
+    if payload["template_count"] != 12:
+        raise AssertionError(f"unexpected template count: {payload['template_count']}")
+    if payload["status_template_counts"] != EXPECTED_STATUS_TEMPLATE_COUNTS:
+        raise AssertionError("unexpected status/template counts")
+    if payload["template_family_count_distribution"] != EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION:
+        raise AssertionError("unexpected template family-count distribution")
+    if payload["core_size_counts"] != {"3": 5, "4": 6, "5": 2, "6": 3}:
+        raise AssertionError("unexpected core-size counts")
+    if payload["status_core_size_counts"] != {
+        "self_edge": {"3": 5, "4": 4, "5": 2, "6": 2},
+        "strict_cycle": {"4": 2, "6": 1},
+    }:
+        raise AssertionError("unexpected status/core-size counts")
+    templates = payload["templates"]
+    families = payload["families"]
+    if not isinstance(templates, list) or len(templates) != 12:
+        raise AssertionError("unexpected template rows")
+    if not isinstance(families, list) or len(families) != 16:
+        raise AssertionError("unexpected family rows")
+    if [family["family_id"] for family in families] != [f"F{idx:02d}" for idx in range(1, 17)]:
+        raise AssertionError("unexpected family id sequence")
+    family_template_ids = {str(family["template_id"]) for family in families}
+    template_ids = {str(template["template_id"]) for template in templates}
+    if family_template_ids - template_ids:
+        raise AssertionError("family row references unknown template id")
+    multi_family_templates = sorted(
+        int(template["family_count"]) for template in templates if int(template["family_count"]) > 1
+    )
+    if multi_family_templates != [2, 4]:
+        raise AssertionError("unexpected multi-family template sizes")
+
+
+def _int_from_row(
+    errors: list[str],
+    row: dict[str, Any],
+    key: str,
+    label: str,
+) -> int | None:
+    try:
+        return int(row[key])
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"{label} has invalid {key}: {exc}")
+        return None
+
+
+def _validate_template_family_links(payload: dict[str, Any], errors: list[str]) -> None:
+    raw_templates = payload.get("templates")
+    raw_families = payload.get("families")
+    if not isinstance(raw_templates, list):
+        errors.append("templates must be a list")
+        return
+    if not isinstance(raw_families, list):
+        errors.append("families must be a list")
+        return
+
+    templates_by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_template in enumerate(raw_templates):
+        if not isinstance(raw_template, dict):
+            errors.append(f"template {index} must be an object")
+            continue
+        template_id = raw_template.get("template_id")
+        if not isinstance(template_id, str) or not template_id:
+            errors.append(f"template {index} has invalid template_id")
+            continue
+        if template_id in templates_by_id:
+            errors.append(f"duplicate template id {template_id}")
+        templates_by_id[template_id] = raw_template
+
+    families_by_template: dict[str, list[str]] = {template_id: [] for template_id in templates_by_id}
+    orbit_by_template: Counter[str] = Counter()
+    family_ids: list[str] = []
+    total_orbit_size = 0
+    for index, raw_family in enumerate(raw_families):
+        if not isinstance(raw_family, dict):
+            errors.append(f"family {index} must be an object")
+            continue
+        family_id = raw_family.get("family_id")
+        template_id = raw_family.get("template_id")
+        if not isinstance(family_id, str) or not family_id:
+            errors.append(f"family {index} has invalid family_id")
+            continue
+        if not isinstance(template_id, str) or template_id not in templates_by_id:
+            errors.append(f"family {family_id} references unknown template {template_id!r}")
+            continue
+        template = templates_by_id[template_id]
+        for key in ("status", "core_size", "strict_edge_count"):
+            if raw_family.get(key) != template.get(key):
+                errors.append(
+                    f"family {family_id} {key} does not match template {template_id}: "
+                    f"{raw_family.get(key)!r} != {template.get(key)!r}"
+                )
+        orbit_size = _int_from_row(errors, raw_family, "orbit_size", f"family {family_id}")
+        if orbit_size is None:
+            continue
+        families_by_template[template_id].append(family_id)
+        orbit_by_template[template_id] += orbit_size
+        family_ids.append(family_id)
+        total_orbit_size += orbit_size
+
+    if len(family_ids) != len(set(family_ids)):
+        errors.append("duplicate family ids in family rows")
+    if len(raw_families) != payload.get("family_count"):
+        errors.append("family_count does not match family row count")
+    if total_orbit_size != payload.get("orbit_size_sum"):
+        errors.append("orbit_size_sum does not match family rows")
+
+    status_template_counts: Counter[str] = Counter()
+    family_count_distribution: Counter[int] = Counter()
+    for template_id, template in templates_by_id.items():
+        status = template.get("status")
+        if isinstance(status, str):
+            status_template_counts[status] += 1
+        listed_families = template.get("families")
+        if not isinstance(listed_families, list) or not all(
+            isinstance(item, str) for item in listed_families
+        ):
+            errors.append(f"template {template_id} families must be a list of strings")
+            continue
+        expected_families = sorted(families_by_template[template_id])
+        if sorted(listed_families) != expected_families:
+            errors.append(
+                f"template {template_id} family list mismatch: "
+                f"expected {expected_families!r}, got {sorted(listed_families)!r}"
+            )
+        family_count = _int_from_row(errors, template, "family_count", f"template {template_id}")
+        orbit_sum = _int_from_row(errors, template, "orbit_size_sum", f"template {template_id}")
+        if family_count is not None:
+            family_count_distribution[family_count] += 1
+            if family_count != len(expected_families):
+                errors.append(f"template {template_id} family_count does not match family rows")
+        if orbit_sum is not None and orbit_sum != orbit_by_template[template_id]:
+            errors.append(f"template {template_id} orbit_size_sum does not match family rows")
+
+    expected_status_counts = {
+        status: status_template_counts[status] for status in sorted(status_template_counts)
+    }
+    if payload.get("status_template_counts") != expected_status_counts:
+        errors.append("status_template_counts does not match template rows")
+    expected_family_distribution = {
+        str(count): family_count_distribution[count] for count in sorted(family_count_distribution)
+    }
+    if payload.get("template_family_count_distribution") != expected_family_distribution:
+        errors.append("template_family_count_distribution does not match template rows")
+
+
+def _validate_packet(packet: Any) -> list[str]:
+    if not isinstance(packet, dict):
+        return ["source packet top level must be a JSON object"]
+    return validate_packet_payload(packet, recompute=False)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    packet: Any | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a local-core template diagnostic."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "family_count": 16,
+        "orbit_size_sum": 184,
+        "template_count": 12,
+        "status_template_counts": EXPECTED_STATUS_TEMPLATE_COUNTS,
+        "template_family_count_distribution": EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION,
+        "max_core_size": 6,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+
+    try:
+        assert_expected_core_template_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected template counts failed: {exc}")
+    _validate_template_family_links(payload, errors)
+
+    if recompute:
+        if packet is None:
+            try:
+                packet = load_artifact(DEFAULT_PACKET)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"failed to load source packet: {exc}")
+                packet = None
+        packet_errors = _validate_packet(packet)
+        if packet_errors:
+            errors.extend(f"source packet invalid: {error}" for error in packet_errors)
+        elif isinstance(packet, dict):
+            try:
+                expected_payload = core_template_payload(packet)
+            except (AssertionError, TypeError, ValueError) as exc:
+                errors.append(f"recomputed template diagnostic failed: {exc}")
+            else:
+                expect_equal(errors, "core-template diagnostic", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "family_count": object_payload.get("family_count"),
+        "template_count": object_payload.get("template_count"),
+        "status_template_counts": object_payload.get("status_template_counts"),
+        "template_family_count_distribution": object_payload.get(
+            "template_family_count_distribution"
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated diagnostic")
+    parser.add_argument("--check", action="store_true", help="validate an existing diagnostic")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
+    packet_path = args.packet if args.packet.is_absolute() else ROOT / args.packet
+    out = args.out if args.out.is_absolute() else ROOT / args.out
+
+    try:
+        packet = load_artifact(packet_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        packet = {}
+        packet_errors = [str(exc)]
+    else:
+        packet_errors = _validate_packet(packet)
+
+    if args.write:
+        if packet_errors:
+            for error in packet_errors:
+                print(f"source packet invalid: {error}", file=sys.stderr)
+            return 1
+        payload = core_template_payload(packet)
+        if args.assert_expected:
+            assert_expected_core_template_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            packet=packet,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+    if packet_errors:
+        errors.extend(f"source packet invalid: {error}" for error in packet_errors)
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle local-core template diagnostic")
+        print(f"artifact: {summary['artifact']}")
+        print(f"families: {summary['family_count']}")
+        print(f"templates: {summary['template_count']}")
+        print(f"status/template counts: {summary['status_template_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: local-core template diagnostic checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -127,6 +127,20 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_core_templates",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_core_templates.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Template diagnostic for n=9 vertex-circle local-core motif "
+            "representatives; not a proof of n=9 or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/tests/test_n9_vertex_circle_core_templates.py
+++ b/tests/test_n9_vertex_circle_core_templates.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.check_n9_vertex_circle_core_templates import (
+    DEFAULT_ARTIFACT,
+    DEFAULT_PACKET,
+    assert_expected_core_template_counts,
+    core_template_payload,
+    load_artifact,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_local_core_template_artifact_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_core_template_counts(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["family_count"] == 16
+    assert payload["orbit_size_sum"] == 184
+    assert payload["template_count"] == 12
+    assert payload["status_template_counts"] == {"self_edge": 9, "strict_cycle": 3}
+    assert payload["template_family_count_distribution"] == {"1": 10, "2": 1, "4": 1}
+
+
+def test_local_core_template_rows_reference_known_templates() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    template_ids = {template["template_id"] for template in payload["templates"]}
+    assert len(template_ids) == 12
+    assert all(family["template_id"] in template_ids for family in payload["families"])
+    assert [family["family_id"] for family in payload["families"]] == [
+        f"F{idx:02d}" for idx in range(1, 17)
+    ]
+    assert {family["status"] for family in payload["families"]} == {
+        "self_edge",
+        "strict_cycle",
+    }
+
+
+def test_local_core_template_checker_rejects_tampered_count() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["template_count"] = 13
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template_count" in error or "template count" in error for error in errors)
+
+
+def test_local_core_template_checker_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_local_core_template_checker_rejects_stale_template_mapping() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["families"][0]["template_id"] = payload["families"][1]["template_id"]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template" in error and "family" in error for error in errors)
+
+
+def test_local_core_template_checker_rejects_invalid_source_packet() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    errors = validate_payload(payload, packet={}, recompute=True)
+
+    assert any("source packet invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_local_core_template_artifact_matches_generator() -> None:
+    packet = load_artifact(DEFAULT_PACKET)
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == core_template_payload(packet)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_local_core_template_checker_passes() -> None:
+    packet = load_artifact(DEFAULT_PACKET)
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, packet=packet)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["family_count"] == 16
+    assert summary["template_count"] == 12
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_local_core_template_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_core_templates.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["family_count"] == 16
+    assert payload["template_count"] == 12

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -60,3 +60,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n9_vertex_circle_core_templates.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary
- add a replay-derived template diagnostic for the 16 `n=9` vertex-circle local-core motif representatives
- group compact local cores into 12 deterministic shape buckets: 9 self-edge templates and 3 strict-cycle templates
- register the artifact in generated-artifact provenance, artifact audit, `verify-n9-review`, docs, and tests

## Scope
This is a reviewer aid for lemma mining over the review-pending `n=9` vertex-circle diagnostics. It is not a proof of `n=9`, not a counterexample, not an independent review of the exhaustive checker, not a source-of-truth promotion, and not a global status update.

## Review Notes
- Implementation review found that cheap validation could accept stale family/template links; fixed by cross-checking template rows against family rows, including family lists, status/core/strict-edge fields, counts, and orbit-size sums.
- Claim/provenance review found no issues.

## Validation
- `python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_core_templates.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_core_templates.py tests/test_n9_vertex_circle_core_templates.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- artifact tier:
  - `python scripts/independent_check_n8_artifacts.py --check --json`
  - `python scripts/enumerate_n8_incidence.py --summary`
  - `python scripts/analyze_n8_exact_survivors.py --check --json`
  - `python scripts/check_round2_certificates.py`
  - `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json`
  - `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
  - `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json`
  - `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
  - `python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json`
  - `python scripts/check_n9_base_apex_escape_budget.py --check --json`
  - `python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
  - `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic`
  - `python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json`
  - `python scripts/check_n9_d3_escape_slice.py --check --json`