### PR TITLE
Add n9 strict-cycle template packet diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check -
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_strict_cycle_template_packet.json
+++ b/data/certificates/n9_vertex_circle_strict_cycle_template_packet.json
@@ -1,0 +1,910 @@
+{
+  "claim_scope": "Template-level packet for the 3 strict-cycle local-core templates covering 26 n=9 strict-cycle frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "connector_path_length_counts": {
+    "0": 6,
+    "1": 28,
+    "2": 26
+  },
+  "core_size_assignment_counts": {
+    "4": 24,
+    "6": 2
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "first_full_assignment_cycle_length_counts": {
+    "2": 22,
+    "3": 4
+  },
+  "interpretation": [
+    "Each template record groups strict-cycle family certificates with the same replay-derived template id.",
+    "Family records keep canonical local-core rows, directed strict-cycle steps, and equality connectors.",
+    "Connector path-length counts summarize the assignment-level transformed strict-cycle path join.",
+    "Cycle-length counts here summarize transformed local-core certificates, not first full-assignment obstruction-shape cycles.",
+    "These records are reviewer-navigation and lemma-mining diagnostics, not theorem names.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "local_core_cycle_length_counts": {
+    "2": 18,
+    "3": 8
+  },
+  "local_core_cycle_step_count": 60,
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_strict_cycle_template_packet.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1",
+  "self_edge_assignment_count": 158,
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_local_cores.json",
+      "role": "canonical strict-cycle family local-core certificates",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": "n9_vertex_circle_local_cores_v1"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_path_join.json",
+      "role": "assignment-level transformed strict-cycle quotient cycles",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_path_join.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "role": "strict-cycle template ids and cycle span summaries",
+      "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_assignment_count": 184,
+  "span_signature_counts": {
+    "2:1,2:1": 18,
+    "2:1,3:1,3:2": 6,
+    "3:1,3:1,3:1": 2
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_cycle_assignment_count": 26,
+  "strict_cycle_family_count": 3,
+  "strict_cycle_template_count": 3,
+  "strict_edge_count_assignment_counts": {
+    "36": 24,
+    "54": 2
+  },
+  "template_assignment_counts": {
+    "T10": 18,
+    "T11": 6,
+    "T12": 2
+  },
+  "template_connector_path_length_counts": {
+    "T10": {
+      "1": 18,
+      "2": 18
+    },
+    "T11": {
+      "0": 6,
+      "1": 6,
+      "2": 6
+    },
+    "T12": {
+      "1": 4,
+      "2": 2
+    }
+  },
+  "template_core_size_counts": {
+    "4": 2,
+    "6": 1
+  },
+  "template_cycle_length_counts": {
+    "T10": {
+      "2": 18
+    },
+    "T11": {
+      "3": 6
+    },
+    "T12": {
+      "3": 2
+    }
+  },
+  "template_cycle_length_distribution": {
+    "2": 1,
+    "3": 2
+  },
+  "template_family_count_distribution": {
+    "1": 3
+  },
+  "template_family_counts": {
+    "T10": 1,
+    "T11": 1,
+    "T12": 1
+  },
+  "template_span_signature_counts": {
+    "T10": {
+      "2:1,2:1": 18
+    },
+    "T11": {
+      "2:1,3:1,3:2": 6
+    },
+    "T12": {
+      "3:1,3:1,3:1": 2
+    }
+  },
+  "template_strict_edge_count_counts": {
+    "36": 2,
+    "54": 1
+  },
+  "templates": [
+    {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A020",
+        "A040",
+        "A047",
+        "A071",
+        "A080",
+        "A081",
+        "A083",
+        "A093",
+        "A095",
+        "A111",
+        "A126",
+        "A147",
+        "A151",
+        "A153",
+        "A154",
+        "A157",
+        "A164",
+        "A180"
+      ],
+      "connector_path_length_counts": {
+        "1": 18,
+        "2": 18
+      },
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_length_counts": {
+        "2": 18
+      },
+      "cycle_span_counts": [
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 2
+        }
+      ],
+      "families": [
+        "F12"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 18,
+          "contradiction": {
+            "cycle_length": 2,
+            "kind": "strict_cycle",
+            "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              5,
+              6
+            ],
+            [
+              3,
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              6,
+              1,
+              3,
+              4,
+              7
+            ],
+            [
+              8,
+              0,
+              3,
+              6,
+              7
+            ]
+          ],
+          "core_size": 4,
+          "cycle_length": 2,
+          "cycle_steps": [
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  1,
+                  6
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      3,
+                      6
+                    ],
+                    "row": 3
+                  },
+                  {
+                    "next_pair": [
+                      1,
+                      6
+                    ],
+                    "row": 6
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  3
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  0,
+                  3
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  6
+                ],
+                "outer_span": 2,
+                "row": 8,
+                "witness_order": [
+                  0,
+                  3,
+                  6,
+                  7
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  6
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      0,
+                      6
+                    ],
+                    "row": 0
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  1
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  1
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  6
+                ],
+                "outer_span": 2,
+                "row": 3,
+                "witness_order": [
+                  4,
+                  6,
+                  0,
+                  1
+                ]
+              }
+            }
+          ],
+          "family_id": "F12",
+          "orbit_size": 18,
+          "span_signature": "2:1,2:1",
+          "status": "strict_cycle",
+          "strict_edge_count": 36,
+          "template_id": "T10"
+        }
+      ],
+      "orbit_size_sum": 18,
+      "span_signature_counts": {
+        "2:1,2:1": 18
+      },
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T10",
+      "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+    },
+    {
+      "assignment_count": 6,
+      "assignment_ids": [
+        "A008",
+        "A015",
+        "A032",
+        "A137",
+        "A141",
+        "A167"
+      ],
+      "connector_path_length_counts": {
+        "0": 6,
+        "1": 6,
+        "2": 6
+      },
+      "core_size": 4,
+      "cycle_length": 3,
+      "cycle_length_counts": {
+        "3": 6
+      },
+      "cycle_span_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3
+        }
+      ],
+      "families": [
+        "F07"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 6,
+          "contradiction": {
+            "cycle_length": 3,
+            "kind": "strict_cycle",
+            "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              5
+            ],
+            [
+              5,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              6,
+              1,
+              5,
+              7,
+              8
+            ]
+          ],
+          "core_size": 4,
+          "cycle_length": 3,
+          "cycle_steps": [
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  3
+                ],
+                "path": [],
+                "start_pair": [
+                  0,
+                  3
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  3
+                ],
+                "inner_span": 2,
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  2
+                ],
+                "outer_span": 3,
+                "row": 1,
+                "witness_order": [
+                  2,
+                  3,
+                  5,
+                  0
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  5,
+                  7
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      5,
+                      7
+                    ],
+                    "row": 5
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  5
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  5
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  5
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  3
+                ],
+                "outer_span": 2,
+                "row": 1,
+                "witness_order": [
+                  2,
+                  3,
+                  5,
+                  0
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  2
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      0,
+                      1
+                    ],
+                    "row": 1
+                  },
+                  {
+                    "next_pair": [
+                      0,
+                      2
+                    ],
+                    "row": 0
+                  }
+                ],
+                "start_pair": [
+                  1,
+                  5
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  5
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  5
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  5,
+                  7
+                ],
+                "outer_span": 3,
+                "row": 6,
+                "witness_order": [
+                  7,
+                  8,
+                  1,
+                  5
+                ]
+              }
+            }
+          ],
+          "family_id": "F07",
+          "orbit_size": 6,
+          "span_signature": "2:1,3:1,3:2",
+          "status": "strict_cycle",
+          "strict_edge_count": 36,
+          "template_id": "T11"
+        }
+      ],
+      "orbit_size_sum": 6,
+      "span_signature_counts": {
+        "2:1,3:1,3:2": 6
+      },
+      "status": "strict_cycle",
+      "strict_edge_count": 36,
+      "template_id": "T11",
+      "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=3|spans=2:1x1,3:1x1,3:2x1"
+    },
+    {
+      "assignment_count": 2,
+      "assignment_ids": [
+        "A082",
+        "A152"
+      ],
+      "connector_path_length_counts": {
+        "1": 4,
+        "2": 2
+      },
+      "core_size": 6,
+      "cycle_length": 3,
+      "cycle_length_counts": {
+        "3": 2
+      },
+      "cycle_span_counts": [
+        {
+          "count": 3,
+          "inner_span": 1,
+          "outer_span": 3
+        }
+      ],
+      "families": [
+        "F16"
+      ],
+      "family_count": 1,
+      "family_records": [
+        {
+          "assignment_count": 2,
+          "contradiction": {
+            "cycle_length": 3,
+            "kind": "strict_cycle",
+            "statement": "strict inequalities form a directed cycle after selected-distance quotienting"
+          },
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              1,
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              2,
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              3,
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              4,
+              1,
+              2,
+              5,
+              7
+            ],
+            [
+              8,
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "core_size": 6,
+          "cycle_length": 3,
+          "cycle_steps": [
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  2,
+                  8
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      2,
+                      8
+                    ],
+                    "row": 8
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  8
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  2
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  3
+                ],
+                "outer_span": 3,
+                "row": 2,
+                "witness_order": [
+                  3,
+                  5,
+                  8,
+                  0
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  1,
+                  7
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      1,
+                      4
+                    ],
+                    "row": 4
+                  },
+                  {
+                    "next_pair": [
+                      1,
+                      7
+                    ],
+                    "row": 1
+                  }
+                ],
+                "start_pair": [
+                  2,
+                  4
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  1,
+                  2
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  2,
+                  4
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  2
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  2,
+                  8
+                ],
+                "outer_span": 3,
+                "row": 1,
+                "witness_order": [
+                  2,
+                  4,
+                  7,
+                  8
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  3
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      0,
+                      3
+                    ],
+                    "row": 3
+                  }
+                ],
+                "start_pair": [
+                  1,
+                  3
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  1,
+                  3
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  1,
+                  2
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  7
+                ],
+                "outer_span": 3,
+                "row": 0,
+                "witness_order": [
+                  1,
+                  3,
+                  6,
+                  7
+                ]
+              }
+            }
+          ],
+          "family_id": "F16",
+          "orbit_size": 2,
+          "span_signature": "3:1,3:1,3:1",
+          "status": "strict_cycle",
+          "strict_edge_count": 54,
+          "template_id": "T12"
+        }
+      ],
+      "orbit_size_sum": 2,
+      "span_signature_counts": {
+        "3:1,3:1,3:1": 2
+      },
+      "status": "strict_cycle",
+      "strict_edge_count": 54,
+      "template_id": "T12",
+      "template_key": "strict_cycle|rows=6|strict_edges=54|cycle=3|spans=3:1x3"
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -73,8 +73,11 @@ family certificates.
 transforms the strict-cycle local-core certificates back into each of the 26
 strict-cycle assignments. Its local-core cycle-length counts (`2: 18`,
 `3: 8`) are distinct from the first full-assignment obstruction-shape counts
-(`2: 22`, `3: 4`). All of these are review-pending diagnostics only, not
-independent proofs and not status promotions.
+(`2: 22`, `3: 4`).
+`data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+compresses those strict-cycle joins to 3 template-level reviewer records with
+canonical family cycles. All of these are review-pending diagnostics only,
+not independent proofs and not status promotions.
 
 ## Commands
 

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -82,6 +82,14 @@ transformed local-core certificates (`2: 18`, `3: 8`), not the first
 full-assignment obstruction-shape cycles (`2: 22`, `3: 4`). This is also a
 reviewer-navigation diagnostic only.
 
+`data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+compresses that strict-cycle side to 3 template-level records. Each template
+record keeps the canonical family local-core directed cycle, assignment ids,
+cycle/span summaries, and connector path-length counts from the assignment
+join. It is a reviewer-navigation packet only, not a theorem list, and keeps
+the local-core cycle counts separate from first full-assignment obstruction
+counts.
+
 `data/certificates/n9_row_ptolemy_product_cancellations.json` contains a
 dependent crosswalk from the row-Ptolemy hit families to these template labels:
 `F02 -> T08`, `F09 -> T01`, and `F13 -> T04`. All three are self-edge
@@ -222,6 +230,19 @@ python scripts/check_n9_vertex_circle_strict_cycle_path_join.py \
   --json
 ```
 
+Generate and check the strict-cycle template packet:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -232,6 +253,7 @@ python -m pytest \
   tests/test_n9_vertex_circle_self_edge_path_join.py \
   tests/test_n9_vertex_circle_self_edge_template_packet.py \
   tests/test_n9_vertex_circle_strict_cycle_path_join.py \
+  tests/test_n9_vertex_circle_strict_cycle_template_packet.py \
   -q
 ```
 

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -66,6 +66,14 @@ these are not the same statistic as the first full-assignment obstruction
 cycle counts in the obstruction-shape diagnostic. This is still a
 review-pending replay aid, not an independent n=9 proof.
 
+The strict-cycle template packet
+`data/certificates/n9_vertex_circle_strict_cycle_template_packet.json` then
+groups those 26 assignment-level joins by the 3 strict-cycle template ids. It
+keeps one canonical local-core directed cycle for each covered strict-cycle
+family and records template-level assignment, span-signature, and connector
+path-length summaries. It is for human review and lemma mining only; template
+ids remain deterministic artifact labels.
+
 The local-core follow-up in `docs/n9-vertex-circle-local-cores.md` shows that
 each of the 16 family representatives has a vertex-circle certificate using at
 most 6 selected rows. Its template diagnostic groups those 16 local cores into
@@ -178,6 +186,19 @@ python scripts/check_n9_vertex_circle_strict_cycle_path_join.py \
   --json
 ```
 
+Generate and check the strict-cycle template packet:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -187,5 +208,6 @@ python -m pytest \
   tests/test_n9_vertex_circle_self_edge_path_join.py \
   tests/test_n9_vertex_circle_self_edge_template_packet.py \
   tests/test_n9_vertex_circle_strict_cycle_path_join.py \
+  tests/test_n9_vertex_circle_strict_cycle_template_packet.py \
   -q
 ```

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -59,6 +59,7 @@ python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check -
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -145,6 +145,9 @@ Next steps:
   assignment-level replay aid for transformed strict-cycle local-core
   quotient cycles, keeping its local-core cycle counts separate from first
   full-assignment obstruction-shape counts;
+- use `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+  to review the 3 strict-cycle template packets before attempting reusable
+  quotient-cycle lemmas;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -76,6 +76,7 @@ python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check -
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -513,6 +513,63 @@ artifacts:
       - the path join is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_strict_cycle_template_packet
+    path: data/certificates/n9_vertex_circle_strict_cycle_template_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_strict_cycle_template_packet.py
+    command: python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_strict_cycle_template_packet.py
+    check_command: python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Template-level packet for the 3 strict-cycle local-core templates covering 26 n=9 strict-cycle frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_strict_cycle_template_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Template-level packet for the 3 strict-cycle local-core templates covering 26 n=9 strict-cycle frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      source_assignment_count: 184
+      self_edge_assignment_count: 158
+      strict_cycle_assignment_count: 26
+      strict_cycle_family_count: 3
+      strict_cycle_template_count: 3
+      local_core_cycle_step_count: 60
+      local_core_cycle_length_counts.2: 18
+      local_core_cycle_length_counts.3: 8
+      first_full_assignment_cycle_length_counts.2: 22
+      first_full_assignment_cycle_length_counts.3: 4
+      core_size_assignment_counts.4: 24
+      core_size_assignment_counts.6: 2
+      strict_edge_count_assignment_counts.36: 24
+      strict_edge_count_assignment_counts.54: 2
+      connector_path_length_counts.0: 6
+      connector_path_length_counts.1: 28
+      connector_path_length_counts.2: 26
+      template_assignment_counts.T10: 18
+      template_assignment_counts.T11: 6
+      template_assignment_counts.T12: 2
+      template_cycle_length_counts.T10.2: 18
+      template_cycle_length_counts.T11.3: 6
+      template_cycle_length_counts.T12.3: 2
+      template_core_size_counts.4: 2
+      template_core_size_counts.6: 1
+      template_cycle_length_distribution.2: 1
+      template_cycle_length_distribution.3: 2
+      provenance.command: python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - local-core cycle counts are first full-assignment cycle counts
+      - the template packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_strict_cycle_template_packet.py
+++ b/scripts/check_n9_vertex_circle_strict_cycle_template_packet.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Generate or check the n=9 strict-cycle template packet diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_core_templates import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATES,
+    validate_payload as validate_template_payload,
+)
+from check_n9_vertex_circle_strict_cycle_path_join import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_PATH_JOIN,
+    validate_payload as validate_path_join_payload,
+)
+from erdos97.n9_vertex_circle_obstruction_shapes import (  # noqa: E402
+    assert_expected_local_core_counts,
+)
+from erdos97.n9_vertex_circle_self_edge_path_join import (  # noqa: E402
+    validate_equality_path,
+)
+from erdos97.n9_vertex_circle_strict_cycle_template_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_strict_cycle_template_packet_counts,
+    strict_cycle_template_packet_payload,
+    strict_cycle_template_packet_source_artifacts,
+)
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import pair  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
+)
+DEFAULT_LOCAL_CORES = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "connector_path_length_counts",
+    "core_size_assignment_counts",
+    "cyclic_order",
+    "first_full_assignment_cycle_length_counts",
+    "interpretation",
+    "local_core_cycle_length_counts",
+    "local_core_cycle_step_count",
+    "n",
+    "provenance",
+    "row_size",
+    "schema",
+    "self_edge_assignment_count",
+    "source_artifacts",
+    "source_assignment_count",
+    "span_signature_counts",
+    "status",
+    "strict_cycle_assignment_count",
+    "strict_cycle_family_count",
+    "strict_cycle_template_count",
+    "strict_edge_count_assignment_counts",
+    "template_assignment_counts",
+    "template_connector_path_length_counts",
+    "template_core_size_counts",
+    "template_cycle_length_counts",
+    "template_cycle_length_distribution",
+    "template_family_count_distribution",
+    "template_family_counts",
+    "template_span_signature_counts",
+    "template_strict_edge_count_counts",
+    "templates",
+    "trust",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    local_cores_path: Path = DEFAULT_LOCAL_CORES,
+    path_join_path: Path = DEFAULT_PATH_JOIN,
+    templates_path: Path = DEFAULT_TEMPLATES,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the strict-cycle template packet."""
+
+    return {
+        "local_cores": load_artifact(_resolve(local_cores_path)),
+        "path_join": load_artifact(_resolve(path_join_path)),
+        "templates": load_artifact(_resolve(templates_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    local_cores = source_payloads.get("local_cores")
+    path_join = source_payloads.get("path_join")
+    templates = source_payloads.get("templates")
+    if not isinstance(local_cores, dict):
+        errors.append("source local-core payload must be an object")
+    else:
+        try:
+            assert_expected_local_core_counts(local_cores)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"source local-core artifact invalid: {exc}")
+    if not isinstance(path_join, dict):
+        errors.append("source strict-cycle path-join payload must be an object")
+    else:
+        path_join_errors = validate_path_join_payload(path_join, recompute=False)
+        if path_join_errors:
+            errors.extend(
+                f"source strict-cycle path join invalid: {error}"
+                for error in path_join_errors
+            )
+    if not isinstance(templates, dict):
+        errors.append("source template payload must be an object")
+    else:
+        template_errors = validate_template_payload(templates, recompute=False)
+        if template_errors:
+            errors.extend(f"source core templates invalid: {error}" for error in template_errors)
+
+
+def _validate_cycle_steps(record: dict[str, Any]) -> None:
+    rows = record["core_selected_rows"]
+    steps = record["cycle_steps"]
+    if len(steps) != int(record["cycle_length"]):
+        raise AssertionError("cycle_length does not match cycle_steps")
+    for index, step in enumerate(steps):
+        edge = step["strict_inequality"]
+        equality = step["equality_to_next_outer_pair"]
+        next_edge = steps[(index + 1) % len(steps)]["strict_inequality"]
+        if pair(*equality["start_pair"]) != pair(*edge["inner_pair"]):
+            raise AssertionError("cycle equality must start at current inner pair")
+        if pair(*equality["end_pair"]) != pair(*next_edge["outer_pair"]):
+            raise AssertionError("cycle equality must end at next outer pair")
+        validate_equality_path(rows, equality)
+
+
+def _validate_family_record(record: dict[str, Any]) -> None:
+    if record.get("status") != "strict_cycle":
+        raise AssertionError("family record status must be strict_cycle")
+    if record.get("contradiction", {}).get("kind") != "strict_cycle":
+        raise AssertionError("family contradiction kind must be strict_cycle")
+    _validate_cycle_steps(record)
+
+
+def _expected_template_rows(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, dict[str, Any]]:
+    try:
+        expected_payload = strict_cycle_template_packet_payload(
+            source_payloads["local_cores"],
+            source_payloads["path_join"],
+            source_payloads["templates"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound strict-cycle template packet failed: {exc}")
+        return {}
+    return {
+        str(template["template_id"]): template
+        for template in expected_payload.get("templates", [])
+        if isinstance(template, dict)
+    }
+
+
+def _validate_source_bound_template(
+    template: dict[str, Any],
+    expected_template: dict[str, Any],
+    errors: list[str],
+) -> None:
+    template_id = str(template.get("template_id"))
+    for key in (
+        "template_key",
+        "status",
+        "core_size",
+        "cycle_length",
+        "strict_edge_count",
+        "family_count",
+        "assignment_count",
+        "orbit_size_sum",
+        "assignment_ids",
+        "families",
+        "cycle_length_counts",
+        "connector_path_length_counts",
+        "span_signature_counts",
+        "cycle_span_counts",
+    ):
+        expect_equal(
+            errors,
+            f"template {template_id} {key}",
+            template.get(key),
+            expected_template.get(key),
+        )
+
+    expected_families = {
+        str(record["family_id"]): record
+        for record in expected_template.get("family_records", [])
+        if isinstance(record, dict)
+    }
+    for family_record in template.get("family_records", []):
+        if not isinstance(family_record, dict):
+            continue
+        family_id = str(family_record.get("family_id"))
+        expected_family = expected_families.get(family_id)
+        if expected_family is None:
+            errors.append(f"template {template_id} unexpected family record {family_id}")
+            continue
+        for key in (
+            "template_id",
+            "status",
+            "assignment_count",
+            "orbit_size",
+            "core_size",
+            "cycle_length",
+            "strict_edge_count",
+            "span_signature",
+            "core_selected_rows",
+            "cycle_steps",
+            "contradiction",
+        ):
+            expect_equal(
+                errors,
+                f"template {template_id} family {family_id} {key}",
+                family_record.get(key),
+                expected_family.get(key),
+            )
+
+
+def _validate_template_rows(
+    payload: dict[str, Any],
+    errors: list[str],
+    *,
+    source_payloads: dict[str, Any],
+) -> None:
+    templates = payload.get("templates")
+    if not isinstance(templates, list):
+        errors.append("templates must be a list")
+        return
+    expected_templates = _expected_template_rows(source_payloads, errors)
+    template_ids: list[str] = []
+    assignment_counts: dict[str, int] = {}
+    family_counts: dict[str, int] = {}
+    cycle_length_counts: dict[str, Any] = {}
+    connector_path_counts: dict[str, Any] = {}
+    span_signature_counts: dict[str, Any] = {}
+    all_assignment_ids: list[str] = []
+    for index, template in enumerate(templates):
+        if not isinstance(template, dict):
+            errors.append(f"template {index} must be an object")
+            continue
+        template_id = str(template.get("template_id"))
+        template_ids.append(template_id)
+        expected_template = expected_templates.get(template_id)
+        if expected_template is None:
+            errors.append(f"unexpected template id {template_id}")
+        else:
+            _validate_source_bound_template(template, expected_template, errors)
+        family_records = template.get("family_records")
+        if not isinstance(family_records, list):
+            errors.append(f"template {template_id} family_records must be a list")
+            continue
+        if sorted(template.get("families", [])) != sorted(
+            record.get("family_id") for record in family_records
+        ):
+            errors.append(f"template {template_id} family list mismatch")
+        assignment_ids = template.get("assignment_ids")
+        if not isinstance(assignment_ids, list) or not all(
+            isinstance(item, str) for item in assignment_ids
+        ):
+            errors.append(f"template {template_id} assignment_ids must be a string list")
+            assignment_ids = []
+        if len(assignment_ids) != template.get("assignment_count"):
+            errors.append(f"template {template_id} assignment_ids count mismatch")
+        if len(assignment_ids) != len(set(assignment_ids)):
+            errors.append(f"template {template_id} duplicate assignment ids")
+        all_assignment_ids.extend(assignment_ids)
+        family_assignment_sum = 0
+        for family_record in family_records:
+            if not isinstance(family_record, dict):
+                errors.append(f"template {template_id} family record must be an object")
+                continue
+            try:
+                _validate_family_record(family_record)
+            except (AssertionError, KeyError, TypeError, ValueError) as exc:
+                errors.append(f"template {template_id} family invalid: {exc}")
+            else:
+                family_assignment_sum += int(family_record["assignment_count"])
+        if family_assignment_sum != template.get("assignment_count"):
+            errors.append(f"template {template_id} assignment count mismatch")
+        assignment_counts[template_id] = int(template.get("assignment_count", 0))
+        family_counts[template_id] = int(template.get("family_count", 0))
+        cycle_length_counts[template_id] = template.get("cycle_length_counts")
+        connector_path_counts[template_id] = template.get("connector_path_length_counts")
+        span_signature_counts[template_id] = template.get("span_signature_counts")
+    if len(template_ids) != len(set(template_ids)):
+        errors.append("duplicate template ids")
+    if len(all_assignment_ids) != len(set(all_assignment_ids)):
+        errors.append("duplicate assignment ids across templates")
+    if len(all_assignment_ids) != payload.get("strict_cycle_assignment_count"):
+        errors.append("assignment_ids do not cover strict-cycle assignment count")
+    expect_equal(
+        errors,
+        "template_assignment_counts",
+        payload.get("template_assignment_counts"),
+        assignment_counts,
+    )
+    expect_equal(
+        errors,
+        "template_family_counts",
+        payload.get("template_family_counts"),
+        family_counts,
+    )
+    expect_equal(
+        errors,
+        "template_cycle_length_counts",
+        payload.get("template_cycle_length_counts"),
+        cycle_length_counts,
+    )
+    expect_equal(
+        errors,
+        "template_connector_path_length_counts",
+        payload.get("template_connector_path_length_counts"),
+        connector_path_counts,
+    )
+    expect_equal(
+        errors,
+        "template_span_signature_counts",
+        payload.get("template_span_signature_counts"),
+        span_signature_counts,
+    )
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a strict-cycle template packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "source_assignment_count": 184,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_assignment_count": 26,
+        "strict_cycle_family_count": 3,
+        "strict_cycle_template_count": 3,
+        "local_core_cycle_step_count": 60,
+        "local_core_cycle_length_counts": {"2": 18, "3": 8},
+        "first_full_assignment_cycle_length_counts": {"2": 22, "3": 4},
+        "core_size_assignment_counts": {"4": 24, "6": 2},
+        "strict_edge_count_assignment_counts": {"36": 24, "54": 2},
+        "connector_path_length_counts": {"0": 6, "1": 28, "2": 26},
+        "span_signature_counts": {
+            "2:1,2:1": 18,
+            "2:1,3:1,3:2": 6,
+            "3:1,3:1,3:1": 2,
+        },
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    elif "No proof of the n=9 case is claimed." not in interpretation:
+        errors.append("interpretation must preserve the no-proof statement")
+    elif not any("not first full-assignment" in item for item in interpretation):
+        errors.append("interpretation must distinguish local-core and full cycles")
+
+    _validate_sources(source_payloads, errors)
+    if not errors:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            strict_cycle_template_packet_source_artifacts(
+                source_payloads["local_cores"],
+                source_payloads["path_join"],
+                source_payloads["templates"],
+            ),
+        )
+        _validate_template_rows(payload, errors, source_payloads=source_payloads)
+
+    try:
+        assert_expected_strict_cycle_template_packet_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected strict-cycle template packet counts failed: {exc}")
+
+    if recompute and not errors:
+        try:
+            expected_payload = strict_cycle_template_packet_payload(
+                source_payloads["local_cores"],
+                source_payloads["path_join"],
+                source_payloads["templates"],
+            )
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"recomputed strict-cycle template packet failed: {exc}")
+        else:
+            expect_equal(errors, "strict-cycle template packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "strict_cycle_assignment_count": object_payload.get(
+            "strict_cycle_assignment_count"
+        ),
+        "strict_cycle_family_count": object_payload.get("strict_cycle_family_count"),
+        "strict_cycle_template_count": object_payload.get("strict_cycle_template_count"),
+        "local_core_cycle_length_counts": object_payload.get(
+            "local_core_cycle_length_counts"
+        ),
+        "first_full_assignment_cycle_length_counts": object_payload.get(
+            "first_full_assignment_cycle_length_counts"
+        ),
+        "template_assignment_counts": object_payload.get("template_assignment_counts"),
+        "template_cycle_length_counts": object_payload.get("template_cycle_length_counts"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--local-cores", type=Path, default=DEFAULT_LOCAL_CORES)
+    parser.add_argument("--path-join", type=Path, default=DEFAULT_PATH_JOIN)
+    parser.add_argument("--templates", type=Path, default=DEFAULT_TEMPLATES)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            local_cores_path=args.local_cores,
+            path_join_path=args.path_join,
+            templates_path=args.templates,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = strict_cycle_template_packet_payload(
+            sources["local_cores"],
+            sources["path_join"],
+            sources["templates"],
+        )
+        if args.assert_expected:
+            assert_expected_strict_cycle_template_packet_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle strict-cycle template packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"strict-cycle assignments: {summary['strict_cycle_assignment_count']}")
+        print(f"strict-cycle families: {summary['strict_cycle_family_count']}")
+        print(f"strict-cycle templates: {summary['strict_cycle_template_count']}")
+        print(f"local-core cycle lengths: {summary['local_core_cycle_length_counts']}")
+        print(f"template assignments: {summary['template_assignment_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: strict-cycle template packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -201,6 +201,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_strict_cycle_template_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_strict_cycle_template_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Template-level packet for the 3 n=9 strict-cycle local-core "
+            "templates; not a proof of n=9, counterexample, or independent "
+            "review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_strict_cycle_template_packet.py
+++ b/src/erdos97/n9_vertex_circle_strict_cycle_template_packet.py
@@ -1,0 +1,497 @@
+"""Build a compact n=9 strict-cycle template packet for reviewer navigation.
+
+This module is diagnostic. It does not prove Erdos Problem #97, does not
+claim a counterexample, and does not promote the review-pending n=9 checker.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_obstruction_shapes import EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS
+from erdos97.n9_vertex_circle_self_edge_path_join import (
+    compact_core_rows,
+    validate_equality_path,
+)
+from erdos97.vertex_circle_quotient_replay import pair
+
+
+SCHEMA = "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Template-level packet for the 3 strict-cycle local-core templates covering "
+    "26 n=9 strict-cycle frontier assignments; not a proof of n=9, not a "
+    "counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_strict_cycle_template_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py "
+        "--assert-expected --write"
+    ),
+}
+EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT = 158
+EXPECTED_STRICT_CYCLE_ASSIGNMENT_COUNT = 26
+EXPECTED_STRICT_CYCLE_FAMILY_COUNT = 3
+EXPECTED_STRICT_CYCLE_TEMPLATE_COUNT = 3
+EXPECTED_LOCAL_CORE_CYCLE_STEP_COUNT = 60
+EXPECTED_LOCAL_CORE_CYCLE_LENGTH_COUNTS = {"2": 18, "3": 8}
+EXPECTED_FIRST_FULL_ASSIGNMENT_CYCLE_LENGTH_COUNTS = {"2": 22, "3": 4}
+EXPECTED_CORE_SIZE_ASSIGNMENT_COUNTS = {"4": 24, "6": 2}
+EXPECTED_STRICT_EDGE_COUNT_ASSIGNMENT_COUNTS = {"36": 24, "54": 2}
+EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS = {"0": 6, "1": 28, "2": 26}
+EXPECTED_SPAN_SIGNATURE_COUNTS = {
+    "2:1,2:1": 18,
+    "2:1,3:1,3:2": 6,
+    "3:1,3:1,3:1": 2,
+}
+EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS = {"T10": 18, "T11": 6, "T12": 2}
+EXPECTED_TEMPLATE_FAMILY_COUNTS = {"T10": 1, "T11": 1, "T12": 1}
+EXPECTED_TEMPLATE_CYCLE_LENGTH_COUNTS = {
+    "T10": {"2": 18},
+    "T11": {"3": 6},
+    "T12": {"3": 2},
+}
+EXPECTED_TEMPLATE_CONNECTOR_PATH_LENGTH_COUNTS = {
+    "T10": {"1": 18, "2": 18},
+    "T11": {"0": 6, "1": 6, "2": 6},
+    "T12": {"1": 4, "2": 2},
+}
+EXPECTED_TEMPLATE_SPAN_SIGNATURE_COUNTS = {
+    "T10": {"2:1,2:1": 18},
+    "T11": {"2:1,3:1,3:2": 6},
+    "T12": {"3:1,3:1,3:1": 2},
+}
+EXPECTED_TEMPLATE_CORE_SIZE_COUNTS = {"4": 2, "6": 1}
+EXPECTED_TEMPLATE_STRICT_EDGE_COUNT_COUNTS = {"36": 2, "54": 1}
+EXPECTED_TEMPLATE_CYCLE_LENGTH_DISTRIBUTION = {"2": 1, "3": 2}
+EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION = {"1": 3}
+
+
+def _strict_cycle_certificates(
+    local_core_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    certificates = local_core_payload.get("certificates")
+    if not isinstance(certificates, list):
+        raise ValueError("local-core payload must contain certificates")
+    return {
+        str(certificate["family_id"]): certificate
+        for certificate in certificates
+        if isinstance(certificate, dict) and certificate.get("status") == "strict_cycle"
+    }
+
+
+def _strict_cycle_template_rows(
+    template_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    templates = template_payload.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template payload must contain templates")
+    return {
+        str(template["template_id"]): template
+        for template in templates
+        if isinstance(template, dict) and template.get("status") == "strict_cycle"
+    }
+
+
+def _strict_cycle_template_family_rows(
+    template_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    families = template_payload.get("families")
+    if not isinstance(families, list):
+        raise ValueError("template payload must contain families")
+    return {
+        str(family["family_id"]): family
+        for family in families
+        if isinstance(family, dict) and family.get("status") == "strict_cycle"
+    }
+
+
+def _path_join_family_rows(path_join_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    families = path_join_payload.get("families")
+    if not isinstance(families, list):
+        raise ValueError("strict-cycle path join must contain families")
+    return {str(family["family_id"]): family for family in families}
+
+
+def _path_join_records_by_template(
+    path_join_payload: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    records = path_join_payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("strict-cycle path join must contain records")
+    by_template: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("strict-cycle path-join records must be objects")
+        by_template[str(record["template_id"])].append(record)
+    return {template_id: rows for template_id, rows in sorted(by_template.items())}
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _span_signature_from_cycle_span_counts(span_counts: Sequence[dict[str, Any]]) -> str:
+    tokens = []
+    for span_count in span_counts:
+        count = int(span_count["count"])
+        outer_span = int(span_count["outer_span"])
+        inner_span = int(span_count["inner_span"])
+        tokens.extend(f"{outer_span}:{inner_span}" for _ in range(count))
+    return ",".join(sorted(tokens))
+
+
+def _validate_cycle_steps(
+    rows: Sequence[Sequence[int]],
+    steps: Sequence[dict[str, Any]],
+) -> None:
+    for index, step in enumerate(steps):
+        edge = step["strict_inequality"]
+        equality = step["equality_to_next_outer_pair"]
+        next_edge = steps[(index + 1) % len(steps)]["strict_inequality"]
+        if pair(*equality["start_pair"]) != pair(*edge["inner_pair"]):
+            raise AssertionError("cycle equality must start at current inner pair")
+        if pair(*equality["end_pair"]) != pair(*next_edge["outer_pair"]):
+            raise AssertionError("cycle equality must end at next outer pair")
+        validate_equality_path(rows, equality)
+
+
+def _family_record(
+    certificate: dict[str, Any],
+    family_row: dict[str, Any],
+    template_family_row: dict[str, Any],
+) -> dict[str, Any]:
+    family_id = str(certificate["family_id"])
+    if family_id != str(family_row["family_id"]):
+        raise AssertionError("family row does not match certificate")
+    if family_id != str(template_family_row["family_id"]):
+        raise AssertionError("template family row does not match certificate")
+    if family_row["status"] != "strict_cycle":
+        raise AssertionError("family row must be strict_cycle")
+    if template_family_row["status"] != "strict_cycle":
+        raise AssertionError("template family row must be strict_cycle")
+
+    rows = compact_core_rows(certificate)
+    steps = certificate["cycle_steps"]
+    _validate_cycle_steps(rows, steps)
+    cycle_span_counts = template_family_row["obstruction_summary"]["cycle_span_counts"]
+    span_signature = _span_signature_from_cycle_span_counts(cycle_span_counts)
+    expected = {
+        "template_id": str(template_family_row["template_id"]),
+        "core_size": int(certificate["core_size"]),
+        "orbit_size": int(certificate["orbit_size"]),
+        "cycle_length": len(steps),
+        "strict_edge_count": int(template_family_row["strict_edge_count"]),
+        "span_signature": span_signature,
+        "status": "strict_cycle",
+    }
+    for key, value in expected.items():
+        if family_row.get(key) != value:
+            raise AssertionError(f"{family_id} {key} mismatch")
+    return {
+        "family_id": family_id,
+        "template_id": str(template_family_row["template_id"]),
+        "status": "strict_cycle",
+        "assignment_count": int(family_row["assignment_count"]),
+        "orbit_size": int(certificate["orbit_size"]),
+        "core_size": int(certificate["core_size"]),
+        "cycle_length": len(steps),
+        "strict_edge_count": int(template_family_row["strict_edge_count"]),
+        "span_signature": span_signature,
+        "core_selected_rows": rows,
+        "cycle_steps": steps,
+        "contradiction": {
+            "kind": "strict_cycle",
+            "statement": (
+                "strict inequalities form a directed cycle after "
+                "selected-distance quotienting"
+            ),
+            "cycle_length": len(steps),
+        },
+    }
+
+
+def _template_record(
+    template_id: str,
+    template_row: dict[str, Any],
+    records: Sequence[dict[str, Any]],
+    family_rows: dict[str, dict[str, Any]],
+    certificates: dict[str, dict[str, Any]],
+    template_family_rows: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    template_families = [str(family_id) for family_id in template_row["families"]]
+    path_join_families = sorted({str(record["family_id"]) for record in records})
+    if path_join_families != sorted(template_families):
+        raise AssertionError(f"{template_id} family coverage mismatch")
+
+    family_records = []
+    for family_id in sorted(template_families):
+        family_row = family_rows.get(family_id)
+        certificate = certificates.get(family_id)
+        template_family_row = template_family_rows.get(family_id)
+        if family_row is None or certificate is None or template_family_row is None:
+            raise AssertionError(f"{template_id} missing family {family_id}")
+        family_records.append(_family_record(certificate, family_row, template_family_row))
+
+    assignment_count = len(records)
+    cycle_length_counts: Counter[int] = Counter(
+        int(record["cycle_length"]) for record in records
+    )
+    connector_path_lengths: Counter[int] = Counter()
+    for record in records:
+        connector_path_lengths.update(
+            int(length) for length in record["connector_path_lengths"]
+        )
+    span_signatures: Counter[str] = Counter(str(record["span_signature"]) for record in records)
+    expected_assignment_count = sum(
+        int(family_rows[family_id]["assignment_count"]) for family_id in template_families
+    )
+    if assignment_count != expected_assignment_count:
+        raise AssertionError(f"{template_id} assignment coverage mismatch")
+    if int(template_row["family_count"]) != len(template_families):
+        raise AssertionError(f"{template_id} family_count mismatch")
+    if int(template_row["orbit_size_sum"]) != assignment_count:
+        raise AssertionError(f"{template_id} orbit_size_sum mismatch")
+    assignment_ids = sorted(str(record["assignment_id"]) for record in records)
+
+    return {
+        "template_id": template_id,
+        "template_key": str(template_row["template_key"]),
+        "status": "strict_cycle",
+        "core_size": int(template_row["core_size"]),
+        "cycle_length": int(template_row["cycle_length"]),
+        "strict_edge_count": int(template_row["strict_edge_count"]),
+        "family_count": len(template_families),
+        "assignment_count": assignment_count,
+        "orbit_size_sum": int(template_row["orbit_size_sum"]),
+        "assignment_ids": assignment_ids,
+        "families": sorted(template_families),
+        "cycle_length_counts": _json_counter(cycle_length_counts),
+        "connector_path_length_counts": _json_counter(connector_path_lengths),
+        "span_signature_counts": _json_counter(span_signatures),
+        "cycle_span_counts": template_row["cycle_span_counts"],
+        "family_records": family_records,
+    }
+
+
+def strict_cycle_template_packet_source_artifacts(
+    local_core_payload: dict[str, Any],
+    path_join_payload: dict[str, Any],
+    template_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the template packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_local_cores.json",
+            "role": "canonical strict-cycle family local-core certificates",
+            "type": local_core_payload.get("type"),
+            "trust": local_core_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_strict_cycle_path_join.json",
+            "role": "assignment-level transformed strict-cycle quotient cycles",
+            "schema": path_join_payload.get("schema"),
+            "status": path_join_payload.get("status"),
+            "trust": path_join_payload.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_core_templates.json",
+            "role": "strict-cycle template ids and cycle span summaries",
+            "schema": template_payload.get("schema"),
+            "status": template_payload.get("status"),
+            "trust": template_payload.get("trust"),
+        },
+    ]
+
+
+def strict_cycle_template_packet_payload(
+    local_core_payload: dict[str, Any],
+    path_join_payload: dict[str, Any],
+    template_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the compact strict-cycle template packet."""
+
+    certificates = _strict_cycle_certificates(local_core_payload)
+    template_rows = _strict_cycle_template_rows(template_payload)
+    family_rows = _path_join_family_rows(path_join_payload)
+    template_family_rows = _strict_cycle_template_family_rows(template_payload)
+    records_by_template = _path_join_records_by_template(path_join_payload)
+
+    template_records = []
+    core_sizes: Counter[int] = Counter()
+    cycle_lengths: Counter[int] = Counter()
+    strict_edge_counts: Counter[int] = Counter()
+    family_count_distribution: Counter[int] = Counter()
+    for template_id in sorted(template_rows):
+        template_row = template_rows[template_id]
+        records = records_by_template.get(template_id, [])
+        record = _template_record(
+            template_id,
+            template_row,
+            records,
+            family_rows,
+            certificates,
+            template_family_rows,
+        )
+        core_sizes[int(record["core_size"])] += 1
+        cycle_lengths[int(record["cycle_length"])] += 1
+        strict_edge_counts[int(record["strict_edge_count"])] += 1
+        family_count_distribution[int(record["family_count"])] += 1
+        template_records.append(record)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "source_assignment_count": int(path_join_payload["source_assignment_count"]),
+        "self_edge_assignment_count": int(path_join_payload["self_edge_assignment_count"]),
+        "strict_cycle_assignment_count": int(
+            path_join_payload["strict_cycle_assignment_count"]
+        ),
+        "strict_cycle_family_count": int(path_join_payload["strict_cycle_family_count"]),
+        "strict_cycle_template_count": len(template_records),
+        "local_core_cycle_step_count": int(path_join_payload["cycle_step_count"]),
+        "local_core_cycle_length_counts": path_join_payload["cycle_length_counts"],
+        "first_full_assignment_cycle_length_counts": path_join_payload[
+            "first_full_assignment_cycle_length_counts"
+        ],
+        "core_size_assignment_counts": path_join_payload["core_size_assignment_counts"],
+        "strict_edge_count_assignment_counts": path_join_payload[
+            "strict_edge_count_assignment_counts"
+        ],
+        "connector_path_length_counts": path_join_payload["connector_path_length_counts"],
+        "span_signature_counts": path_join_payload["span_signature_counts"],
+        "template_assignment_counts": {
+            str(record["template_id"]): int(record["assignment_count"])
+            for record in template_records
+        },
+        "template_family_counts": {
+            str(record["template_id"]): int(record["family_count"])
+            for record in template_records
+        },
+        "template_cycle_length_counts": {
+            str(record["template_id"]): record["cycle_length_counts"]
+            for record in template_records
+        },
+        "template_connector_path_length_counts": {
+            str(record["template_id"]): record["connector_path_length_counts"]
+            for record in template_records
+        },
+        "template_span_signature_counts": {
+            str(record["template_id"]): record["span_signature_counts"]
+            for record in template_records
+        },
+        "template_core_size_counts": _json_counter(core_sizes),
+        "template_cycle_length_distribution": _json_counter(cycle_lengths),
+        "template_strict_edge_count_counts": _json_counter(strict_edge_counts),
+        "template_family_count_distribution": _json_counter(family_count_distribution),
+        "templates": template_records,
+        "interpretation": [
+            "Each template record groups strict-cycle family certificates with the same replay-derived template id.",
+            "Family records keep canonical local-core rows, directed strict-cycle steps, and equality connectors.",
+            "Connector path-length counts summarize the assignment-level transformed strict-cycle path join.",
+            "Cycle-length counts here summarize transformed local-core certificates, not first full-assignment obstruction-shape cycles.",
+            "These records are reviewer-navigation and lemma-mining diagnostics, not theorem names.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": strict_cycle_template_packet_source_artifacts(
+            local_core_payload,
+            path_join_payload,
+            template_payload,
+        ),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_strict_cycle_template_packet_counts(payload)
+    return payload
+
+
+def assert_expected_strict_cycle_template_packet_counts(payload: dict[str, Any]) -> None:
+    """Assert stable headline counts for the strict-cycle template packet."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["n"] != n9.N or payload["row_size"] != n9.ROW_SIZE:
+        raise AssertionError("unexpected n or row size")
+    if payload["cyclic_order"] != list(n9.ORDER):
+        raise AssertionError("unexpected cyclic order")
+    if payload["source_assignment_count"] != EXPECTED_PRE_VERTEX_CIRCLE_ASSIGNMENTS:
+        raise AssertionError("unexpected source assignment count")
+    if payload["self_edge_assignment_count"] != EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected self-edge assignment count")
+    if payload["strict_cycle_assignment_count"] != EXPECTED_STRICT_CYCLE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected strict-cycle assignment count")
+    if payload["strict_cycle_family_count"] != EXPECTED_STRICT_CYCLE_FAMILY_COUNT:
+        raise AssertionError("unexpected strict-cycle family count")
+    if payload["strict_cycle_template_count"] != EXPECTED_STRICT_CYCLE_TEMPLATE_COUNT:
+        raise AssertionError("unexpected strict-cycle template count")
+    if payload["local_core_cycle_step_count"] != EXPECTED_LOCAL_CORE_CYCLE_STEP_COUNT:
+        raise AssertionError("unexpected local-core cycle-step count")
+    if (
+        payload["local_core_cycle_length_counts"]
+        != EXPECTED_LOCAL_CORE_CYCLE_LENGTH_COUNTS
+    ):
+        raise AssertionError("unexpected local-core cycle-length counts")
+    if (
+        payload["first_full_assignment_cycle_length_counts"]
+        != EXPECTED_FIRST_FULL_ASSIGNMENT_CYCLE_LENGTH_COUNTS
+    ):
+        raise AssertionError("unexpected first full-assignment cycle-length counts")
+    if payload["core_size_assignment_counts"] != EXPECTED_CORE_SIZE_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected core-size assignment counts")
+    if (
+        payload["strict_edge_count_assignment_counts"]
+        != EXPECTED_STRICT_EDGE_COUNT_ASSIGNMENT_COUNTS
+    ):
+        raise AssertionError("unexpected strict-edge-count assignment counts")
+    if payload["connector_path_length_counts"] != EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected connector path-length counts")
+    if payload["span_signature_counts"] != EXPECTED_SPAN_SIGNATURE_COUNTS:
+        raise AssertionError("unexpected span-signature counts")
+    if payload["template_assignment_counts"] != EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected template assignment counts")
+    if payload["template_family_counts"] != EXPECTED_TEMPLATE_FAMILY_COUNTS:
+        raise AssertionError("unexpected template family counts")
+    if payload["template_cycle_length_counts"] != EXPECTED_TEMPLATE_CYCLE_LENGTH_COUNTS:
+        raise AssertionError("unexpected template cycle-length counts")
+    if (
+        payload["template_connector_path_length_counts"]
+        != EXPECTED_TEMPLATE_CONNECTOR_PATH_LENGTH_COUNTS
+    ):
+        raise AssertionError("unexpected template connector path-length counts")
+    if payload["template_span_signature_counts"] != EXPECTED_TEMPLATE_SPAN_SIGNATURE_COUNTS:
+        raise AssertionError("unexpected template span-signature counts")
+    if payload["template_core_size_counts"] != EXPECTED_TEMPLATE_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected template core-size counts")
+    if (
+        payload["template_cycle_length_distribution"]
+        != EXPECTED_TEMPLATE_CYCLE_LENGTH_DISTRIBUTION
+    ):
+        raise AssertionError("unexpected template cycle-length distribution")
+    if (
+        payload["template_strict_edge_count_counts"]
+        != EXPECTED_TEMPLATE_STRICT_EDGE_COUNT_COUNTS
+    ):
+        raise AssertionError("unexpected template strict-edge-count counts")
+    if (
+        payload["template_family_count_distribution"]
+        != EXPECTED_TEMPLATE_FAMILY_COUNT_DISTRIBUTION
+    ):
+        raise AssertionError("unexpected template family-count distribution")
+    if len(payload["templates"]) != EXPECTED_STRICT_CYCLE_TEMPLATE_COUNT:
+        raise AssertionError("unexpected template record count")

--- a/tests/test_n9_vertex_circle_strict_cycle_template_packet.py
+++ b/tests/test_n9_vertex_circle_strict_cycle_template_packet.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_strict_cycle_template_packet import (
+    assert_expected_strict_cycle_template_packet_counts,
+    strict_cycle_template_packet_payload,
+)
+from scripts.check_n9_vertex_circle_strict_cycle_template_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_strict_cycle_template_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_strict_cycle_template_packet_counts(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["source_assignment_count"] == 184
+    assert payload["self_edge_assignment_count"] == 158
+    assert payload["strict_cycle_assignment_count"] == 26
+    assert payload["strict_cycle_family_count"] == 3
+    assert payload["strict_cycle_template_count"] == 3
+    assert payload["local_core_cycle_step_count"] == 60
+    assert payload["local_core_cycle_length_counts"] == {"2": 18, "3": 8}
+    assert payload["first_full_assignment_cycle_length_counts"] == {"2": 22, "3": 4}
+    assert payload["connector_path_length_counts"] == {"0": 6, "1": 28, "2": 26}
+    assert payload["template_assignment_counts"] == {"T10": 18, "T11": 6, "T12": 2}
+    assert payload["template_cycle_length_counts"] == {
+        "T10": {"2": 18},
+        "T11": {"3": 6},
+        "T12": {"3": 2},
+    }
+
+
+def test_strict_cycle_template_packet_first_template_record() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    first = payload["templates"][0]
+
+    assert first["template_id"] == "T10"
+    assert first["status"] == "strict_cycle"
+    assert first["families"] == ["F12"]
+    assert first["assignment_count"] == 18
+    assert first["orbit_size_sum"] == 18
+    assert first["assignment_ids"] == [
+        "A020",
+        "A040",
+        "A047",
+        "A071",
+        "A080",
+        "A081",
+        "A083",
+        "A093",
+        "A095",
+        "A111",
+        "A126",
+        "A147",
+        "A151",
+        "A153",
+        "A154",
+        "A157",
+        "A164",
+        "A180",
+    ]
+    assert first["cycle_length_counts"] == {"2": 18}
+    assert first["connector_path_length_counts"] == {"1": 18, "2": 18}
+    assert first["span_signature_counts"] == {"2:1,2:1": 18}
+    family = first["family_records"][0]
+    assert family["family_id"] == "F12"
+    assert family["template_id"] == "T10"
+    assert family["contradiction"]["kind"] == "strict_cycle"
+    assert family["cycle_length"] == len(family["cycle_steps"])
+
+
+def test_strict_cycle_template_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["strict_cycle_template_count"] == 3
+
+
+def test_strict_cycle_template_packet_rejects_tampered_family_list() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["families"] = ["F07"]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family list mismatch" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_rejects_tampered_template_source_fields() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["template_key"] = "bogus"
+    payload["templates"][0]["cycle_length"] = 99
+    payload["templates"][0]["connector_path_length_counts"] = {"bogus": 1}
+    payload["templates"][0]["cycle_span_counts"] = [{"count": 1}]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template T10 template_key mismatch" in error for error in errors)
+    assert any("template T10 cycle_length mismatch" in error for error in errors)
+    assert any(
+        "template T10 connector_path_length_counts mismatch" in error
+        for error in errors
+    )
+    assert any("template T10 cycle_span_counts mismatch" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_rejects_tampered_assignment_id() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["assignment_ids"][0] = "A999"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template T10 assignment_ids mismatch" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_rejects_tampered_family_source_fields() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    family = payload["templates"][0]["family_records"][0]
+    family["template_id"] = "T11"
+    family["span_signature"] = "bogus"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("template T10 family F12 template_id mismatch" in error for error in errors)
+    assert any("template T10 family F12 span_signature mismatch" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_rejects_tampered_cycle_connector() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["family_records"][0]["cycle_steps"][0][
+        "equality_to_next_outer_pair"
+    ]["end_pair"] = [0, 8]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("cycle equality must end" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_rejects_missing_cycle_distinction() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item
+        for item in payload["interpretation"]
+        if "not first full-assignment" not in item
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("distinguish local-core and full cycles" in error for error in errors)
+
+
+def test_strict_cycle_template_packet_detects_source_path_join_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    sources["path_join"]["records"][0]["cycle_length"] = 99
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source strict-cycle path join invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_strict_cycle_template_packet_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == strict_cycle_template_packet_payload(
+        source_payloads["local_cores"],
+        source_payloads["path_join"],
+        source_payloads["templates"],
+    )
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_strict_cycle_template_packet_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_cycle_template_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["strict_cycle_template_count"] == 3
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_strict_cycle_template_packet_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "strict_cycle_template_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_cycle_template_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_strict_cycle_template_packet_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "strict_cycle_template_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_cycle_template_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -110,3 +110,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary

- add a generated/checkable `n9_vertex_circle_strict_cycle_template_packet` artifact that compresses the 26 strict-cycle path-join assignment records into 3 template-level diagnostic records
- preserve the local-core cycle count distinction explicitly with `local_core_cycle_length_counts` (`2:18, 3:8`) alongside first full-assignment counts (`2:22, 3:4`)
- add source-bound checker validation, tamper tests, generated-artifact provenance, and audit/docs/Makefile wiring

## Validation

- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --write --check --assert-expected --json`
- raw `verify-n9-review` command block, including the new strict-cycle template packet checker
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_n9_vertex_circle_exhaustive.py tests/test_n9_vertex_circle_local_cores.py tests/test_n9_vertex_circle_local_core_packet.py tests/test_n9_vertex_circle_core_templates.py tests/test_n9_vertex_circle_frontier_motif_classification.py tests/test_n9_vertex_circle_self_edge_path_join.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_strict_cycle_path_join.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_motif_families.py tests/test_n9_vertex_circle_obstruction_shapes.py tests/test_run_artifact_audit.py -q -m "artifact or not artifact"` (100 passed)

Full local `python -m pytest -q` on Windows: 474 passed, 69 deselected, 8 failed in unrelated C19 replay tests due existing `\\` vs `/` artifact path serialization differences; no n9/strict-cycle packet failures.