### PR TITLE
[codex] Add C19 catalog-prefilter sweep

### DIFF
--- a/data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
+++ b/data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
@@ -1,0 +1,5094 @@
+{
+  "aggregate_accounting": {
+    "direct_prefix_certified_count": 136,
+    "direct_prefix_unclosed_count": 56,
+    "exhaustive_all_orders": false,
+    "exhaustive_window_sweep": true,
+    "fifth_pair_catalog_prefilter_certified_count": 8,
+    "fifth_pair_child_branch_count": 10350,
+    "fifth_pair_child_certified_count": 10350,
+    "fifth_pair_farkas_fallback_attempt_count": 0,
+    "fifth_pair_farkas_fallback_certified_count": 0,
+    "fifth_pair_parent_count": 115,
+    "fifth_pair_prefilter_certified_count": 10350,
+    "fifth_pair_two_row_prefilter_certified_count": 10342,
+    "fourth_pair_child_branch_count": 7392,
+    "fourth_pair_child_certified_count": 7277,
+    "fourth_pair_parents_closed_by_fifth_refinement": 115,
+    "prefix_branch_count": 192,
+    "prefix_branches_closed_after_chain": 192,
+    "prefix_branches_remaining_after_chain": 0,
+    "prefix_parents_closed_by_fifth_refinement": 39,
+    "prefix_parents_closed_by_fourth_refinement": 17,
+    "unclosed_fifth_pair_child_branch_count": 0,
+    "unclosed_fourth_pair_child_branch_count": 115
+  },
+  "notes": [
+    "No general proof of Erdos Problem #97 is claimed.",
+    "No counterexample is claimed.",
+    "This sweep certifies only deterministic C19 three-boundary-prefix windows.",
+    "Direct and fourth-pair closures use ordinary prefix-forced Kalmanson/Farkas certificates.",
+    "Fifth-pair closures first try exact two-row Kalmanson cancellations, then cataloged unit supports; only misses use ordinary Farkas fallback.",
+    "Unclosed children, if any, are not counterexamples and are not evidence of realizability.",
+    "This is not an exhaustive all-order C19 search."
+  ],
+  "parameters": {
+    "anchor_label": 0,
+    "catalog_unit_support_count": 3,
+    "fallback_example_count": 16,
+    "fifth_pair_prefilter": "two_row_then_cataloged_unit_support",
+    "lp_support_tolerance": 1e-09,
+    "start_index": 288,
+    "window_count": 6,
+    "window_size": 32
+  },
+  "pattern": {
+    "circulant_offsets": [
+      -8,
+      -3,
+      5,
+      9
+    ],
+    "n": 19,
+    "name": "C19_skew"
+  },
+  "prefix_label_digest": "a2dcbd0eb6d2513dd906346ab9a4e6a273bb7033d5bcd344cf4f52cd622e8648",
+  "trust": "EXACT_OBSTRUCTION",
+  "type": "c19_kalmanson_prefix_window_catalog_prefilter_sweep_v1",
+  "windows": [
+    {
+      "branch_accounting": {
+        "direct_prefix_certified_count": 32,
+        "direct_prefix_unclosed_count": 0,
+        "exhaustive_all_orders": false,
+        "exhaustive_window_scan": true,
+        "fifth_pair_catalog_prefilter_certified_count": 0,
+        "fifth_pair_child_branch_count": 0,
+        "fifth_pair_child_certified_count": 0,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "fifth_pair_parent_count": 0,
+        "fifth_pair_prefilter_certified_count": 0,
+        "fifth_pair_two_row_prefilter_certified_count": 0,
+        "fourth_pair_child_branch_count": 0,
+        "fourth_pair_child_certified_count": 0,
+        "fourth_pair_parent_count": 0,
+        "fourth_pair_parents_closed_by_fifth_refinement": 0,
+        "prefix_branch_count": 32,
+        "prefix_branches_closed_after_chain": 32,
+        "prefix_branches_remaining_after_chain": 0,
+        "prefix_parents_closed_by_fifth_refinement": 0,
+        "prefix_parents_closed_by_fourth_refinement": 0,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "unclosed_fourth_pair_child_branch_count": 0
+      },
+      "closed_support_size_histograms": {
+        "direct_prefix": {
+          "10": 2,
+          "11": 1,
+          "12": 1,
+          "13": 3,
+          "14": 3,
+          "16": 4,
+          "17": 1,
+          "18": 1,
+          "19": 1,
+          "20": 3,
+          "21": 2,
+          "22": 1,
+          "24": 2,
+          "5": 2,
+          "6": 1,
+          "7": 2,
+          "8": 1,
+          "9": 1
+        },
+        "fifth_pair_farkas_fallback": {},
+        "fifth_pair_prefilter": {},
+        "fourth_pair": {}
+      },
+      "direct_survivor_labels": [],
+      "direct_survivors": [],
+      "end_index": 319,
+      "fifth_pair_farkas_fallback_labels": [],
+      "fifth_pair_survivor_labels": [],
+      "fifth_pair_survivors": [],
+      "forced_row_count_histograms": {
+        "direct_prefix": {
+          "910": 32
+        },
+        "fifth_pair": {},
+        "fourth_pair": {}
+      },
+      "fourth_pair_survivor_labels": [],
+      "fourth_pair_survivors": [],
+      "label_digests": {
+        "fifth_pair_children": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "fourth_pair_children": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "prefix": "cc83bf55e54627845ea5a3bb9d7588cbe6442d9bf6bdaae0c26ab356beb2dfef"
+      },
+      "start_index": 288,
+      "window_size": 32
+    },
+    {
+      "branch_accounting": {
+        "direct_prefix_certified_count": 26,
+        "direct_prefix_unclosed_count": 6,
+        "exhaustive_all_orders": false,
+        "exhaustive_window_scan": true,
+        "fifth_pair_catalog_prefilter_certified_count": 0,
+        "fifth_pair_child_branch_count": 540,
+        "fifth_pair_child_certified_count": 540,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "fifth_pair_parent_count": 6,
+        "fifth_pair_prefilter_certified_count": 540,
+        "fifth_pair_two_row_prefilter_certified_count": 540,
+        "fourth_pair_child_branch_count": 792,
+        "fourth_pair_child_certified_count": 786,
+        "fourth_pair_parent_count": 6,
+        "fourth_pair_parents_closed_by_fifth_refinement": 6,
+        "prefix_branch_count": 32,
+        "prefix_branches_closed_after_chain": 32,
+        "prefix_branches_remaining_after_chain": 0,
+        "prefix_parents_closed_by_fifth_refinement": 3,
+        "prefix_parents_closed_by_fourth_refinement": 3,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "unclosed_fourth_pair_child_branch_count": 6
+      },
+      "closed_support_size_histograms": {
+        "direct_prefix": {
+          "10": 2,
+          "11": 1,
+          "12": 2,
+          "13": 2,
+          "14": 2,
+          "15": 4,
+          "16": 1,
+          "17": 1,
+          "20": 1,
+          "3": 1,
+          "31": 1,
+          "6": 2,
+          "8": 3,
+          "9": 3
+        },
+        "fifth_pair_farkas_fallback": {},
+        "fifth_pair_prefilter": {
+          "2": 540
+        },
+        "fourth_pair": {
+          "10": 1,
+          "11": 3,
+          "13": 1,
+          "14": 3,
+          "15": 2,
+          "16": 3,
+          "17": 5,
+          "18": 7,
+          "19": 1,
+          "2": 1,
+          "20": 2,
+          "21": 8,
+          "22": 7,
+          "23": 6,
+          "25": 3,
+          "26": 2,
+          "27": 7,
+          "28": 11,
+          "29": 11,
+          "3": 5,
+          "30": 10,
+          "31": 10,
+          "32": 15,
+          "33": 16,
+          "34": 19,
+          "35": 22,
+          "36": 28,
+          "37": 38,
+          "38": 19,
+          "39": 35,
+          "4": 3,
+          "40": 40,
+          "41": 28,
+          "42": 44,
+          "43": 37,
+          "44": 50,
+          "45": 48,
+          "46": 44,
+          "47": 25,
+          "48": 34,
+          "49": 31,
+          "50": 23,
+          "51": 21,
+          "52": 10,
+          "53": 7,
+          "54": 11,
+          "55": 8,
+          "56": 7,
+          "57": 2,
+          "58": 1,
+          "6": 4,
+          "60": 1,
+          "61": 1,
+          "7": 3,
+          "9": 2
+        }
+      },
+      "direct_survivor_labels": [
+        "c19_prefix_branch_0338",
+        "c19_prefix_branch_0343",
+        "c19_prefix_branch_0344",
+        "c19_prefix_branch_0348",
+        "c19_prefix_branch_0349",
+        "c19_prefix_branch_0350"
+      ],
+      "direct_survivors": [
+        {
+          "boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            4
+          ],
+          "label": "c19_prefix_branch_0338",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            10
+          ],
+          "label": "c19_prefix_branch_0343",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            11
+          ],
+          "label": "c19_prefix_branch_0344",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            15
+          ],
+          "label": "c19_prefix_branch_0348",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            16
+          ],
+          "label": "c19_prefix_branch_0349",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            18
+          ],
+          "label": "c19_prefix_branch_0350",
+          "middle_label_count": 12
+        }
+      ],
+      "end_index": 351,
+      "fifth_pair_farkas_fallback_labels": [],
+      "fifth_pair_survivor_labels": [],
+      "fifth_pair_survivors": [],
+      "forced_row_count_histograms": {
+        "direct_prefix": {
+          "910": 32
+        },
+        "fifth_pair": {
+          "3300": 540
+        },
+        "fourth_pair": {
+          "1932": 792
+        }
+      },
+      "fourth_pair_survivor_labels": [
+        "c19_window_fourth_child_0338_0063",
+        "c19_window_fourth_child_0338_0065",
+        "c19_window_fourth_child_0348_0066",
+        "c19_window_fourth_child_0348_0073",
+        "c19_window_fourth_child_0348_0076",
+        "c19_window_fourth_child_0350_0075"
+      ],
+      "fourth_pair_survivors": [
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            17,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            4,
+            15
+          ],
+          "label": "c19_window_fourth_child_0338_0063",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0338"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            17,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            4,
+            18
+          ],
+          "label": "c19_window_fourth_child_0338_0065",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0338"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            17,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            15,
+            4
+          ],
+          "label": "c19_window_fourth_child_0348_0066",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0348"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            17,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            15,
+            13
+          ],
+          "label": "c19_window_fourth_child_0348_0073",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0348"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            17,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            15,
+            18
+          ],
+          "label": "c19_window_fourth_child_0348_0076",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0348"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            17,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            18,
+            15
+          ],
+          "label": "c19_window_fourth_child_0350_0075",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            17
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            18
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0350"
+        }
+      ],
+      "label_digests": {
+        "fifth_pair_children": "6ab6c98099e75576601c19e86962d9d7b0c49e2bc77fdbcb3c55ca9c106f43e7",
+        "fourth_pair_children": "c1a6edd266a6180ea2b9240f82a5ebc42a030d791b68a1fc8758fa643abfd5a9",
+        "prefix": "55a45bf59a7a16a4e29d5d4155984eba17d243e0244682cbd3f2f1cd66ea1c81"
+      },
+      "start_index": 320,
+      "window_size": 32
+    },
+    {
+      "branch_accounting": {
+        "direct_prefix_certified_count": 23,
+        "direct_prefix_unclosed_count": 9,
+        "exhaustive_all_orders": false,
+        "exhaustive_window_scan": true,
+        "fifth_pair_catalog_prefilter_certified_count": 0,
+        "fifth_pair_child_branch_count": 720,
+        "fifth_pair_child_certified_count": 720,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "fifth_pair_parent_count": 8,
+        "fifth_pair_prefilter_certified_count": 720,
+        "fifth_pair_two_row_prefilter_certified_count": 720,
+        "fourth_pair_child_branch_count": 1188,
+        "fourth_pair_child_certified_count": 1180,
+        "fourth_pair_parent_count": 9,
+        "fourth_pair_parents_closed_by_fifth_refinement": 8,
+        "prefix_branch_count": 32,
+        "prefix_branches_closed_after_chain": 32,
+        "prefix_branches_remaining_after_chain": 0,
+        "prefix_parents_closed_by_fifth_refinement": 4,
+        "prefix_parents_closed_by_fourth_refinement": 5,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "unclosed_fourth_pair_child_branch_count": 8
+      },
+      "closed_support_size_histograms": {
+        "direct_prefix": {
+          "11": 3,
+          "12": 1,
+          "15": 1,
+          "2": 1,
+          "22": 1,
+          "3": 4,
+          "4": 5,
+          "5": 3,
+          "6": 3,
+          "7": 1
+        },
+        "fifth_pair_farkas_fallback": {},
+        "fifth_pair_prefilter": {
+          "2": 720
+        },
+        "fourth_pair": {
+          "10": 8,
+          "11": 4,
+          "12": 9,
+          "13": 11,
+          "14": 10,
+          "15": 9,
+          "16": 12,
+          "17": 13,
+          "18": 23,
+          "19": 15,
+          "2": 1,
+          "20": 19,
+          "21": 16,
+          "22": 19,
+          "23": 24,
+          "24": 28,
+          "25": 26,
+          "26": 25,
+          "27": 33,
+          "28": 27,
+          "29": 43,
+          "3": 5,
+          "30": 42,
+          "31": 36,
+          "32": 30,
+          "33": 34,
+          "34": 39,
+          "35": 23,
+          "36": 46,
+          "37": 53,
+          "38": 44,
+          "39": 51,
+          "4": 1,
+          "40": 46,
+          "41": 48,
+          "42": 30,
+          "43": 38,
+          "44": 31,
+          "45": 32,
+          "46": 26,
+          "47": 26,
+          "48": 21,
+          "49": 20,
+          "5": 5,
+          "50": 11,
+          "51": 18,
+          "52": 6,
+          "53": 8,
+          "54": 4,
+          "56": 5,
+          "57": 1,
+          "58": 1,
+          "6": 7,
+          "7": 7,
+          "8": 5,
+          "9": 5
+        }
+      },
+      "direct_survivor_labels": [
+        "c19_prefix_branch_0352",
+        "c19_prefix_branch_0357",
+        "c19_prefix_branch_0362",
+        "c19_prefix_branch_0363",
+        "c19_prefix_branch_0364",
+        "c19_prefix_branch_0368",
+        "c19_prefix_branch_0369",
+        "c19_prefix_branch_0374",
+        "c19_prefix_branch_0376"
+      ],
+      "direct_survivors": [
+        {
+          "boundary_left": [
+            1,
+            3,
+            18
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            6
+          ],
+          "label": "c19_prefix_branch_0352",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            18
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            11
+          ],
+          "label": "c19_prefix_branch_0357",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            18
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            16
+          ],
+          "label": "c19_prefix_branch_0362",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            18
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            5,
+            17
+          ],
+          "label": "c19_prefix_branch_0363",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "label": "c19_prefix_branch_0364",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "label": "c19_prefix_branch_0368",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "label": "c19_prefix_branch_0369",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            16
+          ],
+          "label": "c19_prefix_branch_0374",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            18
+          ],
+          "label": "c19_prefix_branch_0376",
+          "middle_label_count": 12
+        }
+      ],
+      "end_index": 383,
+      "fifth_pair_farkas_fallback_labels": [],
+      "fifth_pair_survivor_labels": [],
+      "fifth_pair_survivors": [],
+      "forced_row_count_histograms": {
+        "direct_prefix": {
+          "910": 32
+        },
+        "fifth_pair": {
+          "3300": 720
+        },
+        "fourth_pair": {
+          "1932": 1188
+        }
+      },
+      "fourth_pair_survivor_labels": [
+        "c19_window_fourth_child_0357_0010",
+        "c19_window_fourth_child_0364_0003",
+        "c19_window_fourth_child_0364_0119",
+        "c19_window_fourth_child_0368_0025",
+        "c19_window_fourth_child_0368_0048",
+        "c19_window_fourth_child_0368_0115",
+        "c19_window_fourth_child_0369_0011",
+        "c19_window_fourth_child_0369_0025"
+      ],
+      "fourth_pair_survivors": [
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 17,
+          "child_boundary_left": [
+            1,
+            3,
+            18,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            5,
+            11,
+            17
+          ],
+          "label": "c19_window_fourth_child_0357_0010",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            18
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            5,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0357"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0364_0003",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0364"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            16
+          ],
+          "label": "c19_window_fourth_child_0364_0119",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0364"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            11
+          ],
+          "label": "c19_window_fourth_child_0368_0025",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0368"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 12,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            12
+          ],
+          "label": "c19_window_fourth_child_0368_0048",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0368"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 12,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            12
+          ],
+          "label": "c19_window_fourth_child_0368_0115",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0368"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            5
+          ],
+          "label": "c19_window_fourth_child_0369_0011",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0369"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 10,
+          "child_boundary_left": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            10
+          ],
+          "label": "c19_window_fourth_child_0369_0025",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            4
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0369"
+        }
+      ],
+      "label_digests": {
+        "fifth_pair_children": "03dea0992a7d673d821075723e01359e65487dfecd5c8141c7b3035ebf7875fb",
+        "fourth_pair_children": "f624e0ee444f5ed9cfeb3df205ba5c7a40bc9d3ee44c4c33962004dd55d036aa",
+        "prefix": "b3abe1633018ac764f4403ec50b38de5913e6ae1d80f9146bc4dc9b0d156364b"
+      },
+      "start_index": 352,
+      "window_size": 32
+    },
+    {
+      "branch_accounting": {
+        "direct_prefix_certified_count": 20,
+        "direct_prefix_unclosed_count": 12,
+        "exhaustive_all_orders": false,
+        "exhaustive_window_scan": true,
+        "fifth_pair_catalog_prefilter_certified_count": 0,
+        "fifth_pair_child_branch_count": 1350,
+        "fifth_pair_child_certified_count": 1350,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "fifth_pair_parent_count": 15,
+        "fifth_pair_prefilter_certified_count": 1350,
+        "fifth_pair_two_row_prefilter_certified_count": 1350,
+        "fourth_pair_child_branch_count": 1584,
+        "fourth_pair_child_certified_count": 1569,
+        "fourth_pair_parent_count": 12,
+        "fourth_pair_parents_closed_by_fifth_refinement": 15,
+        "prefix_branch_count": 32,
+        "prefix_branches_closed_after_chain": 32,
+        "prefix_branches_remaining_after_chain": 0,
+        "prefix_parents_closed_by_fifth_refinement": 8,
+        "prefix_parents_closed_by_fourth_refinement": 4,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "unclosed_fourth_pair_child_branch_count": 15
+      },
+      "closed_support_size_histograms": {
+        "direct_prefix": {
+          "10": 2,
+          "11": 1,
+          "15": 1,
+          "2": 3,
+          "3": 2,
+          "4": 2,
+          "5": 3,
+          "6": 2,
+          "7": 2,
+          "8": 2
+        },
+        "fifth_pair_farkas_fallback": {},
+        "fifth_pair_prefilter": {
+          "2": 1350
+        },
+        "fourth_pair": {
+          "10": 23,
+          "11": 22,
+          "12": 19,
+          "13": 29,
+          "14": 20,
+          "15": 32,
+          "16": 34,
+          "17": 29,
+          "18": 30,
+          "19": 27,
+          "20": 29,
+          "21": 38,
+          "22": 50,
+          "23": 27,
+          "24": 43,
+          "25": 39,
+          "26": 61,
+          "27": 41,
+          "28": 50,
+          "29": 52,
+          "3": 7,
+          "30": 50,
+          "31": 54,
+          "32": 52,
+          "33": 41,
+          "34": 56,
+          "35": 63,
+          "36": 54,
+          "37": 50,
+          "38": 41,
+          "39": 41,
+          "4": 7,
+          "40": 41,
+          "41": 33,
+          "42": 29,
+          "43": 27,
+          "44": 31,
+          "45": 23,
+          "46": 20,
+          "47": 22,
+          "48": 14,
+          "49": 16,
+          "5": 13,
+          "50": 9,
+          "51": 6,
+          "52": 4,
+          "53": 2,
+          "54": 3,
+          "55": 6,
+          "56": 2,
+          "6": 12,
+          "7": 12,
+          "8": 23,
+          "9": 10
+        }
+      },
+      "direct_survivor_labels": [
+        "c19_prefix_branch_0391",
+        "c19_prefix_branch_0393",
+        "c19_prefix_branch_0395",
+        "c19_prefix_branch_0396",
+        "c19_prefix_branch_0397",
+        "c19_prefix_branch_0403",
+        "c19_prefix_branch_0404",
+        "c19_prefix_branch_0405",
+        "c19_prefix_branch_0406",
+        "c19_prefix_branch_0407",
+        "c19_prefix_branch_0408",
+        "c19_prefix_branch_0412"
+      ],
+      "direct_survivors": [
+        {
+          "boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "label": "c19_prefix_branch_0391",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "label": "c19_prefix_branch_0393",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "label": "c19_prefix_branch_0395",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "label": "c19_prefix_branch_0396",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "label": "c19_prefix_branch_0397",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "label": "c19_prefix_branch_0403",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "label": "c19_prefix_branch_0404",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "label": "c19_prefix_branch_0405",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "label": "c19_prefix_branch_0406",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "label": "c19_prefix_branch_0407",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "label": "c19_prefix_branch_0408",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "label": "c19_prefix_branch_0412",
+          "middle_label_count": 12
+        }
+      ],
+      "end_index": 415,
+      "fifth_pair_farkas_fallback_labels": [],
+      "fifth_pair_survivor_labels": [],
+      "fifth_pair_survivors": [],
+      "forced_row_count_histograms": {
+        "direct_prefix": {
+          "910": 32
+        },
+        "fifth_pair": {
+          "3300": 1350
+        },
+        "fourth_pair": {
+          "1932": 1584
+        }
+      },
+      "fourth_pair_survivor_labels": [
+        "c19_window_fourth_child_0391_0003",
+        "c19_window_fourth_child_0391_0046",
+        "c19_window_fourth_child_0395_0000",
+        "c19_window_fourth_child_0396_0056",
+        "c19_window_fourth_child_0403_0045",
+        "c19_window_fourth_child_0403_0051",
+        "c19_window_fourth_child_0405_0044",
+        "c19_window_fourth_child_0406_0044",
+        "c19_window_fourth_child_0406_0046",
+        "c19_window_fourth_child_0406_0047",
+        "c19_window_fourth_child_0406_0051",
+        "c19_window_fourth_child_0407_0044",
+        "c19_window_fourth_child_0407_0047",
+        "c19_window_fourth_child_0407_0051",
+        "c19_window_fourth_child_0412_0055"
+      ],
+      "fourth_pair_survivors": [
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            7,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0391_0003",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0391"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 9,
+          "child_boundary_left": [
+            1,
+            3,
+            7,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            9
+          ],
+          "label": "c19_window_fourth_child_0391_0046",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0391"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            7,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            5
+          ],
+          "label": "c19_window_fourth_child_0395_0000",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0395"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            7,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            5
+          ],
+          "label": "c19_window_fourth_child_0396_0056",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            7
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0396"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            7
+          ],
+          "label": "c19_window_fourth_child_0403_0045",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0403"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            15
+          ],
+          "label": "c19_window_fourth_child_0403_0051",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0403"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            7,
+            4
+          ],
+          "label": "c19_window_fourth_child_0405_0044",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0405"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            4
+          ],
+          "label": "c19_window_fourth_child_0406_0044",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0406"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            7
+          ],
+          "label": "c19_window_fourth_child_0406_0046",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0406"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 10,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            10
+          ],
+          "label": "c19_window_fourth_child_0406_0047",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0406"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            15
+          ],
+          "label": "c19_window_fourth_child_0406_0051",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0406"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            4
+          ],
+          "label": "c19_window_fourth_child_0407_0044",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0407"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 9,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            9
+          ],
+          "label": "c19_window_fourth_child_0407_0047",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0407"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            15
+          ],
+          "label": "c19_window_fourth_child_0407_0051",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0407"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            8,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            15,
+            4
+          ],
+          "label": "c19_window_fourth_child_0412_0055",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            8
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0412"
+        }
+      ],
+      "label_digests": {
+        "fifth_pair_children": "d5705c5aa1b7db8d4170a7fc18eccf8424887df55b5781688640e5e0ae6e5de0",
+        "fourth_pair_children": "277a6662622d58e3d89ad827aca8024354116889616e8db4aa6ab69b998c0808",
+        "prefix": "e95b6ddab91d2acfc2e3cd12a1defedc685d5dc7b0e82885aa063adf4329c87c"
+      },
+      "start_index": 384,
+      "window_size": 32
+    },
+    {
+      "branch_accounting": {
+        "direct_prefix_certified_count": 19,
+        "direct_prefix_unclosed_count": 13,
+        "exhaustive_all_orders": false,
+        "exhaustive_window_scan": true,
+        "fifth_pair_catalog_prefilter_certified_count": 7,
+        "fifth_pair_child_branch_count": 4230,
+        "fifth_pair_child_certified_count": 4230,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "fifth_pair_parent_count": 47,
+        "fifth_pair_prefilter_certified_count": 4230,
+        "fifth_pair_two_row_prefilter_certified_count": 4223,
+        "fourth_pair_child_branch_count": 1716,
+        "fourth_pair_child_certified_count": 1669,
+        "fourth_pair_parent_count": 13,
+        "fourth_pair_parents_closed_by_fifth_refinement": 47,
+        "prefix_branch_count": 32,
+        "prefix_branches_closed_after_chain": 32,
+        "prefix_branches_remaining_after_chain": 0,
+        "prefix_parents_closed_by_fifth_refinement": 11,
+        "prefix_parents_closed_by_fourth_refinement": 2,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "unclosed_fourth_pair_child_branch_count": 47
+      },
+      "closed_support_size_histograms": {
+        "direct_prefix": {
+          "10": 1,
+          "11": 1,
+          "12": 1,
+          "13": 1,
+          "14": 1,
+          "18": 1,
+          "4": 4,
+          "5": 3,
+          "7": 3,
+          "8": 3
+        },
+        "fifth_pair_farkas_fallback": {},
+        "fifth_pair_prefilter": {
+          "2": 4223,
+          "3": 6,
+          "6": 1
+        },
+        "fourth_pair": {
+          "10": 16,
+          "11": 21,
+          "12": 22,
+          "13": 34,
+          "14": 31,
+          "15": 28,
+          "16": 30,
+          "17": 31,
+          "18": 32,
+          "19": 29,
+          "2": 7,
+          "20": 37,
+          "21": 52,
+          "22": 33,
+          "23": 43,
+          "24": 53,
+          "25": 42,
+          "26": 54,
+          "27": 61,
+          "28": 60,
+          "29": 58,
+          "3": 11,
+          "30": 53,
+          "31": 63,
+          "32": 59,
+          "33": 53,
+          "34": 48,
+          "35": 48,
+          "36": 43,
+          "37": 40,
+          "38": 43,
+          "39": 50,
+          "4": 13,
+          "40": 34,
+          "41": 36,
+          "42": 30,
+          "43": 27,
+          "44": 27,
+          "45": 18,
+          "46": 26,
+          "47": 13,
+          "48": 15,
+          "49": 8,
+          "5": 25,
+          "50": 5,
+          "51": 4,
+          "52": 3,
+          "54": 1,
+          "56": 3,
+          "58": 1,
+          "6": 21,
+          "7": 26,
+          "8": 20,
+          "9": 28
+        }
+      },
+      "direct_survivor_labels": [
+        "c19_prefix_branch_0429",
+        "c19_prefix_branch_0430",
+        "c19_prefix_branch_0431",
+        "c19_prefix_branch_0433",
+        "c19_prefix_branch_0434",
+        "c19_prefix_branch_0435",
+        "c19_prefix_branch_0436",
+        "c19_prefix_branch_0439",
+        "c19_prefix_branch_0442",
+        "c19_prefix_branch_0443",
+        "c19_prefix_branch_0444",
+        "c19_prefix_branch_0446",
+        "c19_prefix_branch_0447"
+      ],
+      "direct_survivors": [
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "label": "c19_prefix_branch_0429",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "label": "c19_prefix_branch_0430",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "label": "c19_prefix_branch_0431",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "label": "c19_prefix_branch_0433",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "label": "c19_prefix_branch_0434",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "label": "c19_prefix_branch_0435",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "label": "c19_prefix_branch_0436",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            16
+          ],
+          "label": "c19_prefix_branch_0439",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "label": "c19_prefix_branch_0442",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "label": "c19_prefix_branch_0443",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "label": "c19_prefix_branch_0444",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "label": "c19_prefix_branch_0446",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "label": "c19_prefix_branch_0447",
+          "middle_label_count": 12
+        }
+      ],
+      "end_index": 447,
+      "fifth_pair_farkas_fallback_labels": [],
+      "fifth_pair_survivor_labels": [],
+      "fifth_pair_survivors": [],
+      "forced_row_count_histograms": {
+        "direct_prefix": {
+          "910": 32
+        },
+        "fifth_pair": {
+          "3300": 4230
+        },
+        "fourth_pair": {
+          "1932": 1716
+        }
+      },
+      "fourth_pair_survivor_labels": [
+        "c19_window_fourth_child_0429_0077",
+        "c19_window_fourth_child_0429_0081",
+        "c19_window_fourth_child_0429_0085",
+        "c19_window_fourth_child_0429_0119",
+        "c19_window_fourth_child_0430_0003",
+        "c19_window_fourth_child_0430_0013",
+        "c19_window_fourth_child_0430_0077",
+        "c19_window_fourth_child_0430_0081",
+        "c19_window_fourth_child_0430_0125",
+        "c19_window_fourth_child_0433_0033",
+        "c19_window_fourth_child_0433_0044",
+        "c19_window_fourth_child_0434_0027",
+        "c19_window_fourth_child_0434_0070",
+        "c19_window_fourth_child_0434_0073",
+        "c19_window_fourth_child_0434_0084",
+        "c19_window_fourth_child_0435_0023",
+        "c19_window_fourth_child_0435_0027",
+        "c19_window_fourth_child_0435_0055",
+        "c19_window_fourth_child_0435_0078",
+        "c19_window_fourth_child_0435_0083",
+        "c19_window_fourth_child_0435_0085",
+        "c19_window_fourth_child_0435_0122",
+        "c19_window_fourth_child_0435_0127",
+        "c19_window_fourth_child_0435_0130",
+        "c19_window_fourth_child_0436_0027",
+        "c19_window_fourth_child_0436_0082",
+        "c19_window_fourth_child_0436_0083",
+        "c19_window_fourth_child_0436_0127",
+        "c19_window_fourth_child_0436_0130",
+        "c19_window_fourth_child_0442_0023",
+        "c19_window_fourth_child_0442_0029",
+        "c19_window_fourth_child_0442_0110",
+        "c19_window_fourth_child_0442_0118",
+        "c19_window_fourth_child_0442_0120",
+        "c19_window_fourth_child_0443_0065",
+        "c19_window_fourth_child_0443_0110",
+        "c19_window_fourth_child_0443_0120",
+        "c19_window_fourth_child_0444_0022",
+        "c19_window_fourth_child_0446_0033",
+        "c19_window_fourth_child_0446_0035",
+        "c19_window_fourth_child_0446_0040",
+        "c19_window_fourth_child_0446_0044",
+        "c19_window_fourth_child_0446_0098",
+        "c19_window_fourth_child_0447_0065",
+        "c19_window_fourth_child_0447_0110",
+        "c19_window_fourth_child_0447_0118",
+        "c19_window_fourth_child_0447_0120"
+      ],
+      "fourth_pair_survivors": [
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            5
+          ],
+          "label": "c19_window_fourth_child_0429_0077",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0429"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            11
+          ],
+          "label": "c19_window_fourth_child_0429_0081",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0429"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            16
+          ],
+          "label": "c19_window_fourth_child_0429_0085",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0429"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            16
+          ],
+          "label": "c19_window_fourth_child_0429_0119",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0429"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0430_0003",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0430"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 9,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            9
+          ],
+          "label": "c19_window_fourth_child_0430_0013",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0430"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            4
+          ],
+          "label": "c19_window_fourth_child_0430_0077",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0430"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0430_0081",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0430"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0430_0125",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0430"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            4
+          ],
+          "label": "c19_window_fourth_child_0433_0033",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0433"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            4
+          ],
+          "label": "c19_window_fourth_child_0433_0044",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0433"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            13
+          ],
+          "label": "c19_window_fourth_child_0434_0027",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0434"
+        },
+        {
+          "added_left": 13,
+          "added_right_reflection_side": 9,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            13
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            9
+          ],
+          "label": "c19_window_fourth_child_0434_0070",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0434"
+        },
+        {
+          "added_left": 13,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            13
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0434_0073",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0434"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0434_0084",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0434"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            5
+          ],
+          "label": "c19_window_fourth_child_0435_0023",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            13
+          ],
+          "label": "c19_window_fourth_child_0435_0027",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            4
+          ],
+          "label": "c19_window_fourth_child_0435_0055",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            5
+          ],
+          "label": "c19_window_fourth_child_0435_0078",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            13
+          ],
+          "label": "c19_window_fourth_child_0435_0083",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            16
+          ],
+          "label": "c19_window_fourth_child_0435_0085",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            5
+          ],
+          "label": "c19_window_fourth_child_0435_0122",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            13
+          ],
+          "label": "c19_window_fourth_child_0435_0127",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            16
+          ],
+          "label": "c19_window_fourth_child_0435_0130",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0435"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 12,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            12
+          ],
+          "label": "c19_window_fourth_child_0436_0027",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0436"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            11
+          ],
+          "label": "c19_window_fourth_child_0436_0082",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0436"
+        },
+        {
+          "added_left": 14,
+          "added_right_reflection_side": 12,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            14
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            12
+          ],
+          "label": "c19_window_fourth_child_0436_0083",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0436"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 12,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            12
+          ],
+          "label": "c19_window_fourth_child_0436_0127",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0436"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            10,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            16
+          ],
+          "label": "c19_window_fourth_child_0436_0130",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            10
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0436"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            7
+          ],
+          "label": "c19_window_fourth_child_0442_0023",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0442"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            15
+          ],
+          "label": "c19_window_fourth_child_0442_0029",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0442"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            5
+          ],
+          "label": "c19_window_fourth_child_0442_0110",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0442"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            15
+          ],
+          "label": "c19_window_fourth_child_0442_0118",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0442"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            4,
+            18
+          ],
+          "label": "c19_window_fourth_child_0442_0120",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            4
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0442"
+        },
+        {
+          "added_left": 12,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            12
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            18
+          ],
+          "label": "c19_window_fourth_child_0443_0065",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0443"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            4
+          ],
+          "label": "c19_window_fourth_child_0443_0110",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0443"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            18
+          ],
+          "label": "c19_window_fourth_child_0443_0120",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0443"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            7,
+            4
+          ],
+          "label": "c19_window_fourth_child_0444_0022",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0444"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            4
+          ],
+          "label": "c19_window_fourth_child_0446_0033",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0446"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            7
+          ],
+          "label": "c19_window_fourth_child_0446_0035",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0446"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            15
+          ],
+          "label": "c19_window_fourth_child_0446_0040",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0446"
+        },
+        {
+          "added_left": 10,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            10
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            4
+          ],
+          "label": "c19_window_fourth_child_0446_0044",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0446"
+        },
+        {
+          "added_left": 15,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            15
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            18
+          ],
+          "label": "c19_window_fourth_child_0446_0098",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0446"
+        },
+        {
+          "added_left": 12,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            12
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            18
+          ],
+          "label": "c19_window_fourth_child_0447_0065",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0447"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            4
+          ],
+          "label": "c19_window_fourth_child_0447_0110",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0447"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            15
+          ],
+          "label": "c19_window_fourth_child_0447_0118",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0447"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            18
+          ],
+          "label": "c19_window_fourth_child_0447_0120",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0447"
+        }
+      ],
+      "label_digests": {
+        "fifth_pair_children": "bbfcd3e9bf8bf86c900df30cc38a6a6918669c791266f85bf6b3c62d7abfe7e9",
+        "fourth_pair_children": "cfe62a882119a7cf20ad51d062e4c99a83bea2655483ae3ec930589f4db106e1",
+        "prefix": "fec4c7e26b7102f187757b7d305f3b8418f8e134489e8d1455e253b0d0536509"
+      },
+      "start_index": 416,
+      "window_size": 32
+    },
+    {
+      "branch_accounting": {
+        "direct_prefix_certified_count": 16,
+        "direct_prefix_unclosed_count": 16,
+        "exhaustive_all_orders": false,
+        "exhaustive_window_scan": true,
+        "fifth_pair_catalog_prefilter_certified_count": 1,
+        "fifth_pair_child_branch_count": 3510,
+        "fifth_pair_child_certified_count": 3510,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "fifth_pair_parent_count": 39,
+        "fifth_pair_prefilter_certified_count": 3510,
+        "fifth_pair_two_row_prefilter_certified_count": 3509,
+        "fourth_pair_child_branch_count": 2112,
+        "fourth_pair_child_certified_count": 2073,
+        "fourth_pair_parent_count": 16,
+        "fourth_pair_parents_closed_by_fifth_refinement": 39,
+        "prefix_branch_count": 32,
+        "prefix_branches_closed_after_chain": 32,
+        "prefix_branches_remaining_after_chain": 0,
+        "prefix_parents_closed_by_fifth_refinement": 13,
+        "prefix_parents_closed_by_fourth_refinement": 3,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "unclosed_fourth_pair_child_branch_count": 39
+      },
+      "closed_support_size_histograms": {
+        "direct_prefix": {
+          "12": 1,
+          "14": 1,
+          "18": 1,
+          "2": 1,
+          "3": 2,
+          "4": 1,
+          "5": 1,
+          "6": 1,
+          "7": 4,
+          "8": 3
+        },
+        "fifth_pair_farkas_fallback": {},
+        "fifth_pair_prefilter": {
+          "2": 3509,
+          "3": 1
+        },
+        "fourth_pair": {
+          "10": 25,
+          "11": 21,
+          "12": 21,
+          "13": 19,
+          "14": 23,
+          "15": 38,
+          "16": 31,
+          "17": 25,
+          "18": 33,
+          "19": 34,
+          "2": 7,
+          "20": 36,
+          "21": 43,
+          "22": 53,
+          "23": 39,
+          "24": 46,
+          "25": 43,
+          "26": 54,
+          "27": 53,
+          "28": 50,
+          "29": 52,
+          "3": 4,
+          "30": 65,
+          "31": 63,
+          "32": 54,
+          "33": 77,
+          "34": 73,
+          "35": 73,
+          "36": 69,
+          "37": 83,
+          "38": 66,
+          "39": 60,
+          "4": 9,
+          "40": 72,
+          "41": 57,
+          "42": 57,
+          "43": 45,
+          "44": 49,
+          "45": 53,
+          "46": 28,
+          "47": 41,
+          "48": 28,
+          "49": 29,
+          "5": 23,
+          "50": 21,
+          "51": 9,
+          "52": 11,
+          "53": 4,
+          "54": 4,
+          "55": 2,
+          "56": 6,
+          "57": 4,
+          "58": 1,
+          "59": 1,
+          "6": 20,
+          "61": 1,
+          "7": 27,
+          "8": 18,
+          "9": 20
+        }
+      },
+      "direct_survivor_labels": [
+        "c19_prefix_branch_0448",
+        "c19_prefix_branch_0451",
+        "c19_prefix_branch_0454",
+        "c19_prefix_branch_0456",
+        "c19_prefix_branch_0457",
+        "c19_prefix_branch_0460",
+        "c19_prefix_branch_0461",
+        "c19_prefix_branch_0462",
+        "c19_prefix_branch_0464",
+        "c19_prefix_branch_0465",
+        "c19_prefix_branch_0467",
+        "c19_prefix_branch_0470",
+        "c19_prefix_branch_0472",
+        "c19_prefix_branch_0474",
+        "c19_prefix_branch_0475",
+        "c19_prefix_branch_0477"
+      ],
+      "direct_survivors": [
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "label": "c19_prefix_branch_0448",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "label": "c19_prefix_branch_0451",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            18
+          ],
+          "label": "c19_prefix_branch_0454",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "label": "c19_prefix_branch_0456",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "label": "c19_prefix_branch_0457",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "label": "c19_prefix_branch_0460",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "label": "c19_prefix_branch_0461",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "label": "c19_prefix_branch_0462",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "label": "c19_prefix_branch_0464",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            16
+          ],
+          "label": "c19_prefix_branch_0465",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            18
+          ],
+          "label": "c19_prefix_branch_0467",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "label": "c19_prefix_branch_0470",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "label": "c19_prefix_branch_0472",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "label": "c19_prefix_branch_0474",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "label": "c19_prefix_branch_0475",
+          "middle_label_count": 12
+        },
+        {
+          "boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "label": "c19_prefix_branch_0477",
+          "middle_label_count": 12
+        }
+      ],
+      "end_index": 479,
+      "fifth_pair_farkas_fallback_labels": [],
+      "fifth_pair_survivor_labels": [],
+      "fifth_pair_survivors": [],
+      "forced_row_count_histograms": {
+        "direct_prefix": {
+          "910": 32
+        },
+        "fifth_pair": {
+          "3300": 3510
+        },
+        "fourth_pair": {
+          "1932": 2112
+        }
+      },
+      "fourth_pair_survivor_labels": [
+        "c19_window_fourth_child_0448_0055",
+        "c19_window_fourth_child_0448_0057",
+        "c19_window_fourth_child_0448_0068",
+        "c19_window_fourth_child_0451_0033",
+        "c19_window_fourth_child_0451_0110",
+        "c19_window_fourth_child_0451_0120",
+        "c19_window_fourth_child_0454_0103",
+        "c19_window_fourth_child_0454_0130",
+        "c19_window_fourth_child_0456_0003",
+        "c19_window_fourth_child_0456_0004",
+        "c19_window_fourth_child_0456_0008",
+        "c19_window_fourth_child_0456_0015",
+        "c19_window_fourth_child_0456_0059",
+        "c19_window_fourth_child_0456_0065",
+        "c19_window_fourth_child_0456_0126",
+        "c19_window_fourth_child_0456_0130",
+        "c19_window_fourth_child_0457_0026",
+        "c19_window_fourth_child_0457_0071",
+        "c19_window_fourth_child_0457_0126",
+        "c19_window_fourth_child_0460_0004",
+        "c19_window_fourth_child_0460_0037",
+        "c19_window_fourth_child_0460_0065",
+        "c19_window_fourth_child_0461_0000",
+        "c19_window_fourth_child_0461_0004",
+        "c19_window_fourth_child_0461_0027",
+        "c19_window_fourth_child_0461_0029",
+        "c19_window_fourth_child_0461_0037",
+        "c19_window_fourth_child_0461_0040",
+        "c19_window_fourth_child_0461_0060",
+        "c19_window_fourth_child_0461_0073",
+        "c19_window_fourth_child_0462_0027",
+        "c19_window_fourth_child_0462_0096",
+        "c19_window_fourth_child_0465_0106",
+        "c19_window_fourth_child_0470_0071",
+        "c19_window_fourth_child_0472_0057",
+        "c19_window_fourth_child_0472_0062",
+        "c19_window_fourth_child_0474_0029",
+        "c19_window_fourth_child_0474_0073",
+        "c19_window_fourth_child_0475_0068"
+      ],
+      "fourth_pair_survivors": [
+        {
+          "added_left": 10,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            10
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            4
+          ],
+          "label": "c19_window_fourth_child_0448_0055",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0448"
+        },
+        {
+          "added_left": 10,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            10
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            7
+          ],
+          "label": "c19_window_fourth_child_0448_0057",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0448"
+        },
+        {
+          "added_left": 13,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            13
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            7
+          ],
+          "label": "c19_window_fourth_child_0448_0068",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0448"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            15,
+            4
+          ],
+          "label": "c19_window_fourth_child_0451_0033",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0451"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 4,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            15,
+            4
+          ],
+          "label": "c19_window_fourth_child_0451_0110",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0451"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            15,
+            18
+          ],
+          "label": "c19_window_fourth_child_0451_0120",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            15
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0451"
+        },
+        {
+          "added_left": 15,
+          "added_right_reflection_side": 9,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            15
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            18,
+            9
+          ],
+          "label": "c19_window_fourth_child_0454_0103",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            18
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0454"
+        },
+        {
+          "added_left": 17,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            11,
+            17
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            18,
+            15
+          ],
+          "label": "c19_window_fourth_child_0454_0130",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            11
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            18
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0454"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 10,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            10
+          ],
+          "label": "c19_window_fourth_child_0456_0003",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0456_0004",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            16
+          ],
+          "label": "c19_window_fourth_child_0456_0008",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0456_0015",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 10,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            10
+          ],
+          "label": "c19_window_fourth_child_0456_0059",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            18
+          ],
+          "label": "c19_window_fourth_child_0456_0065",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            11
+          ],
+          "label": "c19_window_fourth_child_0456_0126",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            5,
+            16
+          ],
+          "label": "c19_window_fourth_child_0456_0130",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            5
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0456"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            7,
+            11
+          ],
+          "label": "c19_window_fourth_child_0457_0026",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0457"
+        },
+        {
+          "added_left": 13,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            13
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            7,
+            11
+          ],
+          "label": "c19_window_fourth_child_0457_0071",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0457"
+        },
+        {
+          "added_left": 18,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            18
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            7,
+            11
+          ],
+          "label": "c19_window_fourth_child_0457_0126",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0457"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            11
+          ],
+          "label": "c19_window_fourth_child_0460_0004",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0460"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            11
+          ],
+          "label": "c19_window_fourth_child_0460_0037",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0460"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 18,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            10,
+            18
+          ],
+          "label": "c19_window_fourth_child_0460_0065",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            10
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0460"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 5,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            5
+          ],
+          "label": "c19_window_fourth_child_0461_0000",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 4,
+          "added_right_reflection_side": 10,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            4
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            10
+          ],
+          "label": "c19_window_fourth_child_0461_0004",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            13
+          ],
+          "label": "c19_window_fourth_child_0461_0027",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0461_0029",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 10,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            10
+          ],
+          "label": "c19_window_fourth_child_0461_0037",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 8,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            8
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0461_0040",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 10,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            10
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            13
+          ],
+          "label": "c19_window_fourth_child_0461_0060",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 13,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            13
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0461_0073",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0461"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            11
+          ],
+          "label": "c19_window_fourth_child_0462_0027",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0462"
+        },
+        {
+          "added_left": 15,
+          "added_right_reflection_side": 16,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            15
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            13,
+            16
+          ],
+          "label": "c19_window_fourth_child_0462_0096",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            13
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0462"
+        },
+        {
+          "added_left": 15,
+          "added_right_reflection_side": 13,
+          "child_boundary_left": [
+            1,
+            3,
+            12,
+            15
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            16,
+            13
+          ],
+          "label": "c19_window_fourth_child_0465_0106",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            12
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            16
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0465"
+        },
+        {
+          "added_left": 12,
+          "added_right_reflection_side": 11,
+          "child_boundary_left": [
+            1,
+            3,
+            13,
+            12
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            7,
+            11
+          ],
+          "label": "c19_window_fourth_child_0470_0071",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            7
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0470"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            13,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            7
+          ],
+          "label": "c19_window_fourth_child_0472_0057",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0472"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            13,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            9,
+            15
+          ],
+          "label": "c19_window_fourth_child_0472_0062",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            9
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0472"
+        },
+        {
+          "added_left": 7,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            13,
+            7
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0474_0029",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0474"
+        },
+        {
+          "added_left": 12,
+          "added_right_reflection_side": 15,
+          "child_boundary_left": [
+            1,
+            3,
+            13,
+            12
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            11,
+            15
+          ],
+          "label": "c19_window_fourth_child_0474_0073",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            11
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0474"
+        },
+        {
+          "added_left": 11,
+          "added_right_reflection_side": 7,
+          "child_boundary_left": [
+            1,
+            3,
+            13,
+            11
+          ],
+          "child_boundary_right_reflection_side": [
+            2,
+            6,
+            12,
+            7
+          ],
+          "label": "c19_window_fourth_child_0475_0068",
+          "middle_label_count": 10,
+          "parent_boundary_left": [
+            1,
+            3,
+            13
+          ],
+          "parent_boundary_right_reflection_side": [
+            2,
+            6,
+            12
+          ],
+          "prefix_parent_label": "c19_prefix_branch_0475"
+        }
+      ],
+      "label_digests": {
+        "fifth_pair_children": "78b0380c84676cf1f336898277e8f0f5c683ac2d958ea34c0410eb00623a0da6",
+        "fourth_pair_children": "05d0de33b3f793e81d35433a2d52c432396a4e7c9096aeef0bce85309e71cb60",
+        "prefix": "08f9153dbc2a36397525a0800d0427b532874651401199d236dd24c26f2001be"
+      },
+      "start_index": 448,
+      "window_size": 32
+    }
+  ]
+}

--- a/docs/c19-kalmanson-prefix-window-catalog-prefilter-sweep.md
+++ b/docs/c19-kalmanson-prefix-window-catalog-prefilter-sweep.md
@@ -1,0 +1,65 @@
+# C19 Kalmanson Prefix Window Catalog Prefilter Sweep
+
+Status: `EXACT_OBSTRUCTION` for deterministic sampled C19
+three-boundary-prefix windows 288 through 479.
+
+This note does not prove Erdos Problem #97, does not kill abstract
+`C19_skew`, and does not produce a counterexample.
+
+## Artifact
+
+```text
+data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
+```
+
+Regenerate it with:
+
+```bash
+python scripts/sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py \
+  --assert-expected \
+  --out data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
+```
+
+Use `.venv/bin/python` in this checkout if the system `python` does not have
+the repository dependencies installed.
+
+## Scope
+
+This is the same sampled prefix range as the compact two-row prefilter sweep
+in
+[`c19-kalmanson-prefix-window-prefilter-extension.md`](c19-kalmanson-prefix-window-prefilter-extension.md).
+The direct prefix and fourth-pair stages are unchanged.
+
+At the fifth-pair stage, the sweep uses a two-stage exact prefilter:
+
+1. the existing two-row Kalmanson cancellation lookup;
+2. the three cataloged unit supports from
+   [`c19-prefilter-catalog-unit-supports.md`](c19-prefilter-catalog-unit-supports.md).
+
+Only children missed by both exact prefilters call the ordinary
+Kalmanson/Farkas routine.
+
+## Counts
+
+| Count | Value |
+|---|---:|
+| Sampled prefix branches | 192 |
+| Prefix branches closed after chain | 192 |
+| Fourth-pair child branches | 7,392 |
+| Fourth-pair child certificates | 7,277 |
+| Fifth-pair child branches | 10,350 |
+| Fifth-pair two-row prefilter certificates | 10,342 |
+| Fifth-pair catalog prefilter certificates | 8 |
+| Fifth-pair ordinary Farkas fallbacks | 0 |
+| Unclosed fifth-pair children | 0 |
+
+Compared with the two-row-only compact sweep, the catalog prefilter reduces
+ordinary fifth-pair Farkas fallback attempts from eight to zero.
+
+## Claim Boundary
+
+Every closure in this artifact is exact for the recorded sampled branch it
+addresses. The artifact does not certify any branch outside deterministic
+prefix indices 288 through 479 and does not address all cyclic orders of
+`C19_skew`. The catalog supports are reusable exact prefilter rules for these
+recorded fallback states, not a general geometric theorem.

--- a/docs/c19-kalmanson-prefix-window-prefilter-extension.md
+++ b/docs/c19-kalmanson-prefix-window-prefilter-extension.md
@@ -22,6 +22,7 @@ data/certificates/c19_kalmanson_prefix_window_416_447_prefilter.json
 data/certificates/c19_kalmanson_prefix_window_448_479_prefilter.json
 data/certificates/c19_kalmanson_prefix_window_prefilter_sweep_288_479.json
 reports/c19_prefilter_fallback_supports.json
+data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
 ```
 
 Regenerate them with:
@@ -70,6 +71,10 @@ python scripts/sweep_c19_kalmanson_prefix_windows_prefilter.py \
 python scripts/analyze_c19_prefilter_fallback_supports.py \
   --assert-expected \
   --out reports/c19_prefilter_fallback_supports.json
+
+python scripts/sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py \
+  --assert-expected \
+  --out data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
 ```
 
 Use `.venv/bin/python` in this checkout if the system `python` does not have
@@ -103,6 +108,12 @@ The fallback-support diagnostic in
 [`c19-prefilter-fallback-supports.md`](c19-prefilter-fallback-supports.md)
 reconstructs those eight fallback children and records their exact Farkas
 support sizes: 7, 8, 19, 47, 50, 52, 54, and 58 inequalities.
+
+The catalog-prefilter sweep in
+[`c19-kalmanson-prefix-window-catalog-prefilter-sweep.md`](c19-kalmanson-prefix-window-catalog-prefilter-sweep.md)
+keeps the two-row artifact intact and applies three cataloged unit supports
+only after a two-row miss. It records 10,350 fifth-pair prefilter closures and
+zero ordinary Farkas fallbacks over the same 288-479 sampled range.
 
 Together with the initial sampled-prefix chain and the 128-287 compact sweep,
 the currently recorded C19 sampled-prefix coverage is:

--- a/docs/c19-prefilter-catalog-unit-supports.md
+++ b/docs/c19-prefilter-catalog-unit-supports.md
@@ -1,8 +1,8 @@
 # C19 Prefilter Catalog Unit Supports
 
-Status: `EXACT_OBSTRUCTION` diagnostic replaying two cataloged three-row
-unit Kalmanson supports over the eight sampled C19 fifth-pair children that
-miss the two-row prefilter.
+Status: `EXACT_OBSTRUCTION` diagnostic replaying three cataloged unit
+Kalmanson supports over the eight sampled C19 fifth-pair children that miss
+the two-row prefilter.
 
 This note does not prove Erdos Problem #97, does not kill abstract
 `C19_skew`, and does not produce a counterexample.
@@ -32,15 +32,22 @@ The source sweep is:
 data/certificates/c19_kalmanson_prefix_window_prefilter_sweep_288_479.json
 ```
 
-The support catalog is extracted from:
+The first two support patterns are extracted from:
 
 ```text
 reports/c19_prefilter_small_unit_support_search.json
 ```
 
-The analyzer reconstructs only the eight fallback children in the source
-sweep. It then checks the two cataloged three-row unit supports by exact vector
-summation after quotienting by the selected-distance equalities.
+The third support is the six-row unit cancellation recorded in
+`reports/codex_goal_erdos97_log.md`. The analyzer reconstructs only the eight
+fallback children in the source sweep. It then checks the cataloged unit
+supports by exact vector summation after quotienting by the selected-distance
+equalities.
+
+The same catalog is applied as a two-stage prefilter sweep in
+[`c19-kalmanson-prefix-window-catalog-prefilter-sweep.md`](c19-kalmanson-prefix-window-catalog-prefilter-sweep.md).
+That sweep preserves the sampled 288-479 coverage and reduces ordinary
+fifth-pair Farkas fallbacks from eight to zero.
 
 ## Counts
 
@@ -48,9 +55,9 @@ summation after quotienting by the selected-distance equalities.
 |---|---:|
 | Fallback fifth-pair children | 8 |
 | Two-row prefilter misses rechecked | 8 |
-| Cataloged three-row support patterns | 2 |
-| Fallback children closed by the catalog | 7 |
-| Children still missing a catalog support | 1 |
+| Cataloged unit support patterns | 3 |
+| Fallback children closed by the catalog | 8 |
+| Children still missing a catalog support | 0 |
 
 Catalog usage:
 
@@ -58,19 +65,13 @@ Catalog usage:
 |---|---:|
 | `unit_support_000` | 6 |
 | `unit_support_001` | 1 |
-| none | 1 |
-
-The only catalog miss is:
-
-```text
-c19_window_fifth_child_0430_0081_0011
-```
+| `unit_support_002` | 1 |
 
 ## Claim Boundary
 
 Each catalog hit is an exact obstruction for completions of one recorded
 fifth-pair boundary-prefix child. The catalog is a cheap replay of supports
-found by the exhaustive small-unit diagnostic, not a new all-order C19
-argument. The remaining miss still closes by the ordinary exact Farkas
-certificate recorded in
+found by the exhaustive small-unit diagnostic plus the logged six-row
+cancellation, not a new all-order C19 argument. The eight children still have
+ordinary exact Farkas certificates recorded in
 [`c19-prefilter-fallback-supports.md`](c19-prefilter-fallback-supports.md).

--- a/reports/c19_prefilter_catalog_unit_supports.json
+++ b/reports/c19_prefilter_catalog_unit_supports.json
@@ -1,10 +1,10 @@
 {
   "aggregate": {
-    "catalog_certified_count": 7,
-    "catalog_certified_label_digest": "03412b1e4da3c1de13345b052773aef2ae944f06028529f6c0f0d0a39e2a8ea6",
-    "catalog_miss_count": 1,
-    "catalog_support_count": 2,
-    "catalog_support_digest": "b4110d03ca090444ce9585c24d89ca8a71be87d1e7df55507cbc47ef41a5aee5",
+    "catalog_certified_count": 8,
+    "catalog_certified_label_digest": "2dc4965b208144017b7aba73dba920c8c8f8f1eea93a2f84650eb4f5f484f0c8",
+    "catalog_miss_count": 0,
+    "catalog_support_count": 3,
+    "catalog_support_digest": "895860a0c4d7ebc155b32be42c39061531772d2e245821eb68da14e332d8e7a9",
     "fallback_child_count": 8,
     "fallback_label_digest": "2dc4965b208144017b7aba73dba920c8c8f8f1eea93a2f84650eb4f5f484f0c8",
     "input_support_record_count": 7,
@@ -80,6 +80,71 @@
           "weight": 1
         }
       ]
+    },
+    {
+      "catalog_id": "unit_support_002",
+      "support": [
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            0,
+            1,
+            10,
+            8
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K1_diag_gt_sides",
+          "quad": [
+            0,
+            14,
+            8,
+            11
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K1_diag_gt_sides",
+          "quad": [
+            1,
+            7,
+            12,
+            2
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K1_diag_gt_sides",
+          "quad": [
+            3,
+            12,
+            11,
+            2
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            3,
+            10,
+            7,
+            13
+          ],
+          "weight": 1
+        }
+      ]
     }
   ],
   "fallback_records": [
@@ -98,8 +163,74 @@
         11,
         9
       ],
-      "catalog_certificate": null,
-      "catalog_unit_support_found": false,
+      "catalog_certificate": {
+        "catalog_id": "unit_support_002",
+        "forced_inequalities_available": 3300,
+        "inequalities": [
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              1,
+              10,
+              8
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              14,
+              8,
+              11
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              1,
+              7,
+              12,
+              2
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              1,
+              3,
+              7,
+              8
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              3,
+              12,
+              11,
+              2
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              3,
+              10,
+              7,
+              13
+            ],
+            "weight": 1
+          }
+        ],
+        "positive_inequalities": 6
+      },
+      "catalog_unit_support_found": true,
       "fifth_added_left": 7,
       "fifth_added_right_reflection_side": 9,
       "fourth_pair_parent_label": "c19_window_fourth_child_0430_0081",
@@ -522,21 +653,21 @@
   ],
   "histograms": {
     "catalog_usage": {
-      "none": 1,
       "unit_support_000": 6,
-      "unit_support_001": 1
+      "unit_support_001": 1,
+      "unit_support_002": 1
     }
   },
   "notes": [
     "No general proof of Erdos Problem #97 is claimed.",
     "No counterexample is claimed.",
-    "This replays cataloged three-row unit Kalmanson supports over recorded C19 fallback children only.",
+    "This replays cataloged unit Kalmanson supports over recorded C19 fallback children only.",
     "Each catalog hit is rechecked by exact vector summation after selected-distance quotienting.",
     "This does not certify branches beyond the recorded sampled windows and is not an all-order C19 obstruction."
   ],
   "parameters": {
-    "catalog_source": "nonempty supports from c19_prefilter_small_unit_support_search_v1",
-    "fifth_pair_prefilter_chain": "two_row_then_cataloged_three_row_unit_support"
+    "catalog_source": "small-unit support artifact plus logged six-row unit support",
+    "fifth_pair_prefilter_chain": "two_row_then_cataloged_unit_support"
   },
   "pattern": {
     "circulant_offsets": [

--- a/scripts/analyze_c19_prefilter_catalog_unit_supports.py
+++ b/scripts/analyze_c19_prefilter_catalog_unit_supports.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Verify cataloged three-row C19 fallback prefilter supports.
+"""Verify cataloged C19 fallback prefilter unit supports.
 
 The exhaustive small-unit search records one support witness for each sampled
 C19 fifth-pair fallback child where a unit-weight cancellation of size <= 3
-exists.  This analyzer turns those recorded witnesses into a compact catalog
-and replays them as cheap exact prefilter rules over the same fallback states.
+exists.  This analyzer turns those recorded witnesses plus the later logged
+six-row unit support for the lone size-3 miss into a compact catalog and
+replays them as cheap exact prefilter rules over the same fallback states.
 
 The scope is only the recorded fallback children from the compact C19
 prefilter-window sweep.  This is not an all-order C19 search and does not
@@ -48,6 +49,48 @@ DEFAULT_SOURCE = (
 DEFAULT_SUPPORTS = ROOT / "reports" / "c19_prefilter_small_unit_support_search.json"
 DEFAULT_OUT = ROOT / "reports" / "c19_prefilter_catalog_unit_supports.json"
 
+UNIT_SUPPORT_CATALOG = (
+    (
+        ("K1_diag_gt_sides", (0, 3, 10, 11)),
+        ("K2_diag_gt_other", (1, 10, 15, 11)),
+        ("K2_diag_gt_other", (3, 15, 12, 6)),
+    ),
+    (
+        ("K1_diag_gt_sides", (0, 16, 5, 2)),
+        ("K1_diag_gt_sides", (1, 9, 15, 6)),
+        ("K2_diag_gt_other", (16, 15, 5, 6)),
+    ),
+    (
+        ("K2_diag_gt_other", (0, 1, 10, 8)),
+        ("K1_diag_gt_sides", (0, 14, 8, 11)),
+        ("K1_diag_gt_sides", (1, 7, 12, 2)),
+        ("K2_diag_gt_other", (1, 3, 7, 8)),
+        ("K1_diag_gt_sides", (3, 12, 11, 2)),
+        ("K2_diag_gt_other", (3, 10, 7, 13)),
+    ),
+)
+
+
+def catalog_unit_support_catalog() -> list[dict[str, object]]:
+    catalog: list[dict[str, object]] = []
+    for support in UNIT_SUPPORT_CATALOG:
+        payload = [
+            {
+                "weight": 1,
+                "kind": kind,
+                "quad": list(quad),
+            }
+            for kind, quad in support
+        ]
+        catalog.append(
+            {
+                "catalog_id": f"unit_support_{len(catalog):03d}",
+                "support": payload,
+                "support_line": _support_line(payload),
+            }
+        )
+    return catalog
+
 
 def _support_line(support: Sequence[Mapping[str, object]]) -> str:
     parts = []
@@ -79,7 +122,8 @@ def _load_catalog(support_payload: Mapping[str, Any]) -> list[dict[str, object]]
     if support_payload["type"] != "c19_prefilter_small_unit_support_search_v1":
         raise ValueError("expected C19 small-unit support search artifact")
 
-    catalog: list[dict[str, object]] = []
+    catalog = catalog_unit_support_catalog()
+    catalog_lines = {str(item["support_line"]) for item in catalog}
     seen: set[str] = set()
     for row in _as_list(support_payload["fallback_records"], "fallback_records"):
         record = _as_mapping(row, "fallback_record")
@@ -93,21 +137,18 @@ def _load_catalog(support_payload: Mapping[str, Any]) -> list[dict[str, object]]
         if line in seen:
             continue
         seen.add(line)
-        catalog.append(
-            {
-                "catalog_id": f"unit_support_{len(catalog):03d}",
-                "support": support,
-                "support_line": line,
-            }
-        )
+        if line not in catalog_lines:
+            raise AssertionError("small-unit support artifact has an uncataloged support")
     return catalog
 
 
-def _catalog_certificate_for_state(
+def catalog_unit_certificate_for_state(
     state: BoundaryState,
     classes: Mapping[tuple[int, int], int],
-    catalog: Sequence[Mapping[str, object]],
+    catalog: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object] | None:
+    if catalog is None:
+        catalog = catalog_unit_support_catalog()
     rows = prefix_kalmanson_rows(state, classes)
     by_key = {(row.kind, tuple(row.quad)): row for row in rows}
     for item in catalog:
@@ -176,7 +217,7 @@ def analyze_catalog_unit_supports(
             raise AssertionError(f"fallback label now has a two-row certificate: {label}")
         two_row_miss_count += 1
 
-        certificate = _catalog_certificate_for_state(state, classes, catalog)
+        certificate = catalog_unit_certificate_for_state(state, classes, catalog)
         if certificate is None:
             catalog_usage["none"] += 1
         else:
@@ -198,8 +239,8 @@ def analyze_catalog_unit_supports(
     )
     if len(records) != expected_count:
         raise AssertionError(f"reconstructed {len(records)} fallback children, expected {expected_count}")
-    if sorted(certified_labels) != sorted(input_support_labels):
-        raise AssertionError("catalog replay does not match the small-unit support artifact")
+    if not set(input_support_labels).issubset(set(certified_labels)):
+        raise AssertionError("catalog replay lost a small-unit support artifact hit")
 
     support_lines = [str(item["support_line"]) for item in catalog]
     return {
@@ -211,13 +252,13 @@ def analyze_catalog_unit_supports(
         "notes": [
             "No general proof of Erdos Problem #97 is claimed.",
             "No counterexample is claimed.",
-            "This replays cataloged three-row unit Kalmanson supports over recorded C19 fallback children only.",
+            "This replays cataloged unit Kalmanson supports over recorded C19 fallback children only.",
             "Each catalog hit is rechecked by exact vector summation after selected-distance quotienting.",
             "This does not certify branches beyond the recorded sampled windows and is not an all-order C19 obstruction.",
         ],
         "parameters": {
-            "catalog_source": "nonempty supports from c19_prefilter_small_unit_support_search_v1",
-            "fifth_pair_prefilter_chain": "two_row_then_cataloged_three_row_unit_support",
+            "catalog_source": "small-unit support artifact plus logged six-row unit support",
+            "fifth_pair_prefilter_chain": "two_row_then_cataloged_unit_support",
         },
         "pattern": {
             "name": PATTERN_NAME,
@@ -254,22 +295,22 @@ def assert_expected(data: Mapping[str, Any]) -> None:
     expected_aggregate = {
         "fallback_child_count": 8,
         "two_row_prefilter_miss_count": 8,
-        "catalog_support_count": 2,
+        "catalog_support_count": 3,
         "input_support_record_count": 7,
-        "catalog_certified_count": 7,
-        "catalog_miss_count": 1,
+        "catalog_certified_count": 8,
+        "catalog_miss_count": 0,
         "fallback_label_digest": "2dc4965b208144017b7aba73dba920c8c8f8f1eea93a2f84650eb4f5f484f0c8",
-        "catalog_certified_label_digest": "03412b1e4da3c1de13345b052773aef2ae944f06028529f6c0f0d0a39e2a8ea6",
-        "catalog_support_digest": "b4110d03ca090444ce9585c24d89ca8a71be87d1e7df55507cbc47ef41a5aee5",
+        "catalog_certified_label_digest": "2dc4965b208144017b7aba73dba920c8c8f8f1eea93a2f84650eb4f5f484f0c8",
+        "catalog_support_digest": "895860a0c4d7ebc155b32be42c39061531772d2e245821eb68da14e332d8e7a9",
     }
     for key, expected in expected_aggregate.items():
         if aggregate[key] != expected:
             raise AssertionError(f"{key} changed: {aggregate[key]} != {expected}")
     histograms = _as_mapping(data["histograms"], "histograms")
     if histograms["catalog_usage"] != {
-        "none": 1,
         "unit_support_000": 6,
         "unit_support_001": 1,
+        "unit_support_002": 1,
     }:
         raise AssertionError("catalog usage histogram changed")
 

--- a/scripts/certify_c19_kalmanson_prefix_window_prefilter.py
+++ b/scripts/certify_c19_kalmanson_prefix_window_prefilter.py
@@ -19,8 +19,9 @@ import json
 from collections import Counter
 from itertools import islice
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
+from analyze_c19_prefilter_catalog_unit_supports import catalog_unit_certificate_for_state
 from analyze_c19_fifth_pair_two_row_prefilter import two_row_certificate_for_state
 from check_kalmanson_certificate import build_distance_classes
 from certify_c19_kalmanson_prefix_window import child_record, state_record
@@ -61,10 +62,12 @@ def prefilter_summary(
     *,
     row_count: int,
     inequalities: list[dict[str, object]],
+    method: str = "two_row_kalmanson_prefilter",
+    catalog_id: str | None = None,
 ) -> dict[str, object]:
-    return {
+    summary: dict[str, object] = {
         "status": "EXACT_OBSTRUCTION_FOR_PREFIX_BRANCH_COMPLETIONS",
-        "method": "two_row_kalmanson_prefilter",
+        "method": method,
         "positive_inequalities": len(inequalities),
         "forced_inequalities_available": row_count,
         "weight_sum": len(inequalities),
@@ -75,6 +78,9 @@ def prefilter_summary(
             "boundary-prefix child; not an all-order C19 obstruction."
         ),
     }
+    if catalog_id is not None:
+        summary["catalog_id"] = catalog_id
+    return summary
 
 
 def scan_window_with_prefilter(
@@ -84,6 +90,7 @@ def scan_window_with_prefilter(
     include_certificates: bool,
     closed_example_count: int,
     tol: float,
+    catalog_unit_supports: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     if start_index < 0:
         raise ValueError("start_index must be nonnegative")
@@ -120,6 +127,8 @@ def scan_window_with_prefilter(
     fifth_child_count = 0
     fifth_closed = 0
     fifth_prefilter_closed = 0
+    fifth_two_row_prefilter_closed = 0
+    fifth_catalog_prefilter_closed = 0
     fifth_fallback_attempts = 0
     fifth_fallback_closed = 0
     fifth_parent_closed = 0
@@ -224,15 +233,38 @@ def scan_window_with_prefilter(
                     row_count, inequalities = two_row_certificate_for_state(child, classes)
                     fifth_row_count_histogram[row_count] += 1
                     fifth_child_count += 1
+                    prefilter_method = "two_row_kalmanson_prefilter"
+                    catalog_id = None
+                    if not inequalities and catalog_unit_supports is not None:
+                        catalog_certificate = catalog_unit_certificate_for_state(
+                            child,
+                            classes,
+                            catalog_unit_supports,
+                        )
+                        if catalog_certificate is not None:
+                            inequalities = [
+                                dict(_as_mapping(item, "catalog prefilter row"))
+                                for item in catalog_certificate["inequalities"]
+                            ]
+                            prefilter_method = "cataloged_unit_support_prefilter"
+                            catalog_id = str(catalog_certificate["catalog_id"])
                     if inequalities:
                         fifth_closed += 1
                         fifth_prefilter_closed += 1
+                        if prefilter_method == "two_row_kalmanson_prefilter":
+                            fifth_two_row_prefilter_closed += 1
+                        elif prefilter_method == "cataloged_unit_support_prefilter":
+                            fifth_catalog_prefilter_closed += 1
+                        else:
+                            raise AssertionError(f"unknown prefilter method: {prefilter_method}")
                         fifth_prefilter_row_histogram[len(inequalities)] += 1
                         if len(fifth_closed_examples) < closed_example_count:
                             example = dict(record)
                             example["certificate_summary"] = prefilter_summary(
                                 row_count=row_count,
                                 inequalities=inequalities,
+                                method=prefilter_method,
+                                catalog_id=catalog_id,
                             )
                             example["prefilter_inequalities"] = inequalities
                             fifth_closed_examples.append(example)
@@ -273,6 +305,65 @@ def scan_window_with_prefilter(
 
     prefix_count = len(prefix_labels)
     prefix_closed_after_chain = direct_closed + fourth_parent_closed + prefix_closed_by_fifth
+    fifth_pair_prefilter_name = "two_row_kalmanson_prefilter"
+    if catalog_unit_supports is not None:
+        fifth_pair_prefilter_name = "two_row_then_cataloged_unit_support"
+    branch_accounting: dict[str, object] = {
+        "prefix_branch_count": prefix_count,
+        "direct_prefix_certified_count": direct_closed,
+        "direct_prefix_unclosed_count": len(direct_unclosed_prefixes),
+        "fourth_pair_parent_count": len(direct_unclosed_prefixes),
+        "fourth_pair_child_branch_count": fourth_child_count,
+        "fourth_pair_child_certified_count": fourth_closed,
+        "unclosed_fourth_pair_child_branch_count": len(unclosed_fourth_children),
+        "prefix_parents_closed_by_fourth_refinement": fourth_parent_closed,
+        "fifth_pair_parent_count": len(unclosed_fourth_children),
+        "fifth_pair_child_branch_count": fifth_child_count,
+        "fifth_pair_child_certified_count": fifth_closed,
+        "fifth_pair_prefilter_certified_count": fifth_prefilter_closed,
+        "fifth_pair_farkas_fallback_attempt_count": fifth_fallback_attempts,
+        "fifth_pair_farkas_fallback_certified_count": fifth_fallback_closed,
+        "unclosed_fifth_pair_child_branch_count": len(unclosed_fifth_children),
+        "fourth_pair_parents_closed_by_fifth_refinement": fifth_parent_closed,
+        "prefix_parents_closed_by_fifth_refinement": prefix_closed_by_fifth,
+        "prefix_branches_closed_after_chain": prefix_closed_after_chain,
+        "prefix_branches_remaining_after_chain": prefix_count - prefix_closed_after_chain,
+        "exhaustive_window_scan": True,
+        "exhaustive_all_orders": False,
+    }
+    parameters: dict[str, object] = {
+        "start_index": start_index,
+        "window_size": window_size,
+        "boundary_pairs": 3,
+        "include_certificates_in_examples": include_certificates,
+        "closed_example_count": closed_example_count,
+        "lp_support_tolerance": tol,
+        "anchor_label": 0,
+        "fifth_pair_prefilter": fifth_pair_prefilter_name,
+    }
+    if catalog_unit_supports is not None:
+        parameters["catalog_unit_support_count"] = len(catalog_unit_supports)
+        branch_accounting["fifth_pair_two_row_prefilter_certified_count"] = (
+            fifth_two_row_prefilter_closed
+        )
+        branch_accounting["fifth_pair_catalog_prefilter_certified_count"] = (
+            fifth_catalog_prefilter_closed
+        )
+    notes = [
+        "No general proof of Erdos Problem #97 is claimed.",
+        "No counterexample is claimed.",
+        "This certifies only one deterministic C19 three-boundary-prefix window.",
+        "Direct and fourth-pair closures use ordinary prefix-forced Kalmanson/Farkas certificates.",
+        "Fifth-pair closures first try exact two-row Kalmanson cancellations; only misses use ordinary Farkas fallback.",
+        "Unclosed children, if any, are not counterexamples and are not evidence of realizability.",
+        "This is not an exhaustive all-order C19 search.",
+    ]
+    if catalog_unit_supports is not None:
+        notes[4] = (
+            "Fifth-pair closures first try exact two-row Kalmanson cancellations, "
+            "then cataloged unit supports; only misses use ordinary "
+            "Farkas fallback."
+        )
     return {
         "type": "c19_kalmanson_prefix_window_prefilter_chain_v1",
         "trust": "EXACT_OBSTRUCTION",
@@ -281,52 +372,13 @@ def scan_window_with_prefilter(
             "n": N,
             "circulant_offsets": OFFSETS,
         },
-        "notes": [
-            "No general proof of Erdos Problem #97 is claimed.",
-            "No counterexample is claimed.",
-            "This certifies only one deterministic C19 three-boundary-prefix window.",
-            "Direct and fourth-pair closures use ordinary prefix-forced Kalmanson/Farkas certificates.",
-            "Fifth-pair closures first try exact two-row Kalmanson cancellations; only misses use ordinary Farkas fallback.",
-            "Unclosed children, if any, are not counterexamples and are not evidence of realizability.",
-            "This is not an exhaustive all-order C19 search.",
-        ],
-        "parameters": {
-            "start_index": start_index,
-            "window_size": window_size,
-            "boundary_pairs": 3,
-            "include_certificates_in_examples": include_certificates,
-            "closed_example_count": closed_example_count,
-            "lp_support_tolerance": tol,
-            "anchor_label": 0,
-            "fifth_pair_prefilter": "two_row_kalmanson_prefilter",
-        },
+        "notes": notes,
+        "parameters": parameters,
         "global_prefix_space": {
             "raw_three_boundary_state_count": raw_count,
             "canonical_three_boundary_state_count": canonical_count,
         },
-        "branch_accounting": {
-            "prefix_branch_count": prefix_count,
-            "direct_prefix_certified_count": direct_closed,
-            "direct_prefix_unclosed_count": len(direct_unclosed_prefixes),
-            "fourth_pair_parent_count": len(direct_unclosed_prefixes),
-            "fourth_pair_child_branch_count": fourth_child_count,
-            "fourth_pair_child_certified_count": fourth_closed,
-            "unclosed_fourth_pair_child_branch_count": len(unclosed_fourth_children),
-            "prefix_parents_closed_by_fourth_refinement": fourth_parent_closed,
-            "fifth_pair_parent_count": len(unclosed_fourth_children),
-            "fifth_pair_child_branch_count": fifth_child_count,
-            "fifth_pair_child_certified_count": fifth_closed,
-            "fifth_pair_prefilter_certified_count": fifth_prefilter_closed,
-            "fifth_pair_farkas_fallback_attempt_count": fifth_fallback_attempts,
-            "fifth_pair_farkas_fallback_certified_count": fifth_fallback_closed,
-            "unclosed_fifth_pair_child_branch_count": len(unclosed_fifth_children),
-            "fourth_pair_parents_closed_by_fifth_refinement": fifth_parent_closed,
-            "prefix_parents_closed_by_fifth_refinement": prefix_closed_by_fifth,
-            "prefix_branches_closed_after_chain": prefix_closed_after_chain,
-            "prefix_branches_remaining_after_chain": prefix_count - prefix_closed_after_chain,
-            "exhaustive_window_scan": True,
-            "exhaustive_all_orders": False,
-        },
+        "branch_accounting": branch_accounting,
         "forced_row_count_histograms": {
             "direct_prefix": _histogram(direct_row_count_histogram),
             "fourth_pair": _histogram(fourth_row_count_histogram),

--- a/scripts/sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py
+++ b/scripts/sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Run the C19 prefix-window sweep with cataloged fallback prefilter supports.
+
+This is the same deterministic 288-479 C19 sampled-prefix range as
+sweep_c19_kalmanson_prefix_windows_prefilter.py, but fifth-pair children use a
+two-stage exact prefilter:
+
+1. the existing two-row Kalmanson cancellation lookup;
+2. the cataloged unit supports from
+   reports/c19_prefilter_catalog_unit_supports.json.
+
+Only misses for both exact prefilters call the ordinary Kalmanson/Farkas
+routine.  This is a bounded sampled-window sweep, not an all-order C19 search.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from analyze_c19_prefilter_catalog_unit_supports import catalog_unit_support_catalog
+from sweep_c19_kalmanson_prefix_windows_prefilter import (
+    DEFAULT_FALLBACK_EXAMPLE_COUNT,
+    DEFAULT_START_INDEX,
+    DEFAULT_WINDOW_COUNT,
+    DEFAULT_WINDOW_SIZE,
+    _as_mapping,
+    print_table,
+    run_sweep,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json"
+)
+
+
+def assert_expected(data: Mapping[str, Any]) -> None:
+    parameters = _as_mapping(data["parameters"], "parameters")
+    key = (
+        int(parameters["start_index"]),
+        int(parameters["window_size"]),
+        int(parameters["window_count"]),
+        int(parameters["fallback_example_count"]),
+        int(parameters["catalog_unit_support_count"]),
+    )
+    expected_key = (
+        DEFAULT_START_INDEX,
+        DEFAULT_WINDOW_SIZE,
+        DEFAULT_WINDOW_COUNT,
+        DEFAULT_FALLBACK_EXAMPLE_COUNT,
+        3,
+    )
+    if key != expected_key:
+        raise AssertionError(f"no expected counts registered for catalog sweep {key}")
+    if data["type"] != "c19_kalmanson_prefix_window_catalog_prefilter_sweep_v1":
+        raise AssertionError("catalog sweep artifact type changed")
+
+    aggregate = _as_mapping(data["aggregate_accounting"], "aggregate_accounting")
+    expected_aggregate = {
+        "prefix_branch_count": 192,
+        "prefix_branches_closed_after_chain": 192,
+        "prefix_branches_remaining_after_chain": 0,
+        "direct_prefix_certified_count": 136,
+        "direct_prefix_unclosed_count": 56,
+        "fourth_pair_child_branch_count": 7392,
+        "fourth_pair_child_certified_count": 7277,
+        "unclosed_fourth_pair_child_branch_count": 115,
+        "prefix_parents_closed_by_fourth_refinement": 17,
+        "fifth_pair_parent_count": 115,
+        "fifth_pair_child_branch_count": 10350,
+        "fifth_pair_child_certified_count": 10350,
+        "fifth_pair_prefilter_certified_count": 10350,
+        "fifth_pair_two_row_prefilter_certified_count": 10342,
+        "fifth_pair_catalog_prefilter_certified_count": 8,
+        "fifth_pair_farkas_fallback_attempt_count": 0,
+        "fifth_pair_farkas_fallback_certified_count": 0,
+        "unclosed_fifth_pair_child_branch_count": 0,
+        "fourth_pair_parents_closed_by_fifth_refinement": 115,
+        "prefix_parents_closed_by_fifth_refinement": 39,
+        "exhaustive_window_sweep": True,
+        "exhaustive_all_orders": False,
+    }
+    for key, expected in expected_aggregate.items():
+        if aggregate[key] != expected:
+            raise AssertionError(f"{key} changed: {aggregate[key]} != {expected}")
+
+    expected_digest = "a2dcbd0eb6d2513dd906346ab9a4e6a273bb7033d5bcd344cf4f52cd622e8648"
+    if data["prefix_label_digest"] != expected_digest:
+        raise AssertionError("prefix label digest changed")
+
+    windows = data["windows"]
+    if not isinstance(windows, list) or len(windows) != 6:
+        raise AssertionError("window list changed")
+    expected_windows = [
+        (288, 319, 0, 0, 0, []),
+        (320, 351, 540, 0, 0, []),
+        (352, 383, 720, 0, 0, []),
+        (384, 415, 1350, 0, 0, []),
+        (416, 447, 4230, 7, 0, []),
+        (448, 479, 3510, 1, 0, []),
+    ]
+    for window, expected in zip(windows, expected_windows):
+        start, end, prefilter_count, catalog_count, fallback_count, fallback_labels = expected
+        if window["start_index"] != start or window["end_index"] != end:
+            raise AssertionError("window bounds changed")
+        accounting = _as_mapping(window["branch_accounting"], "window accounting")
+        checks = {
+            "fifth_pair_prefilter_certified_count": prefilter_count,
+            "fifth_pair_catalog_prefilter_certified_count": catalog_count,
+            "fifth_pair_farkas_fallback_certified_count": fallback_count,
+            "unclosed_fifth_pair_child_branch_count": 0,
+            "prefix_branches_closed_after_chain": 32,
+            "prefix_branches_remaining_after_chain": 0,
+        }
+        for name, value in checks.items():
+            if accounting.get(name) != value:
+                raise AssertionError(f"window {start} {name} changed")
+        if window["fifth_pair_farkas_fallback_labels"] != fallback_labels:
+            raise AssertionError(f"window {start} fallback labels changed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start-index", type=int, default=DEFAULT_START_INDEX)
+    parser.add_argument("--window-size", type=int, default=DEFAULT_WINDOW_SIZE)
+    parser.add_argument("--window-count", type=int, default=DEFAULT_WINDOW_COUNT)
+    parser.add_argument(
+        "--fallback-example-count",
+        type=int,
+        default=DEFAULT_FALLBACK_EXAMPLE_COUNT,
+        help="closed fallback examples retained only for compact fallback labels",
+    )
+    parser.add_argument("--tol", type=float, default=1e-9, help="LP support threshold")
+    parser.add_argument("--out", type=Path, help="write JSON payload to this path")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    data = run_sweep(
+        start_index=args.start_index,
+        window_size=args.window_size,
+        window_count=args.window_count,
+        fallback_example_count=args.fallback_example_count,
+        tol=args.tol,
+        catalog_unit_supports=catalog_unit_support_catalog(),
+    )
+    if args.assert_expected:
+        assert_expected(data)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        print_table(data)
+        if args.assert_expected:
+            print("OK: C19 catalog prefilter sweep matched expected chain")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sweep_c19_kalmanson_prefix_windows_prefilter.py
+++ b/scripts/sweep_c19_kalmanson_prefix_windows_prefilter.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from certify_c19_kalmanson_prefix_window_prefilter import scan_window_with_prefilter
 from pilot_c19_kalmanson_prefix_branches import N, OFFSETS, PATTERN_NAME, label_digest
@@ -89,6 +89,7 @@ def run_sweep(
     window_count: int,
     fallback_example_count: int,
     tol: float,
+    catalog_unit_supports: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     if start_index < 0:
         raise ValueError("start_index must be nonnegative")
@@ -108,6 +109,7 @@ def run_sweep(
             include_certificates=False,
             closed_example_count=fallback_example_count,
             tol=tol,
+            catalog_unit_supports=catalog_unit_supports,
         )
         windows.append(compact_window_record(window_data))
 
@@ -124,6 +126,8 @@ def run_sweep(
     total_fifth_children = 0
     total_fifth_closed = 0
     total_fifth_prefilter_closed = 0
+    total_fifth_two_row_prefilter_closed = 0
+    total_fifth_catalog_prefilter_closed = 0
     total_fifth_fallback_attempts = 0
     total_fifth_fallback_closed = 0
     total_fifth_survivors = 0
@@ -149,6 +153,12 @@ def run_sweep(
         total_fifth_prefilter_closed += int(
             accounting["fifth_pair_prefilter_certified_count"]
         )
+        total_fifth_two_row_prefilter_closed += int(
+            accounting.get("fifth_pair_two_row_prefilter_certified_count", 0)
+        )
+        total_fifth_catalog_prefilter_closed += int(
+            accounting.get("fifth_pair_catalog_prefilter_certified_count", 0)
+        )
         total_fifth_fallback_attempts += int(
             accounting["fifth_pair_farkas_fallback_attempt_count"]
         )
@@ -167,56 +177,78 @@ def run_sweep(
             for idx in range(int(window["start_index"]), int(window["end_index"]) + 1)
         )
 
+    artifact_type = "c19_kalmanson_prefix_window_prefilter_sweep_v1"
+    fifth_pair_prefilter = "two_row_kalmanson_prefilter"
+    if catalog_unit_supports is not None:
+        artifact_type = "c19_kalmanson_prefix_window_catalog_prefilter_sweep_v1"
+        fifth_pair_prefilter = "two_row_then_cataloged_unit_support"
+    aggregate_accounting: dict[str, object] = {
+        "prefix_branch_count": total_prefixes,
+        "prefix_branches_closed_after_chain": total_closed,
+        "prefix_branches_remaining_after_chain": total_prefixes - total_closed,
+        "direct_prefix_certified_count": total_direct_closed,
+        "direct_prefix_unclosed_count": total_direct_survivors,
+        "fourth_pair_child_branch_count": total_fourth_children,
+        "fourth_pair_child_certified_count": total_fourth_closed,
+        "unclosed_fourth_pair_child_branch_count": total_fourth_survivors,
+        "prefix_parents_closed_by_fourth_refinement": total_prefixes_closed_by_fourth,
+        "fifth_pair_parent_count": total_fifth_parents,
+        "fifth_pair_child_branch_count": total_fifth_children,
+        "fifth_pair_child_certified_count": total_fifth_closed,
+        "fifth_pair_prefilter_certified_count": total_fifth_prefilter_closed,
+        "fifth_pair_farkas_fallback_attempt_count": total_fifth_fallback_attempts,
+        "fifth_pair_farkas_fallback_certified_count": total_fifth_fallback_closed,
+        "unclosed_fifth_pair_child_branch_count": total_fifth_survivors,
+        "fourth_pair_parents_closed_by_fifth_refinement": (
+            total_fourth_parents_closed_by_fifth
+        ),
+        "prefix_parents_closed_by_fifth_refinement": total_prefixes_closed_by_fifth,
+        "exhaustive_window_sweep": True,
+        "exhaustive_all_orders": False,
+    }
+    parameters: dict[str, object] = {
+        "start_index": start_index,
+        "window_size": window_size,
+        "window_count": window_count,
+        "lp_support_tolerance": tol,
+        "anchor_label": 0,
+        "fifth_pair_prefilter": fifth_pair_prefilter,
+        "fallback_example_count": fallback_example_count,
+    }
+    if catalog_unit_supports is not None:
+        parameters["catalog_unit_support_count"] = len(catalog_unit_supports)
+        aggregate_accounting["fifth_pair_two_row_prefilter_certified_count"] = (
+            total_fifth_two_row_prefilter_closed
+        )
+        aggregate_accounting["fifth_pair_catalog_prefilter_certified_count"] = (
+            total_fifth_catalog_prefilter_closed
+        )
+    notes = [
+        "No general proof of Erdos Problem #97 is claimed.",
+        "No counterexample is claimed.",
+        "This sweep certifies only deterministic C19 three-boundary-prefix windows.",
+        "Direct and fourth-pair closures use ordinary prefix-forced Kalmanson/Farkas certificates.",
+        "Fifth-pair closures first try exact two-row Kalmanson cancellations; only misses use ordinary Farkas fallback.",
+        "Unclosed children, if any, are not counterexamples and are not evidence of realizability.",
+        "This is not an exhaustive all-order C19 search.",
+    ]
+    if catalog_unit_supports is not None:
+        notes[4] = (
+            "Fifth-pair closures first try exact two-row Kalmanson cancellations, "
+            "then cataloged unit supports; only misses use ordinary "
+            "Farkas fallback."
+        )
     return {
-        "type": "c19_kalmanson_prefix_window_prefilter_sweep_v1",
+        "type": artifact_type,
         "trust": "EXACT_OBSTRUCTION",
         "pattern": {
             "name": PATTERN_NAME,
             "n": N,
             "circulant_offsets": OFFSETS,
         },
-        "notes": [
-            "No general proof of Erdos Problem #97 is claimed.",
-            "No counterexample is claimed.",
-            "This sweep certifies only deterministic C19 three-boundary-prefix windows.",
-            "Direct and fourth-pair closures use ordinary prefix-forced Kalmanson/Farkas certificates.",
-            "Fifth-pair closures first try exact two-row Kalmanson cancellations; only misses use ordinary Farkas fallback.",
-            "Unclosed children, if any, are not counterexamples and are not evidence of realizability.",
-            "This is not an exhaustive all-order C19 search.",
-        ],
-        "parameters": {
-            "start_index": start_index,
-            "window_size": window_size,
-            "window_count": window_count,
-            "lp_support_tolerance": tol,
-            "anchor_label": 0,
-            "fifth_pair_prefilter": "two_row_kalmanson_prefilter",
-            "fallback_example_count": fallback_example_count,
-        },
-        "aggregate_accounting": {
-            "prefix_branch_count": total_prefixes,
-            "prefix_branches_closed_after_chain": total_closed,
-            "prefix_branches_remaining_after_chain": total_prefixes - total_closed,
-            "direct_prefix_certified_count": total_direct_closed,
-            "direct_prefix_unclosed_count": total_direct_survivors,
-            "fourth_pair_child_branch_count": total_fourth_children,
-            "fourth_pair_child_certified_count": total_fourth_closed,
-            "unclosed_fourth_pair_child_branch_count": total_fourth_survivors,
-            "prefix_parents_closed_by_fourth_refinement": total_prefixes_closed_by_fourth,
-            "fifth_pair_parent_count": total_fifth_parents,
-            "fifth_pair_child_branch_count": total_fifth_children,
-            "fifth_pair_child_certified_count": total_fifth_closed,
-            "fifth_pair_prefilter_certified_count": total_fifth_prefilter_closed,
-            "fifth_pair_farkas_fallback_attempt_count": total_fifth_fallback_attempts,
-            "fifth_pair_farkas_fallback_certified_count": total_fifth_fallback_closed,
-            "unclosed_fifth_pair_child_branch_count": total_fifth_survivors,
-            "fourth_pair_parents_closed_by_fifth_refinement": (
-                total_fourth_parents_closed_by_fifth
-            ),
-            "prefix_parents_closed_by_fifth_refinement": total_prefixes_closed_by_fifth,
-            "exhaustive_window_sweep": True,
-            "exhaustive_all_orders": False,
-        },
+        "notes": notes,
+        "parameters": parameters,
+        "aggregate_accounting": aggregate_accounting,
         "prefix_label_digest": label_digest(prefix_labels),
         "windows": windows,
     }

--- a/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
@@ -1,0 +1,102 @@
+"""Regression tests for the compact C19 catalog-prefilter sweep artifact."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py"
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json"
+)
+
+
+def run_script(*args: str) -> dict[str, object]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_c19_catalog_prefilter_window_sweep_artifact_summary() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert payload["type"] == "c19_kalmanson_prefix_window_catalog_prefilter_sweep_v1"
+    assert payload["trust"] == "EXACT_OBSTRUCTION"
+    assert payload["parameters"]["fifth_pair_prefilter"] == (
+        "two_row_then_cataloged_unit_support"
+    )
+    aggregate = payload["aggregate_accounting"]
+    assert aggregate["prefix_branch_count"] == 192
+    assert aggregate["prefix_branches_closed_after_chain"] == 192
+    assert aggregate["prefix_branches_remaining_after_chain"] == 0
+    assert aggregate["fifth_pair_child_branch_count"] == 10350
+    assert aggregate["fifth_pair_child_certified_count"] == 10350
+    assert aggregate["fifth_pair_prefilter_certified_count"] == 10350
+    assert aggregate["fifth_pair_two_row_prefilter_certified_count"] == 10342
+    assert aggregate["fifth_pair_catalog_prefilter_certified_count"] == 8
+    assert aggregate["fifth_pair_farkas_fallback_attempt_count"] == 0
+    assert aggregate["fifth_pair_farkas_fallback_certified_count"] == 0
+    assert aggregate["unclosed_fifth_pair_child_branch_count"] == 0
+    assert aggregate["exhaustive_all_orders"] is False
+
+    windows = payload["windows"]
+    assert [
+        row["branch_accounting"]["fifth_pair_catalog_prefilter_certified_count"]
+        for row in windows
+    ] == [0, 0, 0, 0, 7, 1]
+    assert [
+        row["branch_accounting"]["fifth_pair_farkas_fallback_certified_count"]
+        for row in windows
+    ] == [0, 0, 0, 0, 0, 0]
+    assert windows[4]["fifth_pair_farkas_fallback_labels"] == []
+    assert windows[5]["fifth_pair_farkas_fallback_labels"] == []
+    assert windows[4]["closed_support_size_histograms"]["fifth_pair_prefilter"] == {
+        "2": 4223,
+        "3": 6,
+        "6": 1,
+    }
+    assert windows[5]["closed_support_size_histograms"]["fifth_pair_prefilter"] == {
+        "2": 3509,
+        "3": 1,
+    }
+
+
+def test_c19_catalog_prefilter_window_sweep_small_replay() -> None:
+    payload = run_script("--window-count", "1", "--json")
+
+    assert payload["type"] == "c19_kalmanson_prefix_window_catalog_prefilter_sweep_v1"
+    aggregate = payload["aggregate_accounting"]
+    assert aggregate["prefix_branch_count"] == 32
+    assert aggregate["prefix_branches_closed_after_chain"] == 32
+    assert aggregate["prefix_branches_remaining_after_chain"] == 0
+    assert aggregate["direct_prefix_certified_count"] == 32
+    assert aggregate["fifth_pair_child_branch_count"] == 0
+    assert aggregate["fifth_pair_catalog_prefilter_certified_count"] == 0
+
+    windows = payload["windows"]
+    assert len(windows) == 1
+    assert windows[0]["start_index"] == 288
+    assert windows[0]["end_index"] == 319
+    assert windows[0]["fifth_pair_farkas_fallback_labels"] == []
+
+
+@pytest.mark.artifact
+@pytest.mark.slow
+def test_c19_catalog_prefilter_window_sweep_full_replay_matches_artifact() -> None:
+    payload = run_script("--assert-expected", "--json")
+    artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert artifact == payload

--- a/tests/test_c19_prefilter_catalog_unit_supports.py
+++ b/tests/test_c19_prefilter_catalog_unit_supports.py
@@ -29,14 +29,14 @@ def test_c19_prefilter_catalog_unit_support_artifact_summary() -> None:
     assert payload["type"] == "c19_prefilter_catalog_unit_supports_v1"
     assert payload["trust"] == "EXACT_OBSTRUCTION"
     assert payload["aggregate"] == {
-        "catalog_certified_count": 7,
+        "catalog_certified_count": 8,
         "catalog_certified_label_digest": (
-            "03412b1e4da3c1de13345b052773aef2ae944f06028529f6c0f0d0a39e2a8ea6"
+            "2dc4965b208144017b7aba73dba920c8c8f8f1eea93a2f84650eb4f5f484f0c8"
         ),
-        "catalog_miss_count": 1,
-        "catalog_support_count": 2,
+        "catalog_miss_count": 0,
+        "catalog_support_count": 3,
         "catalog_support_digest": (
-            "b4110d03ca090444ce9585c24d89ca8a71be87d1e7df55507cbc47ef41a5aee5"
+            "895860a0c4d7ebc155b32be42c39061531772d2e245821eb68da14e332d8e7a9"
         ),
         "fallback_child_count": 8,
         "fallback_label_digest": (
@@ -46,20 +46,21 @@ def test_c19_prefilter_catalog_unit_support_artifact_summary() -> None:
         "two_row_prefilter_miss_count": 8,
     }
     assert payload["histograms"]["catalog_usage"] == {
-        "none": 1,
         "unit_support_000": 6,
         "unit_support_001": 1,
+        "unit_support_002": 1,
     }
     assert [row["catalog_id"] for row in payload["catalog"]] == [
         "unit_support_000",
         "unit_support_001",
+        "unit_support_002",
     ]
     misses = [
         row["label"]
         for row in payload["fallback_records"]
         if not row["catalog_unit_support_found"]
     ]
-    assert misses == ["c19_window_fifth_child_0430_0081_0011"]
+    assert misses == []
 
 
 def test_c19_prefilter_catalog_unit_support_replay_matches_artifact() -> None:


### PR DESCRIPTION
## Summary

Stacked on #134. Adds the catalog-prefilter extension for the recorded C19 prefix-window sweep:

- adds `scripts/sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py`
- records `data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json`
- updates the catalog support analyzer and prefilter scanner to account for two-row vs catalog closures
- adds focused docs and tests for the catalog-prefilter sweep

## Claim Scope

- This is an exact finite artifact update over the recorded C19 windows `288-479`.
- It does not claim a general proof of Erdos Problem #97.
- It does not claim a counterexample.
- Catalog closures are exact unit-support obstructions for recorded fifth-pair children only.

## Validation

Local validation in `/private/tmp/erdos97-pr-c19-catalog`:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `PYTHONPATH=scripts /Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/sweep_c19_kalmanson_prefix_windows_catalog_prefilter.py --assert-expected --out data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q tests/test_c19_prefilter_catalog_unit_supports.py tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py` -> `4 passed, 1 deselected`

## Remaining Limitations

- This PR is stacked on #134 and should be reviewed after the base C19 prefix-window artifact PR.
- The long running research log remains split into a separate follow-up PR.