### PR TITLE
Add n9 strict-cycle path join diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expe
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_strict_cycle_path_join.json
+++ b/data/certificates/n9_vertex_circle_strict_cycle_path_join.json
@@ -1,0 +1,5280 @@
+{
+  "claim_scope": "Assignment-level join of the 26 n=9 strict-cycle frontier assignments to transformed family representative local-core strict cycles; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "connector_path_length_counts": {
+    "0": 6,
+    "1": 28,
+    "2": 26
+  },
+  "core_size_assignment_counts": {
+    "4": 24,
+    "6": 2
+  },
+  "cycle_length_counts": {
+    "2": 18,
+    "3": 8
+  },
+  "cycle_step_count": 60,
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "families": [
+    {
+      "assignment_count": 6,
+      "core_size": 4,
+      "cycle_length": 3,
+      "family_id": "F07",
+      "orbit_size": 6,
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11"
+    },
+    {
+      "assignment_count": 18,
+      "core_size": 4,
+      "cycle_length": 2,
+      "family_id": "F12",
+      "orbit_size": 18,
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10"
+    },
+    {
+      "assignment_count": 2,
+      "core_size": 6,
+      "cycle_length": 3,
+      "family_id": "F16",
+      "orbit_size": 2,
+      "span_signature": "3:1,3:1,3:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 54,
+      "template_id": "T12"
+    }
+  ],
+  "family_assignment_counts": {
+    "F07": 6,
+    "F12": 18,
+    "F16": 2
+  },
+  "first_full_assignment_cycle_length_counts": {
+    "2": 22,
+    "3": 4
+  },
+  "interpretation": [
+    "Each record transforms a strict-cycle family representative local-core certificate into one labelled n=9 frontier assignment.",
+    "The transformed strict-cycle edges are replayed from the assignment's compact core rows.",
+    "Connector paths identify each strict edge's inner pair with the next strict edge's outer pair.",
+    "Cycle-length counts here summarize transformed local-core certificates, not first full-assignment obstruction-shape cycles.",
+    "These records are compact replay aids and lemma-mining diagnostics, not theorem names.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_strict_cycle_path_join.py"
+  },
+  "records": [
+    {
+      "assignment_id": "A008",
+      "connector_path_lengths": [
+        0,
+        1,
+        2
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          6,
+          1,
+          5,
+          7,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              3
+            ],
+            "path": [],
+            "start_pair": [
+              0,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              1,
+              3
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              5,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  7
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              0,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  2
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              1,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              1,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              5,
+              7
+            ],
+            "outer_span": 3,
+            "row": 6,
+            "witness_order": [
+              7,
+              8,
+              1,
+              5
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A015",
+      "connector_path_lengths": [
+        0,
+        1,
+        2
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          5,
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [],
+            "start_pair": [
+              2,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              8
+            ],
+            "inner_interval": [
+              1,
+              3
+            ],
+            "inner_pair": [
+              2,
+              8
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              4,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  6
+                ],
+                "row": 4
+              }
+            ],
+            "start_pair": [
+              4,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              4
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              4,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              8
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              0,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              4
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              4,
+              6
+            ],
+            "outer_span": 3,
+            "row": 5,
+            "witness_order": [
+              6,
+              7,
+              0,
+              4
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A020",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          6,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  6
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              0,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              3,
+              6,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              0,
+              1
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [
+              4,
+              6,
+              0,
+              1
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A032",
+      "connector_path_lengths": [
+        0,
+        1,
+        2
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          5,
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          2,
+          4,
+          7,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [],
+            "start_pair": [
+              2,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              8
+            ],
+            "inner_interval": [
+              0,
+              2
+            ],
+            "inner_pair": [
+              2,
+              8
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              6,
+              8,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              4,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              2,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              6
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              8
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              2,
+              6,
+              8,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              6
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              4,
+              6
+            ],
+            "outer_span": 3,
+            "row": 5,
+            "witness_order": [
+              6,
+              1,
+              3,
+              4
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A040",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          2,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          5,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          8,
+          2,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  2,
+                  7
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              5,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              5,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              8
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              5,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              7,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              8
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              7,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              7
+            ],
+            "outer_span": 2,
+            "row": 5,
+            "witness_order": [
+              7,
+              8,
+              2,
+              4
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A047",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          2,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          5,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          3,
+          5,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  8
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  3,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              2,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              8
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              3
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              2,
+              5,
+              8,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              2,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              3
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              8
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              3,
+              8
+            ],
+            "outer_span": 2,
+            "row": 5,
+            "witness_order": [
+              6,
+              8,
+              2,
+              3
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A071",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          4,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          2,
+          6,
+          7
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  2,
+                  6
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              5,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              5,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              5
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              5
+            ],
+            "outer_span": 2,
+            "row": 4,
+            "witness_order": [
+              5,
+              8,
+              2,
+              3
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              5,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              5
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              5,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              2,
+              6
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              2,
+              5,
+              6
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A080",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  0,
+                  5
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              2,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              8
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              5,
+              8
+            ],
+            "outer_span": 2,
+            "row": 7,
+            "witness_order": [
+              8,
+              2,
+              5,
+              6
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              5,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              0,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              8
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              0,
+              5
+            ],
+            "outer_span": 2,
+            "row": 2,
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_id": "A081",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          4,
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          7,
+          1,
+          4,
+          5,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  1,
+                  5
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              4,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              4,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              4
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [
+              4,
+              7,
+              1,
+              2
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  4
+                ],
+                "row": 4
+              }
+            ],
+            "start_pair": [
+              4,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              4
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              4,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              5
+            ],
+            "outer_span": 2,
+            "row": 7,
+            "witness_order": [
+              8,
+              1,
+              4,
+              5
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A082",
+      "connector_path_lengths": [
+        1,
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          8,
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              0,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 3,
+            "row": 2,
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              2,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              4,
+              7,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              3
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  3
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              6,
+              7
+            ]
+          }
+        }
+      ],
+      "family_id": "F16",
+      "span_signature": "3:1,3:1,3:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 54,
+      "template_id": "T12",
+      "to_canonical_label_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A083",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          6,
+          2,
+          3,
+          7,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  3
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  3,
+                  7
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              0,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              6
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              6
+            ],
+            "outer_span": 2,
+            "row": 5,
+            "witness_order": [
+              6,
+              0,
+              3,
+              4
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              6,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              6
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              6,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              6,
+              7
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A093",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          3,
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          5,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          8,
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  1,
+                  5
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              2,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              5
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              2,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              2,
+              5
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [
+              4,
+              5,
+              8,
+              2
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              2
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              5
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              5
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              1,
+              2,
+              5,
+              7
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_id": "A095",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          8
+        ],
+        [
+          6,
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          7,
+          0,
+          3,
+          4,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              4,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  4
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  4,
+                  8
+                ],
+                "row": 4
+              }
+            ],
+            "start_pair": [
+              1,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              7
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              4,
+              7
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              7,
+              1,
+              4,
+              5
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              4,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  7
+                ],
+                "row": 7
+              }
+            ],
+            "start_pair": [
+              7,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              7
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              7,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              4,
+              8
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              2,
+              4,
+              7,
+              8
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A111",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          3,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          6,
+          0,
+          3,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  0,
+                  4
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              3,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              3,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 2,
+            "row": 2,
+            "witness_order": [
+              3,
+              6,
+              0,
+              1
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              3
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  3
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              3,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              0,
+              4
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              7,
+              0,
+              3,
+              4
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        6,
+        7,
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A126",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          2,
+          3,
+          6,
+          7
+        ],
+        [
+          4,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          7,
+          2,
+          4,
+          5,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  7
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  2,
+                  7
+                ],
+                "row": 7
+              }
+            ],
+            "start_pair": [
+              1,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              4
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              4,
+              7,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              2
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              4
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              2,
+              7
+            ],
+            "outer_span": 2,
+            "row": 4,
+            "witness_order": [
+              5,
+              7,
+              1,
+              2
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        8,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A137",
+      "connector_path_lengths": [
+        0,
+        1,
+        2
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          4,
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          5,
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [],
+            "start_pair": [
+              1,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              7
+            ],
+            "inner_interval": [
+              0,
+              2
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              5,
+              7,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              1,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              5
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              7
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              5,
+              7,
+              8
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  8
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              0,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              5
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              3,
+              5
+            ],
+            "outer_span": 3,
+            "row": 4,
+            "witness_order": [
+              5,
+              0,
+              2,
+              3
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A141",
+      "connector_path_lengths": [
+        0,
+        1,
+        2
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          4,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          8,
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              6
+            ],
+            "path": [],
+            "start_pair": [
+              0,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              6
+            ],
+            "inner_interval": [
+              0,
+              2
+            ],
+            "inner_pair": [
+              0,
+              6
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              7
+            ],
+            "outer_span": 3,
+            "row": 8,
+            "witness_order": [
+              0,
+              4,
+              6,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  4
+                ],
+                "row": 4
+              }
+            ],
+            "start_pair": [
+              0,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              4
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              6
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              4,
+              6,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  7
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              4,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              4,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              4
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              2,
+              4
+            ],
+            "outer_span": 3,
+            "row": 3,
+            "witness_order": [
+              4,
+              8,
+              1,
+              2
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A147",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          5,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          6,
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          7,
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  0,
+                  5
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              3,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              3,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              6
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 2,
+            "row": 7,
+            "witness_order": [
+              8,
+              0,
+              3,
+              6
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              5,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              6
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              5,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              5
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [
+              5,
+              6,
+              0,
+              2
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_id": "A151",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          1,
+          2,
+          6,
+          7
+        ],
+        [
+          4,
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          6,
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  2,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              0,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              3,
+              6
+            ],
+            "outer_span": 2,
+            "row": 4,
+            "witness_order": [
+              5,
+              6,
+              0,
+              3
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  6
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              2,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              6
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              2,
+              3,
+              6,
+              8
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_id": "A152",
+      "connector_path_lengths": [
+        1,
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          5,
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          8,
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "core_size": 6,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              0,
+              1
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 3,
+            "row": 7,
+            "witness_order": [
+              0,
+              1,
+              4,
+              6
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              2,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  8
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              5,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              8
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              5,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 3,
+            "row": 8,
+            "witness_order": [
+              1,
+              2,
+              5,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              6,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              6,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              8
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              2,
+              3,
+              6,
+              8
+            ]
+          }
+        }
+      ],
+      "family_id": "F16",
+      "span_signature": "3:1,3:1,3:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 54,
+      "template_id": "T12",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A153",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          2,
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          5,
+          0,
+          3,
+          4,
+          8
+        ],
+        [
+          6,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          8,
+          1,
+          2,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              4,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  8
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  4,
+                  8
+                ],
+                "row": 8
+              }
+            ],
+            "start_pair": [
+              2,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              2,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              5,
+              8
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              7,
+              8,
+              2,
+              5
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              5,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  5,
+                  8
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              4,
+              5
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              4,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              4,
+              8
+            ],
+            "outer_span": 2,
+            "row": 2,
+            "witness_order": [
+              4,
+              5,
+              8,
+              1
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_id": "A154",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          4,
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          7,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  0,
+                  4
+                ],
+                "row": 4
+              }
+            ],
+            "start_pair": [
+              1,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              4
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 2,
+            "witness_order": [
+              3,
+              4,
+              7,
+              1
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  4
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              0,
+              1
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              4
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              4
+            ],
+            "outer_span": 2,
+            "row": 7,
+            "witness_order": [
+              0,
+              1,
+              4,
+              6
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        1,
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_id": "A157",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          4,
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          7,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          8,
+          0,
+          1,
+          4,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  1,
+                  6
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              4,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              4,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              7
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              1,
+              4,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 7
+              }
+            ],
+            "start_pair": [
+              6,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              7
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              6,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "outer_span": 2,
+            "row": 4,
+            "witness_order": [
+              6,
+              7,
+              1,
+              3
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+        0,
+        8
+      ]
+    },
+    {
+      "assignment_id": "A164",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          1,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          4,
+          2,
+          3,
+          7,
+          8
+        ],
+        [
+          5,
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          7,
+          0,
+          1,
+          3,
+          6
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  3,
+                  7
+                ],
+                "row": 7
+              }
+            ],
+            "start_pair": [
+              1,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              1,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              2,
+              4
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              4,
+              7
+            ],
+            "outer_span": 2,
+            "row": 5,
+            "witness_order": [
+              6,
+              7,
+              1,
+              4
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              4,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  7
+                ],
+                "row": 4
+              }
+            ],
+            "start_pair": [
+              3,
+              4
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              2,
+              4
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              3,
+              4,
+              7,
+              0
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        4,
+        3,
+        2,
+        1,
+        0,
+        8,
+        7,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_id": "A167",
+      "connector_path_lengths": [
+        0,
+        1,
+        2
+      ],
+      "contradiction": {
+        "cycle_length": 3,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          3,
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          4,
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          7,
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [],
+            "start_pair": [
+              1,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              7
+            ],
+            "inner_interval": [
+              1,
+              3
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              7
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              7
+            ],
+            "outer_span": 3,
+            "row": 8,
+            "witness_order": [
+              0,
+              1,
+              3,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              3,
+              7
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              3
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              3,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              7
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              1,
+              3,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  7,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  7
+                ],
+                "row": 7
+              }
+            ],
+            "start_pair": [
+              3,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              7
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              3,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              3
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              3,
+              5
+            ],
+            "outer_span": 3,
+            "row": 4,
+            "witness_order": [
+              5,
+              6,
+              8,
+              3
+            ]
+          }
+        }
+      ],
+      "family_id": "F07",
+      "span_signature": "2:1,3:1,3:2",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "to_canonical_label_map": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_id": "A180",
+      "connector_path_lengths": [
+        2,
+        1
+      ],
+      "contradiction": {
+        "cycle_length": 2,
+        "kind": "strict_cycle",
+        "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+      },
+      "core_selected_rows": [
+        [
+          0,
+          3,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          3,
+          6
+        ],
+        [
+          3,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          6,
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              3,
+              8
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  3,
+                  8
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              0,
+              6
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              6
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              6,
+              0
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              3
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  3
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              0,
+              8
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              6
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              8
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              8,
+              0,
+              3,
+              5
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "span_signature": "2:1,2:1",
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "to_canonical_label_map": [
+        0,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1
+      ]
+    }
+  ],
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_strict_cycle_path_join.v1",
+  "self_edge_assignment_count": 158,
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_local_cores.json",
+      "role": "family representative strict-cycle inequalities and equality connectors",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": "n9_vertex_circle_local_cores_v1"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+      "role": "assignment-to-family label maps and transformed core rows",
+      "schema": "erdos97.n9_vertex_circle_frontier_motif_classification.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "role": "strict-cycle local-core template ids and span summaries",
+      "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_obstruction_shapes.json",
+      "role": "first full-assignment strict-cycle length counts for diagnostic comparison",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": "n9_vertex_circle_obstruction_shapes_v1"
+    }
+  ],
+  "source_assignment_count": 184,
+  "span_signature_counts": {
+    "2:1,2:1": 18,
+    "2:1,3:1,3:2": 6,
+    "3:1,3:1,3:1": 2
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_cycle_assignment_count": 26,
+  "strict_cycle_family_count": 3,
+  "strict_cycle_template_count": 3,
+  "strict_edge_count_assignment_counts": {
+    "36": 24,
+    "54": 2
+  },
+  "template_assignment_counts": {
+    "T10": 18,
+    "T11": 6,
+    "T12": 2
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -59,13 +59,18 @@ those 184 obstructions. It finds 158 self-edge contradictions and 26 strict
 directed cycles; every strict cycle has length 2 or 3. That diagnostic is meant
 to guide a possible general lemma, not to strengthen the repo claim by itself.
 
-Two later review aids make the self-edge part easier to inspect:
+Later review aids make the local quotient certificates easier to inspect:
 `data/certificates/n9_vertex_circle_frontier_motif_classification.json`
 classifies all 184 labelled assignments by motif family and local-core
 template, while
 `data/certificates/n9_vertex_circle_self_edge_path_join.json` transforms the
 family representative equality paths back into each of the 158 labelled
-self-edge assignments. Both are review-pending diagnostics only, not
+self-edge assignments.
+`data/certificates/n9_vertex_circle_strict_cycle_path_join.json` similarly
+transforms the strict-cycle local-core certificates back into each of the 26
+strict-cycle assignments. Its local-core cycle-length counts (`2: 18`,
+`3: 8`) are distinct from the first full-assignment obstruction-shape counts
+(`2: 22`, `3: 4`). All of these are review-pending diagnostics only, not
 independent proofs and not status promotions.
 
 ## Commands

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -64,6 +64,16 @@ compact core rows. This is a lemma-mining and reviewer-navigation diagnostic
 only; it is not an independent proof of `n=9` and does not promote the
 exhaustive checker.
 
+`data/certificates/n9_vertex_circle_strict_cycle_path_join.json` is the
+parallel replay join for the 26 strict-cycle frontier assignments. It
+transforms each family representative local-core cycle into labelled
+assignment coordinates, checks each equality connector from a strict edge's
+inner pair to the next strict edge's outer pair, and replays the transformed
+strict edges from the compact core rows. Its cycle-length counts summarize the
+transformed local-core certificates (`2: 18`, `3: 8`), not the first
+full-assignment obstruction-shape cycles (`2: 22`, `3: 4`). This is also a
+reviewer-navigation diagnostic only.
+
 `data/certificates/n9_row_ptolemy_product_cancellations.json` contains a
 dependent crosswalk from the row-Ptolemy hit families to these template labels:
 `F02 -> T08`, `F09 -> T01`, and `F13 -> T04`. All three are self-edge
@@ -178,6 +188,19 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py \
   --json
 ```
 
+Generate and check the strict-cycle path join:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -186,6 +209,7 @@ python -m pytest \
   tests/test_n9_vertex_circle_core_templates.py \
   tests/test_n9_vertex_circle_frontier_motif_classification.py \
   tests/test_n9_vertex_circle_self_edge_path_join.py \
+  tests/test_n9_vertex_circle_strict_cycle_path_join.py \
   -q
 ```
 

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -49,6 +49,15 @@ certificates, the stored label maps, the transformed core rows, and the
 replayed strict inequality. This is a review-pending diagnostic for lemma
 mining only; the path join is not an independent proof of `n=9`.
 
+The strict-cycle path join
+`data/certificates/n9_vertex_circle_strict_cycle_path_join.json` covers the
+remaining 26 assignments. It stores transformed local-core quotient cycles for
+families `F07`, `F12`, and `F16`, with template counts `T10: 18`, `T11: 6`,
+and `T12: 2`. Its local-core cycle-length counts are `2: 18` and `3: 8`;
+these are not the same statistic as the first full-assignment obstruction
+cycle counts in the obstruction-shape diagnostic. This is still a
+review-pending replay aid, not an independent n=9 proof.
+
 The local-core follow-up in `docs/n9-vertex-circle-local-cores.md` shows that
 each of the 16 family representatives has a vertex-circle certificate using at
 most 6 selected rows. Its template diagnostic groups those 16 local cores into
@@ -135,6 +144,19 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py \
   --json
 ```
 
+Generate and check the strict-cycle path join:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -142,5 +164,6 @@ python -m pytest \
   tests/test_n9_vertex_circle_motif_families.py \
   tests/test_n9_vertex_circle_frontier_motif_classification.py \
   tests/test_n9_vertex_circle_self_edge_path_join.py \
+  tests/test_n9_vertex_circle_strict_cycle_path_join.py \
   -q
 ```

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -57,6 +57,7 @@ python scripts/analyze_n8_exact_survivors.py --check --json \
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -138,6 +138,10 @@ Next steps:
   to keep those lemmas small;
 - use `data/certificates/n9_vertex_circle_self_edge_path_join.json` as the
   assignment-level replay aid for transformed self-edge equality paths;
+- use `data/certificates/n9_vertex_circle_strict_cycle_path_join.json` as the
+  assignment-level replay aid for transformed strict-cycle local-core
+  quotient cycles, keeping its local-core cycle counts separate from first
+  full-assignment obstruction-shape counts;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -74,6 +74,7 @@ python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expe
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -396,6 +396,58 @@ artifacts:
       - the path join is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_strict_cycle_path_join
+    path: data/certificates/n9_vertex_circle_strict_cycle_path_join.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_strict_cycle_path_join.py
+    command: python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_strict_cycle_path_join.py
+    check_command: python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Assignment-level join of the 26 n=9 strict-cycle frontier assignments to transformed family representative local-core strict cycles; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_strict_cycle_path_join.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Assignment-level join of the 26 n=9 strict-cycle frontier assignments to transformed family representative local-core strict cycles; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      source_assignment_count: 184
+      self_edge_assignment_count: 158
+      strict_cycle_assignment_count: 26
+      strict_cycle_family_count: 3
+      strict_cycle_template_count: 3
+      cycle_step_count: 60
+      cycle_length_counts.2: 18
+      cycle_length_counts.3: 8
+      first_full_assignment_cycle_length_counts.2: 22
+      first_full_assignment_cycle_length_counts.3: 4
+      core_size_assignment_counts.4: 24
+      core_size_assignment_counts.6: 2
+      strict_edge_count_assignment_counts.36: 24
+      strict_edge_count_assignment_counts.54: 2
+      connector_path_length_counts.0: 6
+      connector_path_length_counts.1: 28
+      connector_path_length_counts.2: 26
+      family_assignment_counts.F07: 6
+      family_assignment_counts.F12: 18
+      family_assignment_counts.F16: 2
+      template_assignment_counts.T10: 18
+      template_assignment_counts.T11: 6
+      template_assignment_counts.T12: 2
+      provenance.command: python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the path join is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_strict_cycle_path_join.py
+++ b/scripts/check_n9_vertex_circle_strict_cycle_path_join.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""Generate or check the n=9 strict-cycle path-join diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_core_templates import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATES,
+    validate_payload as validate_template_payload,
+)
+from check_n9_vertex_circle_frontier_motif_classification import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_CLASSIFICATION,
+    validate_payload as validate_classification_payload,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_local_core_counts,
+    assert_expected_counts as assert_expected_obstruction_shape_counts,
+)
+from erdos97.n9_vertex_circle_self_edge_path_join import (  # noqa: E402
+    validate_equality_path,
+    validate_label_map,
+)
+from erdos97.n9_vertex_circle_strict_cycle_path_join import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_strict_cycle_path_join_counts,
+    strict_cycle_path_join_payload,
+    strict_cycle_path_join_record,
+    strict_cycle_path_join_source_artifacts,
+)
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import pair  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_path_join.json"
+)
+DEFAULT_LOCAL_CORES = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+DEFAULT_OBSTRUCTION_SHAPES = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_obstruction_shapes.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "connector_path_length_counts",
+    "core_size_assignment_counts",
+    "cycle_length_counts",
+    "cycle_step_count",
+    "cyclic_order",
+    "families",
+    "family_assignment_counts",
+    "first_full_assignment_cycle_length_counts",
+    "interpretation",
+    "n",
+    "provenance",
+    "records",
+    "row_size",
+    "schema",
+    "self_edge_assignment_count",
+    "source_artifacts",
+    "source_assignment_count",
+    "span_signature_counts",
+    "status",
+    "strict_cycle_assignment_count",
+    "strict_cycle_family_count",
+    "strict_cycle_template_count",
+    "strict_edge_count_assignment_counts",
+    "template_assignment_counts",
+    "trust",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    local_cores_path: Path = DEFAULT_LOCAL_CORES,
+    classification_path: Path = DEFAULT_CLASSIFICATION,
+    templates_path: Path = DEFAULT_TEMPLATES,
+    obstruction_shapes_path: Path = DEFAULT_OBSTRUCTION_SHAPES,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the strict-cycle path join."""
+
+    return {
+        "local_cores": load_artifact(_resolve(local_cores_path)),
+        "classification": load_artifact(_resolve(classification_path)),
+        "templates": load_artifact(_resolve(templates_path)),
+        "obstruction_shapes": load_artifact(_resolve(obstruction_shapes_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    local_cores = source_payloads.get("local_cores")
+    classification = source_payloads.get("classification")
+    templates = source_payloads.get("templates")
+    obstruction_shapes = source_payloads.get("obstruction_shapes")
+    if not isinstance(local_cores, dict):
+        errors.append("source local-core payload must be an object")
+    else:
+        try:
+            assert_expected_local_core_counts(local_cores)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"source local-core artifact invalid: {exc}")
+    if not isinstance(classification, dict):
+        errors.append("source classification payload must be an object")
+    else:
+        classification_errors = validate_classification_payload(
+            classification,
+            recompute=False,
+        )
+        if classification_errors:
+            errors.extend(
+                f"source frontier classification invalid: {error}"
+                for error in classification_errors
+            )
+    if not isinstance(templates, dict):
+        errors.append("source template payload must be an object")
+    else:
+        template_errors = validate_template_payload(templates, recompute=False)
+        if template_errors:
+            errors.extend(f"source core templates invalid: {error}" for error in template_errors)
+    if not isinstance(obstruction_shapes, dict):
+        errors.append("source obstruction-shapes payload must be an object")
+    else:
+        try:
+            assert_expected_obstruction_shape_counts(obstruction_shapes)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"source obstruction-shapes artifact invalid: {exc}")
+
+
+def _strict_cycle_certificates(
+    local_core_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    certificates = local_core_payload.get("certificates")
+    if not isinstance(certificates, list):
+        raise ValueError("local-core payload must contain certificates")
+    return {
+        str(certificate["family_id"]): certificate
+        for certificate in certificates
+        if isinstance(certificate, dict) and certificate.get("status") == "strict_cycle"
+    }
+
+
+def _strict_cycle_assignments(
+    classification_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    assignments = classification_payload.get("assignments")
+    if not isinstance(assignments, list):
+        raise ValueError("classification payload must contain assignments")
+    return {
+        str(assignment["assignment_id"]): assignment
+        for assignment in assignments
+        if isinstance(assignment, dict) and assignment.get("status") == "strict_cycle"
+    }
+
+
+def _strict_cycle_template_families(
+    template_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    families = template_payload.get("families")
+    if not isinstance(families, list):
+        raise ValueError("template payload must contain families")
+    return {
+        str(family["family_id"]): family
+        for family in families
+        if isinstance(family, dict) and family.get("status") == "strict_cycle"
+    }
+
+
+def _template_span_signature(template_family: dict[str, Any]) -> str:
+    summary = template_family.get("obstruction_summary")
+    if not isinstance(summary, dict):
+        raise ValueError("template family must contain obstruction_summary")
+    span_counts = summary.get("cycle_span_counts")
+    if not isinstance(span_counts, list):
+        raise ValueError("template family must contain cycle_span_counts")
+    tokens = []
+    for span_count in span_counts:
+        tokens.extend(
+            f"{int(span_count['outer_span'])}:{int(span_count['inner_span'])}"
+            for _ in range(int(span_count["count"]))
+        )
+    return ",".join(sorted(tokens))
+
+
+def _validate_cycle_steps(record: dict[str, Any]) -> None:
+    rows = record["core_selected_rows"]
+    steps = record["cycle_steps"]
+    if len(steps) != int(record["cycle_length"]):
+        raise AssertionError("cycle_length does not match cycle_steps")
+    connector_lengths = [
+        len(step["equality_to_next_outer_pair"]["path"]) for step in steps
+    ]
+    if connector_lengths != record["connector_path_lengths"]:
+        raise AssertionError("connector_path_lengths do not match cycle steps")
+    for index, step in enumerate(steps):
+        edge = step["strict_inequality"]
+        equality = step["equality_to_next_outer_pair"]
+        next_edge = steps[(index + 1) % len(steps)]["strict_inequality"]
+        if pair(*equality["start_pair"]) != pair(*edge["inner_pair"]):
+            raise AssertionError("cycle equality must start at current inner pair")
+        if pair(*equality["end_pair"]) != pair(*next_edge["outer_pair"]):
+            raise AssertionError("cycle equality must end at next outer pair")
+        validate_equality_path(rows, equality)
+
+
+def _validate_family_rows(
+    payload: dict[str, Any],
+    records: Sequence[dict[str, Any]],
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> None:
+    raw_families = payload.get("families")
+    if not isinstance(raw_families, list):
+        errors.append("families must be a list")
+        return
+    certificates = _strict_cycle_certificates(source_payloads["local_cores"])
+    template_families = _strict_cycle_template_families(source_payloads["templates"])
+    record_counts = Counter(str(record.get("family_id")) for record in records)
+    seen: set[str] = set()
+    for index, raw_family in enumerate(raw_families):
+        if not isinstance(raw_family, dict):
+            errors.append(f"family {index} must be an object")
+            continue
+        family_id = str(raw_family.get("family_id"))
+        if family_id in seen:
+            errors.append(f"duplicate family id {family_id}")
+        seen.add(family_id)
+        certificate = certificates.get(family_id)
+        if certificate is None:
+            errors.append(f"family {family_id} missing from source local cores")
+            continue
+        template_family = template_families.get(family_id)
+        if template_family is None:
+            errors.append(f"family {family_id} missing from source templates")
+            continue
+        matching_records = [
+            record for record in records if str(record.get("family_id")) == family_id
+        ]
+        expected = {
+            "assignment_count": int(record_counts[family_id]),
+            "core_size": int(certificate["core_size"]),
+            "cycle_length": int(certificate["cycle_length"]),
+            "family_id": family_id,
+            "orbit_size": int(certificate["orbit_size"]),
+            "span_signature": str(matching_records[0]["span_signature"])
+            if matching_records
+            else None,
+            "status": "strict_cycle",
+            "strict_edge_count": int(matching_records[0]["strict_edge_count"])
+            if matching_records
+            else None,
+            "template_id": str(matching_records[0]["template_id"])
+            if matching_records
+            else None,
+        }
+        for key, value in expected.items():
+            if raw_family.get(key) != value:
+                errors.append(
+                    f"family {family_id} {key} mismatch: "
+                    f"expected {value!r}, got {raw_family.get(key)!r}"
+                )
+        template_expected = {
+            "template_id": str(template_family["template_id"]),
+            "status": "strict_cycle",
+            "core_size": int(template_family["core_size"]),
+            "cycle_length": int(template_family["obstruction_summary"]["cycle_length"]),
+            "strict_edge_count": int(template_family["strict_edge_count"]),
+            "span_signature": _template_span_signature(template_family),
+        }
+        for key, value in template_expected.items():
+            if raw_family.get(key) != value:
+                errors.append(
+                    f"family {family_id} {key} does not match source template: "
+                    f"expected {value!r}, got {raw_family.get(key)!r}"
+                )
+    if len(seen) != payload.get("strict_cycle_family_count"):
+        errors.append("strict_cycle_family_count does not match family rows")
+
+
+def _validate_record_rows(
+    payload: dict[str, Any],
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> None:
+    records = payload.get("records")
+    if not isinstance(records, list):
+        errors.append("records must be a list")
+        return
+    try:
+        certificates = _strict_cycle_certificates(source_payloads["local_cores"])
+        assignments = _strict_cycle_assignments(source_payloads["classification"])
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"could not prepare source maps: {exc}")
+        return
+
+    record_ids: list[str] = []
+    family_counts: Counter[str] = Counter()
+    template_counts: Counter[str] = Counter()
+    cycle_lengths: Counter[int] = Counter()
+    core_sizes: Counter[int] = Counter()
+    strict_edge_counts: Counter[int] = Counter()
+    connector_lengths: Counter[int] = Counter()
+    span_signatures: Counter[str] = Counter()
+    typed_records: list[dict[str, Any]] = []
+    for index, raw_record in enumerate(records):
+        if not isinstance(raw_record, dict):
+            errors.append(f"record {index} must be an object")
+            continue
+        typed_records.append(raw_record)
+        assignment_id = raw_record.get("assignment_id")
+        if isinstance(assignment_id, str):
+            record_ids.append(assignment_id)
+        assignment = assignments.get(str(assignment_id))
+        if assignment is None:
+            errors.append(f"record {assignment_id or index} missing source assignment")
+            continue
+        family_id = str(assignment["family_id"])
+        certificate = certificates.get(family_id)
+        if certificate is None:
+            errors.append(f"record {assignment_id} missing source family {family_id}")
+            continue
+        try:
+            validate_label_map(raw_record["to_canonical_label_map"])
+            _validate_cycle_steps(raw_record)
+            expected_record = strict_cycle_path_join_record(assignment, certificate)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"record {assignment_id or index} invalid: {exc}")
+            continue
+        expect_equal(errors, f"record {assignment_id}", raw_record, expected_record)
+        family_counts[str(raw_record["family_id"])] += 1
+        template_counts[str(raw_record["template_id"])] += 1
+        cycle_length = int(raw_record["cycle_length"])
+        cycle_lengths[cycle_length] += 1
+        core_sizes[int(raw_record["core_size"])] += 1
+        strict_edge_counts[int(raw_record["strict_edge_count"])] += 1
+        span_signatures[str(raw_record["span_signature"])] += 1
+        connector_lengths.update(
+            int(length) for length in raw_record["connector_path_lengths"]
+        )
+
+    if len(record_ids) != len(set(record_ids)):
+        errors.append("duplicate record assignment ids")
+    expect_equal(
+        errors,
+        "family_assignment_counts",
+        payload.get("family_assignment_counts"),
+        {family_id: int(family_counts[family_id]) for family_id in sorted(family_counts)},
+    )
+    expect_equal(
+        errors,
+        "template_assignment_counts",
+        payload.get("template_assignment_counts"),
+        {
+            template_id: int(template_counts[template_id])
+            for template_id in sorted(template_counts)
+        },
+    )
+    expect_equal(
+        errors,
+        "cycle_length_counts",
+        payload.get("cycle_length_counts"),
+        {str(length): int(cycle_lengths[length]) for length in sorted(cycle_lengths)},
+    )
+    expect_equal(
+        errors,
+        "core_size_assignment_counts",
+        payload.get("core_size_assignment_counts"),
+        {str(size): int(core_sizes[size]) for size in sorted(core_sizes)},
+    )
+    expect_equal(
+        errors,
+        "strict_edge_count_assignment_counts",
+        payload.get("strict_edge_count_assignment_counts"),
+        {str(count): int(strict_edge_counts[count]) for count in sorted(strict_edge_counts)},
+    )
+    expect_equal(
+        errors,
+        "connector_path_length_counts",
+        payload.get("connector_path_length_counts"),
+        {str(length): int(connector_lengths[length]) for length in sorted(connector_lengths)},
+    )
+    expect_equal(
+        errors,
+        "span_signature_counts",
+        payload.get("span_signature_counts"),
+        {
+            signature: int(span_signatures[signature])
+            for signature in sorted(span_signatures)
+        },
+    )
+    expect_equal(
+        errors,
+        "cycle_step_count",
+        payload.get("cycle_step_count"),
+        sum(int(record["cycle_length"]) for record in typed_records),
+    )
+    _validate_family_rows(payload, typed_records, source_payloads, errors)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a strict-cycle path-join artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "source_assignment_count": 184,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_assignment_count": 26,
+        "strict_cycle_family_count": 3,
+        "strict_cycle_template_count": 3,
+        "first_full_assignment_cycle_length_counts": {"2": 22, "3": 4},
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+    elif not any("not first full-assignment" in item for item in interpretation):
+        errors.append("interpretation must distinguish local-core and full-assignment cycles")
+
+    _validate_sources(source_payloads, errors)
+    if not errors:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            strict_cycle_path_join_source_artifacts(
+                source_payloads["local_cores"],
+                source_payloads["classification"],
+                source_payloads["templates"],
+                source_payloads["obstruction_shapes"],
+            ),
+        )
+        _validate_record_rows(payload, source_payloads, errors)
+
+    try:
+        assert_expected_strict_cycle_path_join_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected strict-cycle path-join counts failed: {exc}")
+
+    if recompute and not errors:
+        try:
+            expected_payload = strict_cycle_path_join_payload(
+                source_payloads["local_cores"],
+                source_payloads["classification"],
+                source_payloads["templates"],
+                source_payloads["obstruction_shapes"],
+            )
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"recomputed strict-cycle path join failed: {exc}")
+        else:
+            expect_equal(errors, "strict-cycle path join", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "source_assignment_count": object_payload.get("source_assignment_count"),
+        "self_edge_assignment_count": object_payload.get("self_edge_assignment_count"),
+        "strict_cycle_assignment_count": object_payload.get(
+            "strict_cycle_assignment_count"
+        ),
+        "strict_cycle_family_count": object_payload.get("strict_cycle_family_count"),
+        "strict_cycle_template_count": object_payload.get("strict_cycle_template_count"),
+        "cycle_length_counts": object_payload.get("cycle_length_counts"),
+        "first_full_assignment_cycle_length_counts": object_payload.get(
+            "first_full_assignment_cycle_length_counts"
+        ),
+        "connector_path_length_counts": object_payload.get(
+            "connector_path_length_counts"
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--local-cores", type=Path, default=DEFAULT_LOCAL_CORES)
+    parser.add_argument("--classification", type=Path, default=DEFAULT_CLASSIFICATION)
+    parser.add_argument("--templates", type=Path, default=DEFAULT_TEMPLATES)
+    parser.add_argument("--obstruction-shapes", type=Path, default=DEFAULT_OBSTRUCTION_SHAPES)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            local_cores_path=args.local_cores,
+            classification_path=args.classification,
+            templates_path=args.templates,
+            obstruction_shapes_path=args.obstruction_shapes,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = strict_cycle_path_join_payload(
+            sources["local_cores"],
+            sources["classification"],
+            sources["templates"],
+            sources["obstruction_shapes"],
+        )
+        if args.assert_expected:
+            assert_expected_strict_cycle_path_join_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle strict-cycle path join")
+        print(f"artifact: {summary['artifact']}")
+        print(f"strict-cycle assignments: {summary['strict_cycle_assignment_count']}")
+        print(f"strict-cycle families: {summary['strict_cycle_family_count']}")
+        print(f"strict-cycle templates: {summary['strict_cycle_template_count']}")
+        print(f"cycle lengths: {summary['cycle_length_counts']}")
+        print(f"connector path lengths: {summary['connector_path_length_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: strict-cycle path-join checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -171,6 +171,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_strict_cycle_path_join",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_strict_cycle_path_join.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Assignment-level join for the 26 n=9 strict-cycle frontier "
+            "assignments and transformed local-core quotient cycles; not a "
+            "proof of n=9 or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_strict_cycle_path_join.py
+++ b/src/erdos97/n9_vertex_circle_strict_cycle_path_join.py
@@ -1,0 +1,504 @@
+"""Join n=9 strict-cycle assignments to transformed local-core cycles.
+
+This module is diagnostic. It does not prove Erdos Problem #97, does not
+claim a counterexample, and does not promote the review-pending n=9 checker.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_frontier_motif_classification import (
+    invert_label_map,
+    transform_compact_rows,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS
+from erdos97.n9_vertex_circle_obstruction_shapes import (
+    EXPECTED_STRICT_CYCLE_LENGTH_COUNTS as EXPECTED_FULL_ASSIGNMENT_STRICT_CYCLE_LENGTH_COUNTS_RAW,
+)
+from erdos97.n9_vertex_circle_self_edge_path_join import (
+    compact_core_rows,
+    transform_equality_path,
+    transform_pair,
+    validate_equality_path,
+    validate_label_map,
+)
+from erdos97.vertex_circle_quotient_replay import (
+    StrictInequality,
+    _distance_class_union_find,
+    _strict_inequalities,
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+)
+
+
+SCHEMA = "erdos97.n9_vertex_circle_strict_cycle_path_join.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Assignment-level join of the 26 n=9 strict-cycle frontier assignments to "
+    "transformed family representative local-core strict cycles; not a proof "
+    "of n=9, not a counterexample, not an independent review of the exhaustive "
+    "checker, and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_strict_cycle_path_join.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_strict_cycle_path_join.py "
+        "--assert-expected --write"
+    ),
+}
+EXPECTED_SELF_EDGE_ASSIGNMENTS = 158
+EXPECTED_STRICT_CYCLE_ASSIGNMENTS = 26
+EXPECTED_STRICT_CYCLE_FAMILIES = 3
+EXPECTED_STRICT_CYCLE_TEMPLATES = 3
+EXPECTED_CYCLE_STEP_COUNT = 60
+EXPECTED_CYCLE_LENGTH_COUNTS = {"2": 18, "3": 8}
+EXPECTED_FIRST_FULL_ASSIGNMENT_CYCLE_LENGTH_COUNTS = {
+    str(length): int(count)
+    for length, count in EXPECTED_FULL_ASSIGNMENT_STRICT_CYCLE_LENGTH_COUNTS_RAW.items()
+}
+EXPECTED_CORE_SIZE_COUNTS = {"4": 24, "6": 2}
+EXPECTED_STRICT_EDGE_COUNT_COUNTS = {"36": 24, "54": 2}
+EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS = {"0": 6, "1": 28, "2": 26}
+EXPECTED_FAMILY_ASSIGNMENT_COUNTS = {"F07": 6, "F12": 18, "F16": 2}
+EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS = {"T10": 18, "T11": 6, "T12": 2}
+EXPECTED_SPAN_SIGNATURE_COUNTS = {
+    "2:1,2:1": 18,
+    "2:1,3:1,3:2": 6,
+    "3:1,3:1,3:1": 2,
+}
+
+
+def _edge_to_json(edge: StrictInequality) -> dict[str, Any]:
+    return {
+        "row": int(edge.row),
+        "witness_order": [int(label) for label in edge.witness_order],
+        "outer_interval": [int(value) for value in edge.outer_interval],
+        "inner_interval": [int(value) for value in edge.inner_interval],
+        "outer_pair": [int(value) for value in edge.outer_pair],
+        "inner_pair": [int(value) for value in edge.inner_pair],
+        "outer_class": [int(value) for value in edge.outer_class],
+        "inner_class": [int(value) for value in edge.inner_class],
+        "outer_span": int(edge.outer_interval[1] - edge.outer_interval[0]),
+        "inner_span": int(edge.inner_interval[1] - edge.inner_interval[0]),
+    }
+
+
+def _strict_cycle_certificates(
+    local_core_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    certificates = local_core_payload.get("certificates")
+    if not isinstance(certificates, list):
+        raise ValueError("local-core payload must contain certificates")
+    return {
+        str(certificate["family_id"]): certificate
+        for certificate in certificates
+        if certificate.get("status") == "strict_cycle"
+    }
+
+
+def _find_transformed_cycle_edge(
+    edges: Sequence[StrictInequality],
+    expected_row: int,
+    outer_pair: Sequence[int],
+    inner_pair: Sequence[int],
+) -> StrictInequality:
+    expected_outer = pair(*outer_pair)
+    expected_inner = pair(*inner_pair)
+    for edge in edges:
+        if (
+            edge.row == expected_row
+            and edge.outer_pair == expected_outer
+            and edge.inner_pair == expected_inner
+        ):
+            return edge
+    raise AssertionError(
+        f"transformed strict-cycle edge not found: {expected_outer} > {expected_inner}"
+    )
+
+
+def _strict_edges_for_rows(rows: Sequence[Sequence[int]]) -> list[StrictInequality]:
+    """Return all replay strict inequalities for a compact selected-row core."""
+
+    parsed_rows = parse_selected_rows(rows)
+    uf = _distance_class_union_find(n9.N, parsed_rows)
+    return _strict_inequalities(n9.N, list(n9.ORDER), parsed_rows, uf)
+
+
+def _transform_cycle_step(
+    step: dict[str, Any],
+    label_map: Sequence[int],
+) -> dict[str, Any]:
+    raw_edge = step["strict_inequality"]
+    raw_equality = step["equality_to_next_outer_pair"]
+    return {
+        "expected_row": int(label_map[int(raw_edge["row"])]),
+        "expected_outer_pair": transform_pair(raw_edge["outer_pair"], label_map),
+        "expected_inner_pair": transform_pair(raw_edge["inner_pair"], label_map),
+        "equality_to_next_outer_pair": transform_equality_path(raw_equality, label_map),
+    }
+
+
+def _span_signature(edges: Sequence[dict[str, Any]]) -> str:
+    tokens = sorted(
+        f"{int(edge['outer_span'])}:{int(edge['inner_span'])}" for edge in edges
+    )
+    return ",".join(tokens)
+
+
+def _template_family_rows(template_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    families = template_payload.get("families")
+    if not isinstance(families, list):
+        raise ValueError("template payload must contain families")
+    return {
+        str(family["family_id"]): family
+        for family in families
+        if isinstance(family, dict) and family.get("status") == "strict_cycle"
+    }
+
+
+def _template_span_signature(template_family: dict[str, Any]) -> str:
+    summary = template_family.get("obstruction_summary")
+    if not isinstance(summary, dict):
+        raise ValueError("template family must contain obstruction_summary")
+    span_counts = summary.get("cycle_span_counts")
+    if not isinstance(span_counts, list):
+        raise ValueError("template family must contain cycle_span_counts")
+    tokens = []
+    for span_count in span_counts:
+        count = int(span_count["count"])
+        outer_span = int(span_count["outer_span"])
+        inner_span = int(span_count["inner_span"])
+        tokens.extend(f"{outer_span}:{inner_span}" for _ in range(count))
+    return ",".join(sorted(tokens))
+
+
+def _validate_template_family(record: dict[str, Any], template_family: dict[str, Any]) -> None:
+    expected = {
+        "template_id": str(template_family["template_id"]),
+        "status": "strict_cycle",
+        "core_size": int(template_family["core_size"]),
+        "cycle_length": int(template_family["obstruction_summary"]["cycle_length"]),
+        "strict_edge_count": int(template_family["strict_edge_count"]),
+        "span_signature": _template_span_signature(template_family),
+    }
+    for key, value in expected.items():
+        if record.get(key) != value:
+            raise AssertionError(
+                f"{record['assignment_id']} {key} does not match template artifact"
+            )
+
+
+def _validate_transformed_cycle_steps(
+    rows: Sequence[Sequence[int]],
+    steps: Sequence[dict[str, Any]],
+) -> None:
+    for index, step in enumerate(steps):
+        edge = step["strict_inequality"]
+        equality = step["equality_to_next_outer_pair"]
+        next_edge = steps[(index + 1) % len(steps)]["strict_inequality"]
+        if pair(*equality["start_pair"]) != pair(*edge["inner_pair"]):
+            raise AssertionError("cycle equality must start at current inner pair")
+        if pair(*equality["end_pair"]) != pair(*next_edge["outer_pair"]):
+            raise AssertionError("cycle equality must end at next outer pair")
+        validate_equality_path(rows, equality)
+
+
+def strict_cycle_path_join_record(
+    assignment: dict[str, Any],
+    certificate: dict[str, Any],
+) -> dict[str, Any]:
+    """Return one transformed strict-cycle path record for a labelled assignment."""
+
+    family_id = str(assignment["family_id"])
+    validate_label_map(assignment["to_canonical_label_map"])
+    inverse_map = invert_label_map(assignment["to_canonical_label_map"])
+    expected_core_rows = transform_compact_rows(
+        compact_core_rows(certificate),
+        inverse_map,
+    )
+    if assignment["core_selected_rows"] != expected_core_rows:
+        raise AssertionError(
+            f"{assignment['assignment_id']} core rows do not match transformed family core"
+        )
+
+    parsed_rows = parse_selected_rows(assignment["core_selected_rows"])
+    result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parsed_rows,
+    )
+    if result.self_edge_conflicts:
+        raise AssertionError(f"{assignment['assignment_id']} core replay has self-edge")
+    if result.status != "strict_cycle":
+        raise AssertionError(
+            f"{assignment['assignment_id']} core replay status {result.status!r}"
+        )
+    all_strict_edges = _strict_edges_for_rows(assignment["core_selected_rows"])
+    if len(all_strict_edges) != result.strict_edge_count:
+        raise AssertionError("replayed strict-edge count mismatch")
+
+    raw_steps = certificate["cycle_steps"]
+    transformed_steps = [_transform_cycle_step(step, inverse_map) for step in raw_steps]
+    cycle_steps = []
+    for transformed in transformed_steps:
+        edge = _find_transformed_cycle_edge(
+            all_strict_edges,
+            int(transformed["expected_row"]),
+            transformed["expected_outer_pair"],
+            transformed["expected_inner_pair"],
+        )
+        cycle_steps.append(
+            {
+                "strict_inequality": _edge_to_json(edge),
+                "equality_to_next_outer_pair": transformed["equality_to_next_outer_pair"],
+            }
+        )
+    _validate_transformed_cycle_steps(assignment["core_selected_rows"], cycle_steps)
+
+    cycle_length = len(cycle_steps)
+    connector_lengths = [
+        len(step["equality_to_next_outer_pair"]["path"]) for step in cycle_steps
+    ]
+    edge_json = [step["strict_inequality"] for step in cycle_steps]
+    return {
+        "assignment_id": str(assignment["assignment_id"]),
+        "family_id": family_id,
+        "template_id": str(assignment["template_id"]),
+        "status": "strict_cycle",
+        "core_size": int(assignment["core_size"]),
+        "strict_edge_count": int(result.strict_edge_count),
+        "cycle_length": cycle_length,
+        "connector_path_lengths": connector_lengths,
+        "span_signature": _span_signature(edge_json),
+        "to_canonical_label_map": [
+            int(label) for label in assignment["to_canonical_label_map"]
+        ],
+        "core_selected_rows": assignment["core_selected_rows"],
+        "cycle_steps": cycle_steps,
+        "contradiction": {
+            "kind": "strict_cycle",
+            "statement": "strict inequalities form a directed cycle after selected-distance quotienting",
+            "cycle_length": cycle_length,
+        },
+    }
+
+
+def strict_cycle_path_join_source_artifacts(
+    local_core_payload: dict[str, Any],
+    classification_payload: dict[str, Any],
+    template_payload: dict[str, Any],
+    obstruction_shape_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the strict-cycle join."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_local_cores.json",
+            "role": "family representative strict-cycle inequalities and equality connectors",
+            "type": local_core_payload.get("type"),
+            "trust": local_core_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+            "role": "assignment-to-family label maps and transformed core rows",
+            "schema": classification_payload.get("schema"),
+            "status": classification_payload.get("status"),
+            "trust": classification_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_core_templates.json",
+            "role": "strict-cycle local-core template ids and span summaries",
+            "schema": template_payload.get("schema"),
+            "status": template_payload.get("status"),
+            "trust": template_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_obstruction_shapes.json",
+            "role": "first full-assignment strict-cycle length counts for diagnostic comparison",
+            "type": obstruction_shape_payload.get("type"),
+            "trust": obstruction_shape_payload.get("trust"),
+        },
+    ]
+
+
+def strict_cycle_path_join_payload(
+    local_core_payload: dict[str, Any],
+    classification_payload: dict[str, Any],
+    template_payload: dict[str, Any],
+    obstruction_shape_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return transformed strict-cycle records for all strict-cycle assignments."""
+
+    certificates = _strict_cycle_certificates(local_core_payload)
+    template_families = _template_family_rows(template_payload)
+    records = []
+    family_counts: Counter[str] = Counter()
+    template_counts: Counter[str] = Counter()
+    cycle_lengths: Counter[int] = Counter()
+    core_sizes: Counter[int] = Counter()
+    strict_edge_counts: Counter[int] = Counter()
+    connector_lengths: Counter[int] = Counter()
+    span_signatures: Counter[str] = Counter()
+    family_rows: dict[str, dict[str, Any]] = {}
+
+    for assignment in classification_payload["assignments"]:
+        if assignment["status"] != "strict_cycle":
+            continue
+        family_id = str(assignment["family_id"])
+        certificate = certificates[family_id]
+        record = strict_cycle_path_join_record(assignment, certificate)
+        template_family = template_families.get(family_id)
+        if template_family is None:
+            raise AssertionError(f"{family_id} missing from strict-cycle templates")
+        _validate_template_family(record, template_family)
+        family_counts[family_id] += 1
+        template_id = str(record["template_id"])
+        template_counts[template_id] += 1
+        cycle_length = int(record["cycle_length"])
+        core_size = int(record["core_size"])
+        strict_edge_count = int(record["strict_edge_count"])
+        cycle_lengths[cycle_length] += 1
+        core_sizes[core_size] += 1
+        strict_edge_counts[strict_edge_count] += 1
+        span_signatures[str(record["span_signature"])] += 1
+        connector_lengths.update(int(length) for length in record["connector_path_lengths"])
+        family_rows[family_id] = {
+            "assignment_count": int(family_counts[family_id]),
+            "core_size": core_size,
+            "cycle_length": cycle_length,
+            "family_id": family_id,
+            "orbit_size": int(certificate["orbit_size"]),
+            "span_signature": str(record["span_signature"]),
+            "status": "strict_cycle",
+            "strict_edge_count": strict_edge_count,
+            "template_id": template_id,
+        }
+        records.append(record)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "source_assignment_count": int(classification_payload["assignment_count"]),
+        "self_edge_assignment_count": int(
+            classification_payload["status_counts"]["self_edge"]
+        ),
+        "strict_cycle_assignment_count": len(records),
+        "strict_cycle_family_count": len(family_counts),
+        "strict_cycle_template_count": len(template_counts),
+        "cycle_step_count": sum(int(record["cycle_length"]) for record in records),
+        "cycle_length_counts": {
+            str(length): int(cycle_lengths[length]) for length in sorted(cycle_lengths)
+        },
+        "first_full_assignment_cycle_length_counts": obstruction_shape_payload[
+            "strict_cycle_summary"
+        ]["cycle_length_counts"],
+        "core_size_assignment_counts": {
+            str(size): int(core_sizes[size]) for size in sorted(core_sizes)
+        },
+        "strict_edge_count_assignment_counts": {
+            str(count): int(strict_edge_counts[count])
+            for count in sorted(strict_edge_counts)
+        },
+        "connector_path_length_counts": {
+            str(length): int(connector_lengths[length])
+            for length in sorted(connector_lengths)
+        },
+        "span_signature_counts": {
+            signature: int(span_signatures[signature])
+            for signature in sorted(span_signatures)
+        },
+        "family_assignment_counts": {
+            family_id: int(family_counts[family_id]) for family_id in sorted(family_counts)
+        },
+        "template_assignment_counts": {
+            template_id: int(template_counts[template_id])
+            for template_id in sorted(template_counts)
+        },
+        "families": [family_rows[family_id] for family_id in sorted(family_rows)],
+        "records": records,
+        "interpretation": [
+            "Each record transforms a strict-cycle family representative local-core certificate into one labelled n=9 frontier assignment.",
+            "The transformed strict-cycle edges are replayed from the assignment's compact core rows.",
+            "Connector paths identify each strict edge's inner pair with the next strict edge's outer pair.",
+            "Cycle-length counts here summarize transformed local-core certificates, not first full-assignment obstruction-shape cycles.",
+            "These records are compact replay aids and lemma-mining diagnostics, not theorem names.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": strict_cycle_path_join_source_artifacts(
+            local_core_payload,
+            classification_payload,
+            template_payload,
+            obstruction_shape_payload,
+        ),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_strict_cycle_path_join_counts(payload)
+    return payload
+
+
+def assert_expected_strict_cycle_path_join_counts(payload: dict[str, Any]) -> None:
+    """Assert stable headline counts for the transformed strict-cycle join."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["n"] != n9.N or payload["row_size"] != n9.ROW_SIZE:
+        raise AssertionError("unexpected n or row size")
+    if payload["cyclic_order"] != list(n9.ORDER):
+        raise AssertionError("unexpected cyclic order")
+    if payload["source_assignment_count"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError("unexpected source assignment count")
+    if payload["self_edge_assignment_count"] != EXPECTED_SELF_EDGE_ASSIGNMENTS:
+        raise AssertionError("unexpected self-edge assignment count")
+    if payload["strict_cycle_assignment_count"] != EXPECTED_STRICT_CYCLE_ASSIGNMENTS:
+        raise AssertionError("unexpected strict-cycle assignment count")
+    if payload["strict_cycle_family_count"] != EXPECTED_STRICT_CYCLE_FAMILIES:
+        raise AssertionError("unexpected strict-cycle family count")
+    if payload["strict_cycle_template_count"] != EXPECTED_STRICT_CYCLE_TEMPLATES:
+        raise AssertionError("unexpected strict-cycle template count")
+    if payload["cycle_step_count"] != EXPECTED_CYCLE_STEP_COUNT:
+        raise AssertionError("unexpected strict-cycle step count")
+    if payload["cycle_length_counts"] != EXPECTED_CYCLE_LENGTH_COUNTS:
+        raise AssertionError("unexpected cycle-length counts")
+    if (
+        payload["first_full_assignment_cycle_length_counts"]
+        != EXPECTED_FIRST_FULL_ASSIGNMENT_CYCLE_LENGTH_COUNTS
+    ):
+        raise AssertionError("unexpected first full-assignment cycle-length counts")
+    if payload["core_size_assignment_counts"] != EXPECTED_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected core-size counts")
+    if payload["strict_edge_count_assignment_counts"] != EXPECTED_STRICT_EDGE_COUNT_COUNTS:
+        raise AssertionError("unexpected strict-edge-count distribution")
+    if payload["connector_path_length_counts"] != EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected connector path-length counts")
+    if payload["span_signature_counts"] != EXPECTED_SPAN_SIGNATURE_COUNTS:
+        raise AssertionError("unexpected span-signature counts")
+    if payload["family_assignment_counts"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected family assignment counts")
+    if payload["template_assignment_counts"] != EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected template assignment counts")
+    if len(payload["families"]) != EXPECTED_STRICT_CYCLE_FAMILIES:
+        raise AssertionError("unexpected family row count")
+    if len(payload["records"]) != EXPECTED_STRICT_CYCLE_ASSIGNMENTS:
+        raise AssertionError("unexpected record count")
+    family_counts = {
+        str(family["family_id"]): int(family["assignment_count"])
+        for family in payload["families"]
+    }
+    if family_counts != EXPECTED_FAMILY_ASSIGNMENT_COUNTS:
+        raise AssertionError("family rows do not match assignment counts")

--- a/tests/test_n9_vertex_circle_strict_cycle_path_join.py
+++ b/tests/test_n9_vertex_circle_strict_cycle_path_join.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_strict_cycle_path_join import (
+    assert_expected_strict_cycle_path_join_counts,
+    strict_cycle_path_join_payload,
+)
+from scripts.check_n9_vertex_circle_strict_cycle_path_join import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_strict_cycle_path_join_artifact_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_strict_cycle_path_join_counts(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["source_assignment_count"] == 184
+    assert payload["self_edge_assignment_count"] == 158
+    assert payload["strict_cycle_assignment_count"] == 26
+    assert payload["strict_cycle_family_count"] == 3
+    assert payload["strict_cycle_template_count"] == 3
+    assert payload["cycle_step_count"] == 60
+    assert payload["cycle_length_counts"] == {"2": 18, "3": 8}
+    assert payload["first_full_assignment_cycle_length_counts"] == {"2": 22, "3": 4}
+    assert payload["connector_path_length_counts"] == {"0": 6, "1": 28, "2": 26}
+    assert payload["family_assignment_counts"] == {"F07": 6, "F12": 18, "F16": 2}
+    assert payload["template_assignment_counts"] == {"T10": 18, "T11": 6, "T12": 2}
+
+
+def test_strict_cycle_path_join_records_keep_review_maps() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    first = payload["records"][0]
+
+    assert first["assignment_id"] == "A008"
+    assert first["family_id"] == "F07"
+    assert first["template_id"] == "T11"
+    assert first["status"] == "strict_cycle"
+    assert first["cycle_length"] == 3
+    assert first["connector_path_lengths"] == [0, 1, 2]
+    assert first["span_signature"] == "2:1,3:1,3:2"
+    assert first["contradiction"]["kind"] == "strict_cycle"
+    assert first["contradiction"]["cycle_length"] == first["cycle_length"]
+    step = first["cycle_steps"][0]
+    next_step = first["cycle_steps"][1]
+    assert step["equality_to_next_outer_pair"]["start_pair"] == step[
+        "strict_inequality"
+    ]["inner_pair"]
+    assert step["equality_to_next_outer_pair"]["end_pair"] == next_step[
+        "strict_inequality"
+    ]["outer_pair"]
+
+
+def test_strict_cycle_path_join_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["strict_cycle_assignment_count"] == 26
+
+
+def test_strict_cycle_path_join_rejects_tampered_family_id() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["family_id"] = "F12"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("record A008 mismatch" in error for error in errors)
+
+
+def test_strict_cycle_path_join_rejects_invalid_label_map() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["to_canonical_label_map"] = [0] * 9
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("label map" in error for error in errors)
+
+
+def test_strict_cycle_path_join_rejects_tampered_connector_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["cycle_steps"][1]["equality_to_next_outer_pair"]["path"][0][
+        "next_pair"
+    ] = [2, 3]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("does not equate" in error or "record A008 mismatch" in error for error in errors)
+
+
+def test_strict_cycle_path_join_rejects_tampered_cycle_link() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["records"][0]["cycle_steps"][0]["equality_to_next_outer_pair"][
+        "start_pair"
+    ] = [0, 1]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("cycle equality must start" in error for error in errors)
+
+
+def test_strict_cycle_path_join_rejects_tampered_source_artifacts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["source_artifacts"][2]["path"] = "data/certificates/not_the_source.json"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("source_artifacts mismatch" in error for error in errors)
+
+
+def test_strict_cycle_path_join_rejects_missing_local_cycle_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item
+        for item in payload["interpretation"]
+        if "not first full-assignment" not in item
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("local-core and full-assignment cycles" in error for error in errors)
+
+
+def test_strict_cycle_path_join_detects_source_classification_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    strict_assignment = next(
+        assignment
+        for assignment in sources["classification"]["assignments"]
+        if assignment["status"] == "strict_cycle"
+    )
+    strict_assignment["core_selected_rows"][0][1] = 4
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source frontier classification invalid" in error for error in errors)
+
+
+def test_strict_cycle_path_join_detects_source_template_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    family = next(
+        family
+        for family in sources["templates"]["families"]
+        if family["family_id"] == "F07"
+    )
+    family["template_id"] = "T10"
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source core templates invalid" in error
+        or "does not match source template" in error
+        for error in errors
+    )
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_strict_cycle_path_join_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == strict_cycle_path_join_payload(
+        source_payloads["local_cores"],
+        source_payloads["classification"],
+        source_payloads["templates"],
+        source_payloads["obstruction_shapes"],
+    )
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_strict_cycle_path_join_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_cycle_path_join.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["strict_cycle_assignment_count"] == 26
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_strict_cycle_path_join_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "strict_cycle_path_join.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_cycle_path_join.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_strict_cycle_path_join_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "strict_cycle_path_join.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_cycle_path_join.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -100,3 +100,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n9_vertex_circle_strict_cycle_path_join.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary

- add a strict-cycle path-join diagnostic covering the 26 n=9 strict-cycle frontier assignments
- validate transformed local-core strict cycles against source classification, local cores, core templates, and obstruction-shape counts
- wire the new artifact into tests, audit commands, provenance metadata, and n9 review docs

## Verification

- `python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_strict_cycle_path_join.py -q -m "artifact or not artifact"`
- raw `verify-n9-review` command list, including the new strict-cycle checker
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- n9 vertex-circle focused tests: 68 passed

## Notes

Full local `python -m pytest -q` completed its test summary but the shell command timed out after about 13.5 minutes and reported the same 8 unrelated Windows-only C19 path separator mismatches already identified before this PR (`\\` vs `/` in C19 artifact path fields). This PR does not touch those C19 scripts or artifacts.

No proof of n=9, counterexample, independent review completion, or global status update is claimed.