### PR TITLE
Classify n9 frontier survivor with row-Ptolemy

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -193,9 +193,12 @@ The bounded `n=9` incidence/CSP frontier scan in
 and row `0` to the registered seed row `{1,2,3,8}`. In that row0-fixed slice,
 the default run completes before its explicit limits: it checks 3 full patterns,
 killing 1 by an odd forced-perpendicularity cycle and 1 by the phi4
-rectangle-trap filter, leaving 1 `accepted_frontier` incidence/order pattern
-for later filters. This is a bounded diagnostic slice only, not an `n=9`
-completeness theorem. See `docs/n9-incidence-frontier.md` and
+rectangle-trap filter. The remaining previous `accepted_frontier` pattern is
+now classified by 6 row-Ptolemy product-cancellation certificates under the
+fixed natural cyclic order, leaving 0 accepted-frontier items in the default
+slice. This is a bounded diagnostic slice only, not an `n=9` completeness
+theorem, and the row-Ptolemy certificates are fixed supplied-order obstructions
+only. See `docs/n9-incidence-frontier.md` and
 `scripts/check_n9_incidence_frontier.py`.
 
 ### Review-pending exhaustive n=9 vertex-circle check

--- a/data/certificates/n9_incidence_frontier_bounded.json
+++ b/data/certificates/n9_incidence_frontier_bounded.json
@@ -1,5 +1,5 @@
 {
-  "accepted_frontier_count": 1,
+  "accepted_frontier_count": 0,
   "cyclic_order": [
     0,
     1,
@@ -12,103 +12,6 @@
     8
   ],
   "examples": {
-    "accepted_frontier": [
-      {
-        "adjacent_two_overlap_violations": [],
-        "column_indegree_upper_violations": [],
-        "column_pair_cap_violations": [],
-        "crossing_bisector_violations": [],
-        "directed_phi_4_cycle_count": 0,
-        "forced_equality_classes": [],
-        "indegrees": [
-          4,
-          4,
-          4,
-          4,
-          4,
-          4,
-          4,
-          4,
-          4
-        ],
-        "midpoint_matrix_rank": 0,
-        "n": 9,
-        "odd_forced_perpendicular_cycle": null,
-        "order": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
-        "phi_edges": 18,
-        "rectangle_trap_4_cycles": 0,
-        "rectangle_trap_certificates": [],
-        "row_pair_intersection_cap_violations": [],
-        "row_size": 4,
-        "rows": [
-          [
-            1,
-            2,
-            3,
-            8
-          ],
-          [
-            0,
-            3,
-            4,
-            7
-          ],
-          [
-            1,
-            3,
-            5,
-            6
-          ],
-          [
-            2,
-            4,
-            5,
-            8
-          ],
-          [
-            0,
-            3,
-            6,
-            8
-          ],
-          [
-            2,
-            4,
-            6,
-            7
-          ],
-          [
-            1,
-            5,
-            7,
-            8
-          ],
-          [
-            0,
-            1,
-            4,
-            6
-          ],
-          [
-            0,
-            2,
-            5,
-            7
-          ]
-        ],
-        "status": "accepted_frontier"
-      }
-    ],
     "adjacent_two_overlap": [
       {
         "center": 8,
@@ -565,6 +468,8 @@
         "rectangle_trap_4_cycles": 0,
         "rectangle_trap_certificates": [],
         "row_pair_intersection_cap_violations": [],
+        "row_ptolemy_product_cancellation_certificates": [],
+        "row_ptolemy_product_cancellation_count": 0,
         "row_size": 4,
         "rows": [
           [
@@ -755,6 +660,8 @@
           }
         ],
         "row_pair_intersection_cap_violations": [],
+        "row_ptolemy_product_cancellation_certificates": [],
+        "row_ptolemy_product_cancellation_count": 0,
         "row_size": 4,
         "rows": [
           [
@@ -1020,6 +927,307 @@
           8
         ]
       }
+    ],
+    "row_ptolemy_product_cancellation": [
+      {
+        "adjacent_two_overlap_violations": [],
+        "column_indegree_upper_violations": [],
+        "column_pair_cap_violations": [],
+        "crossing_bisector_violations": [],
+        "directed_phi_4_cycle_count": 0,
+        "forced_equality_classes": [],
+        "indegrees": [
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "midpoint_matrix_rank": 0,
+        "n": 9,
+        "odd_forced_perpendicular_cycle": null,
+        "order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "phi_edges": 18,
+        "rectangle_trap_4_cycles": 0,
+        "rectangle_trap_certificates": [],
+        "row_pair_intersection_cap_violations": [],
+        "row_ptolemy_product_cancellation_certificates": [
+          {
+            "cancelled_product": "d01*d23",
+            "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+            "forced_equalities": [
+              {
+                "class_member_count": 28,
+                "distance_class": 0,
+                "left": "d02",
+                "left_pair": [
+                  1,
+                  3
+                ],
+                "right": "d23",
+                "right_pair": [
+                  3,
+                  8
+                ]
+              },
+              {
+                "class_member_count": 28,
+                "distance_class": 0,
+                "left": "d13",
+                "left_pair": [
+                  2,
+                  8
+                ],
+                "right": "d01",
+                "right_pair": [
+                  1,
+                  2
+                ]
+              }
+            ],
+            "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+            "row": 0,
+            "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+            "type": "row_ptolemy_product_cancellation",
+            "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ],
+            "zero_product": {
+              "expression": "d03*d12",
+              "factors": [
+                {
+                  "distance_class": 4,
+                  "name": "d03",
+                  "pair": [
+                    1,
+                    8
+                  ]
+                },
+                {
+                  "distance_class": 0,
+                  "name": "d12",
+                  "pair": [
+                    2,
+                    3
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "cancelled_product": "d01*d23",
+            "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+            "forced_equalities": [
+              {
+                "class_member_count": 28,
+                "distance_class": 0,
+                "left": "d02",
+                "left_pair": [
+                  1,
+                  3
+                ],
+                "right": "d01",
+                "right_pair": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "class_member_count": 28,
+                "distance_class": 0,
+                "left": "d13",
+                "left_pair": [
+                  2,
+                  8
+                ],
+                "right": "d23",
+                "right_pair": [
+                  3,
+                  8
+                ]
+              }
+            ],
+            "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+            "row": 0,
+            "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+            "type": "row_ptolemy_product_cancellation",
+            "variant": "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23",
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ],
+            "zero_product": {
+              "expression": "d03*d12",
+              "factors": [
+                {
+                  "distance_class": 4,
+                  "name": "d03",
+                  "pair": [
+                    1,
+                    8
+                  ]
+                },
+                {
+                  "distance_class": 0,
+                  "name": "d12",
+                  "pair": [
+                    2,
+                    3
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "cancelled_product": "d01*d23",
+            "contradiction": "Ptolemy cancellation forces a product of two ordinary distances to be zero, but distinct strictly convex vertices have positive Euclidean distances.",
+            "forced_equalities": [
+              {
+                "class_member_count": 28,
+                "distance_class": 0,
+                "left": "d02",
+                "left_pair": [
+                  4,
+                  8
+                ],
+                "right": "d23",
+                "right_pair": [
+                  2,
+                  8
+                ]
+              },
+              {
+                "class_member_count": 28,
+                "distance_class": 0,
+                "left": "d13",
+                "left_pair": [
+                  2,
+                  5
+                ],
+                "right": "d01",
+                "right_pair": [
+                  4,
+                  5
+                ]
+              }
+            ],
+            "ptolemy_identity": "d02*d13 = d01*d23 + d03*d12",
+            "row": 3,
+            "scope": "Exact obstruction for this fixed selected-witness row under the supplied/certified row order only.",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER",
+            "type": "row_ptolemy_product_cancellation",
+            "variant": "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01",
+            "witness_order": [
+              4,
+              5,
+              8,
+              2
+            ],
+            "zero_product": {
+              "expression": "d03*d12",
+              "factors": [
+                {
+                  "distance_class": 5,
+                  "name": "d03",
+                  "pair": [
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "distance_class": 0,
+                  "name": "d12",
+                  "pair": [
+                    5,
+                    8
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "row_ptolemy_product_cancellation_count": 6,
+        "row_size": 4,
+        "rows": [
+          [
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            1,
+            3,
+            5,
+            6
+          ],
+          [
+            2,
+            4,
+            5,
+            8
+          ],
+          [
+            0,
+            3,
+            6,
+            8
+          ],
+          [
+            2,
+            4,
+            6,
+            7
+          ],
+          [
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            0,
+            2,
+            5,
+            7
+          ]
+        ],
+        "status": "row_ptolemy_product_cancellation"
+      }
     ]
   },
   "filter_order": [
@@ -1031,10 +1239,11 @@
     "odd_forced_perpendicular_cycle",
     "mutual_midpoint_collapse",
     "phi4_rectangle_trap",
+    "row_ptolemy_product_cancellation",
     "accepted_frontier"
   ],
   "full_classification_counts": {
-    "accepted_frontier": 1,
+    "accepted_frontier": 0,
     "adjacent_two_overlap": 0,
     "column_indegree_upper": 0,
     "column_pair_cap": 0,
@@ -1042,7 +1251,8 @@
     "mutual_midpoint_collapse": 0,
     "odd_forced_perpendicular_cycle": 1,
     "phi4_rectangle_trap": 1,
-    "row_pair_intersection_cap": 0
+    "row_pair_intersection_cap": 0,
+    "row_ptolemy_product_cancellation": 1
   },
   "full_patterns_checked": 3,
   "hit_full_pattern_limit": false,
@@ -1058,7 +1268,8 @@
     "No general proof of Erdos Problem #97 is claimed.",
     "No counterexample is claimed.",
     "The row0-fixed search is bounded by explicit node and full-pattern limits.",
-    "An accepted_frontier item only means the listed necessary filters did not obstruct it."
+    "An accepted_frontier item only means the listed necessary filters did not obstruct it.",
+    "The row-Ptolemy classifier is a fixed supplied-order obstruction only, not an orderless abstract-incidence obstruction."
   ],
   "partial_rejection_counts": {
     "adjacent_two_overlap": 20362,
@@ -1202,6 +1413,8 @@
           }
         ],
         "row_pair_intersection_cap_violations": [],
+        "row_ptolemy_product_cancellation_certificates": [],
+        "row_ptolemy_product_cancellation_count": 0,
         "row_size": 4,
         "rows": [
           [

--- a/docs/n9-incidence-frontier.md
+++ b/docs/n9-incidence-frontier.md
@@ -45,6 +45,7 @@ At full patterns it also applies:
 - odd forced-perpendicularity cycles;
 - mutual-rhombus midpoint collapse;
 - phi 4-cycle rectangle-trap certificates.
+- row-Ptolemy product-cancellation certificates for the supplied cyclic order.
 
 ## Current Result
 
@@ -72,14 +73,17 @@ The three full patterns split as follows:
 ```text
 odd forced-perpendicularity cycle: 1
 phi4 rectangle trap:              1
-accepted frontier:                1
+row-Ptolemy product cancellation: 1
+accepted frontier:                0
 ```
 
-Here `accepted_frontier` means only that the listed exact necessary filters did
-not obstruct the fixed incidence/order pattern. It is not evidence of geometric
-realizability.
+Here `accepted_frontier` would mean only that the listed exact necessary
+filters did not obstruct the fixed incidence/order pattern. The default run now
+has no such item after adding the row-Ptolemy full-pattern classifier, but this
+is still a bounded row0-fixed natural-order diagnostic, not an `n=9`
+completeness theorem.
 
-The surviving fixed-order incidence pattern is:
+The pattern classified by the row-Ptolemy full-pattern filter is:
 
 ```text
 S0 = {1,2,3,8}
@@ -95,7 +99,11 @@ S8 = {0,2,5,7}
 
 It has balanced witness indegrees `[4,4,4,4,4,4,4,4,4]`, `18` phi edges, no
 directed phi 4-cycle, no odd forced-perpendicularity cycle, and no forced
-midpoint equality classes under the current mutual-rhombus filter.
+midpoint equality classes under the current mutual-rhombus filter. Under the
+recorded natural cyclic order, it has `6` row-Ptolemy product-cancellation
+certificates. These are exact obstructions for this fixed selected-witness
+pattern and supplied row order only; they are not orderless abstract-incidence
+obstructions.
 
 ## Reproduction
 
@@ -110,8 +118,9 @@ The `--write` command regenerates
 
 ## Next Use
 
-The immediate value of the artifact is that it reduces this row0-fixed natural
-order slice to one current filter survivor. Good next checks for that survivor
-are the row-circle/Ptolemy equations, radius-propagation diagnostics, interval
-verification attempts, and an even-cycle certificate search beyond the phi4
-rectangle-trap shape.
+The immediate value of the artifact is that it records how the default
+row0-fixed natural-order slice is handled by the listed exact full-pattern
+classifiers. Good next checks are to audit whether the row-Ptolemy classifier
+can be converted into reusable local lemmas, compare it with the n=9
+vertex-circle local-core templates, and keep testing order-sensitive variants
+without treating this bounded slice as a lossless quotient of all `n=9` cases.

--- a/scripts/check_n9_incidence_frontier.py
+++ b/scripts/check_n9_incidence_frontier.py
@@ -13,15 +13,127 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from erdos97.incidence_filters import (  # noqa: E402
+    row_ptolemy_product_cancellation_certificates,
+)
 from erdos97.n9_incidence_frontier import run_bounded_scan  # noqa: E402
 from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_incidence_frontier_bounded.json"
+EXPECTED_FILTER_ORDER = [
+    "row_pair_intersection_cap",
+    "adjacent_two_overlap",
+    "crossing_bisector",
+    "column_indegree_upper",
+    "column_pair_cap",
+    "odd_forced_perpendicular_cycle",
+    "mutual_midpoint_collapse",
+    "phi4_rectangle_trap",
+    "row_ptolemy_product_cancellation",
+    "accepted_frontier",
+]
+
+
+def _require_nonclaiming_notes(payload: dict[str, object]) -> None:
+    notes = payload.get("notes")
+    if not isinstance(notes, list) or not all(isinstance(note, str) for note in notes):
+        raise AssertionError("payload notes should be a list of strings")
+    joined = "\n".join(notes).lower()
+    for phrase in ("no general proof", "no counterexample"):
+        if phrase not in joined:
+            raise AssertionError(f"payload notes must preserve {phrase!r}")
+
+
+def _assert_row_ptolemy_examples(payload: dict[str, object]) -> None:
+    examples = payload["examples"]
+    if not isinstance(examples, dict):
+        raise AssertionError("examples should be a mapping")
+    row_ptolemy_examples = examples.get("row_ptolemy_product_cancellation")
+    limits = payload.get("limits")
+    max_examples = limits.get("max_examples_per_bucket") if isinstance(limits, dict) else None
+    if max_examples == 0:
+        if row_ptolemy_examples is not None:
+            raise AssertionError("max_examples=0 should not store row-Ptolemy examples")
+        return
+    if not isinstance(row_ptolemy_examples, list) or len(row_ptolemy_examples) != 1:
+        raise AssertionError("expected one row-Ptolemy example")
+
+    example = row_ptolemy_examples[0]
+    if not isinstance(example, dict):
+        raise AssertionError("row-Ptolemy example should be a mapping")
+    if example["status"] != "row_ptolemy_product_cancellation":
+        raise AssertionError("row-Ptolemy example has unexpected status")
+    if example["row_ptolemy_product_cancellation_count"] != 6:
+        raise AssertionError("row-Ptolemy example should have six certificates")
+
+    rows = example["rows"]
+    order = example["order"]
+    certificates = example["row_ptolemy_product_cancellation_certificates"]
+    if not isinstance(rows, list) or not isinstance(order, list):
+        raise AssertionError("row-Ptolemy example rows/order should be lists")
+    if not isinstance(certificates, list) or not certificates:
+        raise AssertionError("row-Ptolemy example should store certificate examples")
+    replayed = row_ptolemy_product_cancellation_certificates(rows, order)
+    if len(replayed) != example["row_ptolemy_product_cancellation_count"]:
+        raise AssertionError("row-Ptolemy certificate count does not replay")
+    if replayed[: len(certificates)] != certificates:
+        raise AssertionError("stored row-Ptolemy certificate examples do not replay")
+
+    first_certificate = certificates[0]
+    if first_certificate["type"] != "row_ptolemy_product_cancellation":
+        raise AssertionError("unexpected row-Ptolemy certificate type")
+    if first_certificate["status"] != "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER":
+        raise AssertionError("unexpected row-Ptolemy certificate status")
+    if first_certificate["ptolemy_identity"] != "d02*d13 = d01*d23 + d03*d12":
+        raise AssertionError("unexpected row-Ptolemy identity")
+    if "supplied/certified row order" not in first_certificate["scope"]:
+        raise AssertionError("row-Ptolemy certificate scope must mention supplied row order")
 
 
 def assert_expected(payload: dict[str, object]) -> None:
     if payload["type"] != "n9_incidence_frontier_bounded_scan_v1":
         raise AssertionError("unexpected payload type")
+    if payload["trust"] != "BOUNDED_INCIDENCE_CSP_DIAGNOSTIC":
+        raise AssertionError("unexpected payload trust")
+    _require_nonclaiming_notes(payload)
+    if payload["search_complete"] is not True or payload["truncated"] is not False:
+        raise AssertionError("default bounded frontier scan should complete")
+    if payload["nodes_visited"] != 6793:
+        raise AssertionError("unexpected node count")
+    if payload["row_options_considered"] != 475231:
+        raise AssertionError("unexpected row-options count")
+    if payload["full_patterns_checked"] != 3:
+        raise AssertionError("unexpected full-pattern count")
+
+    full_counts = payload["full_classification_counts"]
+    if not isinstance(full_counts, dict):
+        raise AssertionError("full classification counts should be a mapping")
+    if payload.get("filter_order") != EXPECTED_FILTER_ORDER:
+        raise AssertionError("filter order drifted")
+    if list(full_counts) != EXPECTED_FILTER_ORDER:
+        raise AssertionError("full classification count order drifted")
+    if set(full_counts) != set(EXPECTED_FILTER_ORDER):
+        raise AssertionError("full classification keys drifted")
+    expected_full_counts = {
+        status: 0 for status in EXPECTED_FILTER_ORDER
+    }
+    expected_full_counts.update(
+        {
+            "odd_forced_perpendicular_cycle": 1,
+            "phi4_rectangle_trap": 1,
+            "row_ptolemy_product_cancellation": 1,
+        }
+    )
+    if full_counts != expected_full_counts:
+        raise AssertionError(f"unexpected full classification counts: {full_counts}")
+    if sum(int(count) for count in full_counts.values()) != payload["full_patterns_checked"]:
+        raise AssertionError("full classification counts do not sum to checked patterns")
+    if payload["accepted_frontier_count"] != full_counts["accepted_frontier"]:
+        raise AssertionError("accepted frontier count drifted")
+    if payload["accepted_frontier_count"] != 0:
+        raise AssertionError("row-Ptolemy should kill the previous accepted frontier example")
+    _assert_row_ptolemy_examples(payload)
+
     seeded = payload["seeded_cases"]
     if not isinstance(seeded, list) or len(seeded) != 1:
         raise AssertionError("missing seeded n=9 rectangle-trap case")

--- a/src/erdos97/n9_incidence_frontier.py
+++ b/src/erdos97/n9_incidence_frontier.py
@@ -22,6 +22,7 @@ from erdos97.incidence_filters import (
     phi4_rectangle_trap_certificates,
     phi_directed_4_cycles,
     phi_map,
+    row_ptolemy_product_cancellation_certificates,
 )
 
 N = 9
@@ -52,6 +53,7 @@ FULL_CLASSIFICATION_STATUSES = (
     "odd_forced_perpendicular_cycle",
     "mutual_midpoint_collapse",
     "phi4_rectangle_trap",
+    "row_ptolemy_product_cancellation",
     "accepted_frontier",
 )
 
@@ -247,6 +249,7 @@ def classify_pattern(
     matrix = mutual_midpoint_matrix(S)
     forced_classes = forced_equal_classes_from_matrix(matrix, N)
     rectangle_traps = phi4_rectangle_trap_certificates(S, order)
+    row_ptolemy_certificates = row_ptolemy_product_cancellation_certificates(S, order)
     phis = phi_map(S)
     directed_phi4 = phi_directed_4_cycles(S)
 
@@ -267,6 +270,8 @@ def classify_pattern(
         status = "mutual_midpoint_collapse"
     elif rectangle_traps:
         status = "phi4_rectangle_trap"
+    elif row_ptolemy_certificates:
+        status = "row_ptolemy_product_cancellation"
 
     return {
         "status": status,
@@ -280,6 +285,7 @@ def classify_pattern(
         "phi_edges": len(phis),
         "directed_phi_4_cycle_count": len(directed_phi4),
         "rectangle_trap_4_cycles": len(rectangle_traps),
+        "row_ptolemy_product_cancellation_count": len(row_ptolemy_certificates),
         "midpoint_matrix_rank": int(matrix.rank()),
         "row_pair_intersection_cap_violations": row_pair_violations[:max_details],
         "adjacent_two_overlap_violations": adjacent_violations[:max_details],
@@ -296,6 +302,9 @@ def classify_pattern(
         ),
         "forced_equality_classes": forced_classes[:max_details],
         "rectangle_trap_certificates": rectangle_traps[:max_details],
+        "row_ptolemy_product_cancellation_certificates": row_ptolemy_certificates[
+            :max_details
+        ],
     }
 
 
@@ -513,6 +522,7 @@ def run_bounded_scan(
             "No counterexample is claimed.",
             "The row0-fixed search is bounded by explicit node and full-pattern limits.",
             "An accepted_frontier item only means the listed necessary filters did not obstruct it.",
+            "The row-Ptolemy classifier is a fixed supplied-order obstruction only, not an orderless abstract-incidence obstruction.",
         ],
         "n": N,
         "row_size": ROW_SIZE,
@@ -562,6 +572,7 @@ def run_bounded_scan(
             "odd_forced_perpendicular_cycle",
             "mutual_midpoint_collapse",
             "phi4_rectangle_trap",
+            "row_ptolemy_product_cancellation",
             "accepted_frontier",
         ],
     }

--- a/tests/test_n9_incidence_frontier.py
+++ b/tests/test_n9_incidence_frontier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from erdos97.incidence_filters import row_ptolemy_product_cancellation_certificates
 from erdos97.n9_incidence_frontier import (
     DEFAULT_ROW0_WITNESSES,
     N9_RECTANGLE_TRAP_PATTERN,
@@ -11,6 +12,33 @@ from erdos97.n9_incidence_frontier import (
     row_options,
     run_bounded_scan,
 )
+from scripts.check_n9_incidence_frontier import assert_expected
+
+EXPECTED_FILTER_ORDER = [
+    "row_pair_intersection_cap",
+    "adjacent_two_overlap",
+    "crossing_bisector",
+    "column_indegree_upper",
+    "column_pair_cap",
+    "odd_forced_perpendicular_cycle",
+    "mutual_midpoint_collapse",
+    "phi4_rectangle_trap",
+    "row_ptolemy_product_cancellation",
+    "accepted_frontier",
+]
+
+
+ROW_PTOLEMY_FRONTIER_PATTERN = [
+    [1, 2, 3, 8],
+    [0, 3, 4, 7],
+    [1, 3, 5, 6],
+    [2, 4, 5, 8],
+    [0, 3, 6, 8],
+    [2, 4, 6, 7],
+    [1, 5, 7, 8],
+    [0, 1, 4, 6],
+    [0, 2, 5, 7],
+]
 
 
 def test_registered_n9_rectangle_trap_classifies_as_phi4_obstruction() -> None:
@@ -18,9 +46,38 @@ def test_registered_n9_rectangle_trap_classifies_as_phi4_obstruction() -> None:
 
     assert result["status"] == "phi4_rectangle_trap"
     assert result["rectangle_trap_4_cycles"] == 1
+    assert result["row_ptolemy_product_cancellation_count"] == 0
     assert result["row_pair_intersection_cap_violations"] == []
     assert result["adjacent_two_overlap_violations"] == []
     assert result["crossing_bisector_violations"] == []
+
+
+def test_row_ptolemy_frontier_pattern_classifies_as_fixed_order_obstruction() -> None:
+    result = classify_pattern(ROW_PTOLEMY_FRONTIER_PATTERN)
+    certificates = result["row_ptolemy_product_cancellation_certificates"]
+
+    assert result["status"] == "row_ptolemy_product_cancellation"
+    assert result["rectangle_trap_4_cycles"] == 0
+    assert result["row_ptolemy_product_cancellation_count"] == 6
+    assert certificates
+    assert certificates == row_ptolemy_product_cancellation_certificates(
+        ROW_PTOLEMY_FRONTIER_PATTERN,
+    )[: len(certificates)]
+    assert certificates[0]["type"] == "row_ptolemy_product_cancellation"
+    assert certificates[0]["status"] == "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER"
+    assert certificates[0]["ptolemy_identity"] == "d02*d13 = d01*d23 + d03*d12"
+    assert certificates[0]["witness_order"] == [1, 2, 3, 8]
+    assert certificates[0]["zero_product"]["expression"] == "d03*d12"
+
+
+def test_row_ptolemy_frontier_pattern_is_not_orderless() -> None:
+    result = classify_pattern(
+        ROW_PTOLEMY_FRONTIER_PATTERN,
+        [0, 1, 2, 6, 5, 7, 4, 8, 3],
+    )
+
+    assert result["row_ptolemy_product_cancellation_count"] == 0
+    assert result["status"] != "row_ptolemy_product_cancellation"
 
 
 def test_row0_options_use_default_seed_row_and_other_rows_have_all_choices() -> None:
@@ -43,6 +100,9 @@ def test_tiny_bounded_scan_without_seed_priority_is_deterministic() -> None:
     assert payload["hit_node_limit"] is True
     assert payload["nodes_visited"] == 21
     assert payload["full_patterns_checked"] == 0
+    assert payload["filter_order"] == EXPECTED_FILTER_ORDER
+    assert list(payload["full_classification_counts"]) == EXPECTED_FILTER_ORDER
+    assert set(payload["full_classification_counts"]) == set(EXPECTED_FILTER_ORDER)
     assert payload["partial_rejection_counts"]["adjacent_two_overlap"] > 0
     assert payload["partial_rejection_counts"]["crossing_bisector"] > 0
     assert payload["seeded_cases"][0]["classification"]["status"] == "phi4_rectangle_trap"
@@ -54,6 +114,26 @@ def test_bounded_scan_can_stop_on_full_pattern_limit() -> None:
     assert payload["hit_full_pattern_limit"] is True
     assert payload["full_patterns_checked"] == 1
     assert sum(payload["full_classification_counts"].values()) == 1
+    assert payload["filter_order"] == EXPECTED_FILTER_ORDER
+    assert list(payload["full_classification_counts"]) == EXPECTED_FILTER_ORDER
+    assert set(payload["full_classification_counts"]) == set(EXPECTED_FILTER_ORDER)
+
+
+def test_default_bounded_scan_has_no_remaining_accepted_frontier() -> None:
+    payload = run_bounded_scan(max_examples=1)
+
+    assert payload["full_classification_counts"]["phi4_rectangle_trap"] == 1
+    assert payload["full_classification_counts"]["odd_forced_perpendicular_cycle"] == 1
+    assert payload["full_classification_counts"]["row_ptolemy_product_cancellation"] == 1
+    assert payload["accepted_frontier_count"] == 0
+    assert payload["full_classification_counts"]["accepted_frontier"] == 0
+
+
+def test_checker_assert_expected_allows_zero_example_payloads() -> None:
+    payload = run_bounded_scan(max_examples=0)
+
+    assert payload["examples"] == {}
+    assert_expected(payload)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add row-Ptolemy product-cancellation as a full-pattern classifier after phi4 and before accepted_frontier in the bounded n=9 frontier diagnostic
- regenerate `n9_incidence_frontier_bounded.json`, moving the previous single accepted frontier example into a fixed-order row-Ptolemy bucket with 6 certificates
- strengthen checker/tests to replay row-Ptolemy examples, assert filter order, and cover max_examples=0
- update docs/results wording while preserving bounded-diagnostic scope

## Validation
- `python scripts/check_n9_incidence_frontier.py --assert-expected`
- `python scripts/check_n9_incidence_frontier.py --assert-expected --max-examples 0 --json`
- `python -m pytest tests/test_n9_incidence_frontier.py -q`
- `python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/independent_check_n8_artifacts.py --check --json`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`
- `python scripts/check_round2_certificates.py`
- `python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json`
- `python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json`
- `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`

No general proof, n=9 completeness theorem, counterexample, official/global status update, or orderless row-Ptolemy obstruction is claimed.