### PR TITLE
Add n9 row-Ptolemy shape crosswalk

### DIFF
--- a/data/certificates/n9_row_ptolemy_family_signatures.json
+++ b/data/certificates/n9_row_ptolemy_family_signatures.json
@@ -18,6 +18,7 @@
     "Rows summarize stable certificate histograms within each row-Ptolemy hit family.",
     "The signatures are prompts for local-lemma extraction, not local lemmas by themselves.",
     "Each underlying certificate remains fixed-pattern and fixed-row-order only.",
+    "The local-core shape fields are copied from the review-pending template diagnostic for comparison only.",
     "No proof of the n=9 case is claimed."
   ],
   "n": 9,
@@ -25,7 +26,7 @@
     "command": "python scripts/check_n9_row_ptolemy_family_signatures.py --assert-expected --write",
     "generator": "scripts/check_n9_row_ptolemy_family_signatures.py"
   },
-  "schema": "erdos97.n9_row_ptolemy_family_signatures.v1",
+  "schema": "erdos97.n9_row_ptolemy_family_signatures.v2",
   "signature_rows": [
     {
       "cancelled_product_counts_per_assignment": {
@@ -53,8 +54,38 @@
         "3": 18
       },
       "signature_key": "row_ptolemy_product|hit_rows=3|certs_per_row=2|cancelled=d01*d23|zero=d03*d12",
+      "template_core_size": 6,
       "template_id": "T08",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1",
+      "template_self_edge_conflict_count": 9,
+      "template_self_edge_shape_counts": [
+        {
+          "count": 4,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
       "template_status": "self_edge",
+      "template_strict_edge_count": 54,
       "variant_counts_per_assignment": {
         "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23": 3,
         "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01": 3
@@ -89,8 +120,26 @@
         "6": 6
       },
       "signature_key": "row_ptolemy_product|hit_rows=6|certs_per_row=2|cancelled=d01*d23|zero=d03*d12",
+      "template_core_size": 3,
       "template_id": "T01",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1",
+      "template_self_edge_conflict_count": 2,
+      "template_self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
       "template_status": "self_edge",
+      "template_strict_edge_count": 27,
       "variant_counts_per_assignment": {
         "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23": 6,
         "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01": 6
@@ -125,8 +174,20 @@
         "9": 2
       },
       "signature_key": "row_ptolemy_product|hit_rows=9|certs_per_row=2|cancelled=d01*d23|zero=d03*d12",
+      "template_core_size": 4,
       "template_id": "T04",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2",
+      "template_self_edge_conflict_count": 2,
+      "template_self_edge_shape_counts": [
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        }
+      ],
       "template_status": "self_edge",
+      "template_strict_edge_count": 36,
       "variant_counts_per_assignment": {
         "cancel_d01_d23_via_d02_eq_d01_and_d13_eq_d23": 9,
         "cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01": 9
@@ -136,12 +197,22 @@
       }
     }
   ],
-  "source_artifact": {
-    "path": "data/certificates/n9_row_ptolemy_product_cancellations.json",
-    "schema": "erdos97.n9_row_ptolemy_product_cancellations.v2",
-    "status": "EXPLORATORY_LEDGER_ONLY",
-    "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF"
-  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_row_ptolemy_product_cancellations.json",
+      "role": "row-Ptolemy product-cancellation hit records",
+      "schema": "erdos97.n9_row_ptolemy_product_cancellations.v2",
+      "status": "EXPLORATORY_LEDGER_ONLY",
+      "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "role": "review-pending local-core template shape labels",
+      "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
   "status": "EXPLORATORY_LEDGER_ONLY",
   "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
   "witness_size": 4

--- a/data/certificates/n9_selected_baseline_escape_budget_overlay.json
+++ b/data/certificates/n9_selected_baseline_escape_budget_overlay.json
@@ -1,124 +1,12 @@
 {
   "accepted_frontier_overlay": {
-    "accepted_frontier_count": 1,
-    "interpretation": "This accepted_frontier row system escapes the selected-baseline turn-cover overlay; accepted_frontier means it passed the bounded frontier filters, not that it is geometrically realizable.",
-    "rows": [
-      [
-        1,
-        2,
-        3,
-        8
-      ],
-      [
-        0,
-        3,
-        4,
-        7
-      ],
-      [
-        1,
-        3,
-        5,
-        6
-      ],
-      [
-        2,
-        4,
-        5,
-        8
-      ],
-      [
-        0,
-        3,
-        6,
-        8
-      ],
-      [
-        2,
-        4,
-        6,
-        7
-      ],
-      [
-        1,
-        5,
-        7,
-        8
-      ],
-      [
-        0,
-        1,
-        4,
-        6
-      ],
-      [
-        0,
-        2,
-        5,
-        7
-      ]
-    ],
-    "selected_baseline": {
-      "canonical_relevant_placement": {
-        "spoiled_length2": [
-          0,
-          3,
-          6
-        ],
-        "spoiled_length3": [
-          1,
-          4
-        ]
-      },
-      "deficit_by_cyclic_length": {
-        "1": 0,
-        "2": 3,
-        "3": 2,
-        "4": 4
-      },
-      "overfull_base_count": 0,
-      "saturated_base_count_by_cyclic_length": {
-        "1": 9,
-        "2": 6,
-        "3": 7,
-        "4": 5
-      },
-      "spoiled_base_count_by_cyclic_length": {
-        "1": 0,
-        "2": 3,
-        "3": 2,
-        "4": 4
-      },
-      "spoiled_length2": [
-        0,
-        3,
-        6
-      ],
-      "spoiled_length3": [
-        1,
-        7
-      ],
-      "total_deficit": 9,
-      "usage_by_cyclic_length": {
-        "1": 9,
-        "2": 15,
-        "3": 16,
-        "4": 14
-      }
-    },
+    "accepted_frontier_count": 0,
+    "interpretation": "No accepted_frontier row system is recorded in the bounded frontier artifact; this overlay therefore has no surviving frontier escape example to analyze.",
+    "rows": [],
+    "selected_baseline": null,
     "source": "data/certificates/n9_incidence_frontier_bounded.json",
-    "turn_cover_overlay": {
-      "remaining_minimum_forced_turns": 1,
-      "remaining_turn_clauses": [
-        [
-          5,
-          6
-        ]
-      ],
-      "strict_positive_forces_turn_cover": false,
-      "sum_exceeds_forces_turn_cover": false
-    },
-    "vertex_circle_status": "self_edge"
+    "turn_cover_overlay": null,
+    "vertex_circle_status": "none"
   },
   "base_apex_slack": 9,
   "budget_overlay": {
@@ -574,7 +462,7 @@
     "command": "python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json",
     "generator": "scripts/analyze_n9_selected_baseline_escape_budget_overlay.py"
   },
-  "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v1",
+  "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v2",
   "selected_baseline": {
     "assignment_count": 184,
     "cyclic_base_capacity_total": 63,

--- a/docs/n9-base-apex-frontier.md
+++ b/docs/n9-base-apex-frontier.md
@@ -122,10 +122,12 @@ incidences against total cyclic capacity 63, leaving 9 selected-baseline empty
 capacity units in every case. Under the strict threshold, the selected-baseline
 deficits still force the current turn-cover contradiction in 44 of the 184
 assignments; under the conservative threshold, they force it in 2. The one
-`accepted_frontier` row system from
-`data/certificates/n9_incidence_frontier_bounded.json` has selected-baseline
-deficits on length-2 indices `{0,3,6}` and length-3 indices `{1,7}`, leaving
-only one forced turn, so it is a genuine escape for this diagnostic.
+formerly recorded `accepted_frontier` row system from
+`data/certificates/n9_incidence_frontier_bounded.json` is now classified by
+the row-Ptolemy product-cancellation filter in that bounded natural-order
+slice. The selected-baseline overlay schema `v2` therefore records
+`accepted_frontier_count = 0` and has no surviving frontier escape example to
+analyze.
 
 This overlay is not a geometric realizability test. Actual unselected
 equal-distance triples or profile excess could fill selected-baseline empty

--- a/docs/n9-incidence-frontier.md
+++ b/docs/n9-incidence-frontier.md
@@ -124,7 +124,9 @@ classifiers. The row-Ptolemy sweep now crosswalks its hit families against the
 n=9 vertex-circle local-core template labels in
 `data/certificates/n9_row_ptolemy_product_cancellations.json`, with a compact
 per-family signature summary in
-`data/certificates/n9_row_ptolemy_family_signatures.json`. Good next checks
-are to audit whether those signatures can be converted into reusable local
-lemmas and to keep testing order-sensitive variants without treating this
-bounded slice as a lossless quotient of all `n=9` cases.
+`data/certificates/n9_row_ptolemy_family_signatures.json`; that companion
+summary now carries the matching local-core self-edge shape counts as
+review-pending crosswalk metadata. Good next checks are to audit whether those
+signatures can be converted into reusable local lemmas and to keep testing
+order-sensitive variants without treating this bounded slice as a lossless
+quotient of all `n=9` cases.

--- a/docs/row-ptolemy-product-filter.md
+++ b/docs/row-ptolemy-product-filter.md
@@ -95,9 +95,10 @@ this no-hit side of the crosswalk.
 
 The companion artifact
 `data/certificates/n9_row_ptolemy_family_signatures.json` compresses the
-row-Ptolemy hit records into per-family certificate histograms. It is a
-proof-search aid for spotting reusable-looking local shapes, not a proof and
-not a lemma statement.
+row-Ptolemy hit records into per-family certificate histograms. In schema `v2`
+it also carries the matching local-core self-edge shape counts from the
+review-pending template diagnostic. It is a proof-search aid for spotting
+reusable-looking local shapes, not a proof and not a lemma statement.
 
 For the current fixed natural order, all row-Ptolemy hits use the same
 Ptolemy-side signature: the two stored `cancel_d01_d23...` variants cancel
@@ -108,6 +109,16 @@ is how many rows in each assignment carry this two-certificate local pattern:
 F02 -> T08: 3 hit rows per assignment,  6 certificates per assignment
 F09 -> T01: 6 hit rows per assignment, 12 certificates per assignment
 F13 -> T04: 9 hit rows per assignment, 18 certificates per assignment
+```
+
+The copied local-core shape fields are deterministic crosswalk metadata. They
+come from `data/certificates/n9_vertex_circle_core_templates.json`, where
+template ids are artifact labels rather than theorem names:
+
+```text
+F02 -> T08: self_edge conflicts (2,1,1)x4, (3,1,0)x2, (3,1,1)x2, (3,2,1)x1
+F09 -> T01: self_edge conflicts (3,1,0)x1, (3,1,1)x1
+F13 -> T04: self_edge conflicts (2,1,1)x2
 ```
 
 Across each full dihedral family orbit, every center label appears equally

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -404,7 +404,7 @@ artifacts:
     claim_scope: Focused n=9 selected-baseline escape-budget overlay bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.n9_selected_baseline_escape_budget_overlay.v1
+      schema: erdos97.n9_selected_baseline_escape_budget_overlay.v2
       status: EXPLORATORY_LEDGER_ONLY
       trust: FINITE_BOOKKEEPING_NOT_A_PROOF
       claim_scope: Focused n=9 selected-baseline escape-budget overlay bookkeeping; not a proof of n=9, not a counterexample, not a geometric realizability test, and not a global status update.
@@ -418,9 +418,8 @@ artifacts:
       selected_baseline.strict_positive_forced_assignment_count: 44
       selected_baseline.sum_exceeds_forced_assignment_count: 2
       selected_baseline.dihedral_relevant_placement_class_count: 13
-      accepted_frontier_overlay.selected_baseline.deficit_by_cyclic_length.2: 3
-      accepted_frontier_overlay.selected_baseline.deficit_by_cyclic_length.3: 2
-      accepted_frontier_overlay.turn_cover_overlay.remaining_minimum_forced_turns: 1
+      accepted_frontier_overlay.accepted_frontier_count: 0
+      accepted_frontier_overlay.vertex_circle_status: none
       provenance.command: python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json
     forbidden_claims:
       - n=9 is proved
@@ -516,7 +515,7 @@ artifacts:
     claim_scope: Derived n=9 row-Ptolemy per-family certificate-signature diagnostic for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not an orderless abstract-incidence obstruction, and not a global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.n9_row_ptolemy_family_signatures.v1
+      schema: erdos97.n9_row_ptolemy_family_signatures.v2
       status: EXPLORATORY_LEDGER_ONLY
       trust: FINITE_BOOKKEEPING_NOT_A_PROOF
       claim_scope: Derived n=9 row-Ptolemy per-family certificate-signature diagnostic for the fixed natural cyclic order; not a proof of n=9, not a counterexample, not an orderless abstract-incidence obstruction, and not a global status update.
@@ -525,8 +524,17 @@ artifacts:
       family_count: 3
       hit_assignment_count: 26
       hit_certificate_count: 216
-      source_artifact.path: data/certificates/n9_row_ptolemy_product_cancellations.json
-      source_artifact.schema: erdos97.n9_row_ptolemy_product_cancellations.v2
+      source_artifacts:
+        - path: data/certificates/n9_row_ptolemy_product_cancellations.json
+          role: row-Ptolemy product-cancellation hit records
+          schema: erdos97.n9_row_ptolemy_product_cancellations.v2
+          status: EXPLORATORY_LEDGER_ONLY
+          trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+        - path: data/certificates/n9_vertex_circle_core_templates.json
+          role: review-pending local-core template shape labels
+          schema: erdos97.n9_vertex_circle_core_templates.v1
+          status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+          trust: REVIEW_PENDING_DIAGNOSTIC
       provenance.command: python scripts/check_n9_row_ptolemy_family_signatures.py --assert-expected --write
     forbidden_claims:
       - n=9 is proved

--- a/scripts/check_n9_row_ptolemy_family_signatures.py
+++ b/scripts/check_n9_row_ptolemy_family_signatures.py
@@ -26,11 +26,18 @@ from scripts.check_n9_row_ptolemy_product_cancellations import (  # noqa: E402
     load_artifact,
     validate_payload as validate_row_ptolemy_payload,
 )
+from scripts.check_n9_vertex_circle_core_templates import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_CORE_TEMPLATE_ARTIFACT,
+    SCHEMA as CORE_TEMPLATE_SCHEMA,
+    STATUS as CORE_TEMPLATE_STATUS,
+    TRUST as CORE_TEMPLATE_TRUST,
+    validate_payload as validate_core_template_payload,
+)
 
 DEFAULT_ARTIFACT = (
     ROOT / "data" / "certificates" / "n9_row_ptolemy_family_signatures.json"
 )
-SCHEMA = "erdos97.n9_row_ptolemy_family_signatures.v1"
+SCHEMA = "erdos97.n9_row_ptolemy_family_signatures.v2"
 STATUS = "EXPLORATORY_LEDGER_ONLY"
 TRUST = "FINITE_BOOKKEEPING_NOT_A_PROOF"
 CLAIM_SCOPE = (
@@ -46,12 +53,24 @@ PROVENANCE = {
         "--assert-expected --write"
     ),
 }
-EXPECTED_SOURCE_ARTIFACT = {
-    "path": "data/certificates/n9_row_ptolemy_product_cancellations.json",
-    "schema": "erdos97.n9_row_ptolemy_product_cancellations.v2",
-    "status": "EXPLORATORY_LEDGER_ONLY",
-    "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
-}
+ROW_PTOLEMY_SOURCE_PATH = "data/certificates/n9_row_ptolemy_product_cancellations.json"
+CORE_TEMPLATE_SOURCE_PATH = "data/certificates/n9_vertex_circle_core_templates.json"
+EXPECTED_SOURCE_ARTIFACTS = [
+    {
+        "path": ROW_PTOLEMY_SOURCE_PATH,
+        "role": "row-Ptolemy product-cancellation hit records",
+        "schema": "erdos97.n9_row_ptolemy_product_cancellations.v2",
+        "status": "EXPLORATORY_LEDGER_ONLY",
+        "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+    },
+    {
+        "path": CORE_TEMPLATE_SOURCE_PATH,
+        "role": "review-pending local-core template shape labels",
+        "schema": CORE_TEMPLATE_SCHEMA,
+        "status": CORE_TEMPLATE_STATUS,
+        "trust": CORE_TEMPLATE_TRUST,
+    },
+]
 EXPECTED_TOP_LEVEL_KEYS = {
     "claim_scope",
     "cyclic_order",
@@ -63,7 +82,7 @@ EXPECTED_TOP_LEVEL_KEYS = {
     "provenance",
     "schema",
     "signature_rows",
-    "source_artifact",
+    "source_artifacts",
     "status",
     "trust",
     "witness_size",
@@ -91,6 +110,39 @@ EXPECTED_SIGNATURE_ROWS = [
             "row_ptolemy_product|hit_rows=3|certs_per_row=2|"
             "cancelled=d01*d23|zero=d03*d12"
         ),
+        "template_core_size": 6,
+        "template_key": (
+            "self_edge|rows=6|strict_edges=54|"
+            "conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+        ),
+        "template_self_edge_conflict_count": 9,
+        "template_self_edge_shape_counts": [
+            {
+                "count": 4,
+                "inner_span": 1,
+                "outer_span": 2,
+                "shared_endpoint_count": 1,
+            },
+            {
+                "count": 2,
+                "inner_span": 1,
+                "outer_span": 3,
+                "shared_endpoint_count": 0,
+            },
+            {
+                "count": 2,
+                "inner_span": 1,
+                "outer_span": 3,
+                "shared_endpoint_count": 1,
+            },
+            {
+                "count": 1,
+                "inner_span": 2,
+                "outer_span": 3,
+                "shared_endpoint_count": 1,
+            },
+        ],
+        "template_strict_edge_count": 54,
     },
     {
         "family_id": "F09",
@@ -114,6 +166,26 @@ EXPECTED_SIGNATURE_ROWS = [
             "row_ptolemy_product|hit_rows=6|certs_per_row=2|"
             "cancelled=d01*d23|zero=d03*d12"
         ),
+        "template_core_size": 3,
+        "template_key": (
+            "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+        ),
+        "template_self_edge_conflict_count": 2,
+        "template_self_edge_shape_counts": [
+            {
+                "count": 1,
+                "inner_span": 1,
+                "outer_span": 3,
+                "shared_endpoint_count": 0,
+            },
+            {
+                "count": 1,
+                "inner_span": 1,
+                "outer_span": 3,
+                "shared_endpoint_count": 1,
+            },
+        ],
+        "template_strict_edge_count": 27,
     },
     {
         "family_id": "F13",
@@ -137,6 +209,20 @@ EXPECTED_SIGNATURE_ROWS = [
             "row_ptolemy_product|hit_rows=9|certs_per_row=2|"
             "cancelled=d01*d23|zero=d03*d12"
         ),
+        "template_core_size": 4,
+        "template_key": (
+            "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2"
+        ),
+        "template_self_edge_conflict_count": 2,
+        "template_self_edge_shape_counts": [
+            {
+                "count": 2,
+                "inner_span": 1,
+                "outer_span": 2,
+                "shared_endpoint_count": 1,
+            },
+        ],
+        "template_strict_edge_count": 36,
     },
 ]
 
@@ -184,10 +270,167 @@ def _same_counter(
     return first
 
 
+def _source_artifacts(
+    row_ptolemy_source: dict[str, Any],
+    template_source: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": ROW_PTOLEMY_SOURCE_PATH,
+            "role": "row-Ptolemy product-cancellation hit records",
+            "schema": row_ptolemy_source.get("schema"),
+            "status": row_ptolemy_source.get("status"),
+            "trust": row_ptolemy_source.get("trust"),
+        },
+        {
+            "path": CORE_TEMPLATE_SOURCE_PATH,
+            "role": "review-pending local-core template shape labels",
+            "schema": template_source.get("schema"),
+            "status": template_source.get("status"),
+            "trust": template_source.get("trust"),
+        },
+    ]
+
+
+def _template_crosswalk_source_artifact(template_source: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": CORE_TEMPLATE_SOURCE_PATH,
+        "schema": template_source.get("schema"),
+        "status": template_source.get("status"),
+        "trust": template_source.get("trust"),
+    }
+
+
+def _template_maps(
+    template_source: Any,
+    errors: list[str],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    if not isinstance(template_source, dict):
+        errors.append("local-core template source top level must be an object")
+        return {}, {}
+    template_errors = validate_core_template_payload(template_source, recompute=False)
+    errors.extend(f"local-core template source invalid: {error}" for error in template_errors)
+
+    raw_families = template_source.get("families")
+    raw_templates = template_source.get("templates")
+    if not isinstance(raw_families, list):
+        errors.append("local-core template source families must be a list")
+        return {}, {}
+    if not isinstance(raw_templates, list):
+        errors.append("local-core template source templates must be a list")
+        return {}, {}
+
+    families_by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_family in enumerate(raw_families):
+        if not isinstance(raw_family, dict):
+            errors.append(f"local-core template source families[{index}] must be an object")
+            continue
+        family_id = raw_family.get("family_id")
+        if not isinstance(family_id, str) or not family_id:
+            errors.append(
+                f"local-core template source families[{index}] has invalid family_id"
+            )
+            continue
+        if family_id in families_by_id:
+            errors.append(f"duplicate local-core template family id {family_id}")
+        families_by_id[family_id] = raw_family
+
+    templates_by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_template in enumerate(raw_templates):
+        if not isinstance(raw_template, dict):
+            errors.append(f"local-core template source templates[{index}] must be an object")
+            continue
+        template_id = raw_template.get("template_id")
+        if not isinstance(template_id, str) or not template_id:
+            errors.append(
+                f"local-core template source templates[{index}] has invalid template_id"
+            )
+            continue
+        if template_id in templates_by_id:
+            errors.append(f"duplicate local-core template id {template_id}")
+        templates_by_id[template_id] = raw_template
+    return families_by_id, templates_by_id
+
+
+def _int_field(errors: list[str], row: dict[str, Any], key: str, label: str) -> int:
+    value = row.get(key)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return int(value)
+    errors.append(f"{label} {key} must be an integer")
+    return 0
+
+
+def _self_edge_shape_fields(
+    errors: list[str],
+    *,
+    family_id: str,
+    template_id: str,
+    family_template: dict[str, Any],
+    template: dict[str, Any],
+) -> dict[str, Any]:
+    if template.get("status") != "self_edge":
+        errors.append(
+            f"family {family_id} template {template_id} is not a self_edge template"
+        )
+        return {
+            "template_key": template.get("template_key"),
+            "template_core_size": _int_field(
+                errors, template, "core_size", f"template {template_id}"
+            ),
+            "template_strict_edge_count": _int_field(
+                errors, template, "strict_edge_count", f"template {template_id}"
+            ),
+            "template_self_edge_conflict_count": 0,
+            "template_self_edge_shape_counts": [],
+        }
+
+    obstruction = family_template.get("obstruction_summary")
+    if not isinstance(obstruction, dict):
+        errors.append(f"family {family_id} obstruction_summary must be an object")
+        obstruction = {}
+    shape_counts = template.get("self_edge_shape_counts")
+    if not isinstance(shape_counts, list):
+        errors.append(f"template {template_id} self_edge_shape_counts must be a list")
+        shape_counts = []
+    copied_shape_counts = [
+        dict(row)
+        for row in shape_counts
+        if isinstance(row, dict)
+    ]
+    if obstruction.get("self_edge_shape_counts") != shape_counts:
+        errors.append(
+            f"family {family_id} self_edge_shape_counts do not match template {template_id}"
+        )
+
+    conflict_count = sum(
+        int(row.get("count", 0))
+        for row in shape_counts
+        if isinstance(row, dict) and isinstance(row.get("count"), int)
+    )
+    if obstruction.get("self_edge_conflict_count") != conflict_count:
+        errors.append(
+            f"family {family_id} self_edge conflict count does not match template shapes"
+        )
+
+    return {
+        "template_key": template.get("template_key"),
+        "template_core_size": _int_field(
+            errors, template, "core_size", f"template {template_id}"
+        ),
+        "template_strict_edge_count": _int_field(
+            errors, template, "strict_edge_count", f"template {template_id}"
+        ),
+        "template_self_edge_conflict_count": conflict_count,
+        "template_self_edge_shape_counts": copied_shape_counts,
+    }
+
+
 def _signature_rows(
     source: dict[str, Any],
+    template_source: dict[str, Any],
     errors: list[str],
 ) -> list[dict[str, Any]]:
+    families_by_id, templates_by_id = _template_maps(template_source, errors)
     records_by_family: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for record in source.get("hit_records", []):
         if isinstance(record, dict) and isinstance(record.get("family_id"), str):
@@ -201,11 +444,48 @@ def _signature_rows(
             for row in crosswalk["hit_family_rows"]
             if isinstance(row, dict) and "family_id" in row
         }
+    expect_equal(
+        errors,
+        "row-Ptolemy template_crosswalk source_artifact",
+        crosswalk.get("source_artifact") if isinstance(crosswalk, dict) else None,
+        _template_crosswalk_source_artifact(template_source),
+    )
 
     rows = []
     for family_id in sorted(records_by_family):
         records = records_by_family[family_id]
         family_crosswalk = crosswalk_rows.get(family_id, {})
+        template_id = family_crosswalk.get("template_id")
+        template_shape_fields: dict[str, Any] = {}
+        if not isinstance(template_id, str):
+            errors.append(f"missing template id for {family_id}")
+        else:
+            family_template = families_by_id.get(family_id)
+            template = templates_by_id.get(template_id)
+            if family_template is None:
+                errors.append(f"local-core template source missing family {family_id}")
+            elif template is None:
+                errors.append(f"local-core template source missing template {template_id}")
+            else:
+                expect_equal(
+                    errors,
+                    f"{family_id} local-core template id",
+                    family_template.get("template_id"),
+                    template_id,
+                )
+                expect_equal(
+                    errors,
+                    f"{family_id} local-core template status",
+                    family_template.get("status"),
+                    family_crosswalk.get("template_status"),
+                )
+                template_shape_fields = _self_edge_shape_fields(
+                    errors,
+                    family_id=family_id,
+                    template_id=template_id,
+                    family_template=family_template,
+                    template=template,
+                )
         certificate_count = sum(int(record["certificate_count"]) for record in records)
         certificate_counts = [int(record["certificate_count"]) for record in records]
         if len(set(certificate_counts)) != 1:
@@ -299,19 +579,23 @@ def _signature_rows(
                     counters=zero_counters,
                 ),
                 "signature_key": signature_key,
+                **template_shape_fields,
             }
         )
     return rows
 
 
-def signature_payload(source: dict[str, Any]) -> dict[str, Any]:
+def signature_payload(
+    source: dict[str, Any],
+    template_source: dict[str, Any],
+) -> dict[str, Any]:
     """Return a derived per-family signature diagnostic."""
 
     errors = validate_row_ptolemy_payload(source, recompute=False)
     if errors:
         raise ValueError(f"source row-Ptolemy artifact invalid: {errors[0]}")
     signature_errors: list[str] = []
-    signature_rows = _signature_rows(source, signature_errors)
+    signature_rows = _signature_rows(source, template_source, signature_errors)
     if signature_errors:
         raise ValueError(f"signature derivation failed: {signature_errors[0]}")
 
@@ -335,14 +619,10 @@ def signature_payload(source: dict[str, Any]) -> dict[str, Any]:
             "Rows summarize stable certificate histograms within each row-Ptolemy hit family.",
             "The signatures are prompts for local-lemma extraction, not local lemmas by themselves.",
             "Each underlying certificate remains fixed-pattern and fixed-row-order only.",
+            "The local-core shape fields are copied from the review-pending template diagnostic for comparison only.",
             "No proof of the n=9 case is claimed.",
         ],
-        "source_artifact": {
-            "path": "data/certificates/n9_row_ptolemy_product_cancellations.json",
-            "schema": source["schema"],
-            "status": source["status"],
-            "trust": source["trust"],
-        },
+        "source_artifacts": _source_artifacts(source, template_source),
         "provenance": PROVENANCE,
     }
     assert_expected_signature_counts(payload)
@@ -378,6 +658,7 @@ def validate_payload(
     payload: Any,
     *,
     source: Any | None = None,
+    template_source: Any | None = None,
     recompute: bool = True,
 ) -> list[str]:
     """Return validation errors for a loaded signature artifact."""
@@ -404,7 +685,7 @@ def validate_payload(
         "hit_certificate_count": 216,
         "signature_rows": EXPECTED_SIGNATURE_ROWS,
         "provenance": PROVENANCE,
-        "source_artifact": EXPECTED_SOURCE_ARTIFACT,
+        "source_artifacts": EXPECTED_SOURCE_ARTIFACTS,
     }
     for key, expected in expected_meta.items():
         expect_equal(errors, key, payload.get(key), expected)
@@ -417,6 +698,7 @@ def validate_payload(
     else:
         required = (
             "The signatures are prompts for local-lemma extraction, not local lemmas by themselves.",
+            "The local-core shape fields are copied from the review-pending template diagnostic for comparison only.",
             "No proof of the n=9 case is claimed.",
         )
         for phrase in required:
@@ -435,13 +717,22 @@ def validate_payload(
             except (OSError, json.JSONDecodeError) as exc:
                 errors.append(f"failed to load source row-Ptolemy artifact: {exc}")
                 source = None
-        if isinstance(source, dict):
+        if template_source is None:
             try:
-                expected_payload = signature_payload(source)
-            except (TypeError, ValueError) as exc:
-                errors.append(f"recomputed signature diagnostic failed: {exc}")
+                template_source = load_artifact(DEFAULT_CORE_TEMPLATE_ARTIFACT)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"failed to load local-core template artifact: {exc}")
+                template_source = None
+        if isinstance(source, dict):
+            if not isinstance(template_source, dict):
+                errors.append("local-core template artifact must be an object")
             else:
-                expect_equal(errors, "signature diagnostic", payload, expected_payload)
+                try:
+                    expected_payload = signature_payload(source, template_source)
+                except (AssertionError, TypeError, ValueError) as exc:
+                    errors.append(f"recomputed signature diagnostic failed: {exc}")
+                else:
+                    expect_equal(errors, "signature diagnostic", payload, expected_payload)
         else:
             errors.append("source row-Ptolemy artifact must be an object")
     return errors
@@ -473,6 +764,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
     parser.add_argument("--source", type=Path, default=DEFAULT_ROW_PTOLEMY_ARTIFACT)
+    parser.add_argument(
+        "--template-source",
+        type=Path,
+        default=DEFAULT_CORE_TEMPLATE_ARTIFACT,
+        help="local-core template diagnostic used for shape metadata",
+    )
     parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
     parser.add_argument("--write", action="store_true", help="write generated diagnostic")
     parser.add_argument("--check", action="store_true", help="validate an existing diagnostic")
@@ -485,6 +782,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
     source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    template_source_path = (
+        args.template_source
+        if args.template_source.is_absolute()
+        else ROOT / args.template_source
+    )
     out = args.out if args.out.is_absolute() else ROOT / args.out
 
     try:
@@ -495,12 +797,27 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         source_errors = validate_row_ptolemy_payload(source, recompute=False)
 
+    try:
+        template_source = load_artifact(template_source_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        template_source = {}
+        template_source_errors = [str(exc)]
+    else:
+        template_source_errors = validate_core_template_payload(
+            template_source,
+            recompute=False,
+        )
+
     if args.write:
         if source_errors:
             for error in source_errors:
                 print(f"source artifact invalid: {error}", file=sys.stderr)
             return 1
-        payload = signature_payload(source)
+        if template_source_errors:
+            for error in template_source_errors:
+                print(f"local-core template artifact invalid: {error}", file=sys.stderr)
+            return 1
+        payload = signature_payload(source, template_source)
         if args.assert_expected:
             assert_expected_signature_counts(payload)
         write_json(payload, out)
@@ -516,6 +833,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         errors = validate_payload(
             payload,
             source=source,
+            template_source=template_source,
             recompute=args.check or args.assert_expected,
         )
     except (OSError, json.JSONDecodeError, ValueError) as exc:
@@ -523,6 +841,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         errors = [str(exc)]
     if source_errors:
         errors.extend(f"source artifact invalid: {error}" for error in source_errors)
+    if template_source_errors:
+        errors.extend(
+            f"local-core template artifact invalid: {error}"
+            for error in template_source_errors
+        )
 
     summary = summary_payload(artifact, payload, errors)
     if args.json:

--- a/scripts/check_n9_selected_baseline_escape_budget_overlay.py
+++ b/scripts/check_n9_selected_baseline_escape_budget_overlay.py
@@ -79,7 +79,7 @@ def validate_payload(payload: Any) -> list[str]:
         )
 
     expected_meta = {
-        "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v1",
+        "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v2",
         "status": "EXPLORATORY_LEDGER_ONLY",
         "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
         "n": 9,

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -201,9 +201,9 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--json",
         ),
         claim_scope=(
-            "Derived n=9 row-Ptolemy family-signature diagnostic for fixed row "
-            "order; not a proof of n=9, counterexample, orderless obstruction, "
-            "or official/global status update."
+            "Derived n=9 row-Ptolemy family-signature and local-core shape "
+            "crosswalk diagnostic for fixed row order; not a proof of n=9, "
+            "counterexample, orderless obstruction, or official/global status update."
         ),
     ),
     AuditCommand(

--- a/src/erdos97/n9_selected_baseline_escape_budget.py
+++ b/src/erdos97/n9_selected_baseline_escape_budget.py
@@ -363,7 +363,31 @@ def accepted_frontier_overlay() -> dict[str, object]:
     """Return the selected-baseline overlay for the bounded accepted frontier."""
 
     artifact = json.loads(ACCEPTED_FRONTIER_ARTIFACT.read_text(encoding="utf-8"))
-    frontiers = artifact["examples"]["accepted_frontier"]
+    examples = artifact.get("examples", {})
+    frontiers = (
+        examples.get("accepted_frontier", [])
+        if isinstance(examples, dict)
+        else []
+    )
+    accepted_frontier_count = int(artifact.get("accepted_frontier_count", len(frontiers)))
+    if accepted_frontier_count != len(frontiers):
+        raise AssertionError(
+            "accepted_frontier_count does not match accepted_frontier examples"
+        )
+    if not frontiers:
+        return {
+            "source": "data/certificates/n9_incidence_frontier_bounded.json",
+            "accepted_frontier_count": 0,
+            "rows": [],
+            "vertex_circle_status": "none",
+            "selected_baseline": None,
+            "turn_cover_overlay": None,
+            "interpretation": (
+                "No accepted_frontier row system is recorded in the bounded "
+                "frontier artifact; this overlay therefore has no surviving "
+                "frontier escape example to analyze."
+            ),
+        }
     if len(frontiers) != 1:
         raise AssertionError(f"expected one accepted_frontier, got {len(frontiers)}")
     rows = frontiers[0]["rows"]
@@ -389,7 +413,7 @@ def accepted_frontier_overlay() -> dict[str, object]:
         status = "ok"
     return {
         "source": "data/certificates/n9_incidence_frontier_bounded.json",
-        "accepted_frontier_count": 1,
+        "accepted_frontier_count": accepted_frontier_count,
         "rows": rows,
         "vertex_circle_status": status,
         "selected_baseline": {
@@ -467,7 +491,7 @@ def selected_baseline_escape_budget_overlay() -> dict[str, object]:
         ] += 1
 
     payload = {
-        "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v1",
+        "schema": "erdos97.n9_selected_baseline_escape_budget_overlay.v2",
         "status": "EXPLORATORY_LEDGER_ONLY",
         "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
         "claim_scope": (
@@ -603,16 +627,13 @@ def assert_expected_overlay_counts(payload: dict[str, object]) -> None:
     frontier = payload["accepted_frontier_overlay"]
     if not isinstance(frontier, dict):
         raise AssertionError("missing accepted_frontier_overlay block")
-    if frontier["vertex_circle_status"] != "self_edge":
+    if frontier["accepted_frontier_count"] != 0:
+        raise AssertionError("unexpected accepted-frontier count")
+    if frontier["vertex_circle_status"] != "none":
         raise AssertionError("unexpected accepted-frontier vertex-circle status")
-    frontier_selected = frontier["selected_baseline"]
-    if not isinstance(frontier_selected, dict):
-        raise AssertionError("missing accepted frontier selected-baseline block")
-    if frontier_selected["deficit_by_cyclic_length"] != {"1": 0, "2": 3, "3": 2, "4": 4}:
-        raise AssertionError("unexpected accepted-frontier deficit vector")
-    if frontier_selected["spoiled_length2"] != [0, 3, 6]:
-        raise AssertionError("unexpected accepted-frontier length-2 deficits")
-    if frontier_selected["spoiled_length3"] != [1, 7]:
-        raise AssertionError("unexpected accepted-frontier length-3 deficits")
-    if frontier["turn_cover_overlay"]["remaining_minimum_forced_turns"] != 1:
-        raise AssertionError("unexpected accepted-frontier forced-turn count")
+    if frontier["rows"] != []:
+        raise AssertionError("unexpected accepted-frontier rows")
+    if frontier["selected_baseline"] is not None:
+        raise AssertionError("unexpected accepted-frontier selected-baseline block")
+    if frontier["turn_cover_overlay"] is not None:
+        raise AssertionError("unexpected accepted-frontier turn-cover block")

--- a/tests/test_n9_row_ptolemy_family_signatures.py
+++ b/tests/test_n9_row_ptolemy_family_signatures.py
@@ -9,6 +9,7 @@ import pytest
 
 from scripts.check_n9_row_ptolemy_family_signatures import (
     DEFAULT_ARTIFACT,
+    DEFAULT_CORE_TEMPLATE_ARTIFACT,
     DEFAULT_ROW_PTOLEMY_ARTIFACT,
     EXPECTED_SIGNATURE_ROWS,
     assert_expected_signature_counts,
@@ -56,23 +57,39 @@ def test_row_ptolemy_family_signature_rows_record_stable_shapes() -> None:
         row["family_id"]: row["cancelled_product_counts_per_assignment"]
         for row in payload["signature_rows"]
     } == {"F02": {"d01*d23": 6}, "F09": {"d01*d23": 12}, "F13": {"d01*d23": 18}}
+    assert rows["F02"]["template_key"] == (
+        "self_edge|rows=6|strict_edges=54|"
+        "conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+    )
+    assert rows["F02"]["template_self_edge_conflict_count"] == 9
+    assert rows["F09"]["template_core_size"] == 3
+    assert rows["F13"]["template_self_edge_shape_counts"] == [
+        {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1,
+        }
+    ]
 
 
 @pytest.mark.artifact
 @pytest.mark.exhaustive
 def test_row_ptolemy_family_signature_artifact_matches_generator() -> None:
     source = load_artifact(DEFAULT_ROW_PTOLEMY_ARTIFACT)
+    template_source = load_artifact(DEFAULT_CORE_TEMPLATE_ARTIFACT)
     checked_in = load_artifact(DEFAULT_ARTIFACT)
 
-    assert checked_in == signature_payload(source)
+    assert checked_in == signature_payload(source, template_source)
 
 
 @pytest.mark.artifact
 @pytest.mark.exhaustive
 def test_row_ptolemy_family_signature_checker_passes() -> None:
     source = load_artifact(DEFAULT_ROW_PTOLEMY_ARTIFACT)
+    template_source = load_artifact(DEFAULT_CORE_TEMPLATE_ARTIFACT)
     payload = load_artifact(DEFAULT_ARTIFACT)
-    errors = validate_payload(payload, source=source)
+    errors = validate_payload(payload, source=source, template_source=template_source)
     summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
 
     assert errors == []
@@ -84,6 +101,15 @@ def test_row_ptolemy_family_signature_checker_passes() -> None:
 def test_row_ptolemy_family_signature_checker_rejects_tampered_signature() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     payload["signature_rows"][0]["hit_row_count_per_assignment"] = 4
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("signature_rows" in error for error in errors)
+
+
+def test_row_ptolemy_family_signature_checker_rejects_tampered_shape() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["signature_rows"][0]["template_self_edge_shape_counts"][0]["count"] = 5
 
     errors = validate_payload(payload, recompute=False)
 
@@ -103,11 +129,27 @@ def test_row_ptolemy_family_signature_checker_rejects_missing_no_proof_note() ->
 
 def test_row_ptolemy_family_signature_checker_rejects_tampered_source() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
-    payload["source_artifact"]["schema"] = "erdos97.n9_row_ptolemy_product_cancellations.v1"
+    payload["source_artifacts"][0]["schema"] = (
+        "erdos97.n9_row_ptolemy_product_cancellations.v1"
+    )
 
     errors = validate_payload(payload, recompute=False)
 
-    assert any("source_artifact" in error for error in errors)
+    assert any("source_artifacts" in error for error in errors)
+
+
+def test_row_ptolemy_family_signature_checker_rejects_tampered_template_source() -> None:
+    source = load_artifact(DEFAULT_ROW_PTOLEMY_ARTIFACT)
+    template_source = load_artifact(DEFAULT_CORE_TEMPLATE_ARTIFACT)
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    for template in template_source["templates"]:
+        if template["template_id"] == "T08":
+            template["self_edge_shape_counts"][0]["count"] = 5
+            break
+
+    errors = validate_payload(payload, source=source, template_source=template_source)
+
+    assert any("recomputed signature diagnostic failed" in error for error in errors)
 
 
 @pytest.mark.artifact

--- a/tests/test_n9_selected_baseline_escape_budget_overlay.py
+++ b/tests/test_n9_selected_baseline_escape_budget_overlay.py
@@ -46,13 +46,11 @@ def test_selected_baseline_overlay_artifact_summary_is_nonclaiming() -> None:
     assert selected["strict_positive_forced_assignment_count"] == 44
     assert selected["sum_exceeds_forced_assignment_count"] == 2
     assert selected["dihedral_relevant_placement_class_count"] == 13
-    assert frontier["selected_baseline"]["deficit_by_cyclic_length"] == {
-        "1": 0,
-        "2": 3,
-        "3": 2,
-        "4": 4,
-    }
-    assert frontier["turn_cover_overlay"]["remaining_minimum_forced_turns"] == 1
+    assert frontier["accepted_frontier_count"] == 0
+    assert frontier["rows"] == []
+    assert frontier["vertex_circle_status"] == "none"
+    assert frontier["selected_baseline"] is None
+    assert frontier["turn_cover_overlay"] is None
 
 
 def test_selected_baseline_overlay_budget_rows_pin_universal_forcing_counts() -> None:


### PR DESCRIPTION
## Summary

- bump `n9_row_ptolemy_family_signatures.json` to schema v2 and copy local-core self-edge template shape metadata into each row-Ptolemy hit-family signature row
- make the signature checker validate the local-core template artifact as an explicit second source and reject stale copied shape/source metadata
- update the selected-baseline overlay to schema v2 so the current bounded frontier state with `accepted_frontier_count = 0` is represented directly instead of crashing on a stale example assumption
- refresh docs, generated-artifact metadata, audit wording, and focused tests while preserving exploratory/review-pending claim scope

## Validation

Fast tier:

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`343 passed, 40 deselected`)

Focused/artifact checks:

- `python scripts/check_n9_row_ptolemy_family_signatures.py --assert-expected --write --check --json`
- `python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
- `python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json`
- `python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json`
- `python scripts/check_n9_d3_escape_slice.py --check --json`
- `python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json`
- `python scripts/check_n9_base_apex_escape_budget.py --check --json`
- `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json`

Artifact tier raw commands also run earlier in this branch session included the n8 checks, round2/Kalmanson checks, n9 exhaustive/local-core checks, and n10 singleton spot check. Direct `make verify-artifacts` was not used because `make` is not available in this Windows shell; the underlying Python commands were run directly.

## Claim Scope

This remains diagnostic bookkeeping only. It does not claim a proof of `n=9`, a counterexample, an orderless abstract-incidence obstruction, a geometric realizability count, or any global status update.