### PR TITLE
Add n9 row-Ptolemy gap self-edge cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_admissible_census.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
 	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,9 @@ check:
 make audit-artifacts
 ```
 
-Equivalent raw commands:
+If `make` is unavailable, treat `Makefile` and
+`scripts/run_artifact_audit.py` as the source of truth for the current raw
+command set. The current raw commands are:
 
 ```bash
 python scripts/check_status_consistency.py --max-official-status-age-days 90
@@ -333,7 +335,20 @@ python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalma
 python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
+python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
+python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_order_admissible_census.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
+python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+python scripts/check_n9_base_apex_escape_budget.py --check --json
+python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
+python scripts/check_n9_d3_escape_slice.py --check --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
 ```
 

--- a/data/certificates/n9_row_ptolemy_gap_self_edge_cores.json
+++ b/data/certificates/n9_row_ptolemy_gap_self_edge_cores.json
@@ -1,0 +1,497 @@
+{
+  "assignment_indices": [
+    22,
+    173
+  ],
+  "claim_scope": "Compact self-edge core certificates for the two zero-certificate n=9 row-Ptolemy admissible assignment-order records; not a proof of n=9, not a counterexample, not an all-order obstruction, not an orderless abstract-incidence obstruction, not a geometric realizability count, and not a global status update.",
+  "core_row_index_sets": [
+    [
+      0,
+      2,
+      4
+    ],
+    [
+      0,
+      2,
+      4
+    ]
+  ],
+  "core_self_edge_conflict_count_histogram": {
+    "1": 2
+  },
+  "core_size_counts": {
+    "3": 2
+  },
+  "core_strict_edge_count_histogram": {
+    "27": 2
+  },
+  "equality_path_length_histogram": {
+    "3": 2
+  },
+  "interpretation": [
+    "Each core is a compact replay certificate for one recorded self-edge gap record, not a standalone theorem.",
+    "The selected-distance equality path explains why the strict outer chord and inner chord are identified in the quotient.",
+    "The listed core is the lexicographically first minimal self-edge row subset for that recorded assignment-order pair.",
+    "No proof of the n=9 case is claimed.",
+    "No counterexample or global status update is claimed."
+  ],
+  "minimal_self_edge_core_count_histogram": {
+    "9": 2
+  },
+  "n": 9,
+  "normalized_order": [
+    0,
+    2,
+    4,
+    6,
+    8,
+    1,
+    3,
+    5,
+    7
+  ],
+  "provenance": {
+    "command": "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --assert-expected --write",
+    "generator": "scripts/check_n9_row_ptolemy_gap_self_edge_cores.py"
+  },
+  "record_count": 2,
+  "records": [
+    {
+      "assignment_index": 22,
+      "core_replay": {
+        "cycle_edges": [],
+        "n": 9,
+        "obstructed": true,
+        "order": [
+          0,
+          2,
+          4,
+          6,
+          8,
+          1,
+          3,
+          5,
+          7
+        ],
+        "selected_row_count": 3,
+        "self_edge_conflicts": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              7
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              4
+            ],
+            "row": 2,
+            "witness_order": [
+              4,
+              3,
+              7,
+              0
+            ]
+          }
+        ],
+        "status": "self_edge",
+        "strict_edge_count": 27,
+        "type": "vertex_circle_quotient_replay_result"
+      },
+      "core_row_indices": [
+        0,
+        2,
+        4
+      ],
+      "core_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "row": 4,
+          "witnesses": [
+            0,
+            2,
+            5,
+            6
+          ]
+        }
+      ],
+      "family_id": "F13",
+      "minimality": {
+        "lexicographic_min_core_row_indices": [
+          0,
+          2,
+          4
+        ],
+        "minimal_self_edge_core_count": 9,
+        "minimal_self_edge_core_size": 3,
+        "proper_self_edge_subcore_count": 0,
+        "proper_subcore_status_counts": {
+          "ok": 6
+        }
+      },
+      "order": [
+        0,
+        2,
+        4,
+        6,
+        8,
+        1,
+        3,
+        5,
+        7
+      ],
+      "selected_distance_equality_path": [
+        {
+          "from_pair": [
+            0,
+            4
+          ],
+          "reason": "selected distances from this center to its witnesses are equal",
+          "row": 4,
+          "row_witnesses": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "to_pair": [
+            2,
+            4
+          ]
+        },
+        {
+          "from_pair": [
+            2,
+            4
+          ],
+          "reason": "selected distances from this center to its witnesses are equal",
+          "row": 2,
+          "row_witnesses": [
+            0,
+            3,
+            4,
+            7
+          ],
+          "to_pair": [
+            0,
+            2
+          ]
+        },
+        {
+          "from_pair": [
+            0,
+            2
+          ],
+          "reason": "selected distances from this center to its witnesses are equal",
+          "row": 0,
+          "row_witnesses": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "to_pair": [
+            0,
+            7
+          ]
+        }
+      ],
+      "self_edge_conflict": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          4,
+          3,
+          7,
+          0
+        ]
+      },
+      "source_record": {
+        "selected_row_count": 9,
+        "self_edge_conflict_count": 27,
+        "strict_edge_count": 81
+      },
+      "template_id": "T04"
+    },
+    {
+      "assignment_index": 173,
+      "core_replay": {
+        "cycle_edges": [],
+        "n": 9,
+        "obstructed": true,
+        "order": [
+          0,
+          2,
+          4,
+          6,
+          8,
+          1,
+          3,
+          5,
+          7
+        ],
+        "selected_row_count": 3,
+        "self_edge_conflicts": [
+          {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              4,
+              6
+            ],
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              4
+            ],
+            "row": 2,
+            "witness_order": [
+              4,
+              6,
+              1,
+              0
+            ]
+          }
+        ],
+        "status": "self_edge",
+        "strict_edge_count": 27,
+        "type": "vertex_circle_quotient_replay_result"
+      },
+      "core_row_indices": [
+        0,
+        2,
+        4
+      ],
+      "core_rows": [
+        {
+          "row": 0,
+          "witnesses": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "row": 2,
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "row": 4,
+          "witnesses": [
+            2,
+            3,
+            6,
+            8
+          ]
+        }
+      ],
+      "family_id": "F13",
+      "minimality": {
+        "lexicographic_min_core_row_indices": [
+          0,
+          2,
+          4
+        ],
+        "minimal_self_edge_core_count": 9,
+        "minimal_self_edge_core_size": 3,
+        "proper_self_edge_subcore_count": 0,
+        "proper_subcore_status_counts": {
+          "ok": 6
+        }
+      },
+      "order": [
+        0,
+        2,
+        4,
+        6,
+        8,
+        1,
+        3,
+        5,
+        7
+      ],
+      "selected_distance_equality_path": [
+        {
+          "from_pair": [
+            0,
+            4
+          ],
+          "reason": "selected distances from this center to its witnesses are equal",
+          "row": 0,
+          "row_witnesses": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "to_pair": [
+            0,
+            2
+          ]
+        },
+        {
+          "from_pair": [
+            0,
+            2
+          ],
+          "reason": "selected distances from this center to its witnesses are equal",
+          "row": 2,
+          "row_witnesses": [
+            0,
+            1,
+            4,
+            6
+          ],
+          "to_pair": [
+            2,
+            4
+          ]
+        },
+        {
+          "from_pair": [
+            2,
+            4
+          ],
+          "reason": "selected distances from this center to its witnesses are equal",
+          "row": 4,
+          "row_witnesses": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "to_pair": [
+            4,
+            6
+          ]
+        }
+      ],
+      "self_edge_conflict": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          4,
+          6,
+          1,
+          0
+        ]
+      },
+      "source_record": {
+        "selected_row_count": 9,
+        "self_edge_conflict_count": 27,
+        "strict_edge_count": 81
+      },
+      "template_id": "T04"
+    }
+  ],
+  "schema": "erdos97.n9_row_ptolemy_gap_self_edge_cores.v1",
+  "source_artifact": {
+    "path": "data/certificates/n9_row_ptolemy_admissible_gap_replay.json",
+    "schema": "erdos97.n9_row_ptolemy_admissible_gap_replay.v1",
+    "status": "EXPLORATORY_LEDGER_ONLY",
+    "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF"
+  },
+  "status": "EXPLORATORY_LEDGER_ONLY",
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+  "vertex_circle_status_counts": {
+    "self_edge": 2
+  },
+  "witness_size": 4
+}

--- a/docs/n9-incidence-frontier.md
+++ b/docs/n9-incidence-frontier.md
@@ -140,7 +140,12 @@ row-Ptolemy certificates while remaining vertex-circle self-edge obstructed.
 The narrower replay artifact
 `data/certificates/n9_row_ptolemy_admissible_gap_replay.json` records those two
 rows directly: both use order `[0,2,4,6,8,1,3,5,7]`, crosswalk to `F13 -> T04`,
-and replay with 81 strict vertex-circle edges and 27 self-edge conflicts. Good
-next checks are to audit whether those signatures can be converted into
-reusable local lemmas and to keep testing order-sensitive variants without
-treating this bounded slice as a lossless quotient of all `n=9` cases.
+and replay with 81 strict vertex-circle edges and 27 self-edge conflicts.
+The compact-core artifact
+`data/certificates/n9_row_ptolemy_gap_self_edge_cores.json` then shrinks each
+full replay to the lexicographically first minimal 3-row `self_edge` core,
+rows `[0,2,4]`, with an explicit selected-distance equality path from the
+strict outer chord to the strict inner chord. Good next checks are to audit
+whether those compact signatures can be converted into reusable local lemmas
+and to keep testing order-sensitive variants without treating this bounded
+slice as a lossless quotient of all `n=9` cases.

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -54,6 +54,12 @@ template families, and all strict-cycle template families remain no-hit
 negative controls for the row-Ptolemy diagnostic. This is a consistency join
 between artifacts, not an additional n=9 proof claim.
 
+`data/certificates/n9_row_ptolemy_gap_self_edge_cores.json` applies the same
+replay idea to the two zero-certificate row-Ptolemy admissible-order records.
+It does not enumerate new n=9 cases; it compresses those two recorded `F13`
+gap replays to minimal 3-row `self_edge` cores and stores the selected-distance
+equality path responsible for each self-edge.
+
 ## Certificate Shape
 
 A self-edge core consists of:

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -38,7 +38,11 @@ git diff --check
 
 ## Artifact Checks
 
-Run checked-in artifact and certificate validators explicitly:
+Run checked-in artifact and certificate validators explicitly. The current
+audit command set is maintained in `Makefile` and
+`scripts/run_artifact_audit.py`; the block below records commonly used
+validators and should be cross-checked against those files before a release or
+review packet.
 
 ```bash
 pytest -q -m artifact
@@ -51,6 +55,8 @@ python scripts/analyze_n8_exact_survivors.py --check --json \
   --check-compatible-orders-data data/incidence/n8_compatible_orders.json \
   --check-exact-analysis-data certificates/n8_exact_analysis.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
+python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
 ```
 

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -53,7 +53,9 @@ make audit-artifacts
 The `audit-artifacts` target includes the dated official-status consistency
 check, so this audit path is stricter than the default fast tier.
 
-Equivalent raw commands:
+If `make` is unavailable, treat `Makefile` and
+`scripts/run_artifact_audit.py` as the source of truth for the current raw
+command set. The current raw commands are:
 
 ```bash
 python scripts/check_status_consistency.py --max-official-status-age-days 90
@@ -65,7 +67,22 @@ python scripts/check_round2_certificates.py
 python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
 python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
+python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
+python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_order_admissible_census.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
+python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
+python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+python scripts/check_n9_base_apex_escape_budget.py --check --json
+python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
+python scripts/check_n9_d3_escape_slice.py --check --json
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
 ```
 
 The default pytest configuration excludes tests marked `artifact`, `slow`, or

--- a/docs/row-ptolemy-product-filter.md
+++ b/docs/row-ptolemy-product-filter.md
@@ -207,6 +207,15 @@ violations, and a vertex-circle `self_edge` replay with `81` strict edges and
 `27` self-edge conflicts. This narrows the diagnostic gap to inspect next; it
 does not promote the rows to geometric candidates or change the global status.
 
+The follow-up compact-core artifact
+`data/certificates/n9_row_ptolemy_gap_self_edge_cores.json` records the
+lexicographically first minimal `self_edge` row subset for each of those two
+records. In both cases, rows `[0,2,4]` form a 3-row core with one self-edge
+conflict, `27` strict vertex-circle edges, and no proper subcore with a
+`self_edge` replay. The stored selected-distance equality path explains how the
+strict outer chord and inner chord are identified in the quotient. This is a
+local replay certificate for those two records, not a standalone theorem.
+
 ## Reproduction
 
 ```bash
@@ -248,6 +257,15 @@ python scripts/check_n9_row_ptolemy_admissible_gap_replay.py \
   --write
 
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py \
+  --check \
+  --assert-expected \
+  --json
+
+python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py \
   --check \
   --assert-expected \
   --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -685,6 +685,69 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_row_ptolemy_gap_self_edge_cores
+    path: data/certificates/n9_row_ptolemy_gap_self_edge_cores.json
+    kind: exploratory_ledger_artifact
+    generator: scripts/check_n9_row_ptolemy_gap_self_edge_cores.py
+    command: python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --assert-expected --write
+    checker: scripts/check_n9_row_ptolemy_gap_self_edge_cores.py
+    check_command: python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Compact self-edge core certificates for the two zero-certificate n=9 row-Ptolemy admissible assignment-order records; not a proof of n=9, not a counterexample, not an all-order obstruction, not an orderless abstract-incidence obstruction, not a geometric realizability count, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_row_ptolemy_gap_self_edge_cores.v1
+      status: EXPLORATORY_LEDGER_ONLY
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      claim_scope: Compact self-edge core certificates for the two zero-certificate n=9 row-Ptolemy admissible assignment-order records; not a proof of n=9, not a counterexample, not an all-order obstruction, not an orderless abstract-incidence obstruction, not a geometric realizability count, and not a global status update.
+      n: 9
+      witness_size: 4
+      record_count: 2
+      assignment_indices:
+        - 22
+        - 173
+      normalized_order:
+        - 0
+        - 2
+        - 4
+        - 6
+        - 8
+        - 1
+        - 3
+        - 5
+        - 7
+      core_row_index_sets:
+        - [0, 2, 4]
+        - [0, 2, 4]
+      core_size_counts:
+        "3": 2
+      vertex_circle_status_counts:
+        self_edge: 2
+      core_strict_edge_count_histogram:
+        "27": 2
+      core_self_edge_conflict_count_histogram:
+        "1": 2
+      equality_path_length_histogram:
+        "3": 2
+      minimal_self_edge_core_count_histogram:
+        "9": 2
+      provenance.command: python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - all-order obstruction
+      - orderless abstract-incidence obstruction
+      - compatible cyclic-order obstruction
+      - geometric realizability count
+      - counterexample
+      - standalone theorem
+      - realizable candidate
+      - survivor
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact

--- a/scripts/check_n9_row_ptolemy_gap_self_edge_cores.py
+++ b/scripts/check_n9_row_ptolemy_gap_self_edge_cores.py
@@ -1,0 +1,752 @@
+#!/usr/bin/env python3
+"""Generate or check compact self-edge cores for n=9 row-Ptolemy gaps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict, deque
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+SCRIPTS = ROOT / "scripts"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+from scripts.check_n9_row_ptolemy_admissible_gap_replay import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_GAP_REPLAY_ARTIFACT,
+    load_artifact,
+    validate_payload as validate_gap_replay_payload,
+    write_json,
+)
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_row_ptolemy_gap_self_edge_cores.json"
+)
+SCHEMA = "erdos97.n9_row_ptolemy_gap_self_edge_cores.v1"
+STATUS = "EXPLORATORY_LEDGER_ONLY"
+TRUST = "FINITE_BOOKKEEPING_NOT_A_PROOF"
+CLAIM_SCOPE = (
+    "Compact self-edge core certificates for the two zero-certificate n=9 "
+    "row-Ptolemy admissible assignment-order records; not a proof of n=9, "
+    "not a counterexample, not an all-order obstruction, not an orderless "
+    "abstract-incidence obstruction, not a geometric realizability count, and "
+    "not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_row_ptolemy_gap_self_edge_cores.py",
+    "command": (
+        "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py "
+        "--assert-expected --write"
+    ),
+}
+SOURCE_ARTIFACT = {
+    "path": "data/certificates/n9_row_ptolemy_admissible_gap_replay.json",
+    "schema": "erdos97.n9_row_ptolemy_admissible_gap_replay.v1",
+    "status": "EXPLORATORY_LEDGER_ONLY",
+    "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+}
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_indices",
+    "claim_scope",
+    "core_row_index_sets",
+    "core_self_edge_conflict_count_histogram",
+    "core_size_counts",
+    "core_strict_edge_count_histogram",
+    "equality_path_length_histogram",
+    "interpretation",
+    "minimal_self_edge_core_count_histogram",
+    "n",
+    "normalized_order",
+    "provenance",
+    "record_count",
+    "records",
+    "schema",
+    "source_artifact",
+    "status",
+    "trust",
+    "vertex_circle_status_counts",
+    "witness_size",
+}
+EXPECTED_ASSIGNMENTS = [22, 173]
+EXPECTED_ORDER = [0, 2, 4, 6, 8, 1, 3, 5, 7]
+EXPECTED_CORE_ROW_INDICES = [0, 2, 4]
+EXPECTED_RECORD_COUNT = 2
+EXPECTED_CORE_SIZE_COUNTS = {"3": 2}
+EXPECTED_VERTEX_STATUS_COUNTS = {"self_edge": 2}
+EXPECTED_CORE_STRICT_EDGE_HISTOGRAM = {"27": 2}
+EXPECTED_CORE_CONFLICT_HISTOGRAM = {"1": 2}
+EXPECTED_EQUALITY_PATH_LENGTH_HISTOGRAM = {"3": 2}
+EXPECTED_MINIMAL_CORE_COUNT_HISTOGRAM = {"9": 2}
+
+Pair = tuple[int, int]
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _explicit_rows(raw_rows: Sequence[Any]) -> list[dict[str, Any]]:
+    rows = []
+    for center, witnesses in enumerate(raw_rows):
+        if not isinstance(witnesses, Sequence) or isinstance(witnesses, str):
+            raise ValueError(f"selected row {center} must be a sequence")
+        rows.append(
+            {
+                "row": center,
+                "witnesses": [int(witness) for witness in witnesses],
+            }
+        )
+    return rows
+
+
+def _rows_at_indices(rows: Sequence[dict[str, Any]], indices: Sequence[int]) -> list[dict[str, Any]]:
+    return [rows[index] for index in indices]
+
+
+def _replay_json(n: int, order: Sequence[int], rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    return result_to_json(replay_vertex_circle_quotient(n, order, parse_selected_rows(rows)))
+
+
+def _self_edge_core_indices(
+    n: int,
+    order: Sequence[int],
+    rows: Sequence[dict[str, Any]],
+) -> list[tuple[int, ...]]:
+    """Return every smallest row-index subset that replays as self_edge."""
+
+    for size in range(1, len(rows) + 1):
+        found = []
+        for indices in combinations(range(len(rows)), size):
+            replay = replay_vertex_circle_quotient(
+                n,
+                order,
+                parse_selected_rows(_rows_at_indices(rows, indices)),
+            )
+            if replay.status == "self_edge":
+                found.append(indices)
+        if found:
+            return found
+    return []
+
+
+def _proper_subcore_status_counts(
+    n: int,
+    order: Sequence[int],
+    rows: Sequence[dict[str, Any]],
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for size in range(1, len(rows)):
+        for indices in combinations(range(len(rows)), size):
+            replay = replay_vertex_circle_quotient(
+                n,
+                order,
+                parse_selected_rows(_rows_at_indices(rows, indices)),
+            )
+            counts[replay.status] += 1
+    return dict(sorted(counts.items()))
+
+
+def _selected_equality_graph(
+    rows: Sequence[dict[str, Any]],
+) -> dict[Pair, list[tuple[Pair, dict[str, Any]]]]:
+    graph: dict[Pair, list[tuple[Pair, dict[str, Any]]]] = defaultdict(list)
+    for raw_row in rows:
+        center = int(raw_row["row"])
+        witnesses = [int(witness) for witness in raw_row["witnesses"]]
+        row_pairs = [pair(center, witness) for witness in witnesses]
+        reason = {
+            "row": center,
+            "witnesses": witnesses,
+            "reason": "selected distances from this center to its witnesses are equal",
+        }
+        for left, right in combinations(row_pairs, 2):
+            graph[left].append((right, reason))
+            graph[right].append((left, reason))
+    for neighbors in graph.values():
+        neighbors.sort(key=lambda item: (item[0], item[1]["row"]))
+    return graph
+
+
+def _selected_equality_path(
+    rows: Sequence[dict[str, Any]],
+    start_pair: Sequence[int],
+    end_pair: Sequence[int],
+) -> list[dict[str, Any]]:
+    """Return a stable selected-distance equality path between two pairs."""
+
+    start = pair(int(start_pair[0]), int(start_pair[1]))
+    end = pair(int(end_pair[0]), int(end_pair[1]))
+    graph = _selected_equality_graph(rows)
+    queue: deque[Pair] = deque([start])
+    parents: dict[Pair, tuple[Pair, dict[str, Any]] | None] = {start: None}
+    while queue:
+        node = queue.popleft()
+        if node == end:
+            break
+        for neighbor, reason in graph.get(node, []):
+            if neighbor not in parents:
+                parents[neighbor] = (node, reason)
+                queue.append(neighbor)
+    if end not in parents:
+        raise ValueError(f"no equality path between {start!r} and {end!r}")
+
+    path: list[dict[str, Any]] = []
+    node = end
+    while node != start:
+        parent = parents[node]
+        if parent is None:
+            raise ValueError("malformed equality path parent map")
+        previous, reason = parent
+        path.append(
+            {
+                "from_pair": list(previous),
+                "to_pair": list(node),
+                "row": reason["row"],
+                "row_witnesses": reason["witnesses"],
+                "reason": reason["reason"],
+            }
+        )
+        node = previous
+    path.reverse()
+    return path
+
+
+def _record_payload(record: dict[str, Any]) -> dict[str, Any]:
+    assignment_index = int(record["assignment_index"])
+    order = [int(label) for label in record["order"]]
+    rows = _explicit_rows(record["selected_rows"])
+    minimal_cores = _self_edge_core_indices(9, order, rows)
+    if not minimal_cores:
+        raise ValueError(f"assignment {assignment_index} has no self-edge core")
+    core_indices = list(minimal_cores[0])
+    core_rows = _rows_at_indices(rows, core_indices)
+    core_replay = _replay_json(9, order, core_rows)
+    conflicts = core_replay["self_edge_conflicts"]
+    if len(conflicts) != 1:
+        raise ValueError(f"assignment {assignment_index} core must have one conflict")
+    conflict = conflicts[0]
+    equality_path = _selected_equality_path(
+        core_rows,
+        conflict["outer_pair"],
+        conflict["inner_pair"],
+    )
+    proper_counts = _proper_subcore_status_counts(9, order, core_rows)
+    return {
+        "assignment_index": assignment_index,
+        "family_id": str(record["family_id"]),
+        "template_id": str(record["template_id"]),
+        "source_record": {
+            "selected_row_count": int(record["vertex_circle_replay"]["selected_row_count"]),
+            "strict_edge_count": int(record["vertex_circle_replay"]["strict_edge_count"]),
+            "self_edge_conflict_count": len(
+                record["vertex_circle_replay"]["self_edge_conflicts"]
+            ),
+        },
+        "order": order,
+        "core_row_indices": core_indices,
+        "core_rows": core_rows,
+        "core_replay": core_replay,
+        "self_edge_conflict": conflict,
+        "selected_distance_equality_path": equality_path,
+        "minimality": {
+            "minimal_self_edge_core_size": len(core_indices),
+            "minimal_self_edge_core_count": len(minimal_cores),
+            "lexicographic_min_core_row_indices": core_indices,
+            "proper_subcore_status_counts": proper_counts,
+            "proper_self_edge_subcore_count": int(proper_counts.get("self_edge", 0)),
+        },
+    }
+
+
+def _source_records_by_assignment(source: Any) -> dict[int, dict[str, Any]]:
+    if not isinstance(source, dict):
+        return {}
+    raw_records = source.get("records")
+    if not isinstance(raw_records, Sequence) or isinstance(raw_records, str):
+        return {}
+    records = {}
+    for record in raw_records:
+        if isinstance(record, dict) and isinstance(record.get("assignment_index"), int):
+            records[int(record["assignment_index"])] = record
+    return records
+
+
+def _source_record_summary(source_record: dict[str, Any]) -> dict[str, int]:
+    replay = source_record["vertex_circle_replay"]
+    return {
+        "selected_row_count": int(replay["selected_row_count"]),
+        "strict_edge_count": int(replay["strict_edge_count"]),
+        "self_edge_conflict_count": len(replay["self_edge_conflicts"]),
+    }
+
+
+def self_edge_core_payload(gap_replay: dict[str, Any]) -> dict[str, Any]:
+    """Return the generated compact self-edge core artifact."""
+
+    raw_records = gap_replay.get("records")
+    if not isinstance(raw_records, Sequence) or isinstance(raw_records, str):
+        raise ValueError("gap replay artifact must contain records")
+    records = [
+        _record_payload(record)
+        for record in raw_records
+        if isinstance(record, dict)
+    ]
+    records.sort(key=lambda record: int(record["assignment_index"]))
+
+    core_sizes = Counter(len(record["core_rows"]) for record in records)
+    statuses = Counter(record["core_replay"]["status"] for record in records)
+    strict_edges = Counter(
+        int(record["core_replay"]["strict_edge_count"]) for record in records
+    )
+    conflict_counts = Counter(
+        len(record["core_replay"]["self_edge_conflicts"]) for record in records
+    )
+    path_lengths = Counter(
+        len(record["selected_distance_equality_path"]) for record in records
+    )
+    minimal_counts = Counter(
+        int(record["minimality"]["minimal_self_edge_core_count"])
+        for record in records
+    )
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "witness_size": 4,
+        "source_artifact": SOURCE_ARTIFACT,
+        "provenance": PROVENANCE,
+        "interpretation": [
+            (
+                "Each core is a compact replay certificate for one recorded "
+                "self-edge gap record, not a standalone theorem."
+            ),
+            (
+                "The selected-distance equality path explains why the strict "
+                "outer chord and inner chord are identified in the quotient."
+            ),
+            (
+                "The listed core is the lexicographically first minimal "
+                "self-edge row subset for that recorded assignment-order pair."
+            ),
+            "No proof of the n=9 case is claimed.",
+            "No counterexample or global status update is claimed.",
+        ],
+        "record_count": len(records),
+        "assignment_indices": [
+            int(record["assignment_index"]) for record in records
+        ],
+        "normalized_order": EXPECTED_ORDER,
+        "core_row_index_sets": [
+            record["core_row_indices"] for record in records
+        ],
+        "core_size_counts": _json_counter(core_sizes),
+        "vertex_circle_status_counts": dict(sorted(statuses.items())),
+        "core_strict_edge_count_histogram": _json_counter(strict_edges),
+        "core_self_edge_conflict_count_histogram": _json_counter(conflict_counts),
+        "equality_path_length_histogram": _json_counter(path_lengths),
+        "minimal_self_edge_core_count_histogram": _json_counter(minimal_counts),
+        "records": records,
+    }
+    assert_expected_counts(payload)
+    return payload
+
+
+def assert_expected_counts(payload: dict[str, Any]) -> None:
+    """Raise AssertionError if expected compact-core counts change."""
+
+    assert payload["record_count"] == EXPECTED_RECORD_COUNT
+    assert payload["assignment_indices"] == EXPECTED_ASSIGNMENTS
+    assert payload["normalized_order"] == EXPECTED_ORDER
+    assert payload["core_row_index_sets"] == [EXPECTED_CORE_ROW_INDICES] * 2
+    assert payload["core_size_counts"] == EXPECTED_CORE_SIZE_COUNTS
+    assert payload["vertex_circle_status_counts"] == EXPECTED_VERTEX_STATUS_COUNTS
+    assert payload["core_strict_edge_count_histogram"] == EXPECTED_CORE_STRICT_EDGE_HISTOGRAM
+    assert payload["core_self_edge_conflict_count_histogram"] == EXPECTED_CORE_CONFLICT_HISTOGRAM
+    assert (
+        payload["equality_path_length_histogram"]
+        == EXPECTED_EQUALITY_PATH_LENGTH_HISTOGRAM
+    )
+    assert (
+        payload["minimal_self_edge_core_count_histogram"]
+        == EXPECTED_MINIMAL_CORE_COUNT_HISTOGRAM
+    )
+    assert all(
+        record["minimality"]["proper_self_edge_subcore_count"] == 0
+        for record in payload["records"]
+    )
+
+
+def _validate_equality_path(
+    errors: list[str],
+    record: dict[str, Any],
+    label: str,
+) -> None:
+    conflict = record.get("self_edge_conflict")
+    path = record.get("selected_distance_equality_path")
+    core_rows = record.get("core_rows")
+    if not isinstance(conflict, dict) or not isinstance(path, list):
+        errors.append(f"{label} must contain conflict and equality path")
+        return
+    if not isinstance(core_rows, Sequence) or isinstance(core_rows, str):
+        errors.append(f"{label}.core_rows must be a sequence")
+        return
+    try:
+        expected_path = _selected_equality_path(
+            core_rows,
+            conflict["outer_pair"],
+            conflict["inner_pair"],
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"{label} equality path failed: {exc}")
+        return
+    expect_equal(
+        errors,
+        f"{label}.selected_distance_equality_path",
+        path,
+        expected_path,
+    )
+
+
+def _validate_record(
+    errors: list[str],
+    record: Any,
+    index: int,
+    source_record: dict[str, Any] | None,
+) -> None:
+    if not isinstance(record, dict):
+        errors.append(f"records[{index}] must be an object")
+        return
+    label = f"records[{index}]"
+    expect_equal(errors, f"{label}.family_id", record.get("family_id"), "F13")
+    expect_equal(errors, f"{label}.template_id", record.get("template_id"), "T04")
+    expect_equal(errors, f"{label}.order", record.get("order"), EXPECTED_ORDER)
+    expect_equal(
+        errors,
+        f"{label}.core_row_indices",
+        record.get("core_row_indices"),
+        EXPECTED_CORE_ROW_INDICES,
+    )
+    core_rows = record.get("core_rows")
+    if not isinstance(core_rows, Sequence) or isinstance(core_rows, str):
+        errors.append(f"{label}.core_rows must be a sequence")
+        return
+    if source_record is not None:
+        source_rows = _explicit_rows(source_record["selected_rows"])
+        expected_core_rows = _rows_at_indices(source_rows, record["core_row_indices"])
+        expect_equal(errors, f"{label}.core_rows", core_rows, expected_core_rows)
+        expect_equal(
+            errors,
+            f"{label}.source_record",
+            record.get("source_record"),
+            _source_record_summary(source_record),
+        )
+    try:
+        replay = _replay_json(9, EXPECTED_ORDER, core_rows)
+    except (TypeError, ValueError) as exc:
+        errors.append(f"{label} core replay failed: {exc}")
+        return
+    expect_equal(errors, f"{label}.core_replay", record.get("core_replay"), replay)
+    conflicts = replay["self_edge_conflicts"]
+    if len(conflicts) != 1:
+        errors.append(f"{label} core must replay exactly one self-edge conflict")
+    else:
+        expect_equal(errors, f"{label}.self_edge_conflict", record.get("self_edge_conflict"), conflicts[0])
+    _validate_equality_path(errors, record, label)
+    minimality = record.get("minimality")
+    if not isinstance(minimality, dict):
+        errors.append(f"{label}.minimality must be an object")
+        return
+    expect_equal(
+        errors,
+        f"{label}.minimality.minimal_self_edge_core_size",
+        minimality.get("minimal_self_edge_core_size"),
+        len(core_rows),
+    )
+    expect_equal(
+        errors,
+        f"{label}.minimality.lexicographic_min_core_row_indices",
+        minimality.get("lexicographic_min_core_row_indices"),
+        record.get("core_row_indices"),
+    )
+    proper_counts = _proper_subcore_status_counts(9, EXPECTED_ORDER, core_rows)
+    expect_equal(
+        errors,
+        f"{label}.minimality.proper_subcore_status_counts",
+        minimality.get("proper_subcore_status_counts"),
+        proper_counts,
+    )
+    expect_equal(
+        errors,
+        f"{label}.minimality.proper_self_edge_subcore_count",
+        minimality.get("proper_self_edge_subcore_count"),
+        int(proper_counts.get("self_edge", 0)),
+    )
+    if source_record is not None:
+        source_rows = _explicit_rows(source_record["selected_rows"])
+        minimal_cores = _self_edge_core_indices(9, EXPECTED_ORDER, source_rows)
+        expect_equal(
+            errors,
+            f"{label}.minimality.minimal_self_edge_core_count",
+            minimality.get("minimal_self_edge_core_count"),
+            len(minimal_cores),
+        )
+        expect_equal(
+            errors,
+            f"{label}.minimality.minimal_self_edge_core_size",
+            minimality.get("minimal_self_edge_core_size"),
+            len(minimal_cores[0]) if minimal_cores else None,
+        )
+        expect_equal(
+            errors,
+            f"{label}.minimality.lexicographic_min_core_row_indices",
+            minimality.get("lexicographic_min_core_row_indices"),
+            list(minimal_cores[0]) if minimal_cores else None,
+        )
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source: Any | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a loaded compact-core artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "source_artifact": SOURCE_ARTIFACT,
+        "provenance": PROVENANCE,
+        "n": 9,
+        "witness_size": 4,
+        "record_count": EXPECTED_RECORD_COUNT,
+        "assignment_indices": EXPECTED_ASSIGNMENTS,
+        "normalized_order": EXPECTED_ORDER,
+        "core_row_index_sets": [EXPECTED_CORE_ROW_INDICES] * 2,
+        "core_size_counts": EXPECTED_CORE_SIZE_COUNTS,
+        "vertex_circle_status_counts": EXPECTED_VERTEX_STATUS_COUNTS,
+        "core_strict_edge_count_histogram": EXPECTED_CORE_STRICT_EDGE_HISTOGRAM,
+        "core_self_edge_conflict_count_histogram": EXPECTED_CORE_CONFLICT_HISTOGRAM,
+        "equality_path_length_histogram": EXPECTED_EQUALITY_PATH_LENGTH_HISTOGRAM,
+        "minimal_self_edge_core_count_histogram": EXPECTED_MINIMAL_CORE_COUNT_HISTOGRAM,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        required = (
+            "Each core is a compact replay certificate for one recorded self-edge gap record, not a standalone theorem.",
+            "No proof of the n=9 case is claimed.",
+            "No counterexample or global status update is claimed.",
+        )
+        for phrase in required:
+            if phrase not in interpretation:
+                errors.append(f"interpretation must include {phrase!r}")
+
+    if source is None:
+        try:
+            source = load_artifact(DEFAULT_GAP_REPLAY_ARTIFACT)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"failed to load gap replay artifact: {exc}")
+            source = None
+    source_records = _source_records_by_assignment(source)
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        errors.append("records must be a list")
+    else:
+        expect_equal(errors, "record count", len(records), EXPECTED_RECORD_COUNT)
+        expect_equal(
+            errors,
+            "record assignment indices",
+            [record.get("assignment_index") for record in records if isinstance(record, dict)],
+            EXPECTED_ASSIGNMENTS,
+        )
+        for index, record in enumerate(records):
+            assignment_index = (
+                record.get("assignment_index") if isinstance(record, dict) else None
+            )
+            source_record = (
+                source_records.get(int(assignment_index))
+                if isinstance(assignment_index, int)
+                else None
+            )
+            if source_records and source_record is None:
+                errors.append(f"records[{index}] assignment missing from source artifact")
+            _validate_record(errors, record, index, source_record)
+
+    try:
+        assert_expected_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected counts failed: {exc}")
+
+    if recompute:
+        if isinstance(source, dict):
+            try:
+                expected_payload = self_edge_core_payload(source)
+            except (AssertionError, TypeError, ValueError) as exc:
+                errors.append(f"recomputed self-edge cores failed: {exc}")
+            else:
+                expect_equal(errors, "self-edge core payload", payload, expected_payload)
+        else:
+            errors.append("source gap replay artifact must be an object")
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "record_count": object_payload.get("record_count"),
+        "assignment_indices": object_payload.get("assignment_indices"),
+        "core_row_index_sets": object_payload.get("core_row_index_sets"),
+        "core_size_counts": object_payload.get("core_size_counts"),
+        "vertex_circle_status_counts": object_payload.get(
+            "vertex_circle_status_counts"
+        ),
+        "core_strict_edge_count_histogram": object_payload.get(
+            "core_strict_edge_count_histogram"
+        ),
+        "core_self_edge_conflict_count_histogram": object_payload.get(
+            "core_self_edge_conflict_count_histogram"
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--source", type=Path, default=DEFAULT_GAP_REPLAY_ARTIFACT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated cores")
+    parser.add_argument("--check", action="store_true", help="validate existing cores")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args(raw_argv)
+    args.artifact_explicit = any(
+        item == "--artifact" or item.startswith("--artifact=") for item in raw_argv
+    )
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact if args.artifact.is_absolute() else ROOT / args.artifact
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    out = args.out if args.out.is_absolute() else ROOT / args.out
+    if args.write and args.check:
+        if args.artifact_explicit and artifact != out:
+            print(
+                "combined --write --check requires --artifact to match --out",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        source = load_artifact(source_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        source = {}
+        source_errors = [str(exc)]
+    else:
+        source_errors = validate_gap_replay_payload(source, recompute=False)
+
+    if args.write:
+        if source_errors:
+            for error in source_errors:
+                print(f"source artifact invalid: {error}", file=sys.stderr)
+            return 1
+        payload = self_edge_core_payload(source)
+        if args.assert_expected:
+            assert_expected_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source=source,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+    errors.extend(f"source artifact invalid: {error}" for error in source_errors)
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 row-Ptolemy gap self-edge cores")
+        print(f"artifact: {summary['artifact']}")
+        print(f"records: {summary['record_count']}")
+        print(f"assignments: {summary['assignment_indices']}")
+        print(f"core row indices: {summary['core_row_index_sets']}")
+        print(f"core sizes: {summary['core_size_counts']}")
+        print(f"vertex-circle statuses: {summary['vertex_circle_status_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: row-Ptolemy gap self-edge core checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -254,6 +254,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_row_ptolemy_gap_self_edge_cores",
+        command=(
+            "python",
+            "scripts/check_n9_row_ptolemy_gap_self_edge_cores.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Compact self-edge core certificates for the two zero-certificate "
+            "n=9 row-Ptolemy admissible assignment-order records; not a proof "
+            "of n=9, counterexample, all-order obstruction, orderless "
+            "obstruction, geometric realizability count, or official/global "
+            "status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/tests/test_n9_row_ptolemy_gap_self_edge_cores.py
+++ b/tests/test_n9_row_ptolemy_gap_self_edge_cores.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.vertex_circle_quotient_replay import (
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+from scripts.check_n9_row_ptolemy_admissible_gap_replay import (
+    DEFAULT_ARTIFACT as DEFAULT_GAP_REPLAY_ARTIFACT,
+    load_artifact,
+)
+from scripts.check_n9_row_ptolemy_gap_self_edge_cores import (
+    DEFAULT_ARTIFACT,
+    EXPECTED_CORE_CONFLICT_HISTOGRAM,
+    EXPECTED_CORE_SIZE_COUNTS,
+    EXPECTED_CORE_STRICT_EDGE_HISTOGRAM,
+    EXPECTED_EQUALITY_PATH_LENGTH_HISTOGRAM,
+    EXPECTED_MINIMAL_CORE_COUNT_HISTOGRAM,
+    assert_expected_counts,
+    self_edge_core_payload,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_gap_self_edge_core_scope_and_counts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_counts(payload)
+    assert payload["status"] == "EXPLORATORY_LEDGER_ONLY"
+    assert payload["trust"] == "FINITE_BOOKKEEPING_NOT_A_PROOF"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an all-order obstruction" in payload["claim_scope"]
+    assert "not an orderless abstract-incidence obstruction" in payload["claim_scope"]
+    assert "not a geometric realizability count" in payload["claim_scope"]
+    assert payload["assignment_indices"] == [22, 173]
+    assert payload["core_row_index_sets"] == [[0, 2, 4], [0, 2, 4]]
+    assert payload["core_size_counts"] == EXPECTED_CORE_SIZE_COUNTS
+    assert payload["core_strict_edge_count_histogram"] == EXPECTED_CORE_STRICT_EDGE_HISTOGRAM
+    assert (
+        payload["core_self_edge_conflict_count_histogram"]
+        == EXPECTED_CORE_CONFLICT_HISTOGRAM
+    )
+    assert (
+        payload["equality_path_length_histogram"]
+        == EXPECTED_EQUALITY_PATH_LENGTH_HISTOGRAM
+    )
+    assert (
+        payload["minimal_self_edge_core_count_histogram"]
+        == EXPECTED_MINIMAL_CORE_COUNT_HISTOGRAM
+    )
+
+
+def test_gap_self_edge_core_records_replay_and_are_minimal() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    for record in payload["records"]:
+        replay = result_to_json(
+            replay_vertex_circle_quotient(
+                9,
+                record["order"],
+                parse_selected_rows(record["core_rows"]),
+            )
+        )
+
+        assert record["family_id"] == "F13"
+        assert record["template_id"] == "T04"
+        assert replay == record["core_replay"]
+        assert replay["status"] == "self_edge"
+        assert replay["strict_edge_count"] == 27
+        assert len(replay["self_edge_conflicts"]) == 1
+        assert record["self_edge_conflict"] == replay["self_edge_conflicts"][0]
+        assert record["minimality"]["minimal_self_edge_core_size"] == 3
+        assert record["minimality"]["minimal_self_edge_core_count"] == 9
+        assert record["minimality"]["proper_self_edge_subcore_count"] == 0
+        assert record["minimality"]["proper_subcore_status_counts"] == {"ok": 6}
+        assert len(record["selected_distance_equality_path"]) == 3
+
+
+def test_gap_self_edge_core_equality_paths_connect_conflict_pairs() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    for record in payload["records"]:
+        conflict = record["self_edge_conflict"]
+        path = record["selected_distance_equality_path"]
+
+        assert path[0]["from_pair"] == conflict["outer_pair"]
+        assert path[-1]["to_pair"] == conflict["inner_pair"]
+        for left, right in zip(path, path[1:]):
+            assert left["to_pair"] == right["from_pair"]
+        assert conflict["outer_class"] == conflict["inner_class"]
+
+
+@pytest.mark.artifact
+def test_gap_self_edge_core_artifact_matches_generator() -> None:
+    gap_replay = load_artifact(DEFAULT_GAP_REPLAY_ARTIFACT)
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == self_edge_core_payload(gap_replay)
+
+
+def test_gap_self_edge_core_checker_passes_without_recompute() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["record_count"] == 2
+    assert summary["core_size_counts"] == {"3": 2}
+
+
+def test_gap_self_edge_core_rejects_tampered_core_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["core_rows"][0]["witnesses"] = [1, 2, 3, 7]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("core_replay" in error or "equality path" in error for error in errors)
+
+
+def test_gap_self_edge_core_rejects_core_rows_not_matching_source_indices() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    source = load_artifact(DEFAULT_GAP_REPLAY_ARTIFACT)
+    source_record = source["records"][0]
+    payload["records"][0]["core_rows"] = [
+        {"row": index, "witnesses": source_record["selected_rows"][index]}
+        for index in [1, 3, 5]
+    ]
+
+    errors = validate_payload(payload, source=source, recompute=False)
+
+    assert any("core_rows" in error for error in errors)
+
+
+def test_gap_self_edge_core_rejects_stale_minimality_and_source_summary() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["source_record"]["strict_edge_count"] = 80
+    payload["records"][0]["minimality"]["minimal_self_edge_core_count"] = 8
+    payload["records"][0]["minimality"]["lexicographic_min_core_row_indices"] = [
+        1,
+        3,
+        5,
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("source_record" in error for error in errors)
+    assert any("minimal_self_edge_core_count" in error for error in errors)
+    assert any("lexicographic_min_core_row_indices" in error for error in errors)
+
+
+def test_gap_self_edge_core_rejects_tampered_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["selected_distance_equality_path"][0]["to_pair"] = [0, 7]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("selected_distance_equality_path" in error for error in errors)
+
+
+def test_gap_self_edge_core_rejects_duplicate_record_without_recompute() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"].append(dict(payload["records"][0]))
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("record count" in error for error in errors)
+    assert any("record assignment indices" in error for error in errors)
+
+
+def test_gap_self_edge_core_rejects_missing_nonclaiming_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if "No proof" not in item
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("No proof" in error for error in errors)
+
+
+def test_gap_self_edge_core_rejects_source_metadata_tamper() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["source_artifact"]["schema"] = "erdos97.stale"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("source_artifact" in error for error in errors)
+
+
+def test_gap_self_edge_core_write_check_validates_out_path(tmp_path: Path) -> None:
+    out = tmp_path / "cores-out.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_row_ptolemy_gap_self_edge_cores.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"].endswith("cores-out.json")
+    assert out.exists()
+
+
+def test_gap_self_edge_core_write_check_rejects_mismatched_artifact(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "cores-out.json"
+    artifact = tmp_path / "other.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_row_ptolemy_gap_self_edge_cores.py",
+            "--write",
+            "--check",
+            "--out",
+            str(out),
+            "--artifact",
+            str(artifact),
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "requires --artifact to match --out" in result.stderr
+
+
+@pytest.mark.artifact
+def test_gap_self_edge_core_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_row_ptolemy_gap_self_edge_cores.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["record_count"] == 2

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -76,6 +76,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_local_core_packet.py --check "
         "--assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary

Adds a compact generated core artifact for the two zero-certificate n=9 row-Ptolemy admissible assignment-order records. The new checker shrinks each full 9-row vertex-circle `self_edge` replay to the lexicographically first minimal 3-row self-edge core and records the selected-distance equality path that identifies the strict outer and inner chords.

Both compact records are scoped to the existing `F13` gap rows under order `[0,2,4,6,8,1,3,5,7]`. Each core has rows `[0,2,4]`, 27 strict vertex-circle edges, one self-edge conflict, a length-3 selected-distance equality path, and no proper self-edge subcore. This is a local replay certificate for the two recorded gap records, not a standalone theorem.

No proof of `n=9`, counterexample, all-order obstruction, orderless obstruction, geometric-realizability count, or global status update is claimed.

## Changes

- Add `data/certificates/n9_row_ptolemy_gap_self_edge_cores.json`.
- Add `scripts/check_n9_row_ptolemy_gap_self_edge_cores.py` with generation, recompute validation, lightweight source-bound validation, equality-path checks, and expected-count guards.
- Add tests for scope/counts, replay/minimality, equality-path connectivity, stale core rows, stale minimality/source summaries, duplicate record sets, CLI JSON, and combined `--write --check --out` behavior.
- Register the checker in `verify-n9-review`, artifact audit, and generated artifact metadata.
- Document the compact cores in the row-Ptolemy, n9 frontier, and local-core notes.
- Refresh raw audit command docs so reviewers without `make` do not miss the newer n9 artifact validators.

## Review fixes already applied

- Bound lightweight validation back to the source gap replay rows, so stored core rows cannot silently drift away from their claimed source indices.
- Added lightweight validation for `source_record`, minimal self-edge core count/size, and lexicographic minimal core indices.
- Made combined `--write --check --out ...` validate the just-written output path, and reject mismatched explicit `--artifact`/`--out` pairs.
- Fixed stale raw-audit prose in README, reviewer guide, and reproduction log.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`383 passed, 49 deselected`)
- `python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json`
- Raw artifact tier was run because this Windows shell does not provide `make`: n8 checks, Kalmanson checks, n9 review checks including the new compact cores, n10 singleton spot-check, and C19 Z3 clause diagnostics all passed.