### PR TITLE
Normalize C19 replay artifact paths

### DIFF
--- a/scripts/analyze_c19_branch269_fifth_pair_subfrontier.py
+++ b/scripts/analyze_c19_branch269_fifth_pair_subfrontier.py
@@ -270,9 +270,9 @@ def main() -> int:
 
     frontier = json.loads(args.frontier.read_text(encoding="utf-8"))
     try:
-        frontier_artifact = str(args.frontier.resolve().relative_to(ROOT))
+        frontier_artifact = args.frontier.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        frontier_artifact = str(args.frontier)
+        frontier_artifact = args.frontier.as_posix()
     data = analyze_subfrontier(frontier, frontier_artifact=frontier_artifact)
     if args.assert_expected:
         assert_expected(data)

--- a/scripts/analyze_c19_fifth_pair_frontier.py
+++ b/scripts/analyze_c19_fifth_pair_frontier.py
@@ -306,9 +306,9 @@ def main() -> int:
 
     frontier = json.loads(args.frontier.read_text(encoding="utf-8"))
     try:
-        frontier_artifact = str(args.frontier.resolve().relative_to(ROOT))
+        frontier_artifact = args.frontier.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        frontier_artifact = str(args.frontier)
+        frontier_artifact = args.frontier.as_posix()
     data = analyze_fifth_frontier(frontier, frontier_artifact=frontier_artifact)
     if args.assert_expected:
         assert_expected(data)

--- a/scripts/analyze_c19_fifth_pair_two_row_prefilter.py
+++ b/scripts/analyze_c19_fifth_pair_two_row_prefilter.py
@@ -454,11 +454,13 @@ def main() -> int:
     args = parser.parse_args()
 
     frontier = _as_mapping(json.loads(args.frontier.read_text(encoding="utf-8")), "frontier")
+    try:
+        frontier_artifact = args.frontier.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        frontier_artifact = args.frontier.as_posix()
     data = analyze_two_row_prefilter(
         frontier,
-        frontier_artifact=str(args.frontier.relative_to(ROOT))
-        if args.frontier.is_absolute() and args.frontier.is_relative_to(ROOT)
-        else str(args.frontier),
+        frontier_artifact=frontier_artifact,
     )
     if args.assert_expected:
         assert_expected(data)

--- a/scripts/analyze_c19_fourth_pair_frontier.py
+++ b/scripts/analyze_c19_fourth_pair_frontier.py
@@ -290,9 +290,9 @@ def main() -> int:
 
     payload = json.loads(args.source.read_text(encoding="utf-8"))
     try:
-        source_artifact = str(args.source.resolve().relative_to(ROOT))
+        source_artifact = args.source.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        source_artifact = str(args.source)
+        source_artifact = args.source.as_posix()
     data = analyze_frontier(payload, source_artifact=source_artifact)
     if args.assert_expected:
         assert_expected(data)

--- a/scripts/analyze_c19_kalmanson_sweep_costs.py
+++ b/scripts/analyze_c19_kalmanson_sweep_costs.py
@@ -282,9 +282,9 @@ def main() -> int:
 
     payload = json.loads(args.source.read_text(encoding="utf-8"))
     try:
-        source_artifact = str(args.source.resolve().relative_to(ROOT))
+        source_artifact = args.source.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        source_artifact = str(args.source)
+        source_artifact = args.source.as_posix()
     data = analyze_sweep_costs(payload, source_artifact=source_artifact)
     if args.assert_expected:
         assert_expected(data)

--- a/scripts/analyze_c19_prefilter_fallback_supports.py
+++ b/scripts/analyze_c19_prefilter_fallback_supports.py
@@ -86,9 +86,9 @@ def _certificate_digest(lines: Sequence[str]) -> str:
 
 def _relative_path(path: Path) -> str:
     try:
-        return str(path.resolve().relative_to(ROOT))
+        return path.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        return str(path)
+        return path.as_posix()
 
 
 def _fallback_states(source: Mapping[str, Any]) -> Iterator[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Normalizes repository-relative artifact paths emitted by the C19 replay/analyzer scripts to POSIX-style separators. This keeps regenerated JSON stable across Windows and POSIX hosts and removes the local Windows replay equality drift in the default pytest tier.

This is reproducibility hygiene only. It does not change mathematical artifacts, generated reports, claim status, or the official/global Erdos #97 status.

## Verification

Passed:

- `python -m pytest tests/test_c19_branch269_fifth_pair_subfrontier.py::test_c19_branch269_fifth_pair_subfrontier_replay_matches_artifact tests/test_c19_fifth_pair_frontier.py::test_c19_fifth_pair_frontier_replay_matches_artifact tests/test_c19_fifth_pair_two_row_prefilter.py::test_c19_fifth_pair_two_row_prefilter_replay_matches_artifact tests/test_c19_fourth_pair_frontier.py::test_c19_fourth_pair_frontier_replay_matches_artifact tests/test_c19_kalmanson_sweep_costs.py::test_c19_sweep_cost_diagnostic_replay_matches_artifact tests/test_c19_prefilter_catalog_unit_supports.py::test_c19_prefilter_catalog_unit_support_replay_matches_artifact tests/test_c19_prefilter_fallback_supports.py::test_c19_prefilter_fallback_support_replay_matches_artifact tests/test_c19_prefilter_small_unit_supports.py::test_c19_prefilter_small_unit_support_replay_matches_artifact -q`
- `python -m pytest tests/test_c19_fifth_pair_two_row_prefilter.py::test_c19_fifth_pair_two_row_prefilter_replay_matches_artifact -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`490 passed, 72 deselected`)
