### PR TITLE
Strengthen n10 singleton spot checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
 
 verify-n10-review:
-	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 
 verify-artifacts: verify-n8 verify-kalmanson verify-n9-review verify-n10-review
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
 python scripts/check_n9_base_apex_escape_budget.py --check --json
 python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
 python scripts/check_n9_d3_escape_slice.py --check --json
-python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 ```
 
 Useful exploratory commands:

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -133,13 +133,14 @@ Read first:
 Commands:
 
 ```bash
-python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 python -m pytest tests/test_n10_vertex_circle_singletons.py -q -m "artifact"
 ```
 
 Expected artifacts:
 
 - independent review notes for the generic checker and the imported singleton rows;
+- selected repo-native spot checks for row0 singletons `0`, `63`, and `125`;
 - optional second-implementation counts or a replayable terminal-conflict certificate.
 
 Acceptance criteria:

--- a/docs/n10-vertex-circle-singleton-slices.md
+++ b/docs/n10-vertex-circle-singleton-slices.md
@@ -50,9 +50,9 @@ partial strict cycles:     5,318,250
 ```
 
 The companion generic Python checker reproduces the repo's n=9 counts exactly
-and spot-checks row0 singleton `0` for the n=10 artifact. A full repo-native
-n=10 rerun is intentionally not part of the fast tier; it should be treated as
-artifact-tier work.
+and spot-checks selected row0 singletons `0`, `63`, and `125` for the n=10
+artifact. A full repo-native n=10 rerun is intentionally not part of the fast
+tier; it should be treated as artifact-tier work.
 
 ## Commands
 
@@ -62,15 +62,8 @@ Validate the imported artifact counts:
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected
 ```
 
-Validate the artifact and rerun row0 singleton `0` with the generic checker:
-
-```bash
-python scripts/check_n10_vertex_circle_singletons.py \
-  --assert-expected \
-  --spot-check-generic
-```
-
-Validate selected singleton slices with the generic checker:
+Validate the artifact and rerun selected row0 singletons `0`, `63`, and `125`
+with the generic checker:
 
 ```bash
 python scripts/check_n10_vertex_circle_singletons.py \
@@ -78,6 +71,15 @@ python scripts/check_n10_vertex_circle_singletons.py \
   --spot-check-row0 0 \
   --spot-check-row0 63 \
   --spot-check-row0 125
+```
+
+The legacy shorthand below is still supported and checks only row0 singleton
+`0`:
+
+```bash
+python scripts/check_n10_vertex_circle_singletons.py \
+  --assert-expected \
+  --spot-check-generic
 ```
 
 Regenerate the checked-in artifact from the archived JSONL:
@@ -106,8 +108,8 @@ should check:
 - that the minimum-remaining-options row choice changes only search order;
 - that vertex-circle partial pruning uses only already-fixed selected rows and
   selected-distance equalities;
-- that the generic repo-native checker and the archived C++ checker agree on
-  more than the first n=10 singleton, or that a second independent verifier
+- that the generic repo-native checker and the archived C++ checker agree
+  beyond the selected n=10 singleton spot-checks, or that a second independent verifier
   replays all terminal conflicts;
 - that the artifact remains scoped to the selected-witness n=10 finite case
   and does not alter the global status.

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -63,7 +63,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
-python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 ```
 
 The independent incidence JSON checker validates the 15 stored survivor

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -179,7 +179,7 @@ vertex-circle filters. Treat this as a draft until an independent audit checks:
 - that partial vertex-circle pruning uses only already-fixed selected rows and
   selected-distance equalities;
 - that a second implementation or replayable terminal-conflict certificate
-  agrees with all 126 slices, not only the current row0 `0` spot-check.
+  agrees with all 126 slices, not only the current selected row0 spot-checks.
 
 Acceptance standard: a reviewer should either promote the artifact to the same
 review-pending finite-case status as n=9, or identify the exact implementation,

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -88,7 +88,7 @@ python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
 python scripts/check_n9_base_apex_escape_budget.py --check --json
 python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
 python scripts/check_n9_d3_escape_slice.py --check --json
-python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 ```
 
 The default pytest configuration excludes tests marked `artifact`, `slow`, or

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1073,13 +1073,14 @@ artifacts:
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact
     generator: scripts/check_n10_vertex_circle_singletons.py
-    command: python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-generic
+    command: python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
     direct_edit_allowed: false
     provenance_mode: manifest_only_legacy
     trust: MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING
     claim_scope: Review-pending draft n=10 selected-witness singleton-slice finite-case artifact only.
     json_top_level_type: object
     expected_json:
+      type: n10_vertex_circle_singleton_slices_v1
       n: 10
       row_size: 4
       trust: MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING
@@ -1088,6 +1089,8 @@ artifacts:
       total_full: 0
       total_nodes: 4142738
       aborted_any: false
+      counts.partial_self_edge: 4467592
+      counts.partial_strict_cycle: 5318250
     forbidden_claims:
       - n=10 is proved
       - official/global status update

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -366,10 +366,15 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "python",
             "scripts/check_n10_vertex_circle_singletons.py",
             "--assert-expected",
-            "--spot-check-generic",
+            "--spot-check-row0",
+            "0",
+            "--spot-check-row0",
+            "63",
+            "--spot-check-row0",
+            "125",
         ),
         claim_scope=(
-            "Draft review-pending n=10 singleton-slice artifact spot-check; "
+            "Draft review-pending n=10 singleton-slice artifact selected spot-checks; "
             "not a source-of-truth finite-case result or official/global status update."
         ),
     ),

--- a/tests/test_n10_vertex_circle_singletons.py
+++ b/tests/test_n10_vertex_circle_singletons.py
@@ -21,6 +21,32 @@ from erdos97.n10_vertex_circle_singletons import (
 ROOT = Path(__file__).resolve().parents[1]
 ARTIFACT = ROOT / "data" / "certificates" / "n10_vertex_circle_singleton_slices.json"
 pytestmark = [pytest.mark.artifact, pytest.mark.exhaustive]
+SELECTED_GENERIC_SPOT_CHECK_ROWS = {
+    0: {
+        "row0_witnesses": [1, 2, 3, 4],
+        "nodes": 9759,
+        "counts": {
+            "partial_self_edge": 5256,
+            "partial_strict_cycle": 6031,
+        },
+    },
+    63: {
+        "row0_witnesses": [2, 3, 5, 8],
+        "nodes": 36084,
+        "counts": {
+            "partial_self_edge": 30431,
+            "partial_strict_cycle": 41710,
+        },
+    },
+    125: {
+        "row0_witnesses": [6, 7, 8, 9],
+        "nodes": 11020,
+        "counts": {
+            "partial_self_edge": 9087,
+            "partial_strict_cycle": 7172,
+        },
+    },
+}
 
 
 def test_n10_singleton_artifact_expected_counts() -> None:
@@ -34,10 +60,17 @@ def test_n10_singleton_artifact_expected_counts() -> None:
     assert payload["counts"] == EXPECTED_COUNTS
 
 
-def test_n10_first_singleton_matches_generic_checker() -> None:
+def test_n10_selected_singletons_match_generic_checker() -> None:
     payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
 
-    assert_generic_spot_check(payload, row0_index=0)
+    for row0_index, expected in SELECTED_GENERIC_SPOT_CHECK_ROWS.items():
+        row = payload["rows"][row0_index]
+        assert row["row0_witnesses"] == expected["row0_witnesses"]
+        assert row["nodes"] == expected["nodes"]
+        assert row["full"] == 0
+        assert row["aborted"] is False
+        assert row["counts"] == expected["counts"]
+        assert_generic_spot_check(payload, row0_index=row0_index)
 
 
 def test_n10_artifact_records_explicit_row0_witnesses() -> None:

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -120,3 +120,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "
+        "--spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary

Strengthens the draft n=10 singleton-slice audit path by wiring the existing repo-native generic checker to replay selected row0 singletons `0`, `63`, and `125` instead of only the row0 `0` shorthand.

No artifact counts change and no status is promoted. This remains `MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING`; no proof of n=10, no counterexample, no source-of-truth promotion, and no official/global status update are claimed.

## Verification

Passed:

- `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125`
- `python -m pytest tests/test_n10_vertex_circle_singletons.py -q -m artifact`
- `python -m pytest tests/test_run_artifact_audit.py -q`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`

Broad local Windows pytest result:

- `python -m pytest -q` still has the pre-existing 8 C19 replay failures from local path serialization (`\\` vs `/`) and known helper-masked C19 digest drift; 482 passed, 72 deselected, 8 failed. These failures are outside the n=10 spot-check wiring surface.