### PR TITLE
Add row-Ptolemy guardrails

### DIFF
--- a/docs/row-ptolemy-product-filter.md
+++ b/docs/row-ptolemy-product-filter.md
@@ -53,6 +53,28 @@ This gives an independent Ptolemy-equality certificate for those fixed-order
 assignments, but it does not dominate or replace the vertex-circle checker and
 does not prove the full `n=9` finite case.
 
+## Negative Controls And Order Guardrails
+
+The checked artifact now has regression coverage for both the positive and
+negative family labels in the current `n=9` frontier. The row-Ptolemy sweep
+hits only `F02`, `F09`, and `F13`. The remaining 13 deterministic family labels
+are kept as negative controls with zero row-Ptolemy certificates:
+
+```text
+F01,F03,F04,F05,F06,F07,F08,F10,F11,F12,F14,F15,F16
+```
+
+Those negative controls cover `158` of the `184` pre-vertex-circle assignments.
+They are bookkeeping guardrails, not evidence that those assignments are
+geometrically realizable or that the vertex-circle obstruction is unnecessary.
+
+The checker also replays every stored hit record against its fixed cyclic
+order. It verifies that each certificate's `witness_order`, forced-equality
+pair names, and zero-product pair names match the supplied row order. A
+scrambled non-dihedral order for the first `F02` representative has zero
+row-Ptolemy product-cancellation certificates, while the stored natural order
+has six. This is why the row order remains part of the certificate hypothesis.
+
 ## Reproduction
 
 ```bash

--- a/scripts/check_n9_row_ptolemy_product_cancellations.py
+++ b/scripts/check_n9_row_ptolemy_product_cancellations.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -14,13 +16,33 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from erdos97 import n9_vertex_circle_exhaustive as n9  # noqa: E402
+from erdos97.incidence_filters import (  # noqa: E402
+    row_ptolemy_product_cancellation_certificates,
+)
 from erdos97.n9_row_ptolemy_product_cancellations import (  # noqa: E402
     CLAIM_SCOPE,
+    EXPECTED_CERTIFICATE_COUNT_BY_CENTER,
+    EXPECTED_CERTIFICATES_PER_HIT_ASSIGNMENT,
+    EXPECTED_HIT_ASSIGNMENT_STATUS_COUNTS,
+    EXPECTED_HIT_ASSIGNMENTS,
+    EXPECTED_HIT_CERTIFICATES,
+    EXPECTED_HIT_FAMILIES,
+    EXPECTED_HIT_FAMILY_COUNTS,
+    EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS,
+    EXPECTED_PRE_VERTEX_CIRCLE_NODES,
     PROVENANCE,
     SCHEMA,
     STATUS,
     TRUST,
+    _family_labels,
+    assert_expected_counts,
     row_ptolemy_product_cancellation_report,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    _rows_from_assignment,
+    canonical_dihedral_rows,
+    pre_vertex_circle_assignments,
 )
 
 DEFAULT_ARTIFACT = (
@@ -42,6 +64,25 @@ EXPECTED_TOP_LEVEL_KEYS = {
     "trust",
     "witness_size",
 }
+EXPECTED_CERTIFICATE_TYPE = "row_ptolemy_product_cancellation"
+EXPECTED_CERTIFICATE_STATUS = "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER"
+EXPECTED_PTOLEMY_IDENTITY = "d02*d13 = d01*d23 + d03*d12"
+EXPECTED_CERTIFICATE_SCOPE = (
+    "Exact obstruction for this fixed selected-witness row "
+    "under the supplied/certified row order only."
+)
+EXPECTED_CONTRADICTION = (
+    "Ptolemy cancellation forces a product of two ordinary distances to be "
+    "zero, but distinct strictly convex vertices have positive Euclidean "
+    "distances."
+)
+EXPECTED_ZERO_PRODUCT_BY_CANCELLED = {
+    "d01*d23": "d03*d12",
+    "d03*d12": "d01*d23",
+}
+PAIR_NAMES = {"d01", "d02", "d03", "d12", "d13", "d23"}
+
+SourceAssignmentRecord = dict[str, object]
 
 
 def load_artifact(path: Path) -> Any:
@@ -88,6 +129,504 @@ def _validate_interpretation(errors: list[str], interpretation: Any) -> None:
             errors.append(f"interpretation must include {phrase!r}")
 
 
+def _is_int(value: Any) -> bool:
+    return type(value) is int
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _json_pair(pair: tuple[int, int]) -> list[int]:
+    return [int(pair[0]), int(pair[1])]
+
+
+def _normalize_pair(left: int, right: int) -> tuple[int, int]:
+    return (left, right) if left < right else (right, left)
+
+
+def _parse_cyclic_order(errors: list[str], raw_order: Any, n: int) -> list[int] | None:
+    if not isinstance(raw_order, list) or len(raw_order) != n:
+        errors.append(f"cyclic_order must be a list of length {n}")
+        return None
+    if not all(_is_int(label) for label in raw_order):
+        errors.append("cyclic_order must contain integer labels")
+        return None
+    if sorted(raw_order) != list(range(n)):
+        errors.append(f"cyclic_order must be a permutation of 0..{n - 1}")
+        return None
+    return [int(label) for label in raw_order]
+
+
+def _row_witness_order(
+    order: Sequence[int],
+    center: int,
+    witnesses: Sequence[int],
+) -> list[int]:
+    positions = {label: index for index, label in enumerate(order)}
+    if center not in positions:
+        raise ValueError(f"center {center} is missing from cyclic order")
+    missing = [witness for witness in witnesses if witness not in positions]
+    if missing:
+        raise ValueError(f"witness {missing[0]} is missing from cyclic order")
+    center_pos = positions[center]
+    return sorted(witnesses, key=lambda witness: (positions[witness] - center_pos) % len(order))
+
+
+def _ptolemy_pairs(witness_order: Sequence[int]) -> dict[str, tuple[int, int]]:
+    w0, w1, w2, w3 = witness_order
+    return {
+        "d01": _normalize_pair(w0, w1),
+        "d02": _normalize_pair(w0, w2),
+        "d03": _normalize_pair(w0, w3),
+        "d12": _normalize_pair(w1, w2),
+        "d13": _normalize_pair(w1, w3),
+        "d23": _normalize_pair(w2, w3),
+    }
+
+
+def _rows_key(rows: Sequence[Sequence[int]]) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(int(label) for label in row) for row in rows)
+
+
+@lru_cache(maxsize=1)
+def _source_assignment_records() -> tuple[SourceAssignmentRecord, ...]:
+    assignments, nodes = pre_vertex_circle_assignments()
+    rows_by_assignment = [_rows_from_assignment(assign) for assign in assignments]
+    family_labels, family_orbit_sizes = _family_labels(rows_by_assignment)
+
+    if nodes != EXPECTED_PRE_VERTEX_CIRCLE_NODES:
+        raise AssertionError(f"unexpected source nodes: {nodes}")
+    if len(assignments) != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError(f"unexpected source assignments: {len(assignments)}")
+
+    rows = []
+    for assignment_index, (assign, selected_rows) in enumerate(
+        zip(assignments, rows_by_assignment),
+    ):
+        family_id = family_labels[canonical_dihedral_rows(selected_rows)]
+        rows.append(
+            {
+                "assignment_index": assignment_index,
+                "selected_rows": _rows_key(selected_rows),
+                "family_id": family_id,
+                "family_orbit_size": family_orbit_sizes[family_id],
+                "vertex_circle_status": n9.vertex_circle_status(assign),
+            }
+        )
+    return tuple(rows)
+
+
+def _source_records_or_errors(errors: list[str]) -> tuple[SourceAssignmentRecord, ...]:
+    try:
+        return _source_assignment_records()
+    except (AssertionError, ValueError) as exc:
+        errors.append(f"source assignment replay failed: {exc}")
+        return ()
+
+
+def _parse_selected_rows(
+    errors: list[str],
+    raw_rows: Any,
+    *,
+    label: str,
+    n: int,
+    witness_size: int,
+) -> list[list[int]] | None:
+    if not isinstance(raw_rows, list) or len(raw_rows) != n:
+        errors.append(f"{label} selected_rows must be a list of {n} rows")
+        return None
+
+    rows: list[list[int]] = []
+    for row_index, raw_row in enumerate(raw_rows):
+        row_label = f"{label} selected_rows[{row_index}]"
+        if not isinstance(raw_row, list) or len(raw_row) != witness_size:
+            errors.append(f"{row_label} must contain {witness_size} witnesses")
+            return None
+        if not all(_is_int(witness) for witness in raw_row):
+            errors.append(f"{row_label} must contain integer labels")
+            return None
+        row = [int(witness) for witness in raw_row]
+        if len(set(row)) != witness_size:
+            errors.append(f"{row_label} must not repeat witnesses")
+            return None
+        if row_index in row:
+            errors.append(f"{row_label} must not select its center")
+            return None
+        if any(witness < 0 or witness >= n for witness in row):
+            errors.append(f"{row_label} contains a label outside 0..{n - 1}")
+            return None
+        rows.append(row)
+    return rows
+
+
+def _validate_named_pair(
+    errors: list[str],
+    *,
+    label: str,
+    name: Any,
+    pair: Any,
+    expected_pairs: dict[str, tuple[int, int]],
+) -> None:
+    if not isinstance(name, str):
+        errors.append(f"{label} has invalid Ptolemy pair name {name!r}")
+        return
+    if name not in expected_pairs:
+        errors.append(f"{label} has unknown Ptolemy pair name {name!r}")
+        return
+    if pair != _json_pair(expected_pairs[str(name)]):
+        errors.append(
+            f"{label} pair mismatch for {name}: "
+            f"expected {_json_pair(expected_pairs[str(name)])!r}, got {pair!r}"
+        )
+
+
+def _validate_certificate_shape(
+    errors: list[str],
+    *,
+    record_label: str,
+    certificate_index: int,
+    certificate: Any,
+    selected_rows: Sequence[Sequence[int]],
+    cyclic_order: Sequence[int],
+) -> int | None:
+    cert_label = f"{record_label} certificates[{certificate_index}]"
+    if not isinstance(certificate, dict):
+        errors.append(f"{cert_label} must be an object")
+        return None
+
+    expect_equal(errors, f"{cert_label} type", certificate.get("type"), EXPECTED_CERTIFICATE_TYPE)
+    expect_equal(
+        errors,
+        f"{cert_label} status",
+        certificate.get("status"),
+        EXPECTED_CERTIFICATE_STATUS,
+    )
+    expect_equal(
+        errors,
+        f"{cert_label} Ptolemy identity",
+        certificate.get("ptolemy_identity"),
+        EXPECTED_PTOLEMY_IDENTITY,
+    )
+    expect_equal(errors, f"{cert_label} scope", certificate.get("scope"), EXPECTED_CERTIFICATE_SCOPE)
+    expect_equal(
+        errors,
+        f"{cert_label} contradiction",
+        certificate.get("contradiction"),
+        EXPECTED_CONTRADICTION,
+    )
+
+    row = certificate.get("row")
+    if not _is_int(row) or not 0 <= int(row) < len(selected_rows):
+        errors.append(f"{cert_label} row must be an integer in 0..{len(selected_rows) - 1}")
+        return None
+    row = int(row)
+
+    try:
+        expected_witness_order = _row_witness_order(cyclic_order, row, selected_rows[row])
+    except ValueError as exc:
+        errors.append(f"{cert_label} witness_order could not be checked: {exc}")
+        return row
+    expect_equal(
+        errors,
+        f"{cert_label} witness_order",
+        certificate.get("witness_order"),
+        expected_witness_order,
+    )
+    expected_pairs = _ptolemy_pairs(expected_witness_order)
+
+    forced_equalities = certificate.get("forced_equalities")
+    if not isinstance(forced_equalities, list) or len(forced_equalities) != 2:
+        errors.append(f"{cert_label} forced_equalities must contain two rows")
+    else:
+        for equality_index, equality in enumerate(forced_equalities):
+            equality_label = f"{cert_label} forced_equalities[{equality_index}]"
+            if not isinstance(equality, dict):
+                errors.append(f"{equality_label} must be an object")
+                continue
+            _validate_named_pair(
+                errors,
+                label=f"{equality_label} left_pair",
+                name=equality.get("left"),
+                pair=equality.get("left_pair"),
+                expected_pairs=expected_pairs,
+            )
+            _validate_named_pair(
+                errors,
+                label=f"{equality_label} right_pair",
+                name=equality.get("right"),
+                pair=equality.get("right_pair"),
+                expected_pairs=expected_pairs,
+            )
+            if not isinstance(equality.get("left"), str) or not isinstance(
+                equality.get("right"),
+                str,
+            ):
+                continue
+            if equality.get("left") not in PAIR_NAMES or equality.get("right") not in PAIR_NAMES:
+                continue
+            if not _is_int(equality.get("distance_class")):
+                errors.append(f"{equality_label} distance_class must be an integer")
+            if not _is_int(equality.get("class_member_count")):
+                errors.append(f"{equality_label} class_member_count must be an integer")
+
+    cancelled_product = certificate.get("cancelled_product")
+    if isinstance(cancelled_product, str):
+        expected_zero_product = EXPECTED_ZERO_PRODUCT_BY_CANCELLED.get(cancelled_product)
+    else:
+        expected_zero_product = None
+    if expected_zero_product is None:
+        errors.append(f"{cert_label} has unknown cancelled_product {cancelled_product!r}")
+
+    zero_product = certificate.get("zero_product")
+    if not isinstance(zero_product, dict):
+        errors.append(f"{cert_label} zero_product must be an object")
+    else:
+        factors = zero_product.get("factors")
+        if not isinstance(factors, list) or len(factors) != 2:
+            errors.append(f"{cert_label} zero_product factors must contain two rows")
+        else:
+            names = []
+            for factor_index, factor in enumerate(factors):
+                factor_label = f"{cert_label} zero_product.factors[{factor_index}]"
+                if not isinstance(factor, dict):
+                    errors.append(f"{factor_label} must be an object")
+                    continue
+                names.append(factor.get("name"))
+                _validate_named_pair(
+                    errors,
+                    label=f"{factor_label} pair",
+                    name=factor.get("name"),
+                    pair=factor.get("pair"),
+                    expected_pairs=expected_pairs,
+                )
+                if not _is_int(factor.get("distance_class")):
+                    errors.append(f"{factor_label} distance_class must be an integer")
+            expression = "*".join(str(name) for name in names)
+            expect_equal(
+                errors,
+                f"{cert_label} zero_product expression",
+                zero_product.get("expression"),
+                expression,
+            )
+            if expected_zero_product is not None:
+                expect_equal(
+                    errors,
+                    f"{cert_label} zero_product for cancelled product",
+                    zero_product.get("expression"),
+                    expected_zero_product,
+                )
+
+    return row
+
+
+def _validate_hit_records(
+    errors: list[str],
+    payload: dict[str, Any],
+    *,
+    bind_source_assignments: bool,
+) -> None:
+    summary = payload.get("hit_summary")
+    records = payload.get("hit_records")
+    if not isinstance(summary, dict):
+        errors.append("hit_summary must be an object")
+        return
+    if not isinstance(records, list):
+        errors.append("hit_records must be a list")
+        return
+
+    n = payload.get("n")
+    witness_size = payload.get("witness_size")
+    if not _is_int(n) or not _is_int(witness_size):
+        errors.append("n and witness_size must be integers before hit_records can be checked")
+        return
+    cyclic_order = _parse_cyclic_order(errors, payload.get("cyclic_order"), int(n))
+    if cyclic_order is None:
+        return
+
+    assignment_indices: list[int] = []
+    status_counts: Counter[str] = Counter()
+    family_hit_counts: Counter[str] = Counter()
+    certificate_count_by_center: Counter[int] = Counter()
+    certificates_per_hit: Counter[int] = Counter()
+    family_orbit_sizes: dict[str, int] = {}
+    total_certificates = 0
+    source_records = _source_records_or_errors(errors) if bind_source_assignments else ()
+    source_assignment_count = (
+        len(source_records) if source_records else EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS
+    )
+    selected_row_keys: Counter[tuple[tuple[int, ...], ...]] = Counter()
+
+    for record_index, record in enumerate(records):
+        record_label = f"hit_records[{record_index}]"
+        if not isinstance(record, dict):
+            errors.append(f"{record_label} must be an object")
+            continue
+
+        assignment_index = record.get("assignment_index")
+        if not _is_int(assignment_index):
+            errors.append(f"{record_label} assignment_index must be an integer")
+            assignment_index = None
+        else:
+            assignment_index = int(assignment_index)
+            assignment_indices.append(assignment_index)
+            if not 0 <= assignment_index < source_assignment_count:
+                errors.append(
+                    f"{record_label} assignment_index {assignment_index} is outside "
+                    f"the source range 0..{source_assignment_count - 1}"
+                )
+
+        family_id = record.get("family_id")
+        if not isinstance(family_id, str) or not family_id:
+            errors.append(f"{record_label} family_id must be a non-empty string")
+            family_id = ""
+        family_orbit_size = record.get("family_orbit_size")
+        if not _is_int(family_orbit_size) or int(family_orbit_size) <= 0:
+            errors.append(f"{record_label} family_orbit_size must be a positive integer")
+        elif family_id:
+            previous = family_orbit_sizes.setdefault(family_id, int(family_orbit_size))
+            if previous != int(family_orbit_size):
+                errors.append(f"{record_label} family_orbit_size conflicts for {family_id}")
+
+        vertex_circle_status = record.get("vertex_circle_status")
+        if not isinstance(vertex_circle_status, str) or not vertex_circle_status:
+            errors.append(f"{record_label} vertex_circle_status must be a non-empty string")
+            vertex_circle_status = ""
+
+        selected_rows = _parse_selected_rows(
+            errors,
+            record.get("selected_rows"),
+            label=record_label,
+            n=int(n),
+            witness_size=int(witness_size),
+        )
+        certificates = record.get("certificates")
+        if not isinstance(certificates, list):
+            errors.append(f"{record_label} certificates must be a list")
+            continue
+        certificate_count = record.get("certificate_count")
+        expect_equal(
+            errors,
+            f"{record_label} certificate_count",
+            certificate_count,
+            len(certificates),
+        )
+
+        if vertex_circle_status:
+            status_counts[vertex_circle_status] += 1
+        if family_id:
+            family_hit_counts[family_id] += 1
+        certificates_per_hit[len(certificates)] += 1
+        total_certificates += len(certificates)
+
+        if selected_rows is None:
+            continue
+        selected_rows_key = _rows_key(selected_rows)
+        selected_row_keys[selected_rows_key] += 1
+        if (
+            bind_source_assignments
+            and source_records
+            and assignment_index is not None
+            and 0 <= assignment_index < len(source_records)
+        ):
+            source_record = source_records[assignment_index]
+            expect_equal(
+                errors,
+                f"{record_label} selected_rows for assignment_index {assignment_index}",
+                selected_rows_key,
+                source_record["selected_rows"],
+            )
+            expect_equal(
+                errors,
+                f"{record_label} family_id for assignment_index {assignment_index}",
+                family_id,
+                source_record["family_id"],
+            )
+            expect_equal(
+                errors,
+                f"{record_label} family_orbit_size for assignment_index {assignment_index}",
+                family_orbit_size,
+                source_record["family_orbit_size"],
+            )
+            expect_equal(
+                errors,
+                f"{record_label} vertex_circle_status for assignment_index {assignment_index}",
+                vertex_circle_status,
+                source_record["vertex_circle_status"],
+            )
+        for certificate_index, certificate in enumerate(certificates):
+            row = _validate_certificate_shape(
+                errors,
+                record_label=record_label,
+                certificate_index=certificate_index,
+                certificate=certificate,
+                selected_rows=selected_rows,
+                cyclic_order=cyclic_order,
+            )
+            if row is not None:
+                certificate_count_by_center[row] += 1
+
+        try:
+            expected_certificates = row_ptolemy_product_cancellation_certificates(
+                selected_rows,
+                cyclic_order,
+            )
+        except ValueError as exc:
+            errors.append(f"{record_label} certificates could not be replayed: {exc}")
+        else:
+            expect_equal(
+                errors,
+                f"{record_label} replayed certificates",
+                certificates,
+                expected_certificates,
+            )
+
+    if len(assignment_indices) != len(set(assignment_indices)):
+        errors.append("hit_records assignment_index values must be unique")
+    if assignment_indices != sorted(assignment_indices):
+        errors.append("hit_records assignment_index values must be sorted")
+    duplicate_rows = [rows for rows, count in selected_row_keys.items() if count > 1]
+    if duplicate_rows:
+        errors.append("hit_records selected_rows values must be unique")
+
+    family_rows = [
+        {
+            "family_id": family_id,
+            "hit_assignment_count": int(family_hit_counts[family_id]),
+            "family_orbit_size": int(family_orbit_sizes.get(family_id, 0)),
+        }
+        for family_id in sorted(family_hit_counts)
+    ]
+
+    expect_equal(errors, "hit_records count", len(records), summary.get("hit_assignment_count"))
+    expect_equal(
+        errors,
+        "hit_records certificate total",
+        total_certificates,
+        summary.get("hit_certificate_count"),
+    )
+    expect_equal(errors, "hit_records family count", len(family_hit_counts), summary.get("hit_family_count"))
+    expect_equal(
+        errors,
+        "hit_records status counts",
+        dict(sorted(status_counts.items())),
+        summary.get("hit_assignment_vertex_circle_status_counts"),
+    )
+    expect_equal(errors, "hit_records family counts", family_rows, summary.get("hit_family_counts"))
+    expect_equal(
+        errors,
+        "hit_records certificate center counts",
+        _json_counter(certificate_count_by_center),
+        summary.get("certificate_count_by_center"),
+    )
+    expect_equal(
+        errors,
+        "hit_records certificates-per-hit histogram",
+        _json_counter(certificates_per_hit),
+        summary.get("certificates_per_hit_assignment_counts"),
+    )
+
+
 def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
     """Return validation errors for a loaded cancellation artifact."""
 
@@ -120,25 +659,89 @@ def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
 
     source = payload.get("source_frontier")
     if isinstance(source, dict):
-        expect_equal(errors, "source assignment count", source.get("assignment_count"), 184)
-        expect_equal(errors, "source nodes", source.get("nodes_visited"), 100817)
+        expect_equal(
+            errors,
+            "source assignment count",
+            source.get("assignment_count"),
+            EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS,
+        )
+        expect_equal(
+            errors,
+            "source nodes",
+            source.get("nodes_visited"),
+            EXPECTED_PRE_VERTEX_CIRCLE_NODES,
+        )
         expect_equal(errors, "source families", source.get("dihedral_family_count"), 16)
     else:
         errors.append("source_frontier must be an object")
 
     summary = payload.get("hit_summary")
     if isinstance(summary, dict):
-        expect_equal(errors, "hit assignment count", summary.get("hit_assignment_count"), 26)
-        expect_equal(errors, "hit certificate count", summary.get("hit_certificate_count"), 216)
-        expect_equal(errors, "hit family count", summary.get("hit_family_count"), 3)
+        expect_equal(
+            errors,
+            "hit assignment count",
+            summary.get("hit_assignment_count"),
+            EXPECTED_HIT_ASSIGNMENTS,
+        )
+        expect_equal(
+            errors,
+            "hit certificate count",
+            summary.get("hit_certificate_count"),
+            EXPECTED_HIT_CERTIFICATES,
+        )
+        expect_equal(
+            errors,
+            "hit family count",
+            summary.get("hit_family_count"),
+            EXPECTED_HIT_FAMILIES,
+        )
         expect_equal(
             errors,
             "hit status counts",
             summary.get("hit_assignment_vertex_circle_status_counts"),
-            {"self_edge": 26},
+            EXPECTED_HIT_ASSIGNMENT_STATUS_COUNTS,
+        )
+        raw_family_counts = summary.get("hit_family_counts")
+        if isinstance(raw_family_counts, list):
+            family_counts = {}
+            for index, row in enumerate(raw_family_counts):
+                if not isinstance(row, dict):
+                    errors.append(f"hit_family_counts[{index}] must be an object")
+                    continue
+                family_id = row.get("family_id")
+                hit_assignment_count = row.get("hit_assignment_count")
+                if not isinstance(family_id, str):
+                    errors.append(f"hit_family_counts[{index}] family_id must be a string")
+                    continue
+                if not _is_int(hit_assignment_count):
+                    errors.append(
+                        f"hit_family_counts[{index}] hit_assignment_count must be an integer"
+                    )
+                    continue
+                family_counts[family_id] = int(hit_assignment_count)
+            expect_equal(errors, "hit family counts", family_counts, EXPECTED_HIT_FAMILY_COUNTS)
+        else:
+            errors.append("hit_family_counts must be a list")
+        expect_equal(
+            errors,
+            "certificate center counts",
+            summary.get("certificate_count_by_center"),
+            EXPECTED_CERTIFICATE_COUNT_BY_CENTER,
+        )
+        expect_equal(
+            errors,
+            "certificates-per-hit histogram",
+            summary.get("certificates_per_hit_assignment_counts"),
+            EXPECTED_CERTIFICATES_PER_HIT_ASSIGNMENT,
         )
     else:
         errors.append("hit_summary must be an object")
+
+    try:
+        assert_expected_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected row-Ptolemy counts failed: {exc}")
+    _validate_hit_records(errors, payload, bind_source_assignments=not recompute)
 
     if recompute:
         try:

--- a/tests/test_incidence_filters.py
+++ b/tests/test_incidence_filters.py
@@ -188,6 +188,29 @@ def test_row_ptolemy_product_cancellation_certificate_on_toy_pattern() -> None:
     )
 
 
+def test_row_ptolemy_product_cancellation_depends_on_supplied_order() -> None:
+    rows = [
+        [1, 2, 3, 8],
+        [0, 3, 4, 7],
+        [1, 3, 5, 6],
+        [2, 4, 5, 8],
+        [0, 3, 6, 8],
+        [2, 4, 6, 7],
+        [1, 5, 7, 8],
+        [0, 1, 4, 6],
+        [0, 2, 5, 7],
+    ]
+
+    natural_certs = row_ptolemy_product_cancellation_certificates(rows, list(range(9)))
+    scrambled_certs = row_ptolemy_product_cancellation_certificates(
+        rows,
+        [0, 1, 2, 6, 5, 7, 4, 8, 3],
+    )
+
+    assert len(natural_certs) == 6
+    assert scrambled_certs == []
+
+
 def test_phi4_rectangle_trap_determinant_identity_expands_exactly() -> None:
     import sympy as sp
 

--- a/tests/test_n9_row_ptolemy_product_cancellations.py
+++ b/tests/test_n9_row_ptolemy_product_cancellations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import subprocess
 import sys
@@ -44,8 +45,18 @@ def test_row_ptolemy_product_artifact_records_family_counts() -> None:
         row["family_id"]: row["hit_assignment_count"]
         for row in payload["hit_summary"]["hit_family_counts"]
     }
+    certificate_counts = {}
+    representative_counts = {}
+    for record in payload["hit_records"]:
+        family_id = record["family_id"]
+        certificate_counts[family_id] = (
+            certificate_counts.get(family_id, 0) + record["certificate_count"]
+        )
+        representative_counts.setdefault(family_id, record["certificate_count"])
 
     assert family_counts == {"F02": 18, "F09": 6, "F13": 2}
+    assert certificate_counts == {"F02": 108, "F09": 72, "F13": 36}
+    assert representative_counts == {"F02": 6, "F09": 12, "F13": 18}
     assert payload["hit_summary"]["hit_assignment_vertex_circle_status_counts"] == {
         "self_edge": 26,
     }
@@ -56,6 +67,51 @@ def test_row_ptolemy_product_artifact_records_family_counts() -> None:
     }
     assert payload["hit_summary"]["certificate_count_by_center"] == {
         str(center): 24 for center in range(9)
+    }
+
+
+def test_row_ptolemy_product_negative_control_families_have_no_hits() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet_path = ROOT / "data" / "certificates" / "n9_vertex_circle_local_core_packet.json"
+    packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    all_family_orbits = {
+        row["family_id"]: row["orbit_size"] for row in packet["certificates"]
+    }
+    hit_families = {record["family_id"] for record in payload["hit_records"]}
+    negative_family_orbits = {
+        family_id: orbit_size
+        for family_id, orbit_size in sorted(all_family_orbits.items())
+        if family_id not in hit_families
+    }
+    negative_certificate_counts = {
+        family_id: sum(
+            record["certificate_count"]
+            for record in payload["hit_records"]
+            if record["family_id"] == family_id
+        )
+        for family_id in negative_family_orbits
+    }
+
+    assert hit_families == {"F02", "F09", "F13"}
+    assert negative_family_orbits == {
+        "F01": 18,
+        "F03": 18,
+        "F04": 18,
+        "F05": 18,
+        "F06": 18,
+        "F07": 6,
+        "F08": 2,
+        "F10": 18,
+        "F11": 18,
+        "F12": 18,
+        "F14": 2,
+        "F15": 2,
+        "F16": 2,
+    }
+    assert len(negative_family_orbits) == 13
+    assert sum(negative_family_orbits.values()) == 158
+    assert negative_certificate_counts == {
+        family_id: 0 for family_id in negative_family_orbits
     }
 
 
@@ -118,6 +174,58 @@ def test_row_ptolemy_product_checker_rejects_tampered_count() -> None:
     errors = validate_payload(payload, recompute=False)
 
     assert any("hit assignment count" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_out_of_range_assignment_index() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["hit_records"][0]["assignment_index"] = -1
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("assignment_index -1 is outside" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_binds_rows_to_assignment_index() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    donor = copy.deepcopy(payload["hit_records"][1])
+    payload["hit_records"][0]["selected_rows"] = donor["selected_rows"]
+    payload["hit_records"][0]["certificates"] = donor["certificates"]
+    payload["hit_records"][0]["certificate_count"] = donor["certificate_count"]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("selected_rows for assignment_index 1" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_tampered_witness_order() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["hit_records"][0]["certificates"][0]["witness_order"] = [1, 3, 2, 8]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("witness_order" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_tampered_forced_pair() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["hit_records"][0]["certificates"][0]["forced_equalities"][0][
+        "left_pair"
+    ] = [1, 4]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("forced_equalities[0] left_pair" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_tampered_zero_product_pair() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["hit_records"][0]["certificates"][0]["zero_product"]["factors"][0][
+        "pair"
+    ] = [2, 8]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("zero_product.factors[0] pair" in error for error in errors)
 
 
 @pytest.mark.artifact


### PR DESCRIPTION
## Summary
- harden the n=9 row-Ptolemy checker with per-record certificate replay, source assignment binding for cheap validation, and pair-name consistency checks
- add positive/negative family guardrails and tamper tests for witness order, forced pairs, zero-product pairs, and stale assignment indices
- document the negative controls and fixed-order dependency without changing repo status

## Validation
- `python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
- `python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --check-artifact data/certificates/n9_row_ptolemy_product_cancellations.json`
- `python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

No general proof, n=9 proof, counterexample, or status promotion is claimed.