### PR TITLE
Add n9 template lemma catalog diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/n8-exact-survivors.md`](docs/n8-exact-survivors.md).
 - For the review-pending exhaustive `n=9` vertex-circle finite-case checker,
   read [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
+- For the derived `n=9` vertex-circle template lemma-candidate catalog, read
+  [`docs/n9-vertex-circle-template-lemma-catalog.md`](docs/n9-vertex-circle-template-lemma-catalog.md).
 - For the review-pending `n=10` singleton-slice finite-case draft, read
   [`docs/n10-vertex-circle-singleton-slices.md`](docs/n10-vertex-circle-singleton-slices.md).
 - For a compact human-readable proof-note draft excluding bad convex octagons,
@@ -344,6 +346,7 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-ex
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_template_lemma_catalog.json
+++ b/data/certificates/n9_vertex_circle_template_lemma_catalog.json
@@ -1,0 +1,1262 @@
+{
+  "claim_scope": "Derived lemma-candidate catalog for the 12 n=9 vertex-circle local-core templates covering 184 frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "covered_assignment_count": 184,
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "family_core_size_counts": {
+    "3": 5,
+    "4": 6,
+    "5": 2,
+    "6": 3
+  },
+  "family_count": 16,
+  "family_status_counts": {
+    "self_edge": 13,
+    "strict_cycle": 3
+  },
+  "interpretation": [
+    "Each catalog record is derived from a checked template packet and summarizes one local-core template as a lemma candidate.",
+    "Self-edge records end in a reflexive strict inequality after selected-distance quotienting.",
+    "Strict-cycle records end in a directed strict cycle after selected-distance quotienting.",
+    "Template ids and catalog records are reviewer-navigation and lemma-mining diagnostics, not theorem names.",
+    "The catalog is derived from review-pending n=9 diagnostics and is not an independent review of the exhaustive checker.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_template_lemma_catalog.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_template_lemma_catalog.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_template_lemma_catalog.v1",
+  "self_edge_assignment_count": 158,
+  "self_edge_family_count": 13,
+  "self_edge_template_count": 9,
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "self-edge template packet source for 9 catalog records",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+      "role": "strict-cycle template packet source for 3 catalog records",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_core_templates.json",
+      "role": "family/template crosswalk and core-size distribution source",
+      "schema": "erdos97.n9_vertex_circle_core_templates.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_assignment_count": 184,
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "status_assignment_counts": {
+    "self_edge": 158,
+    "strict_cycle": 26
+  },
+  "strict_cycle_assignment_count": 26,
+  "strict_cycle_family_count": 3,
+  "strict_cycle_template_count": 3,
+  "template_assignment_counts": {
+    "T01": 6,
+    "T02": 40,
+    "T03": 20,
+    "T04": 2,
+    "T05": 18,
+    "T06": 18,
+    "T07": 18,
+    "T08": 18,
+    "T09": 18,
+    "T10": 18,
+    "T11": 6,
+    "T12": 2
+  },
+  "template_core_size_counts": {
+    "3": 2,
+    "4": 5,
+    "5": 2,
+    "6": 3
+  },
+  "template_count": 12,
+  "template_family_counts": {
+    "T01": 1,
+    "T02": 4,
+    "T03": 2,
+    "T04": 1,
+    "T05": 1,
+    "T06": 1,
+    "T07": 1,
+    "T08": 1,
+    "T09": 1,
+    "T10": 1,
+    "T11": 1,
+    "T12": 1
+  },
+  "template_status_counts": {
+    "self_edge": 9,
+    "strict_cycle": 3
+  },
+  "templates": [
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 6,
+        "assignment_ids": [
+          "A014",
+          "A024",
+          "A031",
+          "A140",
+          "A166",
+          "A175"
+        ],
+        "families": [
+          "F09"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 6
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 6,
+          "contradiction_kind": "self_edge",
+          "core_size": 3,
+          "equality_path_length": 3,
+          "family_id": "F09",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 6,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T01"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 3,
+        "path_length_counts": {
+          "3": 6
+        },
+        "selected_path_shape_counts": {
+          "3:1:1:path=3": 6
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 6
+        },
+        "strict_edge_count": 27
+      },
+      "status": "self_edge",
+      "template_id": "T01",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 40,
+        "assignment_ids": [
+          "A001",
+          "A004",
+          "A006",
+          "A009",
+          "A011",
+          "A019",
+          "A022",
+          "A025",
+          "A034",
+          "A035",
+          "A045",
+          "A051",
+          "A056",
+          "A058",
+          "A060",
+          "A061",
+          "A063",
+          "A065",
+          "A070",
+          "A076",
+          "A078",
+          "A087",
+          "A092",
+          "A099",
+          "A101",
+          "A103",
+          "A114",
+          "A115",
+          "A118",
+          "A119",
+          "A121",
+          "A136",
+          "A138",
+          "A145",
+          "A163",
+          "A173",
+          "A176",
+          "A178",
+          "A182",
+          "A184"
+        ],
+        "families": [
+          "F01",
+          "F04",
+          "F08",
+          "F14"
+        ],
+        "family_count": 4,
+        "orbit_size_sum": 40
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 3,
+          "equality_path_length": 3,
+          "family_id": "F01",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T02"
+        },
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 3,
+          "equality_path_length": 3,
+          "family_id": "F04",
+          "inner_pair": [
+            2,
+            3
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            0,
+            2
+          ],
+          "outer_span": 3,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T02"
+        },
+        {
+          "assignment_count": 2,
+          "contradiction_kind": "self_edge",
+          "core_size": 3,
+          "equality_path_length": 3,
+          "family_id": "F08",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 2,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T02"
+        },
+        {
+          "assignment_count": 2,
+          "contradiction_kind": "self_edge",
+          "core_size": 3,
+          "equality_path_length": 3,
+          "family_id": "F14",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 2,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T02"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 3,
+        "path_length_counts": {
+          "3": 40
+        },
+        "selected_path_shape_counts": {
+          "3:1:1:path=3": 40
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 40
+        },
+        "strict_edge_count": 27
+      },
+      "status": "self_edge",
+      "template_id": "T02",
+      "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 20,
+        "assignment_ids": [
+          "A005",
+          "A021",
+          "A042",
+          "A048",
+          "A054",
+          "A068",
+          "A074",
+          "A077",
+          "A079",
+          "A104",
+          "A110",
+          "A116",
+          "A117",
+          "A124",
+          "A131",
+          "A148",
+          "A155",
+          "A156",
+          "A181",
+          "A183"
+        ],
+        "families": [
+          "F05",
+          "F15"
+        ],
+        "family_count": 2,
+        "orbit_size_sum": 20
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 4,
+          "equality_path_length": 3,
+          "family_id": "F05",
+          "inner_pair": [
+            1,
+            7
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            3,
+            7
+          ],
+          "outer_span": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T03"
+        },
+        {
+          "assignment_count": 2,
+          "contradiction_kind": "self_edge",
+          "core_size": 4,
+          "equality_path_length": 3,
+          "family_id": "F15",
+          "inner_pair": [
+            3,
+            4
+          ],
+          "inner_span": 1,
+          "orbit_size": 2,
+          "outer_pair": [
+            1,
+            4
+          ],
+          "outer_span": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T03"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 4,
+        "path_length_counts": {
+          "3": 20
+        },
+        "selected_path_shape_counts": {
+          "2:1:1:path=3": 20
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 20
+        },
+        "strict_edge_count": 36
+      },
+      "status": "self_edge",
+      "template_id": "T03",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [
+          "A023",
+          "A174"
+        ],
+        "families": [
+          "F13"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 2,
+          "contradiction_kind": "self_edge",
+          "core_size": 4,
+          "equality_path_length": 3,
+          "family_id": "F13",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 2,
+          "outer_pair": [
+            1,
+            5
+          ],
+          "outer_span": 2,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T04"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 4,
+        "path_length_counts": {
+          "3": 2
+        },
+        "selected_path_shape_counts": {
+          "2:1:1:path=3": 2
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 2
+        },
+        "strict_edge_count": 36
+      },
+      "status": "self_edge",
+      "template_id": "T04",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A013",
+          "A029",
+          "A036",
+          "A038",
+          "A053",
+          "A057",
+          "A059",
+          "A062",
+          "A072",
+          "A088",
+          "A090",
+          "A100",
+          "A105",
+          "A120",
+          "A129",
+          "A133",
+          "A162",
+          "A170"
+        ],
+        "families": [
+          "F10"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 4,
+          "equality_path_length": 3,
+          "family_id": "F10",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "path_length": 3,
+          "status": "self_edge",
+          "template_id": "T05"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 4,
+        "path_length_counts": {
+          "3": 18
+        },
+        "selected_path_shape_counts": {
+          "3:1:1:path=3": 18
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 18
+        },
+        "strict_edge_count": 36
+      },
+      "status": "self_edge",
+      "template_id": "T05",
+      "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A016",
+          "A018",
+          "A026",
+          "A027",
+          "A041",
+          "A046",
+          "A069",
+          "A094",
+          "A097",
+          "A112",
+          "A127",
+          "A139",
+          "A146",
+          "A158",
+          "A165",
+          "A168",
+          "A172",
+          "A179"
+        ],
+        "families": [
+          "F11"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 5,
+          "equality_path_length": 4,
+          "family_id": "F11",
+          "inner_pair": [
+            3,
+            5
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            3,
+            8
+          ],
+          "outer_span": 2,
+          "path_length": 4,
+          "status": "self_edge",
+          "template_id": "T06"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 5,
+        "path_length_counts": {
+          "4": 18
+        },
+        "selected_path_shape_counts": {
+          "2:1:1:path=4": 18
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 18
+        },
+        "strict_edge_count": 45
+      },
+      "status": "self_edge",
+      "template_id": "T06",
+      "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x1,3:1:0x1,3:1:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A007",
+          "A028",
+          "A037",
+          "A039",
+          "A052",
+          "A055",
+          "A064",
+          "A066",
+          "A075",
+          "A089",
+          "A091",
+          "A098",
+          "A102",
+          "A113",
+          "A125",
+          "A128",
+          "A171",
+          "A177"
+        ],
+        "families": [
+          "F06"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 5,
+          "equality_path_length": 4,
+          "family_id": "F06",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            1,
+            4
+          ],
+          "outer_span": 2,
+          "path_length": 4,
+          "status": "self_edge",
+          "template_id": "T07"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 5,
+        "path_length_counts": {
+          "4": 18
+        },
+        "selected_path_shape_counts": {
+          "2:1:1:path=4": 18
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 3,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 2,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 18
+        },
+        "strict_edge_count": 45
+      },
+      "status": "self_edge",
+      "template_id": "T07",
+      "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x3,3:1:0x1,3:1:1x1,3:2:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A002",
+          "A012",
+          "A043",
+          "A050",
+          "A067",
+          "A084",
+          "A085",
+          "A086",
+          "A096",
+          "A106",
+          "A109",
+          "A122",
+          "A132",
+          "A134",
+          "A143",
+          "A149",
+          "A150",
+          "A159"
+        ],
+        "families": [
+          "F02"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 6,
+          "equality_path_length": 5,
+          "family_id": "F02",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            1,
+            3
+          ],
+          "outer_span": 2,
+          "path_length": 5,
+          "status": "self_edge",
+          "template_id": "T08"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 6,
+        "path_length_counts": {
+          "5": 18
+        },
+        "selected_path_shape_counts": {
+          "2:1:1:path=5": 18
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 4,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 1,
+            "inner_span": 2,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 18
+        },
+        "strict_edge_count": 54
+      },
+      "status": "self_edge",
+      "template_id": "T08",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "strict_inequality",
+          "distance_equality"
+        ],
+        "kind": "self_edge",
+        "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A003",
+          "A010",
+          "A017",
+          "A030",
+          "A033",
+          "A044",
+          "A049",
+          "A073",
+          "A107",
+          "A108",
+          "A123",
+          "A130",
+          "A135",
+          "A142",
+          "A144",
+          "A160",
+          "A161",
+          "A169"
+        ],
+        "families": [
+          "F03"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "self_edge",
+          "core_size": 6,
+          "equality_path_length": 6,
+          "family_id": "F03",
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "orbit_size": 18,
+          "outer_pair": [
+            1,
+            3
+          ],
+          "outer_span": 2,
+          "path_length": 6,
+          "status": "self_edge",
+          "template_id": "T09"
+        }
+      ],
+      "hypothesis_shape": {
+        "core_size": 6,
+        "path_length_counts": {
+          "6": 18
+        },
+        "selected_path_shape_counts": {
+          "2:1:1:path=6": 18
+        },
+        "self_edge_shape_counts": [
+          {
+            "count": 5,
+            "inner_span": 1,
+            "outer_span": 2,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 0
+          },
+          {
+            "count": 4,
+            "inner_span": 1,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          },
+          {
+            "count": 2,
+            "inner_span": 2,
+            "outer_span": 3,
+            "shared_endpoint_count": 1
+          }
+        ],
+        "shared_endpoint_counts": {
+          "1": 18
+        },
+        "strict_edge_count": 54
+      },
+      "status": "self_edge",
+      "template_id": "T09",
+      "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x5,3:1:0x2,3:1:1x4,3:2:1x2"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "cycle_steps",
+          "equality_to_next_outer_pair"
+        ],
+        "kind": "strict_cycle",
+        "strict_graph_obstruction": "directed strict cycle after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A020",
+          "A040",
+          "A047",
+          "A071",
+          "A080",
+          "A081",
+          "A083",
+          "A093",
+          "A095",
+          "A111",
+          "A126",
+          "A147",
+          "A151",
+          "A153",
+          "A154",
+          "A157",
+          "A164",
+          "A180"
+        ],
+        "families": [
+          "F12"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 18,
+          "contradiction_kind": "strict_cycle",
+          "core_size": 4,
+          "cycle_length": 2,
+          "cycle_step_count": 2,
+          "family_id": "F12",
+          "orbit_size": 18,
+          "span_signature": "2:1,2:1",
+          "status": "strict_cycle",
+          "strict_edge_count": 36,
+          "template_id": "T10"
+        }
+      ],
+      "hypothesis_shape": {
+        "connector_path_length_counts": {
+          "1": 18,
+          "2": 18
+        },
+        "core_size": 4,
+        "cycle_length": 2,
+        "cycle_length_counts": {
+          "2": 18
+        },
+        "cycle_span_counts": [
+          {
+            "count": 2,
+            "inner_span": 1,
+            "outer_span": 2
+          }
+        ],
+        "span_signature_counts": {
+          "2:1,2:1": 18
+        },
+        "strict_edge_count": 36
+      },
+      "status": "strict_cycle",
+      "template_id": "T10",
+      "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "cycle_steps",
+          "equality_to_next_outer_pair"
+        ],
+        "kind": "strict_cycle",
+        "strict_graph_obstruction": "directed strict cycle after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 6,
+        "assignment_ids": [
+          "A008",
+          "A015",
+          "A032",
+          "A137",
+          "A141",
+          "A167"
+        ],
+        "families": [
+          "F07"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 6
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 6,
+          "contradiction_kind": "strict_cycle",
+          "core_size": 4,
+          "cycle_length": 3,
+          "cycle_step_count": 3,
+          "family_id": "F07",
+          "orbit_size": 6,
+          "span_signature": "2:1,3:1,3:2",
+          "status": "strict_cycle",
+          "strict_edge_count": 36,
+          "template_id": "T11"
+        }
+      ],
+      "hypothesis_shape": {
+        "connector_path_length_counts": {
+          "0": 6,
+          "1": 6,
+          "2": 6
+        },
+        "core_size": 4,
+        "cycle_length": 3,
+        "cycle_length_counts": {
+          "3": 6
+        },
+        "cycle_span_counts": [
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 2
+          },
+          {
+            "count": 1,
+            "inner_span": 1,
+            "outer_span": 3
+          },
+          {
+            "count": 1,
+            "inner_span": 2,
+            "outer_span": 3
+          }
+        ],
+        "span_signature_counts": {
+          "2:1,3:1,3:2": 6
+        },
+        "strict_edge_count": 36
+      },
+      "status": "strict_cycle",
+      "template_id": "T11",
+      "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=3|spans=2:1x1,3:1x1,3:2x1"
+    },
+    {
+      "conclusion_shape": {
+        "certificate_fields": [
+          "cycle_steps",
+          "equality_to_next_outer_pair"
+        ],
+        "kind": "strict_cycle",
+        "strict_graph_obstruction": "directed strict cycle after selected-distance quotienting"
+      },
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [
+          "A082",
+          "A152"
+        ],
+        "families": [
+          "F16"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "family_summaries": [
+        {
+          "assignment_count": 2,
+          "contradiction_kind": "strict_cycle",
+          "core_size": 6,
+          "cycle_length": 3,
+          "cycle_step_count": 3,
+          "family_id": "F16",
+          "orbit_size": 2,
+          "span_signature": "3:1,3:1,3:1",
+          "status": "strict_cycle",
+          "strict_edge_count": 54,
+          "template_id": "T12"
+        }
+      ],
+      "hypothesis_shape": {
+        "connector_path_length_counts": {
+          "1": 4,
+          "2": 2
+        },
+        "core_size": 6,
+        "cycle_length": 3,
+        "cycle_length_counts": {
+          "3": 2
+        },
+        "cycle_span_counts": [
+          {
+            "count": 3,
+            "inner_span": 1,
+            "outer_span": 3
+          }
+        ],
+        "span_signature_counts": {
+          "3:1,3:1,3:1": 2
+        },
+        "strict_edge_count": 54
+      },
+      "status": "strict_cycle",
+      "template_id": "T12",
+      "template_key": "strict_cycle|rows=6|strict_edges=54|cycle=3|spans=3:1x3"
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-exhaustive.md`](n9-vertex-circle-exhaustive.md):
   review-pending exhaustive `n=9` selected-witness checker using the
   vertex-circle strict-chord filter.
+- [`n9-vertex-circle-template-lemma-catalog.md`](n9-vertex-circle-template-lemma-catalog.md):
+  derived 12-template lemma-candidate catalog for proof-mining review.
 - [`n10-vertex-circle-singleton-slices.md`](n10-vertex-circle-singleton-slices.md):
   review-pending `n=10` singleton-slice finite-case draft and audit target.
 - [`octagon-trap.html`](octagon-trap.html): interactive visualization of the

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -76,8 +76,11 @@ strict-cycle assignments. Its local-core cycle-length counts (`2: 18`,
 (`2: 22`, `3: 4`).
 `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
 compresses those strict-cycle joins to 3 template-level reviewer records with
-canonical family cycles. All of these are review-pending diagnostics only,
-not independent proofs and not status promotions.
+canonical family cycles.
+`data/certificates/n9_vertex_circle_template_lemma_catalog.json` combines the
+9 self-edge templates and 3 strict-cycle templates into one derived
+lemma-candidate crosswalk for proof mining. All of these are review-pending
+diagnostics only, not independent proofs and not status promotions.
 
 ## Commands
 

--- a/docs/n9-vertex-circle-local-cores.md
+++ b/docs/n9-vertex-circle-local-cores.md
@@ -90,6 +90,13 @@ join. It is a reviewer-navigation packet only, not a theorem list, and keeps
 the local-core cycle counts separate from first full-assignment obstruction
 counts.
 
+`data/certificates/n9_vertex_circle_template_lemma_catalog.json` combines the
+9 self-edge template records and the 3 strict-cycle template records into a
+single derived lemma-candidate crosswalk. It records the local-core hypothesis
+shape, assignment/family coverage, and quotient obstruction shape for each
+template. This is proof-mining scaffolding only; template ids are not theorem
+names.
+
 `data/certificates/n9_row_ptolemy_product_cancellations.json` contains a
 dependent crosswalk from the row-Ptolemy hit families to these template labels:
 `F02 -> T08`, `F09 -> T01`, and `F13 -> T04`. All three are self-edge
@@ -243,6 +250,19 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
   --json
 ```
 
+Generate and check the template lemma-candidate catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -254,6 +274,7 @@ python -m pytest \
   tests/test_n9_vertex_circle_self_edge_template_packet.py \
   tests/test_n9_vertex_circle_strict_cycle_path_join.py \
   tests/test_n9_vertex_circle_strict_cycle_template_packet.py \
+  tests/test_n9_vertex_circle_template_lemma_catalog.py \
   -q
 ```
 

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -81,6 +81,13 @@ most 6 selected rows. Its template diagnostic groups those 16 local cores into
 templates. These buckets are review aids for lemma mining; they are not an
 independent n=9 proof path.
 
+The derived catalog
+`data/certificates/n9_vertex_circle_template_lemma_catalog.json` puts those 12
+template buckets in one proof-mining crosswalk. Each record keeps assignment
+coverage, family coverage, a local-core hypothesis shape, and the quotient
+self-edge or strict-cycle conclusion shape. It is still a diagnostic artifact,
+not a theorem list.
+
 ## Loose Obstruction Shapes
 
 As a deliberately coarse diagnostic, the artifact also buckets the first
@@ -199,6 +206,19 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
   --json
 ```
 
+Generate and check the template lemma-candidate catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
 Run the targeted artifact test:
 
 ```bash
@@ -209,5 +229,6 @@ python -m pytest \
   tests/test_n9_vertex_circle_self_edge_template_packet.py \
   tests/test_n9_vertex_circle_strict_cycle_path_join.py \
   tests/test_n9_vertex_circle_strict_cycle_template_packet.py \
+  tests/test_n9_vertex_circle_template_lemma_catalog.py \
   -q
 ```

--- a/docs/n9-vertex-circle-template-lemma-catalog.md
+++ b/docs/n9-vertex-circle-template-lemma-catalog.md
@@ -1,0 +1,62 @@
+# n=9 Vertex-circle Template Lemma-candidate Catalog
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records a derived catalog for proof search. It does not claim a
+proof of `n=9`, does not claim a counterexample, does not complete independent
+review of the exhaustive checker, and does not update the official/global
+status.
+
+## What is cataloged
+
+The checked artifact
+`data/certificates/n9_vertex_circle_template_lemma_catalog.json` combines the
+two template packets:
+
+- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
+- `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+
+The catalog has one record per replay-derived local-core template:
+
+```text
+templates:              12
+self-edge templates:     9
+strict-cycle templates:  3
+families covered:       16
+assignments covered:   184
+```
+
+Each self-edge catalog record summarizes the local-core shape that produces a
+reflexive strict edge after selected-distance quotienting. Each strict-cycle
+record summarizes the local-core shape that produces a directed strict cycle
+after selected-distance quotienting. Template ids are deterministic artifact
+labels for reviewer navigation and lemma mining; they are not theorem names.
+
+## Commands
+
+Generate and check the catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+```
+
+## Review standard
+
+Before any lemma is promoted from this catalog, a reviewer should restate its
+incidence/order hypotheses without using template labels as theorem names,
+then prove the quotient self-edge or strict-cycle conclusion directly from
+those hypotheses. The catalog is intended to make that proof-mining pass
+smaller; it is not itself an independent proof.

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -60,6 +60,7 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-ex
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -148,6 +148,9 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
   to review the 3 strict-cycle template packets before attempting reusable
   quotient-cycle lemmas;
+- use `data/certificates/n9_vertex_circle_template_lemma_catalog.json` as a
+  single 12-template lemma-candidate crosswalk before writing proof-facing
+  local lemmas;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -77,6 +77,7 @@ python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-ex
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -570,6 +570,71 @@ artifacts:
       - the template packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_template_lemma_catalog
+    path: data/certificates/n9_vertex_circle_template_lemma_catalog.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_template_lemma_catalog.py
+    command: python scripts/check_n9_vertex_circle_template_lemma_catalog.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_template_lemma_catalog.py
+    check_command: python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Derived lemma-candidate catalog for the 12 n=9 vertex-circle local-core templates covering 184 frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_template_lemma_catalog.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Derived lemma-candidate catalog for the 12 n=9 vertex-circle local-core templates covering 184 frontier assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      source_assignment_count: 184
+      covered_assignment_count: 184
+      self_edge_assignment_count: 158
+      strict_cycle_assignment_count: 26
+      template_count: 12
+      self_edge_template_count: 9
+      strict_cycle_template_count: 3
+      family_count: 16
+      self_edge_family_count: 13
+      strict_cycle_family_count: 3
+      template_status_counts.self_edge: 9
+      template_status_counts.strict_cycle: 3
+      family_status_counts.self_edge: 13
+      family_status_counts.strict_cycle: 3
+      status_assignment_counts.self_edge: 158
+      status_assignment_counts.strict_cycle: 26
+      template_assignment_counts.T01: 6
+      template_assignment_counts.T02: 40
+      template_assignment_counts.T03: 20
+      template_assignment_counts.T04: 2
+      template_assignment_counts.T05: 18
+      template_assignment_counts.T06: 18
+      template_assignment_counts.T07: 18
+      template_assignment_counts.T08: 18
+      template_assignment_counts.T09: 18
+      template_assignment_counts.T10: 18
+      template_assignment_counts.T11: 6
+      template_assignment_counts.T12: 2
+      template_core_size_counts.3: 2
+      template_core_size_counts.4: 5
+      template_core_size_counts.5: 2
+      template_core_size_counts.6: 3
+      family_core_size_counts.3: 5
+      family_core_size_counts.4: 6
+      family_core_size_counts.5: 2
+      family_core_size_counts.6: 3
+      provenance.command: python scripts/check_n9_vertex_circle_template_lemma_catalog.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the lemma catalog is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_template_lemma_catalog.py
+++ b/scripts/check_n9_vertex_circle_template_lemma_catalog.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Generate or check the n=9 vertex-circle template lemma-candidate catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_core_templates import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_CORE_TEMPLATES,
+    validate_payload as validate_core_template_payload,
+)
+from check_n9_vertex_circle_self_edge_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_SELF_EDGE_PACKET,
+    validate_payload as validate_self_edge_packet,
+)
+from check_n9_vertex_circle_strict_cycle_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_STRICT_CYCLE_PACKET,
+    validate_payload as validate_strict_cycle_packet,
+)
+from erdos97.n9_vertex_circle_template_lemma_catalog import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_template_lemma_catalog_counts,
+    template_lemma_catalog_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_template_lemma_catalog.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "covered_assignment_count",
+    "cyclic_order",
+    "family_core_size_counts",
+    "family_count",
+    "family_status_counts",
+    "interpretation",
+    "n",
+    "provenance",
+    "row_size",
+    "schema",
+    "self_edge_assignment_count",
+    "self_edge_family_count",
+    "self_edge_template_count",
+    "source_artifacts",
+    "source_assignment_count",
+    "status",
+    "status_assignment_counts",
+    "strict_cycle_assignment_count",
+    "strict_cycle_family_count",
+    "strict_cycle_template_count",
+    "template_assignment_counts",
+    "template_core_size_counts",
+    "template_count",
+    "template_family_counts",
+    "template_status_counts",
+    "templates",
+    "trust",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
+    strict_cycle_packet_path: Path = DEFAULT_STRICT_CYCLE_PACKET,
+    core_templates_path: Path = DEFAULT_CORE_TEMPLATES,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the template catalog."""
+
+    return {
+        "self_edge_packet": load_artifact(_resolve(self_edge_packet_path)),
+        "strict_cycle_packet": load_artifact(_resolve(strict_cycle_packet_path)),
+        "core_templates": load_artifact(_resolve(core_templates_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    self_edge = source_payloads.get("self_edge_packet")
+    strict_cycle = source_payloads.get("strict_cycle_packet")
+    core_templates = source_payloads.get("core_templates")
+    if not isinstance(self_edge, dict):
+        errors.append("source self-edge template packet must be an object")
+    else:
+        errors.extend(
+            f"source self-edge template packet invalid: {error}"
+            for error in validate_self_edge_packet(self_edge, recompute=False)
+        )
+    if not isinstance(strict_cycle, dict):
+        errors.append("source strict-cycle template packet must be an object")
+    else:
+        errors.extend(
+            f"source strict-cycle template packet invalid: {error}"
+            for error in validate_strict_cycle_packet(strict_cycle, recompute=False)
+        )
+    if not isinstance(core_templates, dict):
+        errors.append("source core-template payload must be an object")
+    else:
+        errors.extend(
+            f"source core templates invalid: {error}"
+            for error in validate_core_template_payload(core_templates, recompute=False)
+        )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return template_lemma_catalog_payload(
+            source_payloads["self_edge_packet"],
+            source_payloads["strict_cycle_packet"],
+            source_payloads["core_templates"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound template lemma catalog failed: {exc}")
+        return None
+
+
+def _validate_catalog_rows(
+    payload: dict[str, Any],
+    expected_payload: dict[str, Any],
+    errors: list[str],
+) -> None:
+    templates = payload.get("templates")
+    expected_templates = expected_payload.get("templates")
+    if not isinstance(templates, list):
+        errors.append("templates must be a list")
+        return
+    if not isinstance(expected_templates, list):
+        errors.append("expected templates must be a list")
+        return
+    expect_equal(errors, "templates", templates, expected_templates)
+
+    template_ids: list[str] = []
+    assignment_ids: list[str] = []
+    family_ids: list[str] = []
+    assignment_counts: dict[str, int] = {}
+    family_counts: dict[str, int] = {}
+    status_assignment_counts: dict[str, int] = {"self_edge": 0, "strict_cycle": 0}
+    for index, record in enumerate(templates):
+        if not isinstance(record, dict):
+            errors.append(f"template record {index} must be an object")
+            continue
+        template_id = str(record.get("template_id"))
+        template_ids.append(template_id)
+        status = str(record.get("status"))
+        if status not in status_assignment_counts:
+            errors.append(f"template {template_id} has unexpected status {status!r}")
+            continue
+        coverage = record.get("coverage")
+        if not isinstance(coverage, dict):
+            errors.append(f"template {template_id} coverage must be an object")
+            continue
+        ids = coverage.get("assignment_ids")
+        if not isinstance(ids, list) or not all(isinstance(item, str) for item in ids):
+            errors.append(f"template {template_id} assignment_ids must be a string list")
+            ids = []
+        assignment_count = int(coverage.get("assignment_count", -1))
+        if len(ids) != assignment_count:
+            errors.append(f"template {template_id} assignment_ids count mismatch")
+        assignment_ids.extend(ids)
+        assignment_counts[template_id] = assignment_count
+        status_assignment_counts[status] += assignment_count
+        families = coverage.get("families")
+        if not isinstance(families, list) or not all(
+            isinstance(item, str) for item in families
+        ):
+            errors.append(f"template {template_id} families must be a string list")
+            families = []
+        family_counts[template_id] = int(coverage.get("family_count", -1))
+        family_summaries = record.get("family_summaries")
+        if not isinstance(family_summaries, list):
+            errors.append(f"template {template_id} family_summaries must be a list")
+            continue
+        if sorted(families) != sorted(
+            str(summary.get("family_id"))
+            for summary in family_summaries
+            if isinstance(summary, dict)
+        ):
+            errors.append(f"template {template_id} family summary list mismatch")
+        family_ids.extend(families)
+        conclusion = record.get("conclusion_shape")
+        if not isinstance(conclusion, dict) or conclusion.get("kind") != status:
+            errors.append(f"template {template_id} conclusion kind mismatch")
+    if len(template_ids) != len(set(template_ids)):
+        errors.append("duplicate template ids")
+    if len(assignment_ids) != len(set(assignment_ids)):
+        errors.append("duplicate assignment ids across catalog")
+    if len(family_ids) != len(set(family_ids)):
+        errors.append("duplicate families across catalog")
+    expect_equal(
+        errors,
+        "covered_assignment_count",
+        payload.get("covered_assignment_count"),
+        len(assignment_ids),
+    )
+    expect_equal(
+        errors,
+        "family_count",
+        payload.get("family_count"),
+        len(family_ids),
+    )
+    expect_equal(
+        errors,
+        "template_assignment_counts",
+        payload.get("template_assignment_counts"),
+        assignment_counts,
+    )
+    expect_equal(
+        errors,
+        "template_family_counts",
+        payload.get("template_family_counts"),
+        family_counts,
+    )
+    expect_equal(
+        errors,
+        "status_assignment_counts",
+        payload.get("status_assignment_counts"),
+        status_assignment_counts,
+    )
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a template lemma-candidate catalog."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "source_assignment_count": 184,
+        "covered_assignment_count": 184,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_assignment_count": 26,
+        "template_count": 12,
+        "self_edge_template_count": 9,
+        "strict_cycle_template_count": 3,
+        "family_count": 16,
+        "self_edge_family_count": 13,
+        "strict_cycle_family_count": 3,
+        "template_status_counts": {"self_edge": 9, "strict_cycle": 3},
+        "family_status_counts": {"self_edge": 13, "strict_cycle": 3},
+        "status_assignment_counts": {"self_edge": 158, "strict_cycle": 26},
+        "template_core_size_counts": {"3": 2, "4": 5, "5": 2, "6": 3},
+        "family_core_size_counts": {"3": 5, "4": 6, "5": 2, "6": 3},
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the no-proof statement")
+        if not any("not theorem names" in item for item in interpretation):
+            errors.append("interpretation must say template records are not theorem names")
+
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(errors, "source_artifacts", payload.get("source_artifacts"), expected_payload["source_artifacts"])
+        _validate_catalog_rows(payload, expected_payload, errors)
+
+    try:
+        assert_expected_template_lemma_catalog_counts(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected template lemma catalog counts failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "template lemma catalog", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "covered_assignment_count": object_payload.get("covered_assignment_count"),
+        "template_count": object_payload.get("template_count"),
+        "family_count": object_payload.get("family_count"),
+        "template_status_counts": object_payload.get("template_status_counts"),
+        "status_assignment_counts": object_payload.get("status_assignment_counts"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--self-edge-packet", type=Path, default=DEFAULT_SELF_EDGE_PACKET)
+    parser.add_argument("--strict-cycle-packet", type=Path, default=DEFAULT_STRICT_CYCLE_PACKET)
+    parser.add_argument("--core-templates", type=Path, default=DEFAULT_CORE_TEMPLATES)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            self_edge_packet_path=args.self_edge_packet,
+            strict_cycle_packet_path=args.strict_cycle_packet,
+            core_templates_path=args.core_templates,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = template_lemma_catalog_payload(
+            sources["self_edge_packet"],
+            sources["strict_cycle_packet"],
+            sources["core_templates"],
+        )
+        if args.assert_expected:
+            assert_expected_template_lemma_catalog_counts(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle template lemma-candidate catalog")
+        print(f"artifact: {summary['artifact']}")
+        print(f"covered assignments: {summary['covered_assignment_count']}")
+        print(f"templates: {summary['template_count']}")
+        print(f"families: {summary['family_count']}")
+        print(f"template statuses: {summary['template_status_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: template lemma-candidate catalog checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -216,6 +216,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_template_lemma_catalog",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_template_lemma_catalog.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Derived lemma-candidate catalog for the 12 n=9 vertex-circle "
+            "local-core templates; not a proof of n=9, counterexample, "
+            "or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_template_lemma_catalog.py
+++ b/src/erdos97/n9_vertex_circle_template_lemma_catalog.py
@@ -1,0 +1,403 @@
+"""Build a derived n=9 vertex-circle template lemma-candidate catalog.
+
+This module is diagnostic. It does not prove Erdos Problem #97, does not
+claim a counterexample, and does not promote the review-pending n=9 checker.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_template_packet import (
+    EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT,
+    EXPECTED_SELF_EDGE_FAMILY_COUNT,
+    EXPECTED_SELF_EDGE_TEMPLATE_COUNT,
+    EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS as EXPECTED_SELF_EDGE_TEMPLATE_ASSIGNMENTS,
+    EXPECTED_TEMPLATE_FAMILY_COUNTS as EXPECTED_SELF_EDGE_TEMPLATE_FAMILIES,
+    SCHEMA as SELF_EDGE_PACKET_SCHEMA,
+)
+from erdos97.n9_vertex_circle_strict_cycle_template_packet import (
+    EXPECTED_STRICT_CYCLE_ASSIGNMENT_COUNT,
+    EXPECTED_STRICT_CYCLE_FAMILY_COUNT,
+    EXPECTED_STRICT_CYCLE_TEMPLATE_COUNT,
+    EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS as EXPECTED_STRICT_CYCLE_TEMPLATE_ASSIGNMENTS,
+    EXPECTED_TEMPLATE_FAMILY_COUNTS as EXPECTED_STRICT_CYCLE_TEMPLATE_FAMILIES,
+    SCHEMA as STRICT_CYCLE_PACKET_SCHEMA,
+)
+
+
+SCHEMA = "erdos97.n9_vertex_circle_template_lemma_catalog.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Derived lemma-candidate catalog for the 12 n=9 vertex-circle local-core "
+    "templates covering 184 frontier assignments; not a proof of n=9, not a "
+    "counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_template_lemma_catalog.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_template_lemma_catalog.py "
+        "--assert-expected --write"
+    ),
+}
+EXPECTED_SOURCE_ASSIGNMENT_COUNT = 184
+EXPECTED_TEMPLATE_COUNT = 12
+EXPECTED_FAMILY_COUNT = 16
+EXPECTED_COVERED_ASSIGNMENT_COUNT = 184
+EXPECTED_TEMPLATE_STATUS_COUNTS = {"self_edge": 9, "strict_cycle": 3}
+EXPECTED_FAMILY_STATUS_COUNTS = {"self_edge": 13, "strict_cycle": 3}
+EXPECTED_STATUS_ASSIGNMENT_COUNTS = {"self_edge": 158, "strict_cycle": 26}
+EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS = {
+    **EXPECTED_SELF_EDGE_TEMPLATE_ASSIGNMENTS,
+    **EXPECTED_STRICT_CYCLE_TEMPLATE_ASSIGNMENTS,
+}
+EXPECTED_TEMPLATE_FAMILY_COUNTS = {
+    **EXPECTED_SELF_EDGE_TEMPLATE_FAMILIES,
+    **EXPECTED_STRICT_CYCLE_TEMPLATE_FAMILIES,
+}
+EXPECTED_TEMPLATE_CORE_SIZE_COUNTS = {"3": 2, "4": 5, "5": 2, "6": 3}
+EXPECTED_FAMILY_CORE_SIZE_COUNTS = {"3": 5, "4": 6, "5": 2, "6": 3}
+EXPECTED_TEMPLATE_IDS = tuple(f"T{index:02d}" for index in range(1, 13))
+
+
+def _json_counter(counter: Counter[int] | Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _template_rows(packet: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = packet.get("templates")
+    if not isinstance(rows, list):
+        raise ValueError("template packet must contain templates")
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError("template packet rows must be objects")
+    return rows
+
+
+def _core_template_families(core_template_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = core_template_payload.get("families")
+    if not isinstance(rows, list):
+        raise ValueError("core-template artifact must contain families")
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError("core-template family rows must be objects")
+    return rows
+
+
+def _family_summaries(template: dict[str, Any]) -> list[dict[str, Any]]:
+    records = template.get("family_records")
+    if not isinstance(records, list):
+        raise ValueError(f"{template.get('template_id')} must contain family_records")
+    summaries = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("family records must be objects")
+        summary = {
+            "family_id": str(record["family_id"]),
+            "template_id": str(record["template_id"]),
+            "status": str(record["status"]),
+            "assignment_count": int(record["assignment_count"]),
+            "orbit_size": int(record["orbit_size"]),
+            "core_size": int(record["core_size"]),
+        }
+        if record["status"] == "self_edge":
+            edge = record["strict_inequality"]
+            equality = record["distance_equality"]
+            summary.update(
+                {
+                    "path_length": int(record["path_length"]),
+                    "outer_span": int(edge["outer_span"]),
+                    "inner_span": int(edge["inner_span"]),
+                    "outer_pair": edge["outer_pair"],
+                    "inner_pair": edge["inner_pair"],
+                    "equality_path_length": len(equality["path"]),
+                    "contradiction_kind": "self_edge",
+                }
+            )
+        elif record["status"] == "strict_cycle":
+            summary.update(
+                {
+                    "cycle_length": int(record["cycle_length"]),
+                    "strict_edge_count": int(record["strict_edge_count"]),
+                    "span_signature": str(record["span_signature"]),
+                    "cycle_step_count": len(record["cycle_steps"]),
+                    "contradiction_kind": "strict_cycle",
+                }
+            )
+        else:
+            raise ValueError(f"unexpected family status: {record['status']!r}")
+        summaries.append(summary)
+    return summaries
+
+
+def _self_edge_catalog_record(template: dict[str, Any]) -> dict[str, Any]:
+    template_id = str(template["template_id"])
+    return {
+        "template_id": template_id,
+        "status": "self_edge",
+        "template_key": str(template["template_key"]),
+        "coverage": {
+            "assignment_count": int(template["assignment_count"]),
+            "assignment_ids": list(template["assignment_ids"]),
+            "family_count": int(template["family_count"]),
+            "families": list(template["families"]),
+            "orbit_size_sum": int(template["orbit_size_sum"]),
+        },
+        "hypothesis_shape": {
+            "core_size": int(template["core_size"]),
+            "strict_edge_count": int(template["strict_edge_count"]),
+            "path_length_counts": template["path_length_counts"],
+            "shared_endpoint_counts": template["shared_endpoint_counts"],
+            "selected_path_shape_counts": template["selected_path_shape_counts"],
+            "self_edge_shape_counts": template["self_edge_shape_counts"],
+        },
+        "conclusion_shape": {
+            "kind": "self_edge",
+            "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting",
+            "certificate_fields": ["strict_inequality", "distance_equality"],
+        },
+        "family_summaries": _family_summaries(template),
+    }
+
+
+def _strict_cycle_catalog_record(template: dict[str, Any]) -> dict[str, Any]:
+    template_id = str(template["template_id"])
+    return {
+        "template_id": template_id,
+        "status": "strict_cycle",
+        "template_key": str(template["template_key"]),
+        "coverage": {
+            "assignment_count": int(template["assignment_count"]),
+            "assignment_ids": list(template["assignment_ids"]),
+            "family_count": int(template["family_count"]),
+            "families": list(template["families"]),
+            "orbit_size_sum": int(template["orbit_size_sum"]),
+        },
+        "hypothesis_shape": {
+            "core_size": int(template["core_size"]),
+            "strict_edge_count": int(template["strict_edge_count"]),
+            "cycle_length": int(template["cycle_length"]),
+            "cycle_length_counts": template["cycle_length_counts"],
+            "connector_path_length_counts": template["connector_path_length_counts"],
+            "span_signature_counts": template["span_signature_counts"],
+            "cycle_span_counts": template["cycle_span_counts"],
+        },
+        "conclusion_shape": {
+            "kind": "strict_cycle",
+            "strict_graph_obstruction": "directed strict cycle after selected-distance quotienting",
+            "certificate_fields": ["cycle_steps", "equality_to_next_outer_pair"],
+        },
+        "family_summaries": _family_summaries(template),
+    }
+
+
+def _source_artifacts(
+    self_edge_packet: dict[str, Any],
+    strict_cycle_packet: dict[str, Any],
+    core_template_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+            "role": "self-edge template packet source for 9 catalog records",
+            "schema": self_edge_packet.get("schema"),
+            "status": self_edge_packet.get("status"),
+            "trust": self_edge_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+            "role": "strict-cycle template packet source for 3 catalog records",
+            "schema": strict_cycle_packet.get("schema"),
+            "status": strict_cycle_packet.get("status"),
+            "trust": strict_cycle_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_core_templates.json",
+            "role": "family/template crosswalk and core-size distribution source",
+            "schema": core_template_payload.get("schema"),
+            "status": core_template_payload.get("status"),
+            "trust": core_template_payload.get("trust"),
+        },
+    ]
+
+
+def _assert_core_template_crosswalk(
+    records: list[dict[str, Any]],
+    core_template_payload: dict[str, Any],
+) -> dict[str, int]:
+    expected_by_family = {
+        str(row["family_id"]): row for row in _core_template_families(core_template_payload)
+    }
+    actual_by_family = {}
+    for record in records:
+        for family in record["family_summaries"]:
+            actual_by_family[str(family["family_id"])] = {
+                "template_id": str(record["template_id"]),
+                "status": str(record["status"]),
+                "core_size": int(family["core_size"]),
+                "assignment_count": int(family["assignment_count"]),
+            }
+    if set(actual_by_family) != set(expected_by_family):
+        raise AssertionError("catalog family coverage does not match core-template artifact")
+    core_sizes: Counter[int] = Counter()
+    for family_id, expected in expected_by_family.items():
+        actual = actual_by_family[family_id]
+        for key in ("template_id", "status", "core_size"):
+            if actual[key] != expected[key]:
+                raise AssertionError(f"{family_id} {key} mismatch")
+        if actual["assignment_count"] != int(expected["orbit_size"]):
+            raise AssertionError(f"{family_id} orbit/assignment count mismatch")
+        core_sizes[int(expected["core_size"])] += 1
+    return _json_counter(core_sizes)
+
+
+def template_lemma_catalog_payload(
+    self_edge_packet: dict[str, Any],
+    strict_cycle_packet: dict[str, Any],
+    core_template_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the derived n=9 template lemma-candidate catalog."""
+
+    if self_edge_packet.get("schema") != SELF_EDGE_PACKET_SCHEMA:
+        raise ValueError("unexpected self-edge template packet schema")
+    if strict_cycle_packet.get("schema") != STRICT_CYCLE_PACKET_SCHEMA:
+        raise ValueError("unexpected strict-cycle template packet schema")
+
+    records = [
+        _self_edge_catalog_record(template)
+        for template in _template_rows(self_edge_packet)
+    ] + [
+        _strict_cycle_catalog_record(template)
+        for template in _template_rows(strict_cycle_packet)
+    ]
+    records = sorted(records, key=lambda record: str(record["template_id"]))
+
+    template_status_counts: Counter[str] = Counter(str(record["status"]) for record in records)
+    status_assignment_counts: Counter[str] = Counter()
+    template_core_sizes: Counter[int] = Counter()
+    template_assignment_counts: dict[str, int] = {}
+    template_family_counts: dict[str, int] = {}
+    assignment_ids: list[str] = []
+    family_count = 0
+    for record in records:
+        template_id = str(record["template_id"])
+        coverage = record["coverage"]
+        status = str(record["status"])
+        assignment_count = int(coverage["assignment_count"])
+        status_assignment_counts[status] += assignment_count
+        template_core_sizes[int(record["hypothesis_shape"]["core_size"])] += 1
+        template_assignment_counts[template_id] = assignment_count
+        template_family_counts[template_id] = int(coverage["family_count"])
+        assignment_ids.extend(str(item) for item in coverage["assignment_ids"])
+        family_count += int(coverage["family_count"])
+
+    if len(assignment_ids) != len(set(assignment_ids)):
+        raise AssertionError("assignment ids overlap across catalog records")
+    family_core_size_counts = _assert_core_template_crosswalk(records, core_template_payload)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "source_assignment_count": int(self_edge_packet["source_assignment_count"]),
+        "covered_assignment_count": len(assignment_ids),
+        "self_edge_assignment_count": int(self_edge_packet["self_edge_assignment_count"]),
+        "strict_cycle_assignment_count": int(
+            strict_cycle_packet["strict_cycle_assignment_count"]
+        ),
+        "template_count": len(records),
+        "self_edge_template_count": int(self_edge_packet["self_edge_template_count"]),
+        "strict_cycle_template_count": int(
+            strict_cycle_packet["strict_cycle_template_count"]
+        ),
+        "family_count": family_count,
+        "self_edge_family_count": int(self_edge_packet["self_edge_family_count"]),
+        "strict_cycle_family_count": int(strict_cycle_packet["strict_cycle_family_count"]),
+        "template_status_counts": _json_counter(template_status_counts),
+        "family_status_counts": {
+            "self_edge": int(self_edge_packet["self_edge_family_count"]),
+            "strict_cycle": int(strict_cycle_packet["strict_cycle_family_count"]),
+        },
+        "status_assignment_counts": _json_counter(status_assignment_counts),
+        "template_assignment_counts": template_assignment_counts,
+        "template_family_counts": template_family_counts,
+        "template_core_size_counts": _json_counter(template_core_sizes),
+        "family_core_size_counts": family_core_size_counts,
+        "templates": records,
+        "interpretation": [
+            "Each catalog record is derived from a checked template packet and summarizes one local-core template as a lemma candidate.",
+            "Self-edge records end in a reflexive strict inequality after selected-distance quotienting.",
+            "Strict-cycle records end in a directed strict cycle after selected-distance quotienting.",
+            "Template ids and catalog records are reviewer-navigation and lemma-mining diagnostics, not theorem names.",
+            "The catalog is derived from review-pending n=9 diagnostics and is not an independent review of the exhaustive checker.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": _source_artifacts(
+            self_edge_packet,
+            strict_cycle_packet,
+            core_template_payload,
+        ),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_template_lemma_catalog_counts(payload)
+    return payload
+
+
+def assert_expected_template_lemma_catalog_counts(payload: dict[str, Any]) -> None:
+    """Assert stable headline counts for the template lemma-candidate catalog."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["n"] != n9.N or payload["row_size"] != n9.ROW_SIZE:
+        raise AssertionError("unexpected n or row size")
+    if payload["cyclic_order"] != list(n9.ORDER):
+        raise AssertionError("unexpected cyclic order")
+    if payload["source_assignment_count"] != EXPECTED_SOURCE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected source assignment count")
+    if payload["covered_assignment_count"] != EXPECTED_COVERED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected covered assignment count")
+    if payload["self_edge_assignment_count"] != EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected self-edge assignment count")
+    if payload["strict_cycle_assignment_count"] != EXPECTED_STRICT_CYCLE_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected strict-cycle assignment count")
+    if payload["template_count"] != EXPECTED_TEMPLATE_COUNT:
+        raise AssertionError("unexpected template count")
+    if payload["self_edge_template_count"] != EXPECTED_SELF_EDGE_TEMPLATE_COUNT:
+        raise AssertionError("unexpected self-edge template count")
+    if payload["strict_cycle_template_count"] != EXPECTED_STRICT_CYCLE_TEMPLATE_COUNT:
+        raise AssertionError("unexpected strict-cycle template count")
+    if payload["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("unexpected family count")
+    if payload["self_edge_family_count"] != EXPECTED_SELF_EDGE_FAMILY_COUNT:
+        raise AssertionError("unexpected self-edge family count")
+    if payload["strict_cycle_family_count"] != EXPECTED_STRICT_CYCLE_FAMILY_COUNT:
+        raise AssertionError("unexpected strict-cycle family count")
+    if payload["template_status_counts"] != EXPECTED_TEMPLATE_STATUS_COUNTS:
+        raise AssertionError("unexpected template status counts")
+    if payload["family_status_counts"] != EXPECTED_FAMILY_STATUS_COUNTS:
+        raise AssertionError("unexpected family status counts")
+    if payload["status_assignment_counts"] != EXPECTED_STATUS_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected status assignment counts")
+    if payload["template_assignment_counts"] != EXPECTED_TEMPLATE_ASSIGNMENT_COUNTS:
+        raise AssertionError("unexpected template assignment counts")
+    if payload["template_family_counts"] != EXPECTED_TEMPLATE_FAMILY_COUNTS:
+        raise AssertionError("unexpected template family counts")
+    if payload["template_core_size_counts"] != EXPECTED_TEMPLATE_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected template core-size counts")
+    if payload["family_core_size_counts"] != EXPECTED_FAMILY_CORE_SIZE_COUNTS:
+        raise AssertionError("unexpected family core-size counts")
+    template_ids = tuple(record["template_id"] for record in payload["templates"])
+    if template_ids != EXPECTED_TEMPLATE_IDS:
+        raise AssertionError(f"unexpected template ids: {template_ids!r}")

--- a/tests/test_n9_vertex_circle_template_lemma_catalog.py
+++ b/tests/test_n9_vertex_circle_template_lemma_catalog.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_template_lemma_catalog import (
+    assert_expected_template_lemma_catalog_counts,
+    template_lemma_catalog_payload,
+)
+from scripts.check_n9_vertex_circle_template_lemma_catalog import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_template_lemma_catalog_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_template_lemma_catalog_counts(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["source_assignment_count"] == 184
+    assert payload["covered_assignment_count"] == 184
+    assert payload["template_count"] == 12
+    assert payload["family_count"] == 16
+    assert payload["template_status_counts"] == {"self_edge": 9, "strict_cycle": 3}
+    assert payload["family_status_counts"] == {"self_edge": 13, "strict_cycle": 3}
+    assert payload["status_assignment_counts"] == {"self_edge": 158, "strict_cycle": 26}
+    assert payload["template_core_size_counts"] == {"3": 2, "4": 5, "5": 2, "6": 3}
+    assert payload["family_core_size_counts"] == {"3": 5, "4": 6, "5": 2, "6": 3}
+
+
+def test_template_lemma_catalog_records_self_edge_and_strict_cycle_shapes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    records = {record["template_id"]: record for record in payload["templates"]}
+
+    t01 = records["T01"]
+    assert t01["status"] == "self_edge"
+    assert t01["coverage"]["assignment_count"] == 6
+    assert t01["hypothesis_shape"]["core_size"] == 3
+    assert t01["hypothesis_shape"]["path_length_counts"] == {"3": 6}
+    assert t01["conclusion_shape"]["kind"] == "self_edge"
+    assert t01["family_summaries"] == [
+        {
+            "assignment_count": 6,
+            "contradiction_kind": "self_edge",
+            "core_size": 3,
+            "equality_path_length": 3,
+            "family_id": "F09",
+            "inner_pair": [1, 2],
+            "inner_span": 1,
+            "orbit_size": 6,
+            "outer_pair": [1, 8],
+            "outer_span": 3,
+            "path_length": 3,
+            "status": "self_edge",
+            "template_id": "T01",
+        }
+    ]
+
+    t10 = records["T10"]
+    assert t10["status"] == "strict_cycle"
+    assert t10["coverage"]["assignment_count"] == 18
+    assert t10["hypothesis_shape"]["core_size"] == 4
+    assert t10["hypothesis_shape"]["cycle_length_counts"] == {"2": 18}
+    assert t10["hypothesis_shape"]["connector_path_length_counts"] == {
+        "1": 18,
+        "2": 18,
+    }
+    assert t10["conclusion_shape"]["kind"] == "strict_cycle"
+    assert t10["family_summaries"][0]["family_id"] == "F12"
+    assert t10["family_summaries"][0]["span_signature"] == "2:1,2:1"
+
+
+def test_template_lemma_catalog_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["covered_assignment_count"] == 184
+    assert summary["template_count"] == 12
+
+
+def test_template_lemma_catalog_rejects_tampered_assignment_id() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][0]["coverage"]["assignment_ids"][0] = "A999"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("templates mismatch" in error for error in errors)
+
+
+def test_template_lemma_catalog_rejects_tampered_conclusion_kind() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["templates"][9]["conclusion_shape"]["kind"] = "self_edge"
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("conclusion kind mismatch" in error for error in errors)
+
+
+def test_template_lemma_catalog_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_template_lemma_catalog_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    sources["strict_cycle_packet"]["templates"][0]["assignment_ids"][0] = "A999"
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source strict-cycle template packet invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_template_lemma_catalog_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == template_lemma_catalog_payload(
+        source_payloads["self_edge_packet"],
+        source_payloads["strict_cycle_packet"],
+        source_payloads["core_templates"],
+    )
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_template_lemma_catalog_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_template_lemma_catalog.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["template_count"] == 12
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_template_lemma_catalog_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "template_lemma_catalog.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_template_lemma_catalog.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_template_lemma_catalog_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "template_lemma_catalog.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_template_lemma_catalog.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -115,3 +115,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n9_vertex_circle_template_lemma_catalog.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary

Adds a derived n=9 vertex-circle template lemma-candidate catalog over the existing 9 self-edge and 3 strict-cycle template packets. The catalog records one proof-mining/reviewer-navigation record per local-core template, preserving assignment coverage, family coverage, local-core hypothesis shape, and the quotient self-edge or strict-cycle conclusion shape.

This remains `REVIEW_PENDING_DIAGNOSTIC_ONLY`: no proof of n=9, counterexample, independent review completion, or official/global status update is claimed.

## Verification

Passed:

- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --write --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m artifact`
- `python -m pytest tests/test_n9_vertex_circle_template_lemma_catalog.py tests/test_run_artifact_audit.py -q -m 'artifact or exhaustive or not artifact'`
- `python -m pytest tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m 'artifact or exhaustive or not artifact'`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`

Broad local Windows pytest result:

- `python -m pytest -q` still has the pre-existing 8 C19 replay failures from local path serialization (`\\` vs `/`) and known helper-masked C19 digest drift; 482 passed, 72 deselected, 8 failed. These failures are outside the n=9 catalog surface and match the earlier local profile.