### PR TITLE
[codex] Clarify C19 fallback histogram checks

### DIFF
--- a/scripts/certify_c19_kalmanson_prefix_window_prefilter.py
+++ b/scripts/certify_c19_kalmanson_prefix_window_prefilter.py
@@ -765,6 +765,8 @@ def assert_expected_416_447(data: Mapping[str, object]) -> None:
         supports["fifth_pair_farkas_fallback"],
         "window 416-447 fallback histogram",
     )
+    # Farkas support sizes can vary by solver environment; the stable
+    # invariants here are the fallback count and the exact fallback labels.
     if sum(int(count) for count in fallback_supports.values()) != int(
         accounting["fifth_pair_farkas_fallback_certified_count"]
     ):
@@ -856,6 +858,8 @@ def assert_expected_448_479(data: Mapping[str, object]) -> None:
         supports["fifth_pair_farkas_fallback"],
         "window 448-479 fallback histogram",
     )
+    # Farkas support sizes can vary by solver environment; the stable
+    # invariants here are the fallback count and the exact fallback labels.
     if sum(int(count) for count in fallback_supports.values()) != int(
         accounting["fifth_pair_farkas_fallback_certified_count"]
     ):


### PR DESCRIPTION
## Mathematical scope

This PR documents why the existing C19 prefilter expected-value checks pin the stable fallback count and exact fallback labels, but do not pin ordinary Farkas fallback support-size histograms. The support sizes can vary by solver environment, while the recorded labels and total fallback count are the reproducible invariants.

## Files changed

- `scripts/certify_c19_kalmanson_prefix_window_prefilter.py`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m py_compile scripts/certify_c19_kalmanson_prefix_window_prefilter.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q tests/test_c19_kalmanson_prefix_window_prefilter.py` (`12 passed`)

## Remaining limitations

This is a verifier/documentation guardrail only. It does not change any artifact, proof claim, or Erdos97 status.