### PR TITLE
Add n9 self-edge equality-path join diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_self_edge_path_join.json
+++ b/data/certificates/n9_vertex_circle_self_edge_path_join.json
@@ -1,0 +1,21909 @@
+{
+  "claim_scope": "Assignment-level join of the 158 n=9 self-edge frontier assignments to transformed family representative equality paths; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "core_size_assignment_counts": {
+    "3": 46,
+    "4": 40,
+    "5": 36,
+    "6": 36
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "families": [
+    {
+      "assignment_count": 18,
+      "core_size": 3,
+      "family_id": "F01",
+      "orbit_size": 18,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T02"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 6,
+      "family_id": "F02",
+      "orbit_size": 18,
+      "path_length": 5,
+      "status": "self_edge",
+      "template_id": "T08"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 6,
+      "family_id": "F03",
+      "orbit_size": 18,
+      "path_length": 6,
+      "status": "self_edge",
+      "template_id": "T09"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 3,
+      "family_id": "F04",
+      "orbit_size": 18,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T02"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 4,
+      "family_id": "F05",
+      "orbit_size": 18,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T03"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 5,
+      "family_id": "F06",
+      "orbit_size": 18,
+      "path_length": 4,
+      "status": "self_edge",
+      "template_id": "T07"
+    },
+    {
+      "assignment_count": 2,
+      "core_size": 3,
+      "family_id": "F08",
+      "orbit_size": 2,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T02"
+    },
+    {
+      "assignment_count": 6,
+      "core_size": 3,
+      "family_id": "F09",
+      "orbit_size": 6,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T01"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 4,
+      "family_id": "F10",
+      "orbit_size": 18,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T05"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 5,
+      "family_id": "F11",
+      "orbit_size": 18,
+      "path_length": 4,
+      "status": "self_edge",
+      "template_id": "T06"
+    },
+    {
+      "assignment_count": 2,
+      "core_size": 4,
+      "family_id": "F13",
+      "orbit_size": 2,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T04"
+    },
+    {
+      "assignment_count": 2,
+      "core_size": 3,
+      "family_id": "F14",
+      "orbit_size": 2,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T02"
+    },
+    {
+      "assignment_count": 2,
+      "core_size": 4,
+      "family_id": "F15",
+      "orbit_size": 2,
+      "path_length": 3,
+      "status": "self_edge",
+      "template_id": "T03"
+    }
+  ],
+  "family_assignment_counts": {
+    "F01": 18,
+    "F02": 18,
+    "F03": 18,
+    "F04": 18,
+    "F05": 18,
+    "F06": 18,
+    "F08": 2,
+    "F09": 6,
+    "F10": 18,
+    "F11": 18,
+    "F13": 2,
+    "F14": 2,
+    "F15": 2
+  },
+  "interpretation": [
+    "Each record transforms a self-edge family representative equality path into one labelled n=9 frontier assignment.",
+    "The transformed strict inequality is replayed from the assignment's compact core rows.",
+    "These records are compact replay aids and lemma-mining diagnostics, not theorem names.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "path_length_counts": {
+    "3": 86,
+    "4": 36,
+    "5": 18,
+    "6": 18
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_self_edge_path_join.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_self_edge_path_join.py"
+  },
+  "records": [
+    {
+      "assignment_id": "A001",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A002",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A003",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A004",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          5,
+          0
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A005",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          6,
+          1,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          3,
+          7
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          5
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A006",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          5,
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 3,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          1,
+          5
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A007",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          2,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          4
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          7
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A009",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F08",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A010",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          2,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          6
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A011",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          7
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          5
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A012",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          4,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          5,
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              5,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          6,
+          2
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A013",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A014",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F09",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      "template_id": "T01",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A016",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          6,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          8,
+          2,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          3,
+          8
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          3,
+          5,
+          8,
+          0
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A017",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          4,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          5,
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          3,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          6,
+          2
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A018",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          3,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          3,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          0,
+          5
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          3,
+          5
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A019",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          4,
+          0
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A021",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          6,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          3,
+          8
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          7
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          7
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          6,
+          8,
+          1
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A022",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          4,
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          5,
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          3,
+          5,
+          7,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 3,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          0,
+          4
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A023",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          5
+        ]
+      },
+      "family_id": "F13",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "template_id": "T04",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A024",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F09",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          6,
+          8,
+          0
+        ]
+      },
+      "template_id": "T01",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A025",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          4,
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          5,
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          4
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          4
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 3,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          8,
+          4
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A026",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              4
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          2,
+          7
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          7
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A027",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          4,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          6,
+          2,
+          3,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          2,
+          6
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          6
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          0,
+          2
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A028",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          5,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          6,
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          1,
+          4,
+          6,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              0,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          7
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          7
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          4,
+          7,
+          0,
+          1
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A029",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              8
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          6,
+          8,
+          0
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A030",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          7,
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          4,
+          5,
+          6
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A031",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F09",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          7,
+          0,
+          1
+        ]
+      },
+      "template_id": "T01",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A033",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              5
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          4,
+          0
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A034",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          4
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          4
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 3,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          6,
+          2
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A035",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          4
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          4
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 3,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          2
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A036",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          7,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              5
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          3,
+          5,
+          6
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A037",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          6,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          8,
+          1,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          4,
+          7
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          1,
+          4,
+          6,
+          7
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A038",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              0,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          2,
+          6
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A039",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          3,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          8,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              8
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          7
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          7
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          1,
+          4
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A041",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          4,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          4,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          2,
+          6
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          6
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A042",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          1,
+          3,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          1,
+          5
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          5,
+          7,
+          1
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A043",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          6,
+          0,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          8,
+          0,
+          2,
+          3,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              8
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          0,
+          5
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A044",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          0,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          0,
+          5
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A045",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          1
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A046",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          6,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          2,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          6,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              2,
+              4
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          4,
+          8
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          2,
+          4
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A048",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          8,
+          0,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          0,
+          5
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          5,
+          7
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A049",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          7
+        ],
+        [
+          5,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          6,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          3,
+          4,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              3,
+              8
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          3
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A050",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          2,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          7
+        ],
+        [
+          5,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          6,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              6
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          3
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A051",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          7
+        ],
+        [
+          8,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F14",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          6,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A052",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          3,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          8,
+          0,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          4
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A053",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          2,
+          5,
+          7,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 3,
+        "row": 4,
+        "witness_order": [
+          5,
+          0,
+          2,
+          3
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A054",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              5,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          5
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          8,
+          1,
+          3
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A055",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          5,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          7,
+          0,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              5
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          3,
+          6
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          0,
+          3,
+          5,
+          6
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A056",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          3,
+          7
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A057",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          4,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          6,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          7
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          7
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 3,
+        "row": 6,
+        "witness_order": [
+          7,
+          2,
+          4,
+          5
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A058",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          5
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          6,
+          1
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A059",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          5,
+          0
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A060",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 3,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          8,
+          3
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A061",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          7
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 3,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          3
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A062",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          8,
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              6
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A063",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          4,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          0,
+          2,
+          4,
+          5
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 3,
+        "row": 5,
+        "witness_order": [
+          6,
+          1,
+          3,
+          4
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A064",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              1,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          3
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          3
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          3,
+          6
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A065",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          4,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 3,
+        "row": 5,
+        "witness_order": [
+          6,
+          2,
+          3,
+          4
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A066",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          6
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          3,
+          6,
+          8,
+          0
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A067",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          5,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          6
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A068",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          3,
+          2,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          4
+        ]
+      },
+      "family_id": "F15",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          4,
+          8
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A069",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          2,
+          6,
+          7
+        ],
+        [
+          6,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          5
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          8
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          8
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A070",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          5,
+          1,
+          2,
+          6,
+          7
+        ],
+        [
+          6,
+          0,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          1,
+          4,
+          6,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 3,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          0,
+          5
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A072",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          6,
+          2,
+          5,
+          7,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 3,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          8,
+          3
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A073",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          6,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              6
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          7,
+          8,
+          0
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A074",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          6,
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          0,
+          5
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          0,
+          2,
+          5
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A075",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              5
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          4,
+          7
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          1
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A076",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          3,
+          1,
+          2,
+          6,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          7,
+          0,
+          1
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A077",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          1,
+          4,
+          7,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              8
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          3,
+          8
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          5
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          5
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          5,
+          8
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A078",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          6,
+          2,
+          3,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          7
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          7
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          6
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A079",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          5,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          6,
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          2,
+          4,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          2,
+          7
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          7
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          0
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A084",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          5,
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          6,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          4,
+          5,
+          6,
+          8
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          4,
+          5,
+          6
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A085",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          4,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              8
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          7,
+          8,
+          0
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A086",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          3,
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              8
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          4,
+          0
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A087",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          4,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          2,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          2,
+          7
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A088",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          4,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          8
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          8
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 3,
+        "row": 6,
+        "witness_order": [
+          7,
+          8,
+          1,
+          5
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A089",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          7,
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          0,
+          6
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          0,
+          3
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A090",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              1,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 3,
+        "row": 3,
+        "witness_order": [
+          4,
+          8,
+          1,
+          2
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A091",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          7,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          0,
+          3
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          3
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          6,
+          0,
+          2,
+          3
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A092",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          5,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          7,
+          8,
+          0
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A094",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          6,
+          7
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          0,
+          5
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A096",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          6,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          5,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              6
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          5,
+          6,
+          7
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A097",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          4,
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          5,
+          2,
+          3,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          0,
+          4
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          4
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          4
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          7,
+          0
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A098",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              6
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          5,
+          8
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          8,
+          2
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A099",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F14",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          7,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A100",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              5
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 3,
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          2
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A101",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          6,
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          2,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          3,
+          5,
+          6
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A102",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          4,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          4,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          3,
+          6
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          6,
+          0
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A103",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 3,
+        "row": 1,
+        "witness_order": [
+          2,
+          6,
+          8,
+          0
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A104",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              4
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          4,
+          8
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          1,
+          4
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A105",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          7,
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              3,
+              7
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          5
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          5
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 3,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          0,
+          4
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A106",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          5,
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          7,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              7
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          2,
+          3,
+          4
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A107",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          5,
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          2,
+          3,
+          4
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A108",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          3,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          1,
+          2,
+          3
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A109",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          4,
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          6,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              6
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          1,
+          2,
+          3
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A110",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          5,
+          0,
+          2,
+          4,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              6
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          2,
+          6
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          6
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          0,
+          2,
+          4
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A112",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          2,
+          4,
+          7,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          3,
+          8
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A113",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          4,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          6,
+          2,
+          4,
+          5,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          2,
+          5
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          8,
+          2,
+          4,
+          5
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A114",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          8,
+          0,
+          1
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A115",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          6,
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          7
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          7
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          2,
+          6
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A116",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          7,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              4,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          0,
+          4
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          7,
+          0,
+          2
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A117",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          1,
+          6
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          4
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          4
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          4,
+          6,
+          8
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A118",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          5,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          3,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          7
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          7
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 3,
+        "row": 6,
+        "witness_order": [
+          7,
+          3,
+          4,
+          5
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A119",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          5,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          7
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          7
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 3,
+        "row": 6,
+        "witness_order": [
+          7,
+          2,
+          4,
+          5
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A120",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          6,
+          1
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A121",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          6,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          2,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          4,
+          5,
+          6
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A122",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          2,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          5,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          6,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          5,
+          6,
+          8
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          0,
+          1,
+          2
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A123",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          3,
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          4,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              8
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          0,
+          1,
+          2
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A124",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          7,
+          2,
+          4,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              8
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          4,
+          8
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          2,
+          4,
+          6
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A125",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          3,
+          6,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              3,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          2,
+          5
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          3,
+          5,
+          8
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A127",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          5,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          7,
+          0,
+          3,
+          4,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          5,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          3,
+          7
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          1,
+          3
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A128",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          6,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          2,
+          8
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          7
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          7
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          8
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          5,
+          8,
+          1,
+          2
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A129",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          3
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 3,
+        "row": 2,
+        "witness_order": [
+          3,
+          7,
+          0,
+          1
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A130",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          4,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          5,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          5,
+          7
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          5,
+          6,
+          7
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A131",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          6,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          4,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          5,
+          8
+        ]
+      },
+      "family_id": "F15",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A132",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          0,
+          4,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              4
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          8,
+          0,
+          1
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A133",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          5,
+          7,
+          8
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A134",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          5,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          6,
+          3,
+          4,
+          5,
+          7
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              8
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              4
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          3,
+          4,
+          5
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A135",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          5
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          6,
+          3,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          5
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          3,
+          4,
+          5
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A136",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F08",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          5,
+          7,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A138",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          5,
+          7,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A139",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          0,
+          3,
+          4,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          4,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              2,
+              4
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          1,
+          6
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A140",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F09",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          5,
+          7,
+          8
+        ]
+      },
+      "template_id": "T01",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A142",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          7,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              7
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          8,
+          0,
+          1
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A143",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          6,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              7
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          6,
+          7,
+          8
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A144",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          6,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          4,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              5
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          6,
+          7,
+          8
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A145",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          6,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          6,
+          7,
+          8
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A146",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          6,
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          8,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          6
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          4
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          4
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          1,
+          3,
+          6,
+          7
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A148",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          3,
+          7
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "row": 4,
+        "witness_order": [
+          5,
+          7,
+          0,
+          3
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A149",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          2,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              6
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          2,
+          7
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A150",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          3,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          4,
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              4,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          1
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A155",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          8,
+          0,
+          2,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              4,
+              7
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          2,
+          7
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          4
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          4
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          7
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          2,
+          4,
+          7
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A156",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          5,
+          3,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          0,
+          4
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          4
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          4
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "outer_span": 2,
+        "row": 1,
+        "witness_order": [
+          2,
+          4,
+          6,
+          0
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A158",
+      "contradiction": {
+        "inner_pair": [
+          5,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          5,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          1,
+          5
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          5,
+          7,
+          1,
+          2
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A159",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          3,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          3,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          5,
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          7,
+          1,
+          2,
+          6,
+          8
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F02",
+      "path_length": 5,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          8,
+          4
+        ]
+      },
+      "template_id": "T08",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A160",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          6,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          6,
+          7,
+          8,
+          4
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A161",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          2
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          3,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          2,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              3,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          2
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "outer_span": 2,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          2,
+          7
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A162",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              3,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          4,
+          6
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          7
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          7
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "outer_span": 3,
+        "row": 5,
+        "witness_order": [
+          6,
+          1,
+          3,
+          4
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A163",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          4,
+          2,
+          3,
+          7,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 3,
+        "row": 3,
+        "witness_order": [
+          4,
+          0,
+          1,
+          2
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A165",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          3,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          4,
+          2,
+          3,
+          7,
+          8
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          4,
+          8
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          8,
+          1,
+          4,
+          5
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A166",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          6,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          6,
+          8
+        ]
+      },
+      "family_id": "F09",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          6,
+          8
+        ],
+        "outer_span": 3,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          2,
+          6
+        ]
+      },
+      "template_id": "T01",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A168",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          2,
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          3,
+          1,
+          2,
+          6,
+          7
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          3,
+          7
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "row": 5,
+        "witness_order": [
+          7,
+          0,
+          3,
+          4
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A169",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          3,
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          2,
+          5,
+          8
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              6
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F03",
+      "path_length": 6,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          1
+        ]
+      },
+      "template_id": "T09",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A170",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F10",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          3,
+          7
+        ]
+      },
+      "template_id": "T05",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A171",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          }
+        ],
+        "start_pair": [
+          2,
+          8
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          8
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          2,
+          5
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A172",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          4
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          7,
+          1,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              5,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              4
+            ],
+            "row": 4
+          }
+        ],
+        "start_pair": [
+          2,
+          7
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          2,
+          7
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A173",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 3,
+        "row": 4,
+        "witness_order": [
+          5,
+          1,
+          2,
+          3
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A174",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          4,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          8,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          4,
+          8
+        ]
+      },
+      "family_id": "F13",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          1,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          6
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "template_id": "T04",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A175",
+      "contradiction": {
+        "inner_pair": [
+          0,
+          1
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          0,
+          1
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F09",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          1,
+          3,
+          7
+        ]
+      },
+      "template_id": "T01",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A176",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          3
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          3,
+          5
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          8
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          3
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          3,
+          5
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          4
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          4
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "outer_span": 3,
+        "row": 4,
+        "witness_order": [
+          5,
+          0,
+          2,
+          3
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A177",
+      "contradiction": {
+        "inner_pair": [
+          7,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          5,
+          8
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          4,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          7,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              3,
+              7
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          5,
+          8
+        ]
+      },
+      "family_id": "F06",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8
+        ]
+      },
+      "template_id": "T07",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A178",
+      "contradiction": {
+        "inner_pair": [
+          1,
+          2
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          2,
+          4
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          2
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 3,
+        "row": 3,
+        "witness_order": [
+          4,
+          8,
+          1,
+          2
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A179",
+      "contradiction": {
+        "inner_pair": [
+          4,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          4
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          7,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          2,
+          6,
+          7
+        ]
+      ],
+      "core_size": 5,
+      "distance_equality": {
+        "end_pair": [
+          4,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              7
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              6,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              4,
+              6
+            ],
+            "row": 6
+          }
+        ],
+        "start_pair": [
+          0,
+          4
+        ]
+      },
+      "family_id": "F11",
+      "path_length": 4,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "outer_span": 2,
+        "row": 2,
+        "witness_order": [
+          4,
+          6,
+          0,
+          1
+        ]
+      },
+      "template_id": "T06",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A181",
+      "contradiction": {
+        "inner_pair": [
+          3,
+          6
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          1,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          3,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          7,
+          1,
+          3,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          6
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              6
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          6
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          6
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "outer_span": 2,
+        "row": 7,
+        "witness_order": [
+          8,
+          1,
+          3,
+          6
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A182",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          7,
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          5,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F01",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          5,
+          6,
+          7
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A183",
+      "contradiction": {
+        "inner_pair": [
+          2,
+          8
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          2,
+          6
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          7,
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          1,
+          2,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          2,
+          8
+        ],
+        "path": [
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              2,
+              8
+            ],
+            "row": 8
+          }
+        ],
+        "start_pair": [
+          2,
+          6
+        ]
+      },
+      "family_id": "F05",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          6
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          6
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          6
+        ],
+        "outer_span": 2,
+        "row": 3,
+        "witness_order": [
+          4,
+          6,
+          8,
+          2
+        ]
+      },
+      "template_id": "T03",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A184",
+      "contradiction": {
+        "inner_pair": [
+          6,
+          7
+        ],
+        "kind": "self_edge",
+        "outer_pair": [
+          0,
+          7
+        ],
+        "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 3,
+      "distance_equality": {
+        "end_pair": [
+          6,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          }
+        ],
+        "start_pair": [
+          0,
+          7
+        ]
+      },
+      "family_id": "F04",
+      "path_length": 3,
+      "shared_endpoint_count": 1,
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "outer_span": 3,
+        "row": 8,
+        "witness_order": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      "template_id": "T02",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    }
+  ],
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_self_edge_path_join.v1",
+  "self_edge_assignment_count": 158,
+  "self_edge_family_count": 13,
+  "self_edge_template_count": 9,
+  "shared_endpoint_counts": {
+    "1": 158
+  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_local_cores.json",
+      "role": "family representative self-edge strict inequalities and equality paths",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": "n9_vertex_circle_local_cores_v1"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+      "role": "assignment-to-family label maps and transformed core rows",
+      "schema": "erdos97.n9_vertex_circle_frontier_motif_classification.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_assignment_count": 184,
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_cycle_assignment_count": 26,
+  "template_assignment_counts": {
+    "T01": 6,
+    "T02": 40,
+    "T03": 20,
+    "T04": 2,
+    "T05": 18,
+    "T06": 18,
+    "T07": 18,
+    "T08": 18,
+    "T09": 18
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -59,6 +59,15 @@ those 184 obstructions. It finds 158 self-edge contradictions and 26 strict
 directed cycles; every strict cycle has length 2 or 3. That diagnostic is meant
 to guide a possible general lemma, not to strengthen the repo claim by itself.
 
+Two later review aids make the self-edge part easier to inspect:
+`data/certificates/n9_vertex_circle_frontier_motif_classification.json`
+classifies all 184 labelled assignments by motif family and local-core
+template, while
+`data/certificates/n9_vertex_circle_self_edge_path_join.json` transforms the
+family representative equality paths back into each of the 158 labelled
+self-edge assignments. Both are review-pending diagnostics only, not
+independent proofs and not status promotions.
+
 ## Commands
 
 Run the stable checker and assert the expected counts:

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -55,6 +55,15 @@ assignment's original labels. The checker replays the transformed cores, so
 the file is useful for reviewing the family classification without treating
 template ids as theorem names.
 
+`data/certificates/n9_vertex_circle_self_edge_path_join.json` adds a narrower
+self-edge replay join for the 158 self-edge frontier assignments. It transforms
+each family representative selected-distance equality path back into the
+labelled assignment coordinates, preserves the dihedral map used for that
+assignment, and replays the matching vertex-circle strict inequality from the
+compact core rows. This is a lemma-mining and reviewer-navigation diagnostic
+only; it is not an independent proof of `n=9` and does not promote the
+exhaustive checker.
+
 `data/certificates/n9_row_ptolemy_product_cancellations.json` contains a
 dependent crosswalk from the row-Ptolemy hit families to these template labels:
 `F02 -> T08`, `F09 -> T01`, and `F13 -> T04`. All three are self-edge
@@ -156,6 +165,19 @@ python scripts/check_n9_vertex_circle_frontier_motif_classification.py \
   --json
 ```
 
+Generate and check the self-edge equality-path join:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_path_join.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_self_edge_path_join.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -163,6 +185,7 @@ python -m pytest \
   tests/test_n9_vertex_circle_local_cores.py \
   tests/test_n9_vertex_circle_core_templates.py \
   tests/test_n9_vertex_circle_frontier_motif_classification.py \
+  tests/test_n9_vertex_circle_self_edge_path_join.py \
   -q
 ```
 

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -40,6 +40,15 @@ both the full assignment and the transformed compact core. This is a
 review-pending diagnostic classification, not an independent proof and not a
 promotion of the n=9 finite-case status.
 
+The self-edge equality-path join
+`data/certificates/n9_vertex_circle_self_edge_path_join.json` then restricts
+to the 158 self-edge assignments and stores the transformed equality path that
+identifies the outer and inner chord distances in each labelled core. Its
+checker verifies the source classification, the source local-core
+certificates, the stored label maps, the transformed core rows, and the
+replayed strict inequality. This is a review-pending diagnostic for lemma
+mining only; the path join is not an independent proof of `n=9`.
+
 The local-core follow-up in `docs/n9-vertex-circle-local-cores.md` shows that
 each of the 16 family representatives has a vertex-circle certificate using at
 most 6 selected rows. Its template diagnostic groups those 16 local cores into
@@ -113,11 +122,25 @@ python scripts/check_n9_vertex_circle_frontier_motif_classification.py \
   --json
 ```
 
+Generate and check the self-edge equality-path join:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_path_join.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_self_edge_path_join.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
 python -m pytest \
   tests/test_n9_vertex_circle_motif_families.py \
   tests/test_n9_vertex_circle_frontier_motif_classification.py \
+  tests/test_n9_vertex_circle_self_edge_path_join.py \
   -q
 ```

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -56,6 +56,7 @@ python scripts/analyze_n8_exact_survivors.py --check --json \
   --check-exact-analysis-data certificates/n8_exact_analysis.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -136,6 +136,8 @@ Next steps:
   quotient-cycle templates;
 - use `docs/n9-vertex-circle-local-cores.md` as the row-local certificate list
   to keep those lemmas small;
+- use `data/certificates/n9_vertex_circle_self_edge_path_join.json` as the
+  assignment-level replay aid for transformed self-edge equality paths;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -73,6 +73,7 @@ python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -353,6 +353,49 @@ artifacts:
       - motif classification is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_self_edge_path_join
+    path: data/certificates/n9_vertex_circle_self_edge_path_join.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_self_edge_path_join.py
+    command: python scripts/check_n9_vertex_circle_self_edge_path_join.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_self_edge_path_join.py
+    check_command: python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Assignment-level join of the 158 n=9 self-edge frontier assignments to transformed family representative equality paths; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_self_edge_path_join.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Assignment-level join of the 158 n=9 self-edge frontier assignments to transformed family representative equality paths; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      source_assignment_count: 184
+      self_edge_assignment_count: 158
+      strict_cycle_assignment_count: 26
+      self_edge_family_count: 13
+      self_edge_template_count: 9
+      path_length_counts.3: 86
+      path_length_counts.4: 36
+      path_length_counts.5: 18
+      path_length_counts.6: 18
+      shared_endpoint_counts.1: 158
+      core_size_assignment_counts.3: 46
+      core_size_assignment_counts.4: 40
+      core_size_assignment_counts.5: 36
+      core_size_assignment_counts.6: 36
+      provenance.command: python scripts/check_n9_vertex_circle_self_edge_path_join.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the path join is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_self_edge_path_join.py
+++ b/scripts/check_n9_vertex_circle_self_edge_path_join.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Generate or check the n=9 self-edge equality-path join diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_frontier_motif_classification import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_CLASSIFICATION,
+    validate_payload as validate_classification_payload,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_local_core_counts,
+)
+from erdos97.n9_vertex_circle_self_edge_path_join import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_self_edge_path_join_counts,
+    self_edge_path_join_payload,
+    self_edge_path_join_record,
+    self_edge_path_join_source_artifacts,
+    validate_equality_path,
+    validate_label_map,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_self_edge_path_join.json"
+)
+DEFAULT_LOCAL_CORES = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "core_size_assignment_counts",
+    "cyclic_order",
+    "families",
+    "family_assignment_counts",
+    "interpretation",
+    "n",
+    "path_length_counts",
+    "provenance",
+    "records",
+    "row_size",
+    "schema",
+    "self_edge_assignment_count",
+    "self_edge_family_count",
+    "self_edge_template_count",
+    "shared_endpoint_counts",
+    "source_artifacts",
+    "source_assignment_count",
+    "status",
+    "strict_cycle_assignment_count",
+    "template_assignment_counts",
+    "trust",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    local_cores_path: Path = DEFAULT_LOCAL_CORES,
+    classification_path: Path = DEFAULT_CLASSIFICATION,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the self-edge path join."""
+
+    return {
+        "local_cores": load_artifact(_resolve(local_cores_path)),
+        "classification": load_artifact(_resolve(classification_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    local_cores = source_payloads.get("local_cores")
+    classification = source_payloads.get("classification")
+    if not isinstance(local_cores, dict):
+        errors.append("source local-core payload must be an object")
+    else:
+        try:
+            assert_expected_local_core_counts(local_cores)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"source local-core artifact invalid: {exc}")
+    if not isinstance(classification, dict):
+        errors.append("source classification payload must be an object")
+    else:
+        classification_errors = validate_classification_payload(
+            classification,
+            recompute=False,
+        )
+        if classification_errors:
+            errors.extend(
+                f"source frontier classification invalid: {error}"
+                for error in classification_errors
+            )
+
+
+def _self_edge_certificates(local_core_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    certificates = local_core_payload.get("certificates")
+    if not isinstance(certificates, list):
+        raise ValueError("local-core payload must contain certificates")
+    return {
+        str(certificate["family_id"]): certificate
+        for certificate in certificates
+        if isinstance(certificate, dict) and certificate.get("status") == "self_edge"
+    }
+
+
+def _self_edge_assignments(
+    classification_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    assignments = classification_payload.get("assignments")
+    if not isinstance(assignments, list):
+        raise ValueError("classification payload must contain assignments")
+    return {
+        str(assignment["assignment_id"]): assignment
+        for assignment in assignments
+        if isinstance(assignment, dict) and assignment.get("status") == "self_edge"
+    }
+
+
+def _validate_family_rows(
+    payload: dict[str, Any],
+    records: Sequence[dict[str, Any]],
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> None:
+    raw_families = payload.get("families")
+    if not isinstance(raw_families, list):
+        errors.append("families must be a list")
+        return
+    certificates = _self_edge_certificates(source_payloads["local_cores"])
+    record_counts = Counter(str(record.get("family_id")) for record in records)
+    seen: set[str] = set()
+    for index, raw_family in enumerate(raw_families):
+        if not isinstance(raw_family, dict):
+            errors.append(f"family {index} must be an object")
+            continue
+        family_id = str(raw_family.get("family_id"))
+        if family_id in seen:
+            errors.append(f"duplicate family id {family_id}")
+        seen.add(family_id)
+        certificate = certificates.get(family_id)
+        if certificate is None:
+            errors.append(f"family {family_id} missing from source local cores")
+            continue
+        expected = {
+            "assignment_count": int(record_counts[family_id]),
+            "core_size": int(certificate["core_size"]),
+            "family_id": family_id,
+            "orbit_size": int(certificate["orbit_size"]),
+            "path_length": len(certificate["distance_equality"]["path"]),
+            "status": "self_edge",
+        }
+        for key, value in expected.items():
+            if raw_family.get(key) != value:
+                errors.append(
+                    f"family {family_id} {key} mismatch: "
+                    f"expected {value!r}, got {raw_family.get(key)!r}"
+                )
+        if raw_family.get("template_id") not in {
+            str(record.get("template_id"))
+            for record in records
+            if str(record.get("family_id")) == family_id
+        }:
+            errors.append(f"family {family_id} template_id does not match records")
+    if len(seen) != payload.get("self_edge_family_count"):
+        errors.append("self_edge_family_count does not match family rows")
+
+
+def _validate_record_rows(
+    payload: dict[str, Any],
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> None:
+    records = payload.get("records")
+    if not isinstance(records, list):
+        errors.append("records must be a list")
+        return
+    try:
+        certificates = _self_edge_certificates(source_payloads["local_cores"])
+        assignments = _self_edge_assignments(source_payloads["classification"])
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"could not prepare source maps: {exc}")
+        return
+
+    record_ids: list[str] = []
+    family_counts: Counter[str] = Counter()
+    template_counts: Counter[str] = Counter()
+    path_lengths: Counter[int] = Counter()
+    core_sizes: Counter[int] = Counter()
+    shared_endpoints: Counter[int] = Counter()
+    typed_records: list[dict[str, Any]] = []
+    for index, raw_record in enumerate(records):
+        if not isinstance(raw_record, dict):
+            errors.append(f"record {index} must be an object")
+            continue
+        typed_records.append(raw_record)
+        assignment_id = raw_record.get("assignment_id")
+        if isinstance(assignment_id, str):
+            record_ids.append(assignment_id)
+        assignment = assignments.get(str(assignment_id))
+        if assignment is None:
+            errors.append(f"record {assignment_id or index} missing source assignment")
+            continue
+        family_id = str(assignment["family_id"])
+        certificate = certificates.get(family_id)
+        if certificate is None:
+            errors.append(f"record {assignment_id} missing source family {family_id}")
+            continue
+        try:
+            validate_label_map(raw_record["to_canonical_label_map"])
+            validate_equality_path(
+                raw_record["core_selected_rows"],
+                raw_record["distance_equality"],
+            )
+            expected_record = self_edge_path_join_record(assignment, certificate)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"record {assignment_id or index} invalid: {exc}")
+            continue
+        expect_equal(errors, f"record {assignment_id}", raw_record, expected_record)
+        family_counts[str(raw_record["family_id"])] += 1
+        template_counts[str(raw_record["template_id"])] += 1
+        path_lengths[int(raw_record["path_length"])] += 1
+        core_sizes[int(raw_record["core_size"])] += 1
+        shared_endpoints[int(raw_record["shared_endpoint_count"])] += 1
+
+    if len(record_ids) != len(set(record_ids)):
+        errors.append("duplicate record assignment ids")
+    expect_equal(
+        errors,
+        "family_assignment_counts",
+        payload.get("family_assignment_counts"),
+        {family_id: int(family_counts[family_id]) for family_id in sorted(family_counts)},
+    )
+    expect_equal(
+        errors,
+        "template_assignment_counts",
+        payload.get("template_assignment_counts"),
+        {
+            template_id: int(template_counts[template_id])
+            for template_id in sorted(template_counts)
+        },
+    )
+    expect_equal(
+        errors,
+        "path_length_counts",
+        payload.get("path_length_counts"),
+        {str(length): int(path_lengths[length]) for length in sorted(path_lengths)},
+    )
+    expect_equal(
+        errors,
+        "core_size_assignment_counts",
+        payload.get("core_size_assignment_counts"),
+        {str(size): int(core_sizes[size]) for size in sorted(core_sizes)},
+    )
+    expect_equal(
+        errors,
+        "shared_endpoint_counts",
+        payload.get("shared_endpoint_counts"),
+        {
+            str(count): int(shared_endpoints[count])
+            for count in sorted(shared_endpoints)
+        },
+    )
+    _validate_family_rows(payload, typed_records, source_payloads, errors)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a self-edge path-join artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "source_assignment_count": 184,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_assignment_count": 26,
+        "self_edge_family_count": 13,
+        "self_edge_template_count": 9,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+
+    _validate_sources(source_payloads, errors)
+    if not errors:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            self_edge_path_join_source_artifacts(
+                source_payloads["local_cores"],
+                source_payloads["classification"],
+            ),
+        )
+        _validate_record_rows(payload, source_payloads, errors)
+
+    try:
+        assert_expected_self_edge_path_join_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected self-edge path-join counts failed: {exc}")
+
+    if recompute and not errors:
+        try:
+            expected_payload = self_edge_path_join_payload(
+                source_payloads["local_cores"],
+                source_payloads["classification"],
+            )
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"recomputed self-edge path join failed: {exc}")
+        else:
+            expect_equal(errors, "self-edge path join", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "source_assignment_count": object_payload.get("source_assignment_count"),
+        "self_edge_assignment_count": object_payload.get("self_edge_assignment_count"),
+        "strict_cycle_assignment_count": object_payload.get(
+            "strict_cycle_assignment_count"
+        ),
+        "self_edge_family_count": object_payload.get("self_edge_family_count"),
+        "self_edge_template_count": object_payload.get("self_edge_template_count"),
+        "path_length_counts": object_payload.get("path_length_counts"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--local-cores", type=Path, default=DEFAULT_LOCAL_CORES)
+    parser.add_argument("--classification", type=Path, default=DEFAULT_CLASSIFICATION)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            local_cores_path=args.local_cores,
+            classification_path=args.classification,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = self_edge_path_join_payload(
+            sources["local_cores"],
+            sources["classification"],
+        )
+        if args.assert_expected:
+            assert_expected_self_edge_path_join_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle self-edge equality-path join")
+        print(f"artifact: {summary['artifact']}")
+        print(f"self-edge assignments: {summary['self_edge_assignment_count']}")
+        print(f"self-edge families: {summary['self_edge_family_count']}")
+        print(f"self-edge templates: {summary['self_edge_template_count']}")
+        print(f"path lengths: {summary['path_length_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: self-edge path-join checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -156,6 +156,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_self_edge_path_join",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_self_edge_path_join.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Assignment-level join for the 158 n=9 self-edge frontier "
+            "assignments and transformed equality paths; not a proof of n=9 "
+            "or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_self_edge_path_join.py
+++ b/src/erdos97/n9_vertex_circle_self_edge_path_join.py
@@ -1,0 +1,416 @@
+"""Join n=9 self-edge assignments to transformed equality paths.
+
+This module is diagnostic. It does not prove Erdos Problem #97, does not
+claim a counterexample, and does not promote the review-pending n=9 checker.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_frontier_motif_classification import (
+    invert_label_map,
+    transform_compact_rows,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS
+from erdos97.vertex_circle_quotient_replay import (
+    Pair,
+    StrictInequality,
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+)
+
+
+SCHEMA = "erdos97.n9_vertex_circle_self_edge_path_join.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Assignment-level join of the 158 n=9 self-edge frontier assignments to "
+    "transformed family representative equality paths; not a proof of n=9, "
+    "not a counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_self_edge_path_join.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_self_edge_path_join.py "
+        "--assert-expected --write"
+    ),
+}
+EXPECTED_SELF_EDGE_ASSIGNMENTS = 158
+EXPECTED_STRICT_CYCLE_ASSIGNMENTS = 26
+EXPECTED_SELF_EDGE_FAMILIES = 13
+EXPECTED_SELF_EDGE_TEMPLATES = 9
+EXPECTED_PATH_LENGTH_COUNTS = {"3": 86, "4": 36, "5": 18, "6": 18}
+EXPECTED_CORE_SIZE_COUNTS = {"3": 46, "4": 40, "5": 36, "6": 36}
+EXPECTED_SHARED_ENDPOINT_COUNTS = {"1": 158}
+EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS = {
+    "T01": 6,
+    "T02": 40,
+    "T03": 20,
+    "T04": 2,
+    "T05": 18,
+    "T06": 18,
+    "T07": 18,
+    "T08": 18,
+    "T09": 18,
+}
+EXPECTED_FAMILY_ASSIGNMENT_COUNTS = {
+    "F01": 18,
+    "F02": 18,
+    "F03": 18,
+    "F04": 18,
+    "F05": 18,
+    "F06": 18,
+    "F08": 2,
+    "F09": 6,
+    "F10": 18,
+    "F11": 18,
+    "F13": 2,
+    "F14": 2,
+    "F15": 2,
+}
+
+
+def transform_pair(raw_pair: Sequence[int], label_map: Sequence[int]) -> list[int]:
+    """Apply a label map to one unordered pair."""
+
+    if len(raw_pair) != 2:
+        raise ValueError(f"expected pair, got {raw_pair!r}")
+    return [int(value) for value in pair(label_map[int(raw_pair[0])], label_map[int(raw_pair[1])])]
+
+
+def validate_label_map(label_map: Sequence[int], *, n: int = n9.N) -> None:
+    """Validate that a label map is a permutation of ``range(n)``."""
+
+    if len(label_map) != n:
+        raise ValueError(f"label map must have {n} entries")
+    if sorted(int(label) for label in label_map) != list(range(n)):
+        raise ValueError(f"label map must be a permutation of 0..{n - 1}")
+
+
+def _edge_to_json(edge: StrictInequality) -> dict[str, Any]:
+    return {
+        "row": int(edge.row),
+        "witness_order": [int(label) for label in edge.witness_order],
+        "outer_interval": [int(value) for value in edge.outer_interval],
+        "inner_interval": [int(value) for value in edge.inner_interval],
+        "outer_pair": [int(value) for value in edge.outer_pair],
+        "inner_pair": [int(value) for value in edge.inner_pair],
+        "outer_class": [int(value) for value in edge.outer_class],
+        "inner_class": [int(value) for value in edge.inner_class],
+        "outer_span": int(edge.outer_interval[1] - edge.outer_interval[0]),
+        "inner_span": int(edge.inner_interval[1] - edge.inner_interval[0]),
+    }
+
+
+def transform_equality_path(
+    equality: dict[str, Any],
+    label_map: Sequence[int],
+) -> dict[str, Any]:
+    """Transform a representative equality path into assignment labels."""
+
+    return {
+        "start_pair": transform_pair(equality["start_pair"], label_map),
+        "end_pair": transform_pair(equality["end_pair"], label_map),
+        "path": [
+            {
+                "row": int(label_map[int(step["row"])]),
+                "next_pair": transform_pair(step["next_pair"], label_map),
+            }
+            for step in equality["path"]
+        ],
+    }
+
+
+def _selected_pairs_by_row(rows: Sequence[Sequence[int]]) -> dict[int, set[Pair]]:
+    parsed = parse_selected_rows(rows)
+    return {
+        row.center: {pair(row.center, witness) for witness in row.witnesses}
+        for row in parsed
+    }
+
+
+def compact_core_rows(certificate: dict[str, Any]) -> list[list[int]]:
+    """Return detailed local-core rows as compact ``[row, witnesses...]`` rows."""
+
+    compact = []
+    for raw in certificate["core_selected_rows"]:
+        row = int(raw["row"])
+        witnesses = sorted(int(witness) for witness in raw["witnesses"])
+        compact.append([row, *witnesses])
+    return sorted(compact, key=lambda item: item[0])
+
+
+def validate_equality_path(rows: Sequence[Sequence[int]], equality: dict[str, Any]) -> None:
+    """Validate that an equality path follows selected-distance row equalities."""
+
+    selected_pairs = _selected_pairs_by_row(rows)
+    current = pair(*equality["start_pair"])
+    end_pair = pair(*equality["end_pair"])
+    for step in equality["path"]:
+        row = int(step["row"])
+        if row not in selected_pairs:
+            raise ValueError(f"equality path row {row} is not selected")
+        next_pair = pair(*step["next_pair"])
+        if current not in selected_pairs[row] or next_pair not in selected_pairs[row]:
+            raise ValueError(f"row {row} does not equate {current} and {next_pair}")
+        current = next_pair
+    if current != end_pair:
+        raise ValueError(f"equality path ends at {current}, expected {end_pair}")
+
+
+def _self_edge_certificates(local_core_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    certificates = local_core_payload.get("certificates")
+    if not isinstance(certificates, list):
+        raise ValueError("local-core payload must contain certificates")
+    return {
+        str(certificate["family_id"]): certificate
+        for certificate in certificates
+        if certificate.get("status") == "self_edge"
+    }
+
+
+def _find_transformed_self_edge(
+    rows: Sequence[Sequence[int]],
+    expected_row: int,
+    outer_pair: Sequence[int],
+    inner_pair: Sequence[int],
+) -> StrictInequality:
+    result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parse_selected_rows(rows),
+    )
+    expected_outer = pair(*outer_pair)
+    expected_inner = pair(*inner_pair)
+    for edge in result.self_edge_conflicts:
+        if (
+            edge.row == expected_row
+            and edge.outer_pair == expected_outer
+            and edge.inner_pair == expected_inner
+        ):
+            return edge
+    raise AssertionError(
+        f"transformed self-edge conflict not found: {expected_outer} > {expected_inner}"
+    )
+
+
+def self_edge_path_join_record(
+    assignment: dict[str, Any],
+    certificate: dict[str, Any],
+) -> dict[str, Any]:
+    """Return one transformed self-edge path record for a labelled assignment."""
+
+    family_id = str(assignment["family_id"])
+    validate_label_map(assignment["to_canonical_label_map"])
+    inverse_map = invert_label_map(assignment["to_canonical_label_map"])
+    expected_core_rows = transform_compact_rows(
+        compact_core_rows(certificate),
+        inverse_map,
+    )
+    if assignment["core_selected_rows"] != expected_core_rows:
+        raise AssertionError(
+            f"{assignment['assignment_id']} core rows do not match transformed family core"
+        )
+    transformed_equality = transform_equality_path(
+        certificate["distance_equality"],
+        inverse_map,
+    )
+    transformed_edge_row = int(inverse_map[int(certificate["strict_inequality"]["row"])])
+    edge = _find_transformed_self_edge(
+        assignment["core_selected_rows"],
+        transformed_edge_row,
+        transformed_equality["start_pair"],
+        transformed_equality["end_pair"],
+    )
+    validate_equality_path(assignment["core_selected_rows"], transformed_equality)
+
+    path_length = len(transformed_equality["path"])
+    shared_endpoints = len(
+        set(transformed_equality["start_pair"]) & set(transformed_equality["end_pair"])
+    )
+    core_size = int(assignment["core_size"])
+    return {
+        "assignment_id": str(assignment["assignment_id"]),
+        "family_id": family_id,
+        "template_id": str(assignment["template_id"]),
+        "core_size": core_size,
+        "path_length": path_length,
+        "shared_endpoint_count": shared_endpoints,
+        "to_canonical_label_map": [
+            int(label) for label in assignment["to_canonical_label_map"]
+        ],
+        "core_selected_rows": assignment["core_selected_rows"],
+        "strict_inequality": _edge_to_json(edge),
+        "distance_equality": transformed_equality,
+        "contradiction": {
+            "kind": "self_edge",
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs",
+            "outer_pair": transformed_equality["start_pair"],
+            "inner_pair": transformed_equality["end_pair"],
+        },
+    }
+
+
+def self_edge_path_join_source_artifacts(
+    local_core_payload: dict[str, Any],
+    classification_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the path join."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_local_cores.json",
+            "role": "family representative self-edge strict inequalities and equality paths",
+            "type": local_core_payload.get("type"),
+            "trust": local_core_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+            "role": "assignment-to-family label maps and transformed core rows",
+            "schema": classification_payload.get("schema"),
+            "status": classification_payload.get("status"),
+            "trust": classification_payload.get("trust"),
+        },
+    ]
+
+
+def self_edge_path_join_payload(
+    local_core_payload: dict[str, Any],
+    classification_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return transformed self-edge path records for all self-edge assignments."""
+
+    certificates = _self_edge_certificates(local_core_payload)
+    records = []
+    family_counts: Counter[str] = Counter()
+    template_counts: Counter[str] = Counter()
+    path_lengths: Counter[int] = Counter()
+    core_sizes: Counter[int] = Counter()
+    shared_endpoint_counts: Counter[int] = Counter()
+    family_rows: dict[str, dict[str, Any]] = {}
+
+    for assignment in classification_payload["assignments"]:
+        if assignment["status"] != "self_edge":
+            continue
+        family_id = str(assignment["family_id"])
+        certificate = certificates[family_id]
+        record = self_edge_path_join_record(assignment, certificate)
+        path_length = int(record["path_length"])
+        shared_endpoints = int(record["shared_endpoint_count"])
+        core_size = int(record["core_size"])
+        family_counts[family_id] += 1
+        template_counts[str(assignment["template_id"])] += 1
+        path_lengths[path_length] += 1
+        core_sizes[core_size] += 1
+        shared_endpoint_counts[shared_endpoints] += 1
+        family_rows[family_id] = {
+            "assignment_count": int(family_counts[family_id]),
+            "core_size": core_size,
+            "family_id": family_id,
+            "orbit_size": int(certificate["orbit_size"]),
+            "path_length": path_length,
+            "status": "self_edge",
+            "template_id": str(assignment["template_id"]),
+        }
+        records.append(record)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "source_assignment_count": int(classification_payload["assignment_count"]),
+        "self_edge_assignment_count": len(records),
+        "strict_cycle_assignment_count": int(
+            classification_payload["status_counts"]["strict_cycle"]
+        ),
+        "self_edge_family_count": len(family_counts),
+        "self_edge_template_count": len(template_counts),
+        "path_length_counts": {
+            str(length): int(path_lengths[length]) for length in sorted(path_lengths)
+        },
+        "shared_endpoint_counts": {
+            str(count): int(shared_endpoint_counts[count])
+            for count in sorted(shared_endpoint_counts)
+        },
+        "core_size_assignment_counts": {
+            str(size): int(core_sizes[size]) for size in sorted(core_sizes)
+        },
+        "family_assignment_counts": {
+            family_id: int(family_counts[family_id]) for family_id in sorted(family_counts)
+        },
+        "template_assignment_counts": {
+            template_id: int(template_counts[template_id])
+            for template_id in sorted(template_counts)
+        },
+        "families": [family_rows[family_id] for family_id in sorted(family_rows)],
+        "records": records,
+        "interpretation": [
+            "Each record transforms a self-edge family representative equality path into one labelled n=9 frontier assignment.",
+            "The transformed strict inequality is replayed from the assignment's compact core rows.",
+            "These records are compact replay aids and lemma-mining diagnostics, not theorem names.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": self_edge_path_join_source_artifacts(
+            local_core_payload,
+            classification_payload,
+        ),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_self_edge_path_join_counts(payload)
+    return payload
+
+
+def assert_expected_self_edge_path_join_counts(payload: dict[str, Any]) -> None:
+    """Assert stable headline counts for the transformed self-edge path join."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["n"] != n9.N or payload["row_size"] != n9.ROW_SIZE:
+        raise AssertionError("unexpected n or row size")
+    if payload["cyclic_order"] != list(n9.ORDER):
+        raise AssertionError("unexpected cyclic order")
+    if payload["source_assignment_count"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError("unexpected source assignment count")
+    if payload["self_edge_assignment_count"] != EXPECTED_SELF_EDGE_ASSIGNMENTS:
+        raise AssertionError("unexpected self-edge assignment count")
+    if payload["strict_cycle_assignment_count"] != EXPECTED_STRICT_CYCLE_ASSIGNMENTS:
+        raise AssertionError("unexpected strict-cycle assignment count")
+    if payload["self_edge_family_count"] != EXPECTED_SELF_EDGE_FAMILIES:
+        raise AssertionError("unexpected self-edge family count")
+    if payload["self_edge_template_count"] != EXPECTED_SELF_EDGE_TEMPLATES:
+        raise AssertionError("unexpected self-edge template count")
+    if payload["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected path length counts")
+    if payload["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("unexpected shared-endpoint counts")
+    if payload["core_size_assignment_counts"] != EXPECTED_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected core-size counts")
+    if payload["family_assignment_counts"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected family assignment counts")
+    if payload["template_assignment_counts"] != EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected template assignment counts")
+    if len(payload["families"]) != EXPECTED_SELF_EDGE_FAMILIES:
+        raise AssertionError("unexpected family row count")
+    if len(payload["records"]) != EXPECTED_SELF_EDGE_ASSIGNMENTS:
+        raise AssertionError("unexpected record count")
+    family_counts = {
+        str(family["family_id"]): int(family["assignment_count"])
+        for family in payload["families"]
+    }
+    if family_counts != EXPECTED_FAMILY_ASSIGNMENT_COUNTS:
+        raise AssertionError("family rows do not match assignment counts")

--- a/tests/test_n9_vertex_circle_self_edge_path_join.py
+++ b/tests/test_n9_vertex_circle_self_edge_path_join.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_self_edge_path_join import (
+    assert_expected_self_edge_path_join_counts,
+    self_edge_path_join_payload,
+)
+from scripts.check_n9_vertex_circle_self_edge_path_join import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_self_edge_path_join_artifact_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_self_edge_path_join_counts(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["source_assignment_count"] == 184
+    assert payload["self_edge_assignment_count"] == 158
+    assert payload["strict_cycle_assignment_count"] == 26
+    assert payload["self_edge_family_count"] == 13
+    assert payload["self_edge_template_count"] == 9
+    assert payload["path_length_counts"] == {"3": 86, "4": 36, "5": 18, "6": 18}
+    assert payload["shared_endpoint_counts"] == {"1": 158}
+
+
+def test_self_edge_path_join_records_keep_review_maps() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    first = payload["records"][0]
+
+    assert first["assignment_id"] == "A001"
+    assert first["family_id"] == "F01"
+    assert first["template_id"] == "T02"
+    assert first["path_length"] == 3
+    assert first["shared_endpoint_count"] == 1
+    assert first["to_canonical_label_map"] == list(range(9))
+    assert first["contradiction"]["kind"] == "self_edge"
+    assert first["contradiction"]["outer_pair"] == first["distance_equality"]["start_pair"]
+    assert first["contradiction"]["inner_pair"] == first["distance_equality"]["end_pair"]
+
+
+def test_self_edge_path_join_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["self_edge_assignment_count"] == 158
+
+
+def test_self_edge_path_join_rejects_tampered_family_id() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["family_id"] = "F02"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("record A001 mismatch" in error for error in errors)
+
+
+def test_self_edge_path_join_rejects_invalid_label_map() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["to_canonical_label_map"] = [0] * 9
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("label map" in error for error in errors)
+
+
+def test_self_edge_path_join_rejects_tampered_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["distance_equality"]["path"][0]["next_pair"] = [2, 3]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("does not equate" in error or "record A001 mismatch" in error for error in errors)
+
+
+def test_self_edge_path_join_rejects_tampered_core_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["core_selected_rows"][0][1] = 4
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("record A001 invalid" in error or "record A001 mismatch" in error for error in errors)
+
+
+def test_self_edge_path_join_rejects_tampered_source_artifacts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["source_artifacts"][0]["path"] = "data/certificates/not_the_source.json"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("source_artifacts mismatch" in error for error in errors)
+
+
+def test_self_edge_path_join_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_self_edge_path_join_detects_source_classification_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    sources["classification"]["assignments"][0]["core_selected_rows"][0][1] = 4
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source frontier classification invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_self_edge_path_join_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == self_edge_path_join_payload(
+        source_payloads["local_cores"],
+        source_payloads["classification"],
+    )
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_self_edge_path_join_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_self_edge_path_join.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["self_edge_assignment_count"] == 158
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_self_edge_path_join_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "self_edge_path_join.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_self_edge_path_join.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_self_edge_path_join_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "self_edge_path_join.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_self_edge_path_join.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -95,3 +95,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n9_vertex_circle_self_edge_path_join.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary

- add a generated `n9_vertex_circle_self_edge_path_join` diagnostic joining the 158 self-edge frontier assignments to transformed family representative equality paths
- add a checker that validates source artifacts, label-map permutations, transformed core rows, equality paths, and replayed self-edge strict inequalities
- wire the artifact into n=9 review/audit commands and document it as review-pending diagnostic only

## Verification

- `python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_self_edge_path_join.py -q -m 'artifact or not artifact'`
- `python -m pytest -q tests/test_n9_vertex_circle_exhaustive.py tests/test_n9_vertex_circle_local_cores.py tests/test_n9_vertex_circle_local_core_packet.py tests/test_n9_vertex_circle_core_templates.py tests/test_n9_vertex_circle_frontier_motif_classification.py tests/test_n9_vertex_circle_self_edge_path_join.py tests/test_n9_vertex_circle_motif_families.py tests/test_n9_vertex_circle_obstruction_shapes.py`
- raw `verify-n9-review` commands; `make` is unavailable in this PowerShell environment
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_status_consistency.py --max-official-status-age-days 90`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check src/erdos97/n9_vertex_circle_self_edge_path_join.py scripts/check_n9_vertex_circle_self_edge_path_join.py tests/test_n9_vertex_circle_self_edge_path_join.py tests/test_run_artifact_audit.py`
- `git diff --check`

Note: `python -m pytest -q` completed the suite but reported 8 pre-existing/unrelated C19 replay mismatches on Windows path serialization (`\` vs `/`) and one downstream C19 certificate digest view; the n=9 checks above passed.