### PR TITLE
Add n9 self-edge template packet diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expe
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_self_edge_template_packet.json
+++ b/data/certificates/n9_vertex_circle_self_edge_template_packet.json
@@ -1,0 +1,2292 @@
+{
+  "assignment_core_size_counts": {
+    "3": 46,
+    "4": 40,
+    "5": 36,
+    "6": 36
+  },
+  "claim_scope": "Template-level packet for the 9 self-edge local-core templates covering 158 n=9 self-edge frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "interpretation": [
+    "Each template record groups self-edge family certificates with the same replay-derived template id.",
+    "Family records keep canonical local-core rows, one strict inequality, and the equality path identifying its outer and inner pairs.",
+    "Selected path-shape counts summarize the assignment-level representative paths chosen by the self-edge path join.",
+    "Template self-edge shape counts come from the core-template artifact and may include additional self-edge conflict shapes.",
+    "These records are reviewer-navigation and lemma-mining diagnostics, not theorem names.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "path_length_counts": {
+    "3": 86,
+    "4": 36,
+    "5": 18,
+    "6": 18
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_self_edge_template_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_self_edge_template_packet.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+  "self_edge_assignment_count": 158,
+  "self_edge_family_count": 13,
+  "self_edge_template_count": 9,
+  "shared_endpoint_counts": {
+    "1": 158
+  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_local_cores.json",
+      "role": "canonical self-edge family local-core certificates",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": "n9_vertex_circle_local_cores_v1"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_path_join.json",
+      "role": "assignment-level transformed self-edge equality paths",
+      "schema": "erdos97.n9_vertex_circle_self_edge_path_join.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "role": "self-edge template ids and shape summaries",
+      "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_assignment_count": 184,
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_cycle_assignment_count": 26,
+  "template_assignment_counts": {
+    "T01": 6,
+    "T02": 40,
+    "T03": 20,
+    "T04": 2,
+    "T05": 18,
+    "T06": 18,
+    "T07": 18,
+    "T08": 18,
+    "T09": 18
+  },
+  "template_core_size_counts": {
+    "3": 2,
+    "4": 3,
+    "5": 2,
+    "6": 2
+  },
+  "template_family_count_distribution": {
+    "1": 7,
+    "2": 1,
+    "4": 1
+  },
+  "template_family_counts": {
+    "T01": 1,
+    "T02": 4,
+    "T03": 2,
+    "T04": 1,
+    "T05": 1,
+    "T06": 1,
+    "T07": 1,
+    "T08": 1,
+    "T09": 1
+  },
+  "template_path_length_counts": {
+    "T01": {
+      "3": 6
+    },
+    "T02": {
+      "3": 40
+    },
+    "T03": {
+      "3": 20
+    },
+    "T04": {
+      "3": 2
+    },
+    "T05": {
+      "3": 18
+    },
+    "T06": {
+      "4": 18
+    },
+    "T07": {
+      "4": 18
+    },
+    "T08": {
+      "5": 18
+    },
+    "T09": {
+      "6": 18
+    }
+  },
+  "template_strict_edge_count_counts": {
+    "27": 2,
+    "36": 3,
+    "45": 2,
+    "54": 2
+  },
+  "templates": [
+    {
+      "assignment_count": 6,
+      "assignment_ids": [
+        "A014",
+        "A024",
+        "A031",
+        "A140",
+        "A166",
+        "A175"
+      ],
+      "core_size": 3,
+      "families": [
+        "F09"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 6,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              8
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              2,
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "core_size": 3,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  2
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F09",
+          "orbit_size": 6,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "template_id": "T01"
+        }
+      ],
+      "orbit_size_sum": 6,
+      "path_length_counts": {
+        "3": 6
+      },
+      "selected_path_shape_counts": {
+        "3:1:1:path=3": 6
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 6
+      },
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T01",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+    },
+    {
+      "assignment_count": 40,
+      "assignment_ids": [
+        "A001",
+        "A004",
+        "A006",
+        "A009",
+        "A011",
+        "A019",
+        "A022",
+        "A025",
+        "A034",
+        "A035",
+        "A045",
+        "A051",
+        "A056",
+        "A058",
+        "A060",
+        "A061",
+        "A063",
+        "A065",
+        "A070",
+        "A076",
+        "A078",
+        "A087",
+        "A092",
+        "A099",
+        "A101",
+        "A103",
+        "A114",
+        "A115",
+        "A118",
+        "A119",
+        "A121",
+        "A136",
+        "A138",
+        "A145",
+        "A163",
+        "A173",
+        "A176",
+        "A178",
+        "A182",
+        "A184"
+      ],
+      "core_size": 3,
+      "families": [
+        "F01",
+        "F04",
+        "F08",
+        "F14"
+      ],
+      "family_count": 4,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              8
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              4,
+              7
+            ],
+            [
+              8,
+              0,
+              1,
+              4,
+              5
+            ]
+          ],
+          "core_size": 3,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F01",
+          "orbit_size": 18,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "template_id": "T02"
+        },
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              2,
+              3
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              0,
+              2
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              6
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              5
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              8
+            ]
+          ],
+          "core_size": 3,
+          "distance_equality": {
+            "end_pair": [
+              2,
+              3
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              0,
+              2
+            ]
+          },
+          "family_id": "F04",
+          "orbit_size": 18,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          },
+          "template_id": "T02"
+        },
+        {
+          "assignment_count": 2,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              8
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              5
+            ],
+            [
+              8,
+              0,
+              1,
+              3,
+              7
+            ]
+          ],
+          "core_size": 3,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F08",
+          "orbit_size": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "template_id": "T02"
+        },
+        {
+          "assignment_count": 2,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              8
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              6,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              7
+            ],
+            [
+              8,
+              0,
+              1,
+              5,
+              7
+            ]
+          ],
+          "core_size": 3,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F14",
+          "orbit_size": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              6,
+              8
+            ]
+          },
+          "template_id": "T02"
+        }
+      ],
+      "orbit_size_sum": 40,
+      "path_length_counts": {
+        "3": 40
+      },
+      "selected_path_shape_counts": {
+        "3:1:1:path=3": 40
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 40
+      },
+      "status": "self_edge",
+      "strict_edge_count": 27,
+      "template_id": "T02",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+    },
+    {
+      "assignment_count": 20,
+      "assignment_ids": [
+        "A005",
+        "A021",
+        "A042",
+        "A048",
+        "A054",
+        "A068",
+        "A074",
+        "A077",
+        "A079",
+        "A104",
+        "A110",
+        "A116",
+        "A117",
+        "A124",
+        "A131",
+        "A148",
+        "A155",
+        "A156",
+        "A181",
+        "A183"
+      ],
+      "core_size": 4,
+      "families": [
+        "F05",
+        "F15"
+      ],
+      "family_count": 2,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              7
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              3,
+              7
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              1,
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              8
+            ],
+            [
+              3,
+              0,
+              2,
+              4,
+              7
+            ],
+            [
+              6,
+              1,
+              3,
+              5,
+              7
+            ]
+          ],
+          "core_size": 4,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              3,
+              7
+            ]
+          },
+          "family_id": "F05",
+          "orbit_size": 18,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              7,
+              1,
+              3,
+              5
+            ]
+          },
+          "template_id": "T03"
+        },
+        {
+          "assignment_count": 2,
+          "contradiction": {
+            "inner_pair": [
+              3,
+              4
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              4
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              3,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              4,
+              5
+            ],
+            [
+              2,
+              1,
+              3,
+              5,
+              6
+            ],
+            [
+              3,
+              2,
+              4,
+              6,
+              7
+            ]
+          ],
+          "core_size": 4,
+          "distance_equality": {
+            "end_pair": [
+              3,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  3,
+                  4
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              1,
+              4
+            ]
+          },
+          "family_id": "F15",
+          "orbit_size": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              4,
+              8
+            ]
+          },
+          "template_id": "T03"
+        }
+      ],
+      "orbit_size_sum": 20,
+      "path_length_counts": {
+        "3": 20
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=3": 20
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 20
+      },
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T03",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+    },
+    {
+      "assignment_count": 2,
+      "assignment_ids": [
+        "A023",
+        "A174"
+      ],
+      "core_size": 4,
+      "families": [
+        "F13"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 2,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              5
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              5,
+              7
+            ],
+            [
+              1,
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              3,
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              5,
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "core_size": 4,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  1,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              5
+            ]
+          },
+          "family_id": "F13",
+          "orbit_size": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              5
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              5,
+              7
+            ]
+          },
+          "template_id": "T04"
+        }
+      ],
+      "orbit_size_sum": 2,
+      "path_length_counts": {
+        "3": 2
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=3": 2
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 2
+      },
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T04",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2"
+    },
+    {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A013",
+        "A029",
+        "A036",
+        "A038",
+        "A053",
+        "A057",
+        "A059",
+        "A062",
+        "A072",
+        "A088",
+        "A090",
+        "A100",
+        "A105",
+        "A120",
+        "A129",
+        "A133",
+        "A162",
+        "A170"
+      ],
+      "core_size": 4,
+      "families": [
+        "F10"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              8
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              7
+            ],
+            [
+              7,
+              2,
+              5,
+              6,
+              8
+            ],
+            [
+              8,
+              0,
+              1,
+              6,
+              7
+            ]
+          ],
+          "core_size": 4,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  7,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  2,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F10",
+          "orbit_size": 18,
+          "path_length": 3,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "template_id": "T05"
+        }
+      ],
+      "orbit_size_sum": 18,
+      "path_length_counts": {
+        "3": 18
+      },
+      "selected_path_shape_counts": {
+        "3:1:1:path=3": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "status": "self_edge",
+      "strict_edge_count": 36,
+      "template_id": "T05",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+    },
+    {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A016",
+        "A018",
+        "A026",
+        "A027",
+        "A041",
+        "A046",
+        "A069",
+        "A094",
+        "A097",
+        "A112",
+        "A127",
+        "A139",
+        "A146",
+        "A158",
+        "A165",
+        "A168",
+        "A172",
+        "A179"
+      ],
+      "core_size": 5,
+      "families": [
+        "F11"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              3,
+              5
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              3,
+              8
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              1,
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              5,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              6,
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              7,
+              0,
+              1,
+              5,
+              6
+            ],
+            [
+              8,
+              2,
+              3,
+              6,
+              7
+            ]
+          ],
+          "core_size": 5,
+          "distance_equality": {
+            "end_pair": [
+              3,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  6,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  6,
+                  7
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  5,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              3,
+              8
+            ]
+          },
+          "family_id": "F11",
+          "orbit_size": 18,
+          "path_length": 4,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              3,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              8
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          },
+          "template_id": "T06"
+        }
+      ],
+      "orbit_size_sum": 18,
+      "path_length_counts": {
+        "4": 18
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=4": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "status": "self_edge",
+      "strict_edge_count": 45,
+      "template_id": "T06",
+      "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x1,3:1:0x1,3:1:1x1"
+    },
+    {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A007",
+        "A028",
+        "A037",
+        "A039",
+        "A052",
+        "A055",
+        "A064",
+        "A066",
+        "A075",
+        "A089",
+        "A091",
+        "A098",
+        "A102",
+        "A113",
+        "A125",
+        "A128",
+        "A171",
+        "A177"
+      ],
+      "core_size": 5,
+      "families": [
+        "F06"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              4
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              7
+            ],
+            [
+              2,
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              4,
+              1,
+              3,
+              5,
+              7
+            ],
+            [
+              5,
+              3,
+              4,
+              6,
+              8
+            ],
+            [
+              6,
+              0,
+              2,
+              5,
+              7
+            ]
+          ],
+          "core_size": 5,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  5
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  5,
+                  6
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  2,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              4
+            ]
+          },
+          "family_id": "F06",
+          "orbit_size": 18,
+          "path_length": 4,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              7
+            ]
+          },
+          "template_id": "T07"
+        }
+      ],
+      "orbit_size_sum": 18,
+      "path_length_counts": {
+        "4": 18
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=4": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 3,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "status": "self_edge",
+      "strict_edge_count": 45,
+      "template_id": "T07",
+      "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x3,3:1:0x1,3:1:1x1,3:2:1x1"
+    },
+    {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A002",
+        "A012",
+        "A043",
+        "A050",
+        "A067",
+        "A084",
+        "A085",
+        "A086",
+        "A096",
+        "A106",
+        "A109",
+        "A122",
+        "A132",
+        "A134",
+        "A143",
+        "A149",
+        "A150",
+        "A159"
+      ],
+      "core_size": 6,
+      "families": [
+        "F02"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              3
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              2,
+              1,
+              3,
+              5,
+              6
+            ],
+            [
+              5,
+              2,
+              4,
+              6,
+              7
+            ],
+            [
+              6,
+              1,
+              5,
+              7,
+              8
+            ],
+            [
+              7,
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "core_size": 6,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  6,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  5,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "family_id": "F02",
+          "orbit_size": 18,
+          "path_length": 5,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "template_id": "T08"
+        }
+      ],
+      "orbit_size_sum": 18,
+      "path_length_counts": {
+        "5": 18
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=5": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 4,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "status": "self_edge",
+      "strict_edge_count": 54,
+      "template_id": "T08",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+    },
+    {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A003",
+        "A010",
+        "A017",
+        "A030",
+        "A033",
+        "A044",
+        "A049",
+        "A073",
+        "A107",
+        "A108",
+        "A123",
+        "A130",
+        "A135",
+        "A142",
+        "A144",
+        "A160",
+        "A161",
+        "A169"
+      ],
+      "core_size": 6,
+      "families": [
+        "F03"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "inner_pair": [
+              1,
+              2
+            ],
+            "kind": "self_edge",
+            "outer_pair": [
+              1,
+              3
+            ],
+            "statement": "strict inequality outer_pair > inner_pair while selected-distance equalities identify the two pairs"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              5,
+              7
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              6
+            ],
+            [
+              3,
+              2,
+              4,
+              5,
+              8
+            ],
+            [
+              4,
+              0,
+              3,
+              6,
+              8
+            ],
+            [
+              8,
+              0,
+              1,
+              4,
+              7
+            ]
+          ],
+          "core_size": 6,
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  4,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  3,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "family_id": "F03",
+          "orbit_size": 18,
+          "path_length": 6,
+          "status": "self_edge",
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "template_id": "T09"
+        }
+      ],
+      "orbit_size_sum": 18,
+      "path_length_counts": {
+        "6": 18
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=6": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 5,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 4,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "status": "self_edge",
+      "strict_edge_count": 54,
+      "template_id": "T09",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x5,3:1:0x2,3:1:1x4,3:2:1x2"
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -66,6 +66,9 @@ template, while
 `data/certificates/n9_vertex_circle_self_edge_path_join.json` transforms the
 family representative equality paths back into each of the 158 labelled
 self-edge assignments.
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json` compresses
+those self-edge joins to 9 template-level reviewer records with canonical
+family certificates.
 `data/certificates/n9_vertex_circle_strict_cycle_path_join.json` similarly
 transforms the strict-cycle local-core certificates back into each of the 26
 strict-cycle assignments. Its local-core cycle-length counts (`2: 18`,

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -64,6 +64,14 @@ compact core rows. This is a lemma-mining and reviewer-navigation diagnostic
 only; it is not an independent proof of `n=9` and does not promote the
 exhaustive checker.
 
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json` compresses
+the same self-edge side to 9 template-level records. Each template record keeps
+the canonical family local-core certificates covered by that template, plus
+assignment-count and selected-path shape summaries from the assignment-level
+join. It distinguishes the selected equality-path representative from the
+broader self-edge shape counts in the template artifact. This is a
+reviewer-navigation packet only, not a theorem list.
+
 `data/certificates/n9_vertex_circle_strict_cycle_path_join.json` is the
 parallel replay join for the 26 strict-cycle frontier assignments. It
 transforms each family representative local-core cycle into labelled
@@ -188,6 +196,19 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py \
   --json
 ```
 
+Generate and check the self-edge template packet:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Generate and check the strict-cycle path join:
 
 ```bash
@@ -209,6 +230,7 @@ python -m pytest \
   tests/test_n9_vertex_circle_core_templates.py \
   tests/test_n9_vertex_circle_frontier_motif_classification.py \
   tests/test_n9_vertex_circle_self_edge_path_join.py \
+  tests/test_n9_vertex_circle_self_edge_template_packet.py \
   tests/test_n9_vertex_circle_strict_cycle_path_join.py \
   -q
 ```

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -49,6 +49,14 @@ certificates, the stored label maps, the transformed core rows, and the
 replayed strict inequality. This is a review-pending diagnostic for lemma
 mining only; the path join is not an independent proof of `n=9`.
 
+The self-edge template packet
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json` then groups
+those 158 assignment-level joins by the 9 self-edge template ids. It keeps one
+canonical local-core certificate for each of the 13 covered self-edge families
+and records template-level assignment counts (`T01: 6`, `T02: 40`, `T03: 20`,
+`T04: 2`, and `T05` through `T09`: 18 each). This packet is for human review
+and lemma mining only; template ids remain deterministic artifact labels.
+
 The strict-cycle path join
 `data/certificates/n9_vertex_circle_strict_cycle_path_join.json` covers the
 remaining 26 assignments. It stores transformed local-core quotient cycles for
@@ -144,6 +152,19 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py \
   --json
 ```
 
+Generate and check the self-edge template packet:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Generate and check the strict-cycle path join:
 
 ```bash
@@ -164,6 +185,7 @@ python -m pytest \
   tests/test_n9_vertex_circle_motif_families.py \
   tests/test_n9_vertex_circle_frontier_motif_classification.py \
   tests/test_n9_vertex_circle_self_edge_path_join.py \
+  tests/test_n9_vertex_circle_self_edge_template_packet.py \
   tests/test_n9_vertex_circle_strict_cycle_path_join.py \
   -q
 ```

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -57,6 +57,7 @@ python scripts/analyze_n8_exact_survivors.py --check --json \
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -138,6 +138,9 @@ Next steps:
   to keep those lemmas small;
 - use `data/certificates/n9_vertex_circle_self_edge_path_join.json` as the
   assignment-level replay aid for transformed self-edge equality paths;
+- use `data/certificates/n9_vertex_circle_self_edge_template_packet.json` to
+  review the 9 self-edge template packets before attempting reusable local
+  lemmas;
 - use `data/certificates/n9_vertex_circle_strict_cycle_path_join.json` as the
   assignment-level replay aid for transformed strict-cycle local-core
   quotient cycles, keeping its local-core cycle counts separate from first

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -74,6 +74,7 @@ python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expe
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -396,6 +396,71 @@ artifacts:
       - the path join is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_self_edge_template_packet
+    path: data/certificates/n9_vertex_circle_self_edge_template_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_self_edge_template_packet.py
+    command: python scripts/check_n9_vertex_circle_self_edge_template_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_self_edge_template_packet.py
+    check_command: python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Template-level packet for the 9 self-edge local-core templates covering 158 n=9 self-edge frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_self_edge_template_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Template-level packet for the 9 self-edge local-core templates covering 158 n=9 self-edge frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      source_assignment_count: 184
+      self_edge_assignment_count: 158
+      strict_cycle_assignment_count: 26
+      self_edge_family_count: 13
+      self_edge_template_count: 9
+      template_assignment_counts.T01: 6
+      template_assignment_counts.T02: 40
+      template_assignment_counts.T03: 20
+      template_assignment_counts.T04: 2
+      template_assignment_counts.T05: 18
+      template_assignment_counts.T06: 18
+      template_assignment_counts.T07: 18
+      template_assignment_counts.T08: 18
+      template_assignment_counts.T09: 18
+      template_family_counts.T01: 1
+      template_family_counts.T02: 4
+      template_family_counts.T03: 2
+      template_family_counts.T04: 1
+      template_family_counts.T05: 1
+      template_family_counts.T06: 1
+      template_family_counts.T07: 1
+      template_family_counts.T08: 1
+      template_family_counts.T09: 1
+      path_length_counts.3: 86
+      path_length_counts.4: 36
+      path_length_counts.5: 18
+      path_length_counts.6: 18
+      shared_endpoint_counts.1: 158
+      assignment_core_size_counts.3: 46
+      assignment_core_size_counts.4: 40
+      assignment_core_size_counts.5: 36
+      assignment_core_size_counts.6: 36
+      template_core_size_counts.3: 2
+      template_core_size_counts.4: 3
+      template_core_size_counts.5: 2
+      template_core_size_counts.6: 2
+      provenance.command: python scripts/check_n9_vertex_circle_self_edge_template_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the template packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_strict_cycle_path_join
     path: data/certificates/n9_vertex_circle_strict_cycle_path_join.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_vertex_circle_self_edge_template_packet.py
+++ b/scripts/check_n9_vertex_circle_self_edge_template_packet.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Generate or check the n=9 self-edge template packet diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_core_templates import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATES,
+    validate_payload as validate_template_payload,
+)
+from check_n9_vertex_circle_self_edge_path_join import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_PATH_JOIN,
+    validate_payload as validate_path_join_payload,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_local_core_counts,
+)
+from erdos97.n9_vertex_circle_self_edge_path_join import (  # noqa: E402
+    validate_equality_path,
+)
+from erdos97.n9_vertex_circle_self_edge_template_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_self_edge_template_packet_counts,
+    self_edge_template_packet_payload,
+    self_edge_template_packet_source_artifacts,
+)
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import pair  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_self_edge_template_packet.json"
+)
+DEFAULT_LOCAL_CORES = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_core_size_counts",
+    "claim_scope",
+    "cyclic_order",
+    "interpretation",
+    "n",
+    "provenance",
+    "row_size",
+    "schema",
+    "self_edge_assignment_count",
+    "self_edge_family_count",
+    "self_edge_template_count",
+    "path_length_counts",
+    "shared_endpoint_counts",
+    "source_artifacts",
+    "source_assignment_count",
+    "status",
+    "strict_cycle_assignment_count",
+    "template_assignment_counts",
+    "template_core_size_counts",
+    "template_family_count_distribution",
+    "template_family_counts",
+    "template_path_length_counts",
+    "template_strict_edge_count_counts",
+    "templates",
+    "trust",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    local_cores_path: Path = DEFAULT_LOCAL_CORES,
+    path_join_path: Path = DEFAULT_PATH_JOIN,
+    templates_path: Path = DEFAULT_TEMPLATES,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the self-edge template packet."""
+
+    return {
+        "local_cores": load_artifact(_resolve(local_cores_path)),
+        "path_join": load_artifact(_resolve(path_join_path)),
+        "templates": load_artifact(_resolve(templates_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    local_cores = source_payloads.get("local_cores")
+    path_join = source_payloads.get("path_join")
+    templates = source_payloads.get("templates")
+    if not isinstance(local_cores, dict):
+        errors.append("source local-core payload must be an object")
+    else:
+        try:
+            assert_expected_local_core_counts(local_cores)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"source local-core artifact invalid: {exc}")
+    if not isinstance(path_join, dict):
+        errors.append("source self-edge path-join payload must be an object")
+    else:
+        path_join_errors = validate_path_join_payload(path_join, recompute=False)
+        if path_join_errors:
+            errors.extend(
+                f"source self-edge path join invalid: {error}"
+                for error in path_join_errors
+            )
+    if not isinstance(templates, dict):
+        errors.append("source template payload must be an object")
+    else:
+        template_errors = validate_template_payload(templates, recompute=False)
+        if template_errors:
+            errors.extend(f"source core templates invalid: {error}" for error in template_errors)
+
+
+def _validate_family_record(record: dict[str, Any]) -> None:
+    if record.get("status") != "self_edge":
+        raise AssertionError("family record status must be self_edge")
+    equality = record["distance_equality"]
+    edge = record["strict_inequality"]
+    if pair(*equality["start_pair"]) != pair(*edge["outer_pair"]):
+        raise AssertionError("family equality must start at outer pair")
+    if pair(*equality["end_pair"]) != pair(*edge["inner_pair"]):
+        raise AssertionError("family equality must end at inner pair")
+    validate_equality_path(record["core_selected_rows"], equality)
+
+
+def _expected_template_rows(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, dict[str, Any]]:
+    try:
+        expected_payload = self_edge_template_packet_payload(
+            source_payloads["local_cores"],
+            source_payloads["path_join"],
+            source_payloads["templates"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound self-edge template packet failed: {exc}")
+        return {}
+    return {
+        str(template["template_id"]): template
+        for template in expected_payload.get("templates", [])
+        if isinstance(template, dict)
+    }
+
+
+def _validate_source_bound_template(
+    template: dict[str, Any],
+    expected_template: dict[str, Any],
+    errors: list[str],
+) -> None:
+    template_id = str(template.get("template_id"))
+    for key in (
+        "template_key",
+        "status",
+        "core_size",
+        "strict_edge_count",
+        "family_count",
+        "assignment_count",
+        "orbit_size_sum",
+        "assignment_ids",
+        "families",
+        "path_length_counts",
+        "shared_endpoint_counts",
+        "selected_path_shape_counts",
+        "self_edge_shape_counts",
+    ):
+        expect_equal(
+            errors,
+            f"template {template_id} {key}",
+            template.get(key),
+            expected_template.get(key),
+        )
+
+    expected_families = {
+        str(record["family_id"]): record
+        for record in expected_template.get("family_records", [])
+        if isinstance(record, dict)
+    }
+    for family_record in template.get("family_records", []):
+        if not isinstance(family_record, dict):
+            continue
+        family_id = str(family_record.get("family_id"))
+        expected_family = expected_families.get(family_id)
+        if expected_family is None:
+            errors.append(f"template {template_id} unexpected family record {family_id}")
+            continue
+        for key in (
+            "template_id",
+            "status",
+            "assignment_count",
+            "orbit_size",
+            "core_size",
+            "path_length",
+            "core_selected_rows",
+            "strict_inequality",
+            "distance_equality",
+            "contradiction",
+        ):
+            expect_equal(
+                errors,
+                f"template {template_id} family {family_id} {key}",
+                family_record.get(key),
+                expected_family.get(key),
+            )
+
+
+def _validate_template_rows(
+    payload: dict[str, Any],
+    errors: list[str],
+    *,
+    source_payloads: dict[str, Any],
+) -> None:
+    templates = payload.get("templates")
+    if not isinstance(templates, list):
+        errors.append("templates must be a list")
+        return
+    expected_templates = _expected_template_rows(source_payloads, errors)
+    template_ids: list[str] = []
+    assignment_counts: dict[str, int] = {}
+    family_counts: dict[str, int] = {}
+    path_length_counts: dict[str, Any] = {}
+    all_assignment_ids: list[str] = []
+    for index, template in enumerate(templates):
+        if not isinstance(template, dict):
+            errors.append(f"template {index} must be an object")
+            continue
+        template_id = str(template.get("template_id"))
+        template_ids.append(template_id)
+        expected_template = expected_templates.get(template_id)
+        if expected_template is None:
+            errors.append(f"unexpected template id {template_id}")
+        else:
+            _validate_source_bound_template(template, expected_template, errors)
+        family_records = template.get("family_records")
+        if not isinstance(family_records, list):
+            errors.append(f"template {template_id} family_records must be a list")
+            continue
+        if sorted(template.get("families", [])) != sorted(
+            record.get("family_id") for record in family_records
+        ):
+            errors.append(f"template {template_id} family list mismatch")
+        assignment_ids = template.get("assignment_ids")
+        if not isinstance(assignment_ids, list) or not all(
+            isinstance(item, str) for item in assignment_ids
+        ):
+            errors.append(f"template {template_id} assignment_ids must be a string list")
+            assignment_ids = []
+        if len(assignment_ids) != template.get("assignment_count"):
+            errors.append(f"template {template_id} assignment_ids count mismatch")
+        if len(assignment_ids) != len(set(assignment_ids)):
+            errors.append(f"template {template_id} duplicate assignment ids")
+        all_assignment_ids.extend(assignment_ids)
+        family_assignment_sum = 0
+        for family_record in family_records:
+            if not isinstance(family_record, dict):
+                errors.append(f"template {template_id} family record must be an object")
+                continue
+            try:
+                _validate_family_record(family_record)
+            except (AssertionError, KeyError, TypeError, ValueError) as exc:
+                errors.append(f"template {template_id} family invalid: {exc}")
+            else:
+                family_assignment_sum += int(family_record["assignment_count"])
+        if family_assignment_sum != template.get("assignment_count"):
+            errors.append(f"template {template_id} assignment count mismatch")
+        assignment_counts[template_id] = int(template.get("assignment_count", 0))
+        family_counts[template_id] = int(template.get("family_count", 0))
+        path_length_counts[template_id] = template.get("path_length_counts")
+    if len(template_ids) != len(set(template_ids)):
+        errors.append("duplicate template ids")
+    if len(all_assignment_ids) != len(set(all_assignment_ids)):
+        errors.append("duplicate assignment ids across templates")
+    if len(all_assignment_ids) != payload.get("self_edge_assignment_count"):
+        errors.append("assignment_ids do not cover self-edge assignment count")
+    expect_equal(
+        errors,
+        "template_assignment_counts",
+        payload.get("template_assignment_counts"),
+        assignment_counts,
+    )
+    expect_equal(
+        errors,
+        "template_family_counts",
+        payload.get("template_family_counts"),
+        family_counts,
+    )
+    expect_equal(
+        errors,
+        "template_path_length_counts",
+        payload.get("template_path_length_counts"),
+        path_length_counts,
+    )
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a self-edge template packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "source_assignment_count": 184,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_assignment_count": 26,
+        "self_edge_family_count": 13,
+        "self_edge_template_count": 9,
+        "path_length_counts": {"3": 86, "4": 36, "5": 18, "6": 18},
+        "shared_endpoint_counts": {"1": 158},
+        "assignment_core_size_counts": {"3": 46, "4": 40, "5": 36, "6": 36},
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+
+    _validate_sources(source_payloads, errors)
+    if not errors:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            self_edge_template_packet_source_artifacts(
+                source_payloads["local_cores"],
+                source_payloads["path_join"],
+                source_payloads["templates"],
+            ),
+        )
+        _validate_template_rows(payload, errors, source_payloads=source_payloads)
+
+    try:
+        assert_expected_self_edge_template_packet_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected self-edge template packet counts failed: {exc}")
+
+    if recompute and not errors:
+        try:
+            expected_payload = self_edge_template_packet_payload(
+                source_payloads["local_cores"],
+                source_payloads["path_join"],
+                source_payloads["templates"],
+            )
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"recomputed self-edge template packet failed: {exc}")
+        else:
+            expect_equal(errors, "self-edge template packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "self_edge_assignment_count": object_payload.get("self_edge_assignment_count"),
+        "self_edge_family_count": object_payload.get("self_edge_family_count"),
+        "self_edge_template_count": object_payload.get("self_edge_template_count"),
+        "template_assignment_counts": object_payload.get("template_assignment_counts"),
+        "template_family_counts": object_payload.get("template_family_counts"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--local-cores", type=Path, default=DEFAULT_LOCAL_CORES)
+    parser.add_argument("--path-join", type=Path, default=DEFAULT_PATH_JOIN)
+    parser.add_argument("--templates", type=Path, default=DEFAULT_TEMPLATES)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            local_cores_path=args.local_cores,
+            path_join_path=args.path_join,
+            templates_path=args.templates,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = self_edge_template_packet_payload(
+            sources["local_cores"],
+            sources["path_join"],
+            sources["templates"],
+        )
+        if args.assert_expected:
+            assert_expected_self_edge_template_packet_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle self-edge template packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"self-edge assignments: {summary['self_edge_assignment_count']}")
+        print(f"self-edge families: {summary['self_edge_family_count']}")
+        print(f"self-edge templates: {summary['self_edge_template_count']}")
+        if args.check or args.assert_expected:
+            print("OK: self-edge template packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -171,6 +171,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_self_edge_template_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_self_edge_template_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Template-level packet for the 9 n=9 self-edge local-core "
+            "templates and their canonical family certificates; not a proof "
+            "of n=9 or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_strict_cycle_path_join",
         command=(
             "python",

--- a/src/erdos97/n9_vertex_circle_self_edge_template_packet.py
+++ b/src/erdos97/n9_vertex_circle_self_edge_template_packet.py
@@ -1,0 +1,419 @@
+"""Build a compact n=9 self-edge template packet for reviewer navigation.
+
+This module is diagnostic. It does not prove Erdos Problem #97, does not
+claim a counterexample, and does not promote the review-pending n=9 checker.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_path_join import (
+    compact_core_rows,
+    validate_equality_path,
+)
+from erdos97.vertex_circle_quotient_replay import pair
+
+
+SCHEMA = "erdos97.n9_vertex_circle_self_edge_template_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Template-level packet for the 9 self-edge local-core templates covering "
+    "158 n=9 self-edge frontier assignments; not a proof of n=9, not a "
+    "counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_self_edge_template_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_self_edge_template_packet.py "
+        "--assert-expected --write"
+    ),
+}
+EXPECTED_SOURCE_ASSIGNMENT_COUNT = 184
+EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT = 158
+EXPECTED_STRICT_CYCLE_ASSIGNMENT_COUNT = 26
+EXPECTED_SELF_EDGE_FAMILY_COUNT = 13
+EXPECTED_SELF_EDGE_TEMPLATE_COUNT = 9
+EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS = {
+    "T01": 6,
+    "T02": 40,
+    "T03": 20,
+    "T04": 2,
+    "T05": 18,
+    "T06": 18,
+    "T07": 18,
+    "T08": 18,
+    "T09": 18,
+}
+EXPECTED_TEMPLATE_FAMILY_COUNTS = {
+    "T01": 1,
+    "T02": 4,
+    "T03": 2,
+    "T04": 1,
+    "T05": 1,
+    "T06": 1,
+    "T07": 1,
+    "T08": 1,
+    "T09": 1,
+}
+EXPECTED_TEMPLATE_PATH_LENGTH_COUNTS = {
+    "T01": {"3": 6},
+    "T02": {"3": 40},
+    "T03": {"3": 20},
+    "T04": {"3": 2},
+    "T05": {"3": 18},
+    "T06": {"4": 18},
+    "T07": {"4": 18},
+    "T08": {"5": 18},
+    "T09": {"6": 18},
+}
+EXPECTED_PATH_LENGTH_COUNTS = {"3": 86, "4": 36, "5": 18, "6": 18}
+EXPECTED_SHARED_ENDPOINT_COUNTS = {"1": 158}
+EXPECTED_ASSIGNMENT_CORE_SIZE_COUNTS = {"3": 46, "4": 40, "5": 36, "6": 36}
+EXPECTED_TEMPLATE_CORE_SIZE_COUNTS = {
+    "3": 2,
+    "4": 3,
+    "5": 2,
+    "6": 2,
+}
+EXPECTED_TEMPLATE_STRICT_EDGE_COUNT_COUNTS = {
+    "27": 2,
+    "36": 3,
+    "45": 2,
+    "54": 2,
+}
+EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION = {"1": 7, "2": 1, "4": 1}
+
+
+def _self_edge_certificates(
+    local_core_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    certificates = local_core_payload.get("certificates")
+    if not isinstance(certificates, list):
+        raise ValueError("local-core payload must contain certificates")
+    return {
+        str(certificate["family_id"]): certificate
+        for certificate in certificates
+        if isinstance(certificate, dict) and certificate.get("status") == "self_edge"
+    }
+
+
+def _self_edge_template_rows(
+    template_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    templates = template_payload.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template payload must contain templates")
+    return {
+        str(template["template_id"]): template
+        for template in templates
+        if isinstance(template, dict) and template.get("status") == "self_edge"
+    }
+
+
+def _path_join_family_rows(path_join_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    families = path_join_payload.get("families")
+    if not isinstance(families, list):
+        raise ValueError("self-edge path join must contain families")
+    return {str(family["family_id"]): family for family in families}
+
+
+def _path_join_records_by_template(
+    path_join_payload: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    records = path_join_payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("self-edge path join must contain records")
+    by_template: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("self-edge path-join records must be objects")
+        by_template[str(record["template_id"])].append(record)
+    return {template_id: rows for template_id, rows in sorted(by_template.items())}
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _selected_path_shape(record: dict[str, Any]) -> str:
+    edge = record["strict_inequality"]
+    return (
+        f"{int(edge['outer_span'])}:{int(edge['inner_span'])}:"
+        f"{int(record['shared_endpoint_count'])}:path={int(record['path_length'])}"
+    )
+
+
+def _family_record(
+    certificate: dict[str, Any],
+    family_row: dict[str, Any],
+) -> dict[str, Any]:
+    if str(certificate["family_id"]) != str(family_row["family_id"]):
+        raise AssertionError("family row does not match certificate")
+    if family_row["status"] != "self_edge":
+        raise AssertionError("family row must be self_edge")
+    rows = compact_core_rows(certificate)
+    equality = certificate["distance_equality"]
+    validate_equality_path(rows, equality)
+    edge = certificate["strict_inequality"]
+    if pair(*equality["start_pair"]) != pair(*edge["outer_pair"]):
+        raise AssertionError("self-edge equality must start at outer pair")
+    if pair(*equality["end_pair"]) != pair(*edge["inner_pair"]):
+        raise AssertionError("self-edge equality must end at inner pair")
+
+    expected = {
+        "core_size": int(certificate["core_size"]),
+        "orbit_size": int(certificate["orbit_size"]),
+        "path_length": len(equality["path"]),
+        "status": "self_edge",
+    }
+    for key, value in expected.items():
+        if family_row.get(key) != value:
+            raise AssertionError(f"{family_row['family_id']} {key} mismatch")
+    return {
+        "family_id": str(certificate["family_id"]),
+        "template_id": str(family_row["template_id"]),
+        "status": "self_edge",
+        "assignment_count": int(family_row["assignment_count"]),
+        "orbit_size": int(certificate["orbit_size"]),
+        "core_size": int(certificate["core_size"]),
+        "path_length": len(equality["path"]),
+        "core_selected_rows": rows,
+        "strict_inequality": edge,
+        "distance_equality": equality,
+        "contradiction": {
+            "kind": "self_edge",
+            "outer_pair": edge["outer_pair"],
+            "inner_pair": edge["inner_pair"],
+            "statement": (
+                "strict inequality outer_pair > inner_pair while "
+                "selected-distance equalities identify the two pairs"
+            ),
+        },
+    }
+
+
+def _template_record(
+    template_id: str,
+    template_row: dict[str, Any],
+    records: Sequence[dict[str, Any]],
+    family_rows: dict[str, dict[str, Any]],
+    certificates: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    template_families = [str(family_id) for family_id in template_row["families"]]
+    path_join_families = sorted({str(record["family_id"]) for record in records})
+    if path_join_families != sorted(template_families):
+        raise AssertionError(f"{template_id} family coverage mismatch")
+
+    family_records = []
+    for family_id in sorted(template_families):
+        family_row = family_rows.get(family_id)
+        certificate = certificates.get(family_id)
+        if family_row is None or certificate is None:
+            raise AssertionError(f"{template_id} missing family {family_id}")
+        family_records.append(_family_record(certificate, family_row))
+
+    assignment_count = len(records)
+    path_length_counts: Counter[int] = Counter(int(record["path_length"]) for record in records)
+    shared_endpoint_counts: Counter[int] = Counter(
+        int(record["shared_endpoint_count"]) for record in records
+    )
+    selected_path_shapes: Counter[str] = Counter(_selected_path_shape(record) for record in records)
+    expected_assignment_count = sum(
+        int(family_rows[family_id]["assignment_count"]) for family_id in template_families
+    )
+    if assignment_count != expected_assignment_count:
+        raise AssertionError(f"{template_id} assignment coverage mismatch")
+    if int(template_row["family_count"]) != len(template_families):
+        raise AssertionError(f"{template_id} family_count mismatch")
+    if int(template_row["orbit_size_sum"]) != assignment_count:
+        raise AssertionError(f"{template_id} orbit_size_sum mismatch")
+    assignment_ids = sorted(str(record["assignment_id"]) for record in records)
+
+    return {
+        "template_id": template_id,
+        "template_key": str(template_row["template_key"]),
+        "status": "self_edge",
+        "core_size": int(template_row["core_size"]),
+        "strict_edge_count": int(template_row["strict_edge_count"]),
+        "family_count": len(template_families),
+        "assignment_count": assignment_count,
+        "orbit_size_sum": int(template_row["orbit_size_sum"]),
+        "assignment_ids": assignment_ids,
+        "families": sorted(template_families),
+        "path_length_counts": _json_counter(path_length_counts),
+        "shared_endpoint_counts": _json_counter(shared_endpoint_counts),
+        "selected_path_shape_counts": _json_counter(selected_path_shapes),
+        "self_edge_shape_counts": template_row["self_edge_shape_counts"],
+        "family_records": family_records,
+    }
+
+
+def self_edge_template_packet_source_artifacts(
+    local_core_payload: dict[str, Any],
+    path_join_payload: dict[str, Any],
+    template_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the template packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_local_cores.json",
+            "role": "canonical self-edge family local-core certificates",
+            "type": local_core_payload.get("type"),
+            "trust": local_core_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_self_edge_path_join.json",
+            "role": "assignment-level transformed self-edge equality paths",
+            "schema": path_join_payload.get("schema"),
+            "status": path_join_payload.get("status"),
+            "trust": path_join_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_core_templates.json",
+            "role": "self-edge template ids and shape summaries",
+            "schema": template_payload.get("schema"),
+            "status": template_payload.get("status"),
+            "trust": template_payload.get("trust"),
+        },
+    ]
+
+
+def self_edge_template_packet_payload(
+    local_core_payload: dict[str, Any],
+    path_join_payload: dict[str, Any],
+    template_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the compact self-edge template packet."""
+
+    certificates = _self_edge_certificates(local_core_payload)
+    template_rows = _self_edge_template_rows(template_payload)
+    family_rows = _path_join_family_rows(path_join_payload)
+    records_by_template = _path_join_records_by_template(path_join_payload)
+
+    template_records = []
+    core_sizes: Counter[int] = Counter()
+    strict_edge_counts: Counter[int] = Counter()
+    family_count_distribution: Counter[int] = Counter()
+    for template_id in sorted(template_rows):
+        template_row = template_rows[template_id]
+        records = records_by_template.get(template_id, [])
+        record = _template_record(
+            template_id,
+            template_row,
+            records,
+            family_rows,
+            certificates,
+        )
+        core_sizes[int(record["core_size"])] += 1
+        strict_edge_counts[int(record["strict_edge_count"])] += 1
+        family_count_distribution[int(record["family_count"])] += 1
+        template_records.append(record)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "source_assignment_count": int(path_join_payload["source_assignment_count"]),
+        "self_edge_assignment_count": int(path_join_payload["self_edge_assignment_count"]),
+        "strict_cycle_assignment_count": int(path_join_payload["strict_cycle_assignment_count"]),
+        "self_edge_family_count": int(path_join_payload["self_edge_family_count"]),
+        "self_edge_template_count": len(template_records),
+        "template_assignment_counts": {
+            str(record["template_id"]): int(record["assignment_count"])
+            for record in template_records
+        },
+        "template_family_counts": {
+            str(record["template_id"]): int(record["family_count"])
+            for record in template_records
+        },
+        "template_path_length_counts": {
+            str(record["template_id"]): record["path_length_counts"]
+            for record in template_records
+        },
+        "path_length_counts": path_join_payload["path_length_counts"],
+        "shared_endpoint_counts": path_join_payload["shared_endpoint_counts"],
+        "assignment_core_size_counts": path_join_payload["core_size_assignment_counts"],
+        "template_core_size_counts": _json_counter(core_sizes),
+        "template_strict_edge_count_counts": _json_counter(strict_edge_counts),
+        "template_family_count_distribution": _json_counter(family_count_distribution),
+        "templates": template_records,
+        "interpretation": [
+            "Each template record groups self-edge family certificates with the same replay-derived template id.",
+            "Family records keep canonical local-core rows, one strict inequality, and the equality path identifying its outer and inner pairs.",
+            "Selected path-shape counts summarize the assignment-level representative paths chosen by the self-edge path join.",
+            "Template self-edge shape counts come from the core-template artifact and may include additional self-edge conflict shapes.",
+            "These records are reviewer-navigation and lemma-mining diagnostics, not theorem names.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": self_edge_template_packet_source_artifacts(
+            local_core_payload,
+            path_join_payload,
+            template_payload,
+        ),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_self_edge_template_packet_counts(payload)
+    return payload
+
+
+def assert_expected_self_edge_template_packet_counts(payload: dict[str, Any]) -> None:
+    """Assert stable headline counts for the self-edge template packet."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["n"] != n9.N or payload["row_size"] != n9.ROW_SIZE:
+        raise AssertionError("unexpected n or row size")
+    if payload["cyclic_order"] != list(n9.ORDER):
+        raise AssertionError("unexpected cyclic order")
+    if payload["source_assignment_count"] != EXPECTED_SOURCE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected source assignment count")
+    if payload["self_edge_assignment_count"] != EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected self-edge assignment count")
+    if payload["strict_cycle_assignment_count"] != EXPECTED_STRICT_CYCLE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected strict-cycle assignment count")
+    if payload["self_edge_family_count"] != EXPECTED_SELF_EDGE_FAMILY_COUNT:
+        raise AssertionError("unexpected self-edge family count")
+    if payload["self_edge_template_count"] != EXPECTED_SELF_EDGE_TEMPLATE_COUNT:
+        raise AssertionError("unexpected self-edge template count")
+    if payload["template_assignment_counts"] != EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected template assignment counts")
+    if payload["template_family_counts"] != EXPECTED_TEMPLATE_FAMILY_COUNTS:
+        raise AssertionError("unexpected template family counts")
+    if payload["template_path_length_counts"] != EXPECTED_TEMPLATE_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected template path-length counts")
+    if payload["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected path-length counts")
+    if payload["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("unexpected shared-endpoint counts")
+    if payload["assignment_core_size_counts"] != EXPECTED_ASSIGNMENT_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected assignment core-size counts")
+    if payload["template_core_size_counts"] != EXPECTED_TEMPLATE_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected template core-size counts")
+    if (
+        payload["template_strict_edge_count_counts"]
+        != EXPECTED_TEMPLATE_STRICT_EDGE_COUNT_COUNTS
+    ):
+        raise AssertionError("unexpected template strict-edge-count counts")
+    if (
+        payload["template_family_count_distribution"]
+        != EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION
+    ):
+        raise AssertionError("unexpected template family-count distribution")
+    if len(payload["templates"]) != EXPECTED_SELF_EDGE_TEMPLATE_COUNT:
+        raise AssertionError("unexpected template record count")

--- a/tests/test_n9_vertex_circle_self_edge_template_packet.py
+++ b/tests/test_n9_vertex_circle_self_edge_template_packet.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_self_edge_template_packet import (
+    assert_expected_self_edge_template_packet_counts,
+    self_edge_template_packet_payload,
+)
+from scripts.check_n9_vertex_circle_self_edge_template_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_self_edge_template_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_self_edge_template_packet_counts(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["source_assignment_count"] == 184
+    assert payload["self_edge_assignment_count"] == 158
+    assert payload["strict_cycle_assignment_count"] == 26
+    assert payload["self_edge_family_count"] == 13
+    assert payload["self_edge_template_count"] == 9
+    assert payload["path_length_counts"] == {"3": 86, "4": 36, "5": 18, "6": 18}
+    assert payload["shared_endpoint_counts"] == {"1": 158}
+    assert payload["assignment_core_size_counts"] == {"3": 46, "4": 40, "5": 36, "6": 36}
+    assert payload["template_assignment_counts"] == {
+        "T01": 6,
+        "T02": 40,
+        "T03": 20,
+        "T04": 2,
+        "T05": 18,
+        "T06": 18,
+        "T07": 18,
+        "T08": 18,
+        "T09": 18,
+    }
+    assert payload["template_family_counts"] == {
+        "T01": 1,
+        "T02": 4,
+        "T03": 2,
+        "T04": 1,
+        "T05": 1,
+        "T06": 1,
+        "T07": 1,
+        "T08": 1,
+        "T09": 1,
+    }
+
+
+def test_self_edge_template_packet_first_template_record() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    first = payload["templates"][0]
+
+    assert first["template_id"] == "T01"
+    assert first["status"] == "self_edge"
+    assert first["families"] == ["F09"]
+    assert first["assignment_count"] == 6
+    assert first["orbit_size_sum"] == 6
+    assert first["assignment_ids"] == ["A014", "A024", "A031", "A140", "A166", "A175"]
+    assert first["path_length_counts"] == {"3": 6}
+    assert first["selected_path_shape_counts"] == {"3:1:1:path=3": 6}
+    family = first["family_records"][0]
+    assert family["family_id"] == "F09"
+    assert family["template_id"] == "T01"
+    assert family["contradiction"]["kind"] == "self_edge"
+    assert family["distance_equality"]["start_pair"] == family["strict_inequality"][
+        "outer_pair"
+    ]
+    assert family["distance_equality"]["end_pair"] == family["strict_inequality"][
+        "inner_pair"
+    ]
+
+
+def test_self_edge_template_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["self_edge_template_count"] == 9
+
+
+def test_self_edge_template_packet_rejects_tampered_family_list() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][1]["families"] = ["F01"]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family list mismatch" in error for error in errors)
+
+
+def test_self_edge_template_packet_rejects_tampered_template_source_fields() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["template_key"] = "bogus"
+    payload["templates"][0]["core_size"] = 99
+    payload["templates"][0]["selected_path_shape_counts"] = {"bogus": 6}
+    payload["templates"][0]["self_edge_shape_counts"] = {"bogus": 1}
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template T01 template_key mismatch" in error for error in errors)
+    assert any("template T01 core_size mismatch" in error for error in errors)
+    assert any("template T01 selected_path_shape_counts mismatch" in error for error in errors)
+    assert any("template T01 self_edge_shape_counts mismatch" in error for error in errors)
+
+
+def test_self_edge_template_packet_rejects_tampered_assignment_id() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["assignment_ids"][0] = "A999"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template T01 assignment_ids mismatch" in error for error in errors)
+
+
+def test_self_edge_template_packet_rejects_tampered_family_source_fields() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    family = payload["templates"][0]["family_records"][0]
+    family["template_id"] = "T02"
+    family["core_size"] = 99
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template T01 family F09 template_id mismatch" in error for error in errors)
+    assert any("template T01 family F09 core_size mismatch" in error for error in errors)
+
+
+def test_self_edge_template_packet_rejects_tampered_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["family_records"][0]["distance_equality"]["path"][0][
+        "next_pair"
+    ] = [2, 3]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("does not equate" in error or "template T01 family invalid" in error for error in errors)
+
+
+def test_self_edge_template_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_self_edge_template_packet_detects_source_path_join_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    sources["path_join"]["records"][0]["path_length"] = 99
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source self-edge path join invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_self_edge_template_packet_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == self_edge_template_packet_payload(
+        source_payloads["local_cores"],
+        source_payloads["path_join"],
+        source_payloads["templates"],
+    )
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_self_edge_template_packet_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_self_edge_template_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["self_edge_template_count"] == 9
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_self_edge_template_packet_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "self_edge_template_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_self_edge_template_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_self_edge_template_packet_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "self_edge_template_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_self_edge_template_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -101,6 +101,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_self_edge_template_packet.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_strict_cycle_path_join.py "
         "--check --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary

- add a generated/checkable `n9_vertex_circle_self_edge_template_packet` artifact that compresses the 158 self-edge path-join assignment records into 9 template-level diagnostic records
- add source-bound checker validation, targeted tamper tests, generated-artifact provenance, and audit/Makefile wiring
- document the packet as reviewer navigation and lemma-mining support only, with no proof, counterexample, independent-review, or global-status claim

## Validation

- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --write --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json`
- n9 review raw checks for vertex-circle, row-Ptolemy, and base-apex ledgers
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_n9_vertex_circle_exhaustive.py tests/test_n9_vertex_circle_local_cores.py tests/test_n9_vertex_circle_local_core_packet.py tests/test_n9_vertex_circle_core_templates.py tests/test_n9_vertex_circle_frontier_motif_classification.py tests/test_n9_vertex_circle_self_edge_path_join.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_strict_cycle_path_join.py tests/test_n9_vertex_circle_motif_families.py tests/test_n9_vertex_circle_obstruction_shapes.py tests/test_run_artifact_audit.py -q -m "artifact or not artifact"` (82 passed)

Full local `python -m pytest -q` on Windows: 459 passed, 66 deselected, 8 failed in unrelated C19 replay tests due existing `\\` vs `/` artifact path serialization differences; no n9/self-edge failures.