### PR TITLE
Add n9 row-Ptolemy template crosswalk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
 	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
 

--- a/data/certificates/n9_row_ptolemy_product_cancellations.json
+++ b/data/certificates/n9_row_ptolemy_product_cancellations.json
@@ -16229,6 +16229,7 @@
     "The proof uses Ptolemy on a row witness circle plus exact selected-distance quotient equalities.",
     "The filter kills 26 of the 184 n=9 pre-vertex-circle assignments, covering 3 of the 16 deterministic dihedral family labels.",
     "For this n=9 frontier, every hit is also a vertex-circle self-edge case; this diagnostic does not dominate or replace the vertex-circle checker.",
+    "The template crosswalk only joins deterministic artifact labels; template ids are not theorem names.",
     "The row order must be supplied or certified. This is not an orderless abstract-incidence obstruction.",
     "No proof of the n=9 case is claimed."
   ],
@@ -16237,7 +16238,7 @@
     "command": "python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --out data/certificates/n9_row_ptolemy_product_cancellations.json",
     "generator": "scripts/analyze_n9_row_ptolemy_product_cancellations.py"
   },
-  "schema": "erdos97.n9_row_ptolemy_product_cancellations.v1",
+  "schema": "erdos97.n9_row_ptolemy_product_cancellations.v2",
   "source_artifacts": [
     {
       "path": "data/certificates/n9_vertex_circle_exhaustive.json",
@@ -16246,6 +16247,10 @@
     {
       "path": "data/certificates/n9_vertex_circle_motif_families.json",
       "role": "deterministic family-id convention used for F02/F09/F13 labels"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "role": "review-pending local-core template labels used for the diagnostic crosswalk"
     },
     {
       "path": "data/runs/2026-05-05/new_obstructions.md",
@@ -16260,6 +16265,122 @@
     "row0_choices": 70
   },
   "status": "EXPLORATORY_LEDGER_ONLY",
+  "template_crosswalk": {
+    "claim_scope": "Diagnostic join from row-Ptolemy hit families to review-pending n=9 vertex-circle local-core template labels; not a proof of n=9, not a counterexample, and not a global status update.",
+    "hit_family_rows": [
+      {
+        "certificate_count_per_hit_assignment": 6,
+        "family_id": "F02",
+        "family_orbit_size": 18,
+        "hit_assignment_count": 18,
+        "hit_certificate_count": 108,
+        "template_core_size": 6,
+        "template_family_count": 1,
+        "template_id": "T08",
+        "template_orbit_size_sum": 18,
+        "template_status": "self_edge",
+        "template_strict_edge_count": 54
+      },
+      {
+        "certificate_count_per_hit_assignment": 12,
+        "family_id": "F09",
+        "family_orbit_size": 6,
+        "hit_assignment_count": 6,
+        "hit_certificate_count": 72,
+        "template_core_size": 3,
+        "template_family_count": 1,
+        "template_id": "T01",
+        "template_orbit_size_sum": 6,
+        "template_status": "self_edge",
+        "template_strict_edge_count": 27
+      },
+      {
+        "certificate_count_per_hit_assignment": 18,
+        "family_id": "F13",
+        "family_orbit_size": 2,
+        "hit_assignment_count": 2,
+        "hit_certificate_count": 36,
+        "template_core_size": 4,
+        "template_family_count": 1,
+        "template_id": "T04",
+        "template_orbit_size_sum": 2,
+        "template_status": "self_edge",
+        "template_strict_edge_count": 36
+      }
+    ],
+    "hit_family_template_ids": {
+      "F02": "T08",
+      "F09": "T01",
+      "F13": "T04"
+    },
+    "hit_template_assignment_counts": {
+      "T01": 6,
+      "T04": 2,
+      "T08": 18
+    },
+    "hit_template_certificate_counts": {
+      "T01": 72,
+      "T04": 36,
+      "T08": 108
+    },
+    "hit_template_count": 3,
+    "hit_template_rows": [
+      {
+        "families": [
+          "F09"
+        ],
+        "hit_assignment_count": 6,
+        "hit_certificate_count": 72,
+        "hit_family_count": 1,
+        "template_id": "T01",
+        "template_status": "self_edge"
+      },
+      {
+        "families": [
+          "F13"
+        ],
+        "hit_assignment_count": 2,
+        "hit_certificate_count": 36,
+        "hit_family_count": 1,
+        "template_id": "T04",
+        "template_status": "self_edge"
+      },
+      {
+        "families": [
+          "F02"
+        ],
+        "hit_assignment_count": 18,
+        "hit_certificate_count": 108,
+        "hit_family_count": 1,
+        "template_id": "T08",
+        "template_status": "self_edge"
+      }
+    ],
+    "hit_template_status_counts": {
+      "self_edge": 3
+    },
+    "nonhit_family_count": 13,
+    "nonhit_family_orbit_size_sum": 158,
+    "nonhit_template_ids": [
+      "T02",
+      "T03",
+      "T05",
+      "T06",
+      "T07",
+      "T09",
+      "T10",
+      "T11",
+      "T12"
+    ],
+    "source_artifact": {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    "strict_cycle_hit_family_count": 0,
+    "strict_cycle_nonhit_family_count": 3
+  },
   "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
   "witness_size": 4
 }

--- a/docs/n9-incidence-frontier.md
+++ b/docs/n9-incidence-frontier.md
@@ -120,7 +120,9 @@ The `--write` command regenerates
 
 The immediate value of the artifact is that it records how the default
 row0-fixed natural-order slice is handled by the listed exact full-pattern
-classifiers. Good next checks are to audit whether the row-Ptolemy classifier
-can be converted into reusable local lemmas, compare it with the n=9
-vertex-circle local-core templates, and keep testing order-sensitive variants
-without treating this bounded slice as a lossless quotient of all `n=9` cases.
+classifiers. The row-Ptolemy sweep now crosswalks its hit families against the
+n=9 vertex-circle local-core template labels in
+`data/certificates/n9_row_ptolemy_product_cancellations.json`. Good next
+checks are to audit whether that comparison can be converted into reusable
+local lemmas and to keep testing order-sensitive variants without treating this
+bounded slice as a lossless quotient of all `n=9` cases.

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -47,6 +47,13 @@ family ids covered by each bucket. These template ids are deterministic
 artifact labels only; they are not theorem names and do not promote the n=9
 finite-case status.
 
+`data/certificates/n9_row_ptolemy_product_cancellations.json` contains a
+dependent crosswalk from the row-Ptolemy hit families to these template labels:
+`F02 -> T08`, `F09 -> T01`, and `F13 -> T04`. All three are self-edge
+template families, and all strict-cycle template families remain no-hit
+negative controls for the row-Ptolemy diagnostic. This is a consistency join
+between artifacts, not an additional n=9 proof claim.
+
 ## Certificate Shape
 
 A self-edge core consists of:

--- a/docs/row-ptolemy-product-filter.md
+++ b/docs/row-ptolemy-product-filter.md
@@ -53,6 +53,21 @@ This gives an independent Ptolemy-equality certificate for those fixed-order
 assignments, but it does not dominate or replace the vertex-circle checker and
 does not prove the full `n=9` finite case.
 
+The same artifact now includes a crosswalk to
+`data/certificates/n9_vertex_circle_core_templates.json`. This is a diagnostic
+join on deterministic family/template labels only:
+
+```text
+F02 -> T08, self_edge, orbit 18, row-Ptolemy certificates 108
+F09 -> T01, self_edge, orbit  6, row-Ptolemy certificates  72
+F13 -> T04, self_edge, orbit  2, row-Ptolemy certificates  36
+```
+
+The hit assignment count matches the full dihedral orbit size for each of
+these three family labels. The crosswalk is useful for comparing local lemma
+shapes, but the template ids are artifact labels, not theorem names, and this
+does not promote the review-pending n=9 status.
+
 ## Negative Controls And Order Guardrails
 
 The checked artifact now has regression coverage for both the positive and
@@ -67,6 +82,14 @@ F01,F03,F04,F05,F06,F07,F08,F10,F11,F12,F14,F15,F16
 Those negative controls cover `158` of the `184` pre-vertex-circle assignments.
 They are bookkeeping guardrails, not evidence that those assignments are
 geometrically realizable or that the vertex-circle obstruction is unnecessary.
+They occupy nine local-core template ids with no row-Ptolemy hits:
+
+```text
+T02,T03,T05,T06,T07,T09,T10,T11,T12
+```
+
+All strict-cycle local-core families, currently `F07`, `F12`, and `F16`, are in
+this no-hit side of the crosswalk.
 
 The checker also replays every stored hit record against its fixed cyclic
 order. It verifies that each certificate's `witness_order`, forced-equality

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -481,7 +481,7 @@ artifacts:
     claim_scope: Focused n=9 row-Ptolemy product-cancellation bookkeeping for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.n9_row_ptolemy_product_cancellations.v1
+      schema: erdos97.n9_row_ptolemy_product_cancellations.v2
       status: EXPLORATORY_LEDGER_ONLY
       trust: FINITE_BOOKKEEPING_NOT_A_PROOF
       claim_scope: Focused n=9 row-Ptolemy product-cancellation bookkeeping for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.

--- a/scripts/check_n9_row_ptolemy_product_cancellations.py
+++ b/scripts/check_n9_row_ptolemy_product_cancellations.py
@@ -13,8 +13,13 @@ from typing import Any, Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
+SCRIPTS = ROOT / "scripts"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
 
 from erdos97 import n9_vertex_circle_exhaustive as n9  # noqa: E402
 from erdos97.incidence_filters import (  # noqa: E402
@@ -29,11 +34,22 @@ from erdos97.n9_row_ptolemy_product_cancellations import (  # noqa: E402
     EXPECTED_HIT_CERTIFICATES,
     EXPECTED_HIT_FAMILIES,
     EXPECTED_HIT_FAMILY_COUNTS,
+    EXPECTED_HIT_FAMILY_TEMPLATE_IDS,
+    EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS,
+    EXPECTED_HIT_TEMPLATE_CERTIFICATE_COUNTS,
+    EXPECTED_HIT_TEMPLATE_STATUS_COUNTS,
+    EXPECTED_NONHIT_FAMILY_COUNT,
+    EXPECTED_NONHIT_FAMILY_ORBIT_SIZE_SUM,
+    EXPECTED_NONHIT_TEMPLATE_IDS,
     EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS,
     EXPECTED_PRE_VERTEX_CIRCLE_NODES,
+    EXPECTED_STRICT_CYCLE_HIT_FAMILY_COUNT,
+    EXPECTED_STRICT_CYCLE_NONHIT_FAMILY_COUNT,
     PROVENANCE,
     SCHEMA,
     STATUS,
+    TEMPLATE_CROSSWALK_CLAIM_SCOPE,
+    TEMPLATE_CROSSWALK_SOURCE_PATH,
     TRUST,
     _family_labels,
     assert_expected_counts,
@@ -44,10 +60,14 @@ from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
     canonical_dihedral_rows,
     pre_vertex_circle_assignments,
 )
+from scripts.check_n9_vertex_circle_core_templates import (  # noqa: E402
+    validate_payload as validate_template_payload,
+)
 
 DEFAULT_ARTIFACT = (
     ROOT / "data" / "certificates" / "n9_row_ptolemy_product_cancellations.json"
 )
+DEFAULT_TEMPLATE_ARTIFACT = ROOT / TEMPLATE_CROSSWALK_SOURCE_PATH
 EXPECTED_TOP_LEVEL_KEYS = {
     "claim_scope",
     "cyclic_order",
@@ -61,9 +81,28 @@ EXPECTED_TOP_LEVEL_KEYS = {
     "source_artifacts",
     "source_frontier",
     "status",
+    "template_crosswalk",
     "trust",
     "witness_size",
 }
+EXPECTED_SOURCE_ARTIFACTS = [
+    {
+        "path": "data/certificates/n9_vertex_circle_exhaustive.json",
+        "role": "review-pending source frontier count target",
+    },
+    {
+        "path": "data/certificates/n9_vertex_circle_motif_families.json",
+        "role": "deterministic family-id convention used for F02/F09/F13 labels",
+    },
+    {
+        "path": TEMPLATE_CROSSWALK_SOURCE_PATH,
+        "role": "review-pending local-core template labels used for the diagnostic crosswalk",
+    },
+    {
+        "path": "data/runs/2026-05-05/new_obstructions.md",
+        "role": "archived exploratory memo for the historical F15 alias",
+    },
+]
 EXPECTED_CERTIFICATE_TYPE = "row_ptolemy_product_cancellation"
 EXPECTED_CERTIFICATE_STATUS = "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_ROW_ORDER"
 EXPECTED_PTOLEMY_IDENTITY = "d02*d13 = d01*d23 + d03*d12"
@@ -627,7 +666,337 @@ def _validate_hit_records(
     )
 
 
-def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
+def _template_family_maps(
+    errors: list[str],
+    template_payload: Any,
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    if not isinstance(template_payload, dict):
+        errors.append("template crosswalk source top level must be an object")
+        return {}, {}
+    template_errors = validate_template_payload(template_payload, recompute=False)
+    errors.extend(f"template crosswalk source invalid: {error}" for error in template_errors)
+
+    raw_families = template_payload.get("families")
+    raw_templates = template_payload.get("templates")
+    if not isinstance(raw_families, list):
+        errors.append("template crosswalk source families must be a list")
+        return {}, {}
+    if not isinstance(raw_templates, list):
+        errors.append("template crosswalk source templates must be a list")
+        return {}, {}
+
+    families_by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_family in enumerate(raw_families):
+        if not isinstance(raw_family, dict):
+            errors.append(f"template crosswalk source families[{index}] must be an object")
+            continue
+        family_id = raw_family.get("family_id")
+        if not isinstance(family_id, str) or not family_id:
+            errors.append(f"template crosswalk source families[{index}] has invalid family_id")
+            continue
+        families_by_id[family_id] = raw_family
+
+    templates_by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_template in enumerate(raw_templates):
+        if not isinstance(raw_template, dict):
+            errors.append(f"template crosswalk source templates[{index}] must be an object")
+            continue
+        template_id = raw_template.get("template_id")
+        if not isinstance(template_id, str) or not template_id:
+            errors.append(f"template crosswalk source templates[{index}] has invalid template_id")
+            continue
+        templates_by_id[template_id] = raw_template
+    return families_by_id, templates_by_id
+
+
+def _template_family_row(errors: list[str], family: dict[str, Any], key: str) -> Any:
+    if key not in family:
+        errors.append(f"template crosswalk source family {family.get('family_id')!r} missing {key}")
+        return None
+    return family[key]
+
+
+def _template_int_field(errors: list[str], row: dict[str, Any], key: str, label: str) -> int:
+    value = row.get(key)
+    if _is_int(value):
+        return int(value)
+    errors.append(f"{label} {key} must be an integer")
+    return 0
+
+
+def _hit_family_counts_from_records(
+    payload: dict[str, Any],
+) -> tuple[Counter[str], Counter[str]]:
+    family_hit_counts: Counter[str] = Counter()
+    family_certificate_counts: Counter[str] = Counter()
+    records = payload.get("hit_records")
+    if not isinstance(records, list):
+        return family_hit_counts, family_certificate_counts
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        family_id = record.get("family_id")
+        certificate_count = record.get("certificate_count")
+        if isinstance(family_id, str) and _is_int(certificate_count):
+            family_hit_counts[family_id] += 1
+            family_certificate_counts[family_id] += int(certificate_count)
+    return family_hit_counts, family_certificate_counts
+
+
+def _expected_template_crosswalk(
+    *,
+    errors: list[str],
+    payload: dict[str, Any],
+    families_by_id: dict[str, dict[str, Any]],
+    templates_by_id: dict[str, dict[str, Any]],
+    template_payload: dict[str, Any],
+) -> dict[str, Any]:
+    family_hit_counts, family_certificate_counts = _hit_family_counts_from_records(payload)
+
+    hit_family_template_ids: dict[str, str] = {}
+    hit_family_rows = []
+    template_assignment_counts: Counter[str] = Counter()
+    template_certificate_counts: Counter[str] = Counter()
+
+    for family_id in sorted(family_hit_counts):
+        family = families_by_id[family_id]
+        template_id = _template_family_row(errors, family, "template_id")
+        status = _template_family_row(errors, family, "status")
+        core_size = _template_family_row(errors, family, "core_size")
+        strict_edge_count = _template_family_row(errors, family, "strict_edge_count")
+        orbit_size = _template_family_row(errors, family, "orbit_size")
+        if template_id is None:
+            continue
+        template_id = str(template_id)
+        template = templates_by_id.get(template_id)
+        if template is None:
+            errors.append(f"template crosswalk source missing template {template_id!r}")
+            continue
+        hit_assignment_count = int(family_hit_counts[family_id])
+        hit_certificate_count = int(family_certificate_counts[family_id])
+        template_assignment_counts[template_id] += hit_assignment_count
+        template_certificate_counts[template_id] += hit_certificate_count
+        hit_family_template_ids[family_id] = template_id
+        hit_family_rows.append(
+            {
+                "family_id": family_id,
+                "template_id": template_id,
+                "template_status": str(status),
+                "template_core_size": int(core_size) if _is_int(core_size) else 0,
+                "template_strict_edge_count": (
+                    int(strict_edge_count) if _is_int(strict_edge_count) else 0
+                ),
+                "family_orbit_size": int(orbit_size) if _is_int(orbit_size) else 0,
+                "hit_assignment_count": hit_assignment_count,
+                "hit_certificate_count": hit_certificate_count,
+                "certificate_count_per_hit_assignment": (
+                    hit_certificate_count // hit_assignment_count
+                ),
+                "template_family_count": _template_int_field(
+                    errors,
+                    template,
+                    "family_count",
+                    f"template crosswalk source template {template_id}",
+                ),
+                "template_orbit_size_sum": _template_int_field(
+                    errors,
+                    template,
+                    "orbit_size_sum",
+                    f"template crosswalk source template {template_id}",
+                ),
+            }
+        )
+
+    template_status_counts = Counter(
+        str(templates_by_id[template_id].get("status"))
+        for template_id in template_assignment_counts
+    )
+    hit_template_rows = []
+    for template_id in sorted(template_assignment_counts):
+        template = templates_by_id[template_id]
+        hit_families = sorted(
+            family_id
+            for family_id, row_template_id in hit_family_template_ids.items()
+            if row_template_id == template_id
+        )
+        hit_template_rows.append(
+            {
+                "template_id": template_id,
+                "template_status": str(template.get("status")),
+                "families": hit_families,
+                "hit_family_count": len(hit_families),
+                "hit_assignment_count": int(template_assignment_counts[template_id]),
+                "hit_certificate_count": int(template_certificate_counts[template_id]),
+            }
+        )
+
+    all_family_ids = set(families_by_id)
+    hit_family_ids = set(hit_family_template_ids)
+    nonhit_family_ids = sorted(all_family_ids - hit_family_ids)
+    return {
+        "claim_scope": TEMPLATE_CROSSWALK_CLAIM_SCOPE,
+        "source_artifact": {
+            "path": TEMPLATE_CROSSWALK_SOURCE_PATH,
+            "schema": template_payload.get("schema"),
+            "status": template_payload.get("status"),
+            "trust": template_payload.get("trust"),
+        },
+        "hit_template_count": len(template_assignment_counts),
+        "hit_family_template_ids": hit_family_template_ids,
+        "hit_template_assignment_counts": {
+            template_id: int(template_assignment_counts[template_id])
+            for template_id in sorted(template_assignment_counts)
+        },
+        "hit_template_certificate_counts": {
+            template_id: int(template_certificate_counts[template_id])
+            for template_id in sorted(template_certificate_counts)
+        },
+        "hit_template_status_counts": {
+            status: int(template_status_counts[status])
+            for status in sorted(template_status_counts)
+        },
+        "strict_cycle_hit_family_count": sum(
+            1
+            for family_id in hit_family_ids
+            if families_by_id[family_id].get("status") == "strict_cycle"
+        ),
+        "nonhit_family_count": len(nonhit_family_ids),
+        "nonhit_family_orbit_size_sum": sum(
+            _template_int_field(
+                errors,
+                families_by_id[family_id],
+                "orbit_size",
+                f"template crosswalk source family {family_id}",
+            )
+            for family_id in nonhit_family_ids
+        ),
+        "strict_cycle_nonhit_family_count": sum(
+            1
+            for family_id in nonhit_family_ids
+            if families_by_id[family_id].get("status") == "strict_cycle"
+        ),
+        "nonhit_template_ids": sorted(
+            {
+                str(families_by_id[family_id].get("template_id"))
+                for family_id in nonhit_family_ids
+                if families_by_id[family_id].get("template_id") is not None
+            }
+        ),
+        "hit_family_rows": hit_family_rows,
+        "hit_template_rows": hit_template_rows,
+    }
+
+
+def _validate_template_crosswalk(
+    errors: list[str],
+    payload: dict[str, Any],
+    template_payload: Any,
+) -> None:
+    crosswalk = payload.get("template_crosswalk")
+    if not isinstance(crosswalk, dict):
+        errors.append("template_crosswalk must be an object")
+        return
+
+    if not isinstance(template_payload, dict):
+        _template_family_maps(errors, template_payload)
+        return
+    families_by_id, templates_by_id = _template_family_maps(errors, template_payload)
+    if not families_by_id or not templates_by_id:
+        return
+
+    family_hit_counts, _certificate_counts = _hit_family_counts_from_records(payload)
+    missing_families = sorted(set(family_hit_counts) - set(families_by_id))
+    if missing_families:
+        errors.append(
+            "template_crosswalk missing source family rows for "
+            f"{missing_families!r}"
+        )
+        return
+    missing_template_ids = sorted(
+        {
+            str(families_by_id[family_id].get("template_id"))
+            for family_id in family_hit_counts
+        }
+        - set(templates_by_id)
+    )
+    if missing_template_ids:
+        errors.append(
+            "template_crosswalk missing source template rows for "
+            f"{missing_template_ids!r}"
+        )
+        return
+
+    expected = _expected_template_crosswalk(
+        errors=errors,
+        payload=payload,
+        families_by_id=families_by_id,
+        templates_by_id=templates_by_id,
+        template_payload=template_payload,
+    )
+    expect_equal(errors, "template_crosswalk", crosswalk, expected)
+
+    expect_equal(
+        errors,
+        "template_crosswalk hit_family_template_ids",
+        crosswalk.get("hit_family_template_ids"),
+        EXPECTED_HIT_FAMILY_TEMPLATE_IDS,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk hit_template_assignment_counts",
+        crosswalk.get("hit_template_assignment_counts"),
+        EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk hit_template_certificate_counts",
+        crosswalk.get("hit_template_certificate_counts"),
+        EXPECTED_HIT_TEMPLATE_CERTIFICATE_COUNTS,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk hit_template_status_counts",
+        crosswalk.get("hit_template_status_counts"),
+        EXPECTED_HIT_TEMPLATE_STATUS_COUNTS,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk strict_cycle_hit_family_count",
+        crosswalk.get("strict_cycle_hit_family_count"),
+        EXPECTED_STRICT_CYCLE_HIT_FAMILY_COUNT,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk nonhit_family_count",
+        crosswalk.get("nonhit_family_count"),
+        EXPECTED_NONHIT_FAMILY_COUNT,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk nonhit_family_orbit_size_sum",
+        crosswalk.get("nonhit_family_orbit_size_sum"),
+        EXPECTED_NONHIT_FAMILY_ORBIT_SIZE_SUM,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk strict_cycle_nonhit_family_count",
+        crosswalk.get("strict_cycle_nonhit_family_count"),
+        EXPECTED_STRICT_CYCLE_NONHIT_FAMILY_COUNT,
+    )
+    expect_equal(
+        errors,
+        "template_crosswalk nonhit_template_ids",
+        crosswalk.get("nonhit_template_ids"),
+        EXPECTED_NONHIT_TEMPLATE_IDS,
+    )
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    recompute: bool = True,
+    template_payload: Any | None = None,
+) -> list[str]:
     """Return validation errors for a loaded cancellation artifact."""
 
     if not isinstance(payload, dict):
@@ -656,6 +1025,12 @@ def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
     _validate_claim_scope(errors, payload.get("claim_scope"))
     _validate_interpretation(errors, payload.get("interpretation"))
     expect_equal(errors, "provenance", payload.get("provenance"), PROVENANCE)
+    expect_equal(
+        errors,
+        "source_artifacts",
+        payload.get("source_artifacts"),
+        EXPECTED_SOURCE_ARTIFACTS,
+    )
 
     source = payload.get("source_frontier")
     if isinstance(source, dict):
@@ -742,6 +1117,13 @@ def validate_payload(payload: Any, *, recompute: bool = True) -> list[str]:
     except (AssertionError, KeyError, TypeError, ValueError) as exc:
         errors.append(f"expected row-Ptolemy counts failed: {exc}")
     _validate_hit_records(errors, payload, bind_source_assignments=not recompute)
+    if template_payload is None:
+        try:
+            template_payload = load_artifact(DEFAULT_TEMPLATE_ARTIFACT)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"failed to load template crosswalk source: {exc}")
+            template_payload = {}
+    _validate_template_crosswalk(errors, payload, template_payload)
 
     if recompute:
         try:
@@ -794,6 +1176,16 @@ def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str
         ),
         "hit_family_count": (
             hit_summary.get("hit_family_count") if isinstance(hit_summary, dict) else None
+        ),
+        "hit_template_count": (
+            object_payload.get("template_crosswalk", {}).get("hit_template_count")
+            if isinstance(object_payload.get("template_crosswalk"), dict)
+            else None
+        ),
+        "hit_family_template_ids": (
+            object_payload.get("template_crosswalk", {}).get("hit_family_template_ids")
+            if isinstance(object_payload.get("template_crosswalk"), dict)
+            else None
         ),
         "validation_errors": list(errors),
     }

--- a/src/erdos97/n9_row_ptolemy_product_cancellations.py
+++ b/src/erdos97/n9_row_ptolemy_product_cancellations.py
@@ -9,8 +9,10 @@ counterexample.
 
 from __future__ import annotations
 
+import json
 from collections import Counter, defaultdict
-from typing import Sequence
+from pathlib import Path
+from typing import Any, Sequence
 
 from erdos97 import n9_vertex_circle_exhaustive as n9
 from erdos97.incidence_filters import row_ptolemy_product_cancellation_certificates
@@ -20,7 +22,7 @@ from erdos97.n9_vertex_circle_obstruction_shapes import (
     pre_vertex_circle_assignments,
 )
 
-SCHEMA = "erdos97.n9_row_ptolemy_product_cancellations.v1"
+SCHEMA = "erdos97.n9_row_ptolemy_product_cancellations.v2"
 STATUS = "EXPLORATORY_LEDGER_ONLY"
 TRUST = "FINITE_BOOKKEEPING_NOT_A_PROOF"
 CLAIM_SCOPE = (
@@ -36,6 +38,14 @@ PROVENANCE = {
         "data/certificates/n9_row_ptolemy_product_cancellations.json"
     ),
 }
+TEMPLATE_CROSSWALK_SOURCE_PATH = (
+    "data/certificates/n9_vertex_circle_core_templates.json"
+)
+TEMPLATE_CROSSWALK_CLAIM_SCOPE = (
+    "Diagnostic join from row-Ptolemy hit families to review-pending n=9 "
+    "vertex-circle local-core template labels; not a proof of n=9, not a "
+    "counterexample, and not a global status update."
+)
 
 EXPECTED_PRE_VERTEX_CIRCLE_NODES = 100_817
 EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS = 184
@@ -46,6 +56,25 @@ EXPECTED_HIT_ASSIGNMENT_STATUS_COUNTS = {"self_edge": 26}
 EXPECTED_HIT_FAMILY_COUNTS = {"F02": 18, "F09": 6, "F13": 2}
 EXPECTED_CERTIFICATE_COUNT_BY_CENTER = {str(center): 24 for center in range(n9.N)}
 EXPECTED_CERTIFICATES_PER_HIT_ASSIGNMENT = {"6": 18, "12": 6, "18": 2}
+EXPECTED_HIT_FAMILY_TEMPLATE_IDS = {"F02": "T08", "F09": "T01", "F13": "T04"}
+EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS = {"T01": 6, "T04": 2, "T08": 18}
+EXPECTED_HIT_TEMPLATE_CERTIFICATE_COUNTS = {"T01": 72, "T04": 36, "T08": 108}
+EXPECTED_HIT_TEMPLATE_STATUS_COUNTS = {"self_edge": 3}
+EXPECTED_NONHIT_TEMPLATE_IDS = [
+    "T02",
+    "T03",
+    "T05",
+    "T06",
+    "T07",
+    "T09",
+    "T10",
+    "T11",
+    "T12",
+]
+EXPECTED_NONHIT_FAMILY_COUNT = 13
+EXPECTED_NONHIT_FAMILY_ORBIT_SIZE_SUM = 158
+EXPECTED_STRICT_CYCLE_HIT_FAMILY_COUNT = 0
+EXPECTED_STRICT_CYCLE_NONHIT_FAMILY_COUNT = 3
 
 
 def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
@@ -87,6 +116,150 @@ def _hit_record(
         "selected_rows": [[int(label) for label in row] for row in rows],
         "certificate_count": len(certificates),
         "certificates": list(certificates),
+    }
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_template_payload() -> dict[str, Any]:
+    path = _repo_root() / TEMPLATE_CROSSWALK_SOURCE_PATH
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{TEMPLATE_CROSSWALK_SOURCE_PATH} is not a JSON object")
+    return payload
+
+
+def _template_crosswalk(
+    *,
+    template_payload: dict[str, Any],
+    hit_records: Sequence[dict[str, object]],
+) -> dict[str, object]:
+    families = template_payload.get("families")
+    templates = template_payload.get("templates")
+    if not isinstance(families, list) or not isinstance(templates, list):
+        raise ValueError("template payload must contain family and template rows")
+    families_by_id = {
+        str(family["family_id"]): family
+        for family in families
+        if isinstance(family, dict) and "family_id" in family
+    }
+    templates_by_id = {
+        str(template["template_id"]): template
+        for template in templates
+        if isinstance(template, dict) and "template_id" in template
+    }
+
+    hit_assignment_counts = Counter(str(record["family_id"]) for record in hit_records)
+    hit_certificate_counts: Counter[str] = Counter()
+    for record in hit_records:
+        hit_certificate_counts[str(record["family_id"])] += int(record["certificate_count"])
+
+    hit_family_rows = []
+    template_assignment_counts: Counter[str] = Counter()
+    template_certificate_counts: Counter[str] = Counter()
+    hit_family_template_ids: dict[str, str] = {}
+    for family_id in sorted(hit_assignment_counts):
+        family = families_by_id[family_id]
+        template_id = str(family["template_id"])
+        template = templates_by_id[template_id]
+        hit_count = int(hit_assignment_counts[family_id])
+        certificate_count = int(hit_certificate_counts[family_id])
+        template_assignment_counts[template_id] += hit_count
+        template_certificate_counts[template_id] += certificate_count
+        hit_family_template_ids[family_id] = template_id
+        hit_family_rows.append(
+            {
+                "family_id": family_id,
+                "template_id": template_id,
+                "template_status": str(family["status"]),
+                "template_core_size": int(family["core_size"]),
+                "template_strict_edge_count": int(family["strict_edge_count"]),
+                "family_orbit_size": int(family["orbit_size"]),
+                "hit_assignment_count": hit_count,
+                "hit_certificate_count": certificate_count,
+                "certificate_count_per_hit_assignment": certificate_count // hit_count,
+                "template_family_count": int(template["family_count"]),
+                "template_orbit_size_sum": int(template["orbit_size_sum"]),
+            }
+        )
+
+    template_status_counts = Counter(
+        str(templates_by_id[template_id]["status"])
+        for template_id in template_assignment_counts
+    )
+    hit_template_rows = []
+    for template_id in sorted(template_assignment_counts):
+        template = templates_by_id[template_id]
+        hit_template_rows.append(
+            {
+                "template_id": template_id,
+                "template_status": str(template["status"]),
+                "families": sorted(
+                    family_id
+                    for family_id, row_template_id in hit_family_template_ids.items()
+                    if row_template_id == template_id
+                ),
+                "hit_family_count": sum(
+                    1
+                    for row_template_id in hit_family_template_ids.values()
+                    if row_template_id == template_id
+                ),
+                "hit_assignment_count": int(template_assignment_counts[template_id]),
+                "hit_certificate_count": int(template_certificate_counts[template_id]),
+            }
+        )
+
+    all_family_ids = set(families_by_id)
+    hit_family_ids = set(hit_family_template_ids)
+    nonhit_family_ids = sorted(all_family_ids - hit_family_ids)
+    nonhit_template_ids = sorted(
+        {str(families_by_id[family_id]["template_id"]) for family_id in nonhit_family_ids}
+    )
+    strict_cycle_hit_family_count = sum(
+        1
+        for family_id in hit_family_ids
+        if families_by_id[family_id]["status"] == "strict_cycle"
+    )
+    strict_cycle_nonhit_family_count = sum(
+        1
+        for family_id in nonhit_family_ids
+        if families_by_id[family_id]["status"] == "strict_cycle"
+    )
+
+    return {
+        "claim_scope": TEMPLATE_CROSSWALK_CLAIM_SCOPE,
+        "source_artifact": {
+            "path": TEMPLATE_CROSSWALK_SOURCE_PATH,
+            "schema": template_payload.get("schema"),
+            "status": template_payload.get("status"),
+            "trust": template_payload.get("trust"),
+        },
+        "hit_template_count": len(template_assignment_counts),
+        "hit_family_template_ids": hit_family_template_ids,
+        "hit_template_assignment_counts": {
+            template_id: int(template_assignment_counts[template_id])
+            for template_id in sorted(template_assignment_counts)
+        },
+        "hit_template_certificate_counts": {
+            template_id: int(template_certificate_counts[template_id])
+            for template_id in sorted(template_certificate_counts)
+        },
+        "hit_template_status_counts": {
+            status: int(template_status_counts[status])
+            for status in sorted(template_status_counts)
+        },
+        "strict_cycle_hit_family_count": strict_cycle_hit_family_count,
+        "nonhit_family_count": len(nonhit_family_ids),
+        "nonhit_family_orbit_size_sum": sum(
+            int(families_by_id[family_id]["orbit_size"])
+            for family_id in nonhit_family_ids
+        ),
+        "strict_cycle_nonhit_family_count": strict_cycle_nonhit_family_count,
+        "nonhit_template_ids": nonhit_template_ids,
+        "hit_family_rows": hit_family_rows,
+        "hit_template_rows": hit_template_rows,
     }
 
 
@@ -133,6 +306,11 @@ def row_ptolemy_product_cancellation_report() -> dict[str, object]:
                 certificates,
             )
         )
+    template_payload = _load_template_payload()
+    template_crosswalk = _template_crosswalk(
+        template_payload=template_payload,
+        hit_records=hit_records,
+    )
 
     hit_family_rows = [
         {
@@ -192,9 +370,11 @@ def row_ptolemy_product_cancellation_report() -> dict[str, object]:
             "The proof uses Ptolemy on a row witness circle plus exact selected-distance quotient equalities.",
             "The filter kills 26 of the 184 n=9 pre-vertex-circle assignments, covering 3 of the 16 deterministic dihedral family labels.",
             "For this n=9 frontier, every hit is also a vertex-circle self-edge case; this diagnostic does not dominate or replace the vertex-circle checker.",
+            "The template crosswalk only joins deterministic artifact labels; template ids are not theorem names.",
             "The row order must be supplied or certified. This is not an orderless abstract-incidence obstruction.",
             "No proof of the n=9 case is claimed.",
         ],
+        "template_crosswalk": template_crosswalk,
         "source_artifacts": [
             {
                 "path": "data/certificates/n9_vertex_circle_exhaustive.json",
@@ -203,6 +383,10 @@ def row_ptolemy_product_cancellation_report() -> dict[str, object]:
             {
                 "path": "data/certificates/n9_vertex_circle_motif_families.json",
                 "role": "deterministic family-id convention used for F02/F09/F13 labels",
+            },
+            {
+                "path": TEMPLATE_CROSSWALK_SOURCE_PATH,
+                "role": "review-pending local-core template labels used for the diagnostic crosswalk",
             },
             {
                 "path": "data/runs/2026-05-05/new_obstructions.md",
@@ -259,3 +443,44 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
         != EXPECTED_CERTIFICATES_PER_HIT_ASSIGNMENT
     ):
         raise AssertionError("unexpected certificate-per-hit histogram")
+
+    crosswalk = payload.get("template_crosswalk")
+    if not isinstance(crosswalk, dict):
+        raise AssertionError("missing template crosswalk")
+    if crosswalk.get("claim_scope") != TEMPLATE_CROSSWALK_CLAIM_SCOPE:
+        raise AssertionError("unexpected template crosswalk claim scope")
+    if crosswalk.get("hit_template_count") != len(EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS):
+        raise AssertionError("unexpected hit template count")
+    if crosswalk.get("hit_family_template_ids") != EXPECTED_HIT_FAMILY_TEMPLATE_IDS:
+        raise AssertionError("unexpected hit family/template ids")
+    if (
+        crosswalk.get("hit_template_assignment_counts")
+        != EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS
+    ):
+        raise AssertionError("unexpected hit template assignment counts")
+    if (
+        crosswalk.get("hit_template_certificate_counts")
+        != EXPECTED_HIT_TEMPLATE_CERTIFICATE_COUNTS
+    ):
+        raise AssertionError("unexpected hit template certificate counts")
+    if crosswalk.get("hit_template_status_counts") != EXPECTED_HIT_TEMPLATE_STATUS_COUNTS:
+        raise AssertionError("unexpected hit template status counts")
+    if (
+        crosswalk.get("strict_cycle_hit_family_count")
+        != EXPECTED_STRICT_CYCLE_HIT_FAMILY_COUNT
+    ):
+        raise AssertionError("unexpected strict-cycle hit family count")
+    if crosswalk.get("nonhit_family_count") != EXPECTED_NONHIT_FAMILY_COUNT:
+        raise AssertionError("unexpected nonhit family count")
+    if (
+        crosswalk.get("nonhit_family_orbit_size_sum")
+        != EXPECTED_NONHIT_FAMILY_ORBIT_SIZE_SUM
+    ):
+        raise AssertionError("unexpected nonhit family orbit-size sum")
+    if (
+        crosswalk.get("strict_cycle_nonhit_family_count")
+        != EXPECTED_STRICT_CYCLE_NONHIT_FAMILY_COUNT
+    ):
+        raise AssertionError("unexpected strict-cycle nonhit family count")
+    if crosswalk.get("nonhit_template_ids") != EXPECTED_NONHIT_TEMPLATE_IDS:
+        raise AssertionError("unexpected nonhit template ids")

--- a/tests/test_n9_row_ptolemy_product_cancellations.py
+++ b/tests/test_n9_row_ptolemy_product_cancellations.py
@@ -9,10 +9,15 @@ from pathlib import Path
 import pytest
 
 from erdos97.n9_row_ptolemy_product_cancellations import (
+    EXPECTED_HIT_FAMILY_TEMPLATE_IDS,
+    EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS,
+    EXPECTED_HIT_TEMPLATE_CERTIFICATE_COUNTS,
+    EXPECTED_NONHIT_TEMPLATE_IDS,
     row_ptolemy_product_cancellation_report,
 )
 from scripts.check_n9_row_ptolemy_product_cancellations import (
     DEFAULT_ARTIFACT,
+    DEFAULT_TEMPLATE_ARTIFACT,
     load_artifact,
     summary_payload,
     validate_payload,
@@ -115,6 +120,65 @@ def test_row_ptolemy_product_negative_control_families_have_no_hits() -> None:
     }
 
 
+def test_row_ptolemy_product_crosswalks_to_core_templates() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    crosswalk = payload["template_crosswalk"]
+
+    assert crosswalk["claim_scope"].startswith("Diagnostic join")
+    assert crosswalk["source_artifact"] == {
+        "path": "data/certificates/n9_vertex_circle_core_templates.json",
+        "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+        "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+    }
+    assert crosswalk["hit_template_count"] == 3
+    assert crosswalk["hit_family_template_ids"] == EXPECTED_HIT_FAMILY_TEMPLATE_IDS
+    assert (
+        crosswalk["hit_template_assignment_counts"]
+        == EXPECTED_HIT_TEMPLATE_ASSIGNMENT_COUNTS
+    )
+    assert (
+        crosswalk["hit_template_certificate_counts"]
+        == EXPECTED_HIT_TEMPLATE_CERTIFICATE_COUNTS
+    )
+
+
+def test_row_ptolemy_product_crosswalk_hit_counts_match_template_orbits() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    family_rows = {
+        row["family_id"]: row for row in payload["template_crosswalk"]["hit_family_rows"]
+    }
+
+    assert family_rows["F02"]["template_id"] == "T08"
+    assert family_rows["F02"]["family_orbit_size"] == 18
+    assert family_rows["F02"]["hit_assignment_count"] == 18
+    assert family_rows["F02"]["hit_certificate_count"] == 108
+    assert family_rows["F09"]["template_id"] == "T01"
+    assert family_rows["F09"]["family_orbit_size"] == 6
+    assert family_rows["F09"]["hit_assignment_count"] == 6
+    assert family_rows["F09"]["hit_certificate_count"] == 72
+    assert family_rows["F13"]["template_id"] == "T04"
+    assert family_rows["F13"]["family_orbit_size"] == 2
+    assert family_rows["F13"]["hit_assignment_count"] == 2
+    assert family_rows["F13"]["hit_certificate_count"] == 36
+
+
+def test_row_ptolemy_product_crosswalk_strict_cycle_templates_have_no_hits() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    template_payload = load_artifact(DEFAULT_TEMPLATE_ARTIFACT)
+    strict_cycle_families = {
+        family["family_id"]
+        for family in template_payload["families"]
+        if family["status"] == "strict_cycle"
+    }
+
+    assert strict_cycle_families == {"F07", "F12", "F16"}
+    assert not (strict_cycle_families & set(payload["template_crosswalk"]["hit_family_template_ids"]))
+    assert payload["template_crosswalk"]["strict_cycle_hit_family_count"] == 0
+    assert payload["template_crosswalk"]["strict_cycle_nonhit_family_count"] == 3
+    assert payload["template_crosswalk"]["nonhit_template_ids"] == EXPECTED_NONHIT_TEMPLATE_IDS
+
+
 def test_row_ptolemy_product_certificate_shape_is_exact_and_ordered() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     cert = payload["hit_records"][0]["certificates"][0]
@@ -158,6 +222,15 @@ def test_row_ptolemy_product_checker_rejects_tampered_provenance() -> None:
     assert any("provenance" in error for error in errors)
 
 
+def test_row_ptolemy_product_checker_rejects_tampered_source_artifacts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["source_artifacts"] = []
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("source_artifacts" in error for error in errors)
+
+
 def test_row_ptolemy_product_checker_rejects_unknown_top_level_key() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     payload["unchecked_schema_drift"] = {"ok": False}
@@ -174,6 +247,50 @@ def test_row_ptolemy_product_checker_rejects_tampered_count() -> None:
     errors = validate_payload(payload, recompute=False)
 
     assert any("hit assignment count" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_tampered_template_crosswalk() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["template_crosswalk"]["hit_family_template_ids"]["F02"] = "T01"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template_crosswalk hit_family_template_ids" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_rejects_stale_template_source_status() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    template_payload = load_artifact(DEFAULT_TEMPLATE_ARTIFACT)
+    for family in template_payload["families"]:
+        if family["family_id"] == "F02":
+            family["status"] = "strict_cycle"
+            break
+
+    errors = validate_payload(
+        payload,
+        recompute=False,
+        template_payload=template_payload,
+    )
+
+    assert any("template_crosswalk" in error for error in errors)
+
+
+def test_row_ptolemy_product_checker_reports_malformed_template_source() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    template_payload = load_artifact(DEFAULT_TEMPLATE_ARTIFACT)
+    for family in template_payload["families"]:
+        if family["family_id"] == "F02":
+            del family["core_size"]
+            break
+
+    errors = validate_payload(
+        payload,
+        recompute=False,
+        template_payload=template_payload,
+    )
+
+    assert any("template crosswalk source invalid" in error for error in errors)
+    assert any("missing core_size" in error for error in errors)
 
 
 def test_row_ptolemy_product_checker_rejects_out_of_range_assignment_index() -> None:

--- a/tests/test_n9_vertex_circle_core_templates.py
+++ b/tests/test_n9_vertex_circle_core_templates.py
@@ -19,6 +19,9 @@ from scripts.check_n9_vertex_circle_core_templates import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+ROW_PTOLEMY_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_row_ptolemy_product_cancellations.json"
+)
 
 
 def test_local_core_template_artifact_counts_and_scope() -> None:
@@ -49,6 +52,25 @@ def test_local_core_template_rows_reference_known_templates() -> None:
         "self_edge",
         "strict_cycle",
     }
+
+
+def test_local_core_template_artifact_marks_row_ptolemy_hit_families() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    row_ptolemy_payload = json.loads(ROW_PTOLEMY_ARTIFACT.read_text(encoding="utf-8"))
+    template_families = {family["family_id"]: family for family in payload["families"]}
+    hit_family_template_ids = row_ptolemy_payload["template_crosswalk"][
+        "hit_family_template_ids"
+    ]
+
+    assert hit_family_template_ids == {"F02": "T08", "F09": "T01", "F13": "T04"}
+    assert {
+        family_id: template_families[family_id]["status"]
+        for family_id in hit_family_template_ids
+    } == {"F02": "self_edge", "F09": "self_edge", "F13": "self_edge"}
+    assert {
+        family_id: template_families[family_id]["core_size"]
+        for family_id in hit_family_template_ids
+    } == {"F02": 6, "F09": 3, "F13": 4}
 
 
 def test_local_core_template_checker_rejects_tampered_count() -> None:


### PR DESCRIPTION
## Summary
- add a generated `template_crosswalk` section to the n=9 row-Ptolemy product-cancellation artifact, mapping hit families `F02/F09/F13` to local-core templates `T08/T01/T04`
- harden the row-Ptolemy checker against stale crosswalk/source provenance and malformed template-source rows
- document the diagnostic-only crosswalk and wire the row-Ptolemy checker into `verify-n9-review`

## Validation
- `python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
- `python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --check-artifact data/certificates/n9_row_ptolemy_product_cancellations.json`
- `python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_row_ptolemy_product_cancellations.py tests/test_n9_vertex_circle_core_templates.py tests/test_run_artifact_audit.py -q`
- fast tier: `python scripts/check_text_clean.py`; `python scripts/check_status_consistency.py`; `python scripts/check_artifact_provenance.py`; `git diff --check`; `python -m ruff check .`; `python -m pytest -q`
- artifact commands from `verify-artifacts` run individually in Windows Python; direct `make verify-artifacts` is unavailable in PowerShell and WSL lacks repo Python deps

No proof of n=9, no counterexample, and no global status update are claimed.