### PR TITLE
Add n9 T01 self-edge lemma packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
+++ b/data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
@@ -1,0 +1,441 @@
+{
+  "assignment_count": 6,
+  "assignment_ids": [
+    "A014",
+    "A024",
+    "A031",
+    "A140",
+    "A166",
+    "A175"
+  ],
+  "claim_scope": "Focused T01/F09 self-edge local lemma packet for six n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "core_selected_rows": [
+    [
+      0,
+      1,
+      2,
+      4,
+      8
+    ],
+    [
+      1,
+      0,
+      3,
+      5,
+      8
+    ],
+    [
+      2,
+      0,
+      1,
+      4,
+      6
+    ]
+  ],
+  "core_size": 3,
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "distance_equality": {
+    "end_pair": [
+      1,
+      2
+    ],
+    "path": [
+      {
+        "next_pair": [
+          0,
+          1
+        ],
+        "row": 1
+      },
+      {
+        "next_pair": [
+          0,
+          2
+        ],
+        "row": 0
+      },
+      {
+        "next_pair": [
+          1,
+          2
+        ],
+        "row": 2
+      }
+    ],
+    "start_pair": [
+      1,
+      8
+    ]
+  },
+  "equality_chain": [
+    [
+      1,
+      8
+    ],
+    [
+      0,
+      1
+    ],
+    [
+      0,
+      2
+    ],
+    [
+      1,
+      2
+    ]
+  ],
+  "family_count": 1,
+  "family_id": "F09",
+  "interpretation": [
+    "This packet isolates the T01/F09 self-edge motif from existing review-pending n=9 diagnostics.",
+    "The three local rows force the displayed equality chain of ordinary pair distances.",
+    "The row-0 vertex-circle order gives the displayed strict inequality between the same quotient class.",
+    "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "local_lemma": {
+    "contradiction": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+    "equality_statement": "Rows 1, 0, and 2 identify [1, 8] with [1, 2] in the selected-distance quotient.",
+    "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the three listed selected rows; no claim is made about other n=9 templates.",
+    "packet_name": "T01/F09 self-edge local lemma packet",
+    "review_status": "review_pending",
+    "selected_distance_equalities": [
+      {
+        "left_pair": [
+          1,
+          8
+        ],
+        "right_pair": [
+          0,
+          1
+        ],
+        "row": 1
+      },
+      {
+        "left_pair": [
+          0,
+          1
+        ],
+        "right_pair": [
+          0,
+          2
+        ],
+        "row": 0
+      },
+      {
+        "left_pair": [
+          0,
+          2
+        ],
+        "right_pair": [
+          1,
+          2
+        ],
+        "row": 2
+      }
+    ],
+    "strict_inequality_statement": "Row 0 has witness order [1, 2, 4, 8], so the outer pair [1, 8] strictly contains the inner pair [1, 2] in the row-0 vertex-circle order."
+  },
+  "n": 9,
+  "orbit_size": 6,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py"
+  },
+  "replay": {
+    "cycle_edge_count": 0,
+    "primary_self_edge_conflict": {
+      "inner_class": [
+        0,
+        1
+      ],
+      "inner_interval": [
+        0,
+        1
+      ],
+      "inner_pair": [
+        1,
+        2
+      ],
+      "inner_span": 1,
+      "outer_class": [
+        0,
+        1
+      ],
+      "outer_interval": [
+        0,
+        3
+      ],
+      "outer_pair": [
+        1,
+        8
+      ],
+      "outer_span": 3,
+      "row": 0,
+      "witness_order": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    "selected_row_count": 3,
+    "self_edge_conflict_count": 2,
+    "self_edge_conflicts": [
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      }
+    ],
+    "status": "self_edge",
+    "strict_edge_count": 27
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "source T01/F09 self-edge template record",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+      "role": "catalog crosswalk confirming T01 coverage and shape summary",
+      "schema": "erdos97.n9_vertex_circle_template_lemma_catalog.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_catalog_record": {
+    "conclusion_shape": {
+      "certificate_fields": [
+        "strict_inequality",
+        "distance_equality"
+      ],
+      "kind": "self_edge",
+      "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+    },
+    "coverage": {
+      "assignment_count": 6,
+      "assignment_ids": [
+        "A014",
+        "A024",
+        "A031",
+        "A140",
+        "A166",
+        "A175"
+      ],
+      "families": [
+        "F09"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 6
+    },
+    "family_summaries": [
+      {
+        "assignment_count": 6,
+        "contradiction_kind": "self_edge",
+        "core_size": 3,
+        "equality_path_length": 3,
+        "family_id": "F09",
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "orbit_size": 6,
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "path_length": 3,
+        "status": "self_edge",
+        "template_id": "T01"
+      }
+    ],
+    "hypothesis_shape": {
+      "core_size": 3,
+      "path_length_counts": {
+        "3": 6
+      },
+      "selected_path_shape_counts": {
+        "3:1:1:path=3": 6
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 6
+      },
+      "strict_edge_count": 27
+    },
+    "status": "self_edge",
+    "template_id": "T01",
+    "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+  },
+  "source_template_record": {
+    "assignment_count": 6,
+    "assignment_ids": [
+      "A014",
+      "A024",
+      "A031",
+      "A140",
+      "A166",
+      "A175"
+    ],
+    "core_size": 3,
+    "families": [
+      "F09"
+    ],
+    "family_count": 1,
+    "path_length_counts": {
+      "3": 6
+    },
+    "selected_path_shape_counts": {
+      "3:1:1:path=3": 6
+    },
+    "self_edge_shape_counts": [
+      {
+        "count": 1,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoint_count": 0
+      },
+      {
+        "count": 1,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoint_count": 1
+      }
+    ],
+    "status": "self_edge",
+    "strict_edge_count": 27,
+    "template_id": "T01",
+    "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_inequality": {
+    "inner_class": [
+      0,
+      1
+    ],
+    "inner_interval": [
+      0,
+      1
+    ],
+    "inner_pair": [
+      1,
+      2
+    ],
+    "inner_span": 1,
+    "outer_class": [
+      0,
+      1
+    ],
+    "outer_interval": [
+      0,
+      3
+    ],
+    "outer_pair": [
+      1,
+      8
+    ],
+    "outer_span": 3,
+    "row": 0,
+    "witness_order": [
+      1,
+      2,
+      4,
+      8
+    ]
+  },
+  "template_id": "T01",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,9 @@ put detailed reconciliation in the canonical synthesis.
   vertex-circle strict-chord filter.
 - [`n9-vertex-circle-template-lemma-catalog.md`](n9-vertex-circle-template-lemma-catalog.md):
   derived 12-template lemma-candidate catalog for proof-mining review.
+- [`n9-vertex-circle-t01-self-edge-lemma.md`](n9-vertex-circle-t01-self-edge-lemma.md):
+  focused review-pending T01/F09 self-edge local lemma packet for proof
+  mining.
 - [`n10-vertex-circle-singleton-slices.md`](n10-vertex-circle-singleton-slices.md):
   review-pending `n=10` singleton-slice finite-case draft and audit target.
 - [`octagon-trap.html`](octagon-trap.html): interactive visualization of the

--- a/docs/n9-vertex-circle-t01-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t01-self-edge-lemma.md
@@ -1,0 +1,78 @@
+# n=9 Vertex-circle T01 Self-edge Local Lemma Packet
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one focused proof-mining packet for the `T01/F09`
+self-edge motif. It does not claim a proof of `n=9`, does not claim a
+counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Packet scope
+
+The checked artifact is
+`data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json`.
+It is derived from:
+
+- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
+- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
+
+The packet covers the six T01 assignment ids:
+
+```text
+A014, A024, A031, A140, A166, A175
+```
+
+The local core is the family `F09` three-row certificate:
+
+```text
+[0, 1, 2, 4, 8]
+[1, 0, 3, 5, 8]
+[2, 0, 1, 4, 6]
+```
+
+For row `0`, the witness order `[1, 2, 4, 8]` gives the strict
+vertex-circle inequality
+
+```text
+[1, 8] > [1, 2]
+```
+
+The selected-distance equality path is:
+
+```text
+[1, 8] -- row 1 --> [0, 1]
+[0, 1] -- row 0 --> [0, 2]
+[0, 2] -- row 2 --> [1, 2]
+```
+
+Thus the packet isolates a local self-edge shape: a strict edge from a
+selected-distance quotient class back to itself.
+
+## Commands
+
+Generate and check the packet:
+
+```bash
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m "artifact"
+```
+
+## Review standard
+
+Before treating this as a reusable local lemma, a reviewer should restate the
+incidence and cyclic-order hypotheses without relying on `T01` as a theorem
+name, then prove directly that the three rows force the displayed equality
+path and that row `0` gives the displayed strict inequality. The packet is a
+small replay aid for that review, not an independent proof of the `n=9` case.

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -61,6 +61,7 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -151,6 +151,8 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_template_lemma_catalog.json` as a
   single 12-template lemma-candidate crosswalk before writing proof-facing
   local lemmas;
+- use `data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json` as
+  the first focused review-pending T01/F09 self-edge local lemma packet;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   known `C19_skew` vertex-circle survivor;
 - use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -78,6 +78,7 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -635,6 +635,73 @@ artifacts:
       - the lemma catalog is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_t01_self_edge_lemma_packet
+    path: data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py
+    command: python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py
+    check_command: python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused T01/F09 self-edge local lemma packet for six n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Focused T01/F09 self-edge local lemma packet for six n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      template_id: T01
+      family_id: F09
+      assignment_count: 6
+      assignment_ids:
+        - A014
+        - A024
+        - A031
+        - A140
+        - A166
+        - A175
+      family_count: 1
+      orbit_size: 6
+      core_size: 3
+      strict_inequality.row: 0
+      strict_inequality.witness_order:
+        - 1
+        - 2
+        - 4
+        - 8
+      strict_inequality.outer_pair:
+        - 1
+        - 8
+      strict_inequality.inner_pair:
+        - 1
+        - 2
+      strict_inequality.outer_span: 3
+      strict_inequality.inner_span: 1
+      equality_chain:
+        - [1, 8]
+        - [0, 1]
+        - [0, 2]
+        - [1, 2]
+      local_lemma.review_status: review_pending
+      replay.status: self_edge
+      replay.selected_row_count: 3
+      replay.strict_edge_count: 27
+      replay.self_edge_conflict_count: 2
+      provenance.command: python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - T01 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the local lemma packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Generate or check the focused T01/F09 n=9 self-edge local lemma packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_self_edge_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_SELF_EDGE_PACKET,
+    validate_payload as validate_self_edge_packet,
+)
+from check_n9_vertex_circle_template_lemma_catalog import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATE_CATALOG,
+    validate_payload as validate_template_catalog,
+)
+from erdos97.n9_vertex_circle_t01_self_edge_lemma_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_t01_self_edge_lemma_packet,
+    source_artifacts,
+    t01_self_edge_lemma_packet_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t01_self_edge_lemma_packet.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_count",
+    "assignment_ids",
+    "claim_scope",
+    "core_selected_rows",
+    "core_size",
+    "cyclic_order",
+    "distance_equality",
+    "equality_chain",
+    "family_count",
+    "family_id",
+    "interpretation",
+    "local_lemma",
+    "n",
+    "orbit_size",
+    "provenance",
+    "replay",
+    "row_size",
+    "schema",
+    "source_artifacts",
+    "source_catalog_record",
+    "source_template_record",
+    "status",
+    "strict_inequality",
+    "template_id",
+    "trust",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
+    template_catalog_path: Path = DEFAULT_TEMPLATE_CATALOG,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the focused T01 packet."""
+
+    return {
+        "self_edge_packet": load_artifact(_resolve(self_edge_packet_path)),
+        "template_catalog": load_artifact(_resolve(template_catalog_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    self_edge = source_payloads.get("self_edge_packet")
+    catalog = source_payloads.get("template_catalog")
+    if not isinstance(self_edge, dict):
+        errors.append("source self-edge template packet must be an object")
+    else:
+        errors.extend(
+            f"source self-edge template packet invalid: {error}"
+            for error in validate_self_edge_packet(self_edge, recompute=False)
+        )
+    if not isinstance(catalog, dict):
+        errors.append("source template lemma catalog must be an object")
+    else:
+        errors.extend(
+            f"source template lemma catalog invalid: {error}"
+            for error in validate_template_catalog(catalog, recompute=False)
+        )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return t01_self_edge_lemma_packet_payload(
+            source_payloads["self_edge_packet"],
+            source_payloads["template_catalog"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound T01 self-edge lemma packet failed: {exc}")
+        return None
+
+
+def _validate_local_lemma(payload: dict[str, Any], errors: list[str]) -> None:
+    lemma = payload.get("local_lemma")
+    if not isinstance(lemma, dict):
+        errors.append("local_lemma must be an object")
+        return
+    expect_equal(errors, "local_lemma review_status", lemma.get("review_status"), "review_pending")
+    selected_equalities = lemma.get("selected_distance_equalities")
+    if not isinstance(selected_equalities, list) or len(selected_equalities) != 3:
+        errors.append("local_lemma selected_distance_equalities must have three steps")
+    statement = str(lemma.get("strict_inequality_statement", ""))
+    if "[1, 8]" not in statement or "[1, 2]" not in statement:
+        errors.append("local_lemma strict inequality statement must name [1, 8] and [1, 2]")
+    contradiction = str(lemma.get("contradiction", ""))
+    if "reflexive strict edge" not in contradiction:
+        errors.append("local_lemma contradiction must mention a reflexive strict edge")
+
+
+def _validate_replay(payload: dict[str, Any], errors: list[str]) -> None:
+    replay = payload.get("replay")
+    if not isinstance(replay, dict):
+        errors.append("replay must be an object")
+        return
+    expect_equal(errors, "replay status", replay.get("status"), "self_edge")
+    expect_equal(errors, "replay selected_row_count", replay.get("selected_row_count"), 3)
+    expect_equal(errors, "replay strict_edge_count", replay.get("strict_edge_count"), 27)
+    expect_equal(
+        errors,
+        "replay self_edge_conflict_count",
+        replay.get("self_edge_conflict_count"),
+        2,
+    )
+    primary = replay.get("primary_self_edge_conflict")
+    if not isinstance(primary, dict):
+        errors.append("replay primary_self_edge_conflict must be an object")
+        return
+    expect_equal(errors, "primary row", primary.get("row"), 0)
+    expect_equal(errors, "primary witness_order", primary.get("witness_order"), [1, 2, 4, 8])
+    expect_equal(errors, "primary outer_pair", primary.get("outer_pair"), [1, 8])
+    expect_equal(errors, "primary inner_pair", primary.get("inner_pair"), [1, 2])
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a focused T01/F09 local lemma packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "template_id": "T01",
+        "family_id": "F09",
+        "assignment_count": 6,
+        "assignment_ids": ["A014", "A024", "A031", "A140", "A166", "A175"],
+        "family_count": 1,
+        "orbit_size": 6,
+        "core_size": 3,
+        "core_selected_rows": [
+            [0, 1, 2, 4, 8],
+            [1, 0, 3, 5, 8],
+            [2, 0, 1, 4, 6],
+        ],
+        "equality_chain": [[1, 8], [0, 1], [0, 2], [1, 2]],
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    strict = payload.get("strict_inequality")
+    if not isinstance(strict, dict):
+        errors.append("strict_inequality must be an object")
+    else:
+        expect_equal(errors, "strict row", strict.get("row"), 0)
+        expect_equal(errors, "strict witness_order", strict.get("witness_order"), [1, 2, 4, 8])
+        expect_equal(errors, "strict outer_pair", strict.get("outer_pair"), [1, 8])
+        expect_equal(errors, "strict inner_pair", strict.get("inner_pair"), [1, 2])
+        expect_equal(errors, "strict outer_span", strict.get("outer_span"), 3)
+        expect_equal(errors, "strict inner_span", strict.get("inner_span"), 1)
+
+    equality = payload.get("distance_equality")
+    if not isinstance(equality, dict):
+        errors.append("distance_equality must be an object")
+    else:
+        expect_equal(errors, "equality start_pair", equality.get("start_pair"), [1, 8])
+        expect_equal(errors, "equality end_pair", equality.get("end_pair"), [1, 2])
+        expect_equal(
+            errors,
+            "equality path",
+            equality.get("path"),
+            [
+                {"row": 1, "next_pair": [0, 1]},
+                {"row": 0, "next_pair": [0, 2]},
+                {"row": 2, "next_pair": [1, 2]},
+            ],
+        )
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the no-proof statement")
+        if not any("proof mining" in item for item in interpretation):
+            errors.append("interpretation must preserve the proof-mining scope")
+
+    _validate_local_lemma(payload, errors)
+    _validate_replay(payload, errors)
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            source_artifacts(
+                source_payloads["self_edge_packet"],
+                source_payloads["template_catalog"],
+            ),
+        )
+        expect_equal(
+            errors,
+            "source_template_record",
+            payload.get("source_template_record"),
+            expected_payload["source_template_record"],
+        )
+        expect_equal(
+            errors,
+            "source_catalog_record",
+            payload.get("source_catalog_record"),
+            expected_payload["source_catalog_record"],
+        )
+
+    try:
+        assert_expected_t01_self_edge_lemma_packet(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected T01 self-edge lemma packet counts failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "T01 self-edge lemma packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    replay = object_payload.get("replay")
+    replay = replay if isinstance(replay, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "template_id": object_payload.get("template_id"),
+        "family_id": object_payload.get("family_id"),
+        "assignment_count": object_payload.get("assignment_count"),
+        "core_size": object_payload.get("core_size"),
+        "replay_status": replay.get("status"),
+        "strict_edge_count": replay.get("strict_edge_count"),
+        "self_edge_conflict_count": replay.get("self_edge_conflict_count"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--self-edge-packet", type=Path, default=DEFAULT_SELF_EDGE_PACKET)
+    parser.add_argument("--template-catalog", type=Path, default=DEFAULT_TEMPLATE_CATALOG)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            self_edge_packet_path=args.self_edge_packet,
+            template_catalog_path=args.template_catalog,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = t01_self_edge_lemma_packet_payload(
+            sources["self_edge_packet"],
+            sources["template_catalog"],
+        )
+        if args.assert_expected:
+            assert_expected_t01_self_edge_lemma_packet(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle T01/F09 self-edge local lemma packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"assignments: {summary['assignment_count']}")
+        print(f"core size: {summary['core_size']}")
+        print(f"replay status: {summary['replay_status']}")
+        if args.check or args.assert_expected:
+            print("OK: T01 self-edge local lemma packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -231,6 +231,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_t01_self_edge_lemma_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused T01/F09 n=9 self-edge local lemma packet; proof-mining "
+            "scaffolding only, not a proof of n=9, counterexample, or "
+            "independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_t01_self_edge_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t01_self_edge_lemma_packet.py
@@ -1,0 +1,389 @@
+"""Build a focused T01/F09 n=9 self-edge local lemma packet.
+
+This module is proof-mining scaffolding. It does not prove the full n=9 case,
+does not claim a counterexample, and does not promote the review-pending n=9
+checker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path
+from erdos97.n9_vertex_circle_self_edge_template_packet import (
+    SCHEMA as SELF_EDGE_TEMPLATE_PACKET_SCHEMA,
+)
+from erdos97.n9_vertex_circle_template_lemma_catalog import (
+    SCHEMA as TEMPLATE_LEMMA_CATALOG_SCHEMA,
+)
+from erdos97.vertex_circle_quotient_replay import (
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+
+SCHEMA = "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused T01/F09 self-edge local lemma packet for six n=9 frontier "
+    "assignments; proof-mining scaffolding only, not a proof of n=9, not a "
+    "counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py "
+        "--assert-expected --write"
+    ),
+}
+
+EXPECTED_TEMPLATE_ID = "T01"
+EXPECTED_FAMILY_ID = "F09"
+EXPECTED_ASSIGNMENT_IDS = ("A014", "A024", "A031", "A140", "A166", "A175")
+EXPECTED_ASSIGNMENT_COUNT = 6
+EXPECTED_FAMILY_COUNT = 1
+EXPECTED_ORBIT_SIZE = 6
+EXPECTED_CORE_SIZE = 3
+EXPECTED_STRICT_EDGE_COUNT = 27
+EXPECTED_SELF_EDGE_CONFLICT_COUNT = 2
+EXPECTED_CORE_SELECTED_ROWS = (
+    (0, 1, 2, 4, 8),
+    (1, 0, 3, 5, 8),
+    (2, 0, 1, 4, 6),
+)
+EXPECTED_STRICT_INEQUALITY = {
+    "row": 0,
+    "witness_order": [1, 2, 4, 8],
+    "outer_interval": [0, 3],
+    "inner_interval": [0, 1],
+    "outer_pair": [1, 8],
+    "inner_pair": [1, 2],
+    "outer_class": [0, 1],
+    "inner_class": [0, 1],
+    "outer_span": 3,
+    "inner_span": 1,
+}
+EXPECTED_DISTANCE_EQUALITY = {
+    "start_pair": [1, 8],
+    "end_pair": [1, 2],
+    "path": [
+        {"row": 1, "next_pair": [0, 1]},
+        {"row": 0, "next_pair": [0, 2]},
+        {"row": 2, "next_pair": [1, 2]},
+    ],
+}
+EXPECTED_EQUALITY_CHAIN = ([1, 8], [0, 1], [0, 2], [1, 2])
+
+
+def _template_record(packet: dict[str, Any]) -> dict[str, Any]:
+    templates = packet.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("self-edge template packet must contain templates")
+    for template in templates:
+        if isinstance(template, dict) and template.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return template
+    raise ValueError(f"missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _family_record(template: dict[str, Any]) -> dict[str, Any]:
+    records = template.get("family_records")
+    if not isinstance(records, list):
+        raise ValueError(f"{EXPECTED_TEMPLATE_ID} must contain family_records")
+    for record in records:
+        if isinstance(record, dict) and record.get("family_id") == EXPECTED_FAMILY_ID:
+            return record
+    raise ValueError(f"missing family {EXPECTED_FAMILY_ID}")
+
+
+def _catalog_record(catalog: dict[str, Any]) -> dict[str, Any]:
+    templates = catalog.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template lemma catalog must contain templates")
+    for record in templates:
+        if isinstance(record, dict) and record.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return record
+    raise ValueError(f"catalog missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _normalize_rows(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    return [[int(value) for value in row] for row in rows]
+
+
+def equality_chain(equality: dict[str, Any]) -> list[list[int]]:
+    """Return the pair chain traversed by a selected-distance equality path."""
+
+    chain = [[int(value) for value in pair(*equality["start_pair"])]]
+    for step in equality["path"]:
+        chain.append([int(value) for value in pair(*step["next_pair"])])
+    return chain
+
+
+def equality_steps(equality: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return row-labelled equality steps for the local lemma packet."""
+
+    current = [int(value) for value in pair(*equality["start_pair"])]
+    steps = []
+    for step in equality["path"]:
+        next_pair = [int(value) for value in pair(*step["next_pair"])]
+        steps.append(
+            {
+                "row": int(step["row"]),
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+    return steps
+
+
+def source_artifacts(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the T01 packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+            "role": "source T01/F09 self-edge template record",
+            "schema": self_edge_packet.get("schema"),
+            "status": self_edge_packet.get("status"),
+            "trust": self_edge_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+            "role": "catalog crosswalk confirming T01 coverage and shape summary",
+            "schema": template_catalog.get("schema"),
+            "status": template_catalog.get("status"),
+            "trust": template_catalog.get("trust"),
+        },
+    ]
+
+
+def _primary_conflict(replay: dict[str, Any]) -> dict[str, Any]:
+    for conflict in replay["self_edge_conflicts"]:
+        if (
+            conflict["row"] == EXPECTED_STRICT_INEQUALITY["row"]
+            and conflict["outer_pair"] == EXPECTED_STRICT_INEQUALITY["outer_pair"]
+            and conflict["inner_pair"] == EXPECTED_STRICT_INEQUALITY["inner_pair"]
+        ):
+            return {
+                **conflict,
+                "outer_span": EXPECTED_STRICT_INEQUALITY["outer_span"],
+                "inner_span": EXPECTED_STRICT_INEQUALITY["inner_span"],
+            }
+    raise AssertionError("primary T01 self-edge conflict not found in replay")
+
+
+def _source_template_summary(template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_id": str(template["template_id"]),
+        "template_key": str(template["template_key"]),
+        "status": str(template["status"]),
+        "assignment_count": int(template["assignment_count"]),
+        "assignment_ids": list(template["assignment_ids"]),
+        "family_count": int(template["family_count"]),
+        "families": list(template["families"]),
+        "core_size": int(template["core_size"]),
+        "strict_edge_count": int(template["strict_edge_count"]),
+        "path_length_counts": template["path_length_counts"],
+        "selected_path_shape_counts": template["selected_path_shape_counts"],
+        "self_edge_shape_counts": template["self_edge_shape_counts"],
+    }
+
+
+def _assert_source_records(
+    template: dict[str, Any],
+    family: dict[str, Any],
+    catalog_record: dict[str, Any],
+) -> None:
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    strict = family["strict_inequality"]
+    validate_equality_path(rows, equality)
+
+    if template["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected template id")
+    if template["status"] != "self_edge":
+        raise AssertionError("T01 must remain a self-edge template")
+    if template["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("unexpected T01 assignment ids")
+    if template["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected T01 assignment count")
+    if template["families"] != [EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected T01 family list")
+    if family["family_id"] != EXPECTED_FAMILY_ID:
+        raise AssertionError("unexpected family id")
+    if family["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("family/template mismatch")
+    if family["orbit_size"] != EXPECTED_ORBIT_SIZE:
+        raise AssertionError("unexpected F09 orbit size")
+    if family["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected F09 core size")
+    if rows != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS):
+        raise AssertionError("unexpected T01/F09 core rows")
+    if strict != EXPECTED_STRICT_INEQUALITY:
+        raise AssertionError("unexpected T01 strict inequality")
+    if equality != EXPECTED_DISTANCE_EQUALITY:
+        raise AssertionError("unexpected T01 equality path")
+    if equality_chain(equality) != [list(item) for item in EXPECTED_EQUALITY_CHAIN]:
+        raise AssertionError("unexpected T01 equality chain")
+    if catalog_record["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected catalog template id")
+    if catalog_record["status"] != "self_edge":
+        raise AssertionError("unexpected catalog T01 status")
+    if catalog_record["coverage"]["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("catalog T01 assignment ids mismatch")
+    if catalog_record["coverage"]["families"] != [EXPECTED_FAMILY_ID]:
+        raise AssertionError("catalog T01 family mismatch")
+
+
+def t01_self_edge_lemma_packet_payload(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the focused review-pending T01/F09 local lemma packet."""
+
+    if self_edge_packet.get("schema") != SELF_EDGE_TEMPLATE_PACKET_SCHEMA:
+        raise ValueError("unexpected self-edge template packet schema")
+    if template_catalog.get("schema") != TEMPLATE_LEMMA_CATALOG_SCHEMA:
+        raise ValueError("unexpected template lemma catalog schema")
+
+    template = _template_record(self_edge_packet)
+    family = _family_record(template)
+    catalog_record = _catalog_record(template_catalog)
+    _assert_source_records(template, family, catalog_record)
+
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    replay_result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parse_selected_rows(rows),
+    )
+    replay = result_to_json(replay_result)
+    primary = _primary_conflict(replay)
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "family_id": EXPECTED_FAMILY_ID,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "orbit_size": EXPECTED_ORBIT_SIZE,
+        "core_size": EXPECTED_CORE_SIZE,
+        "core_selected_rows": rows,
+        "strict_inequality": family["strict_inequality"],
+        "distance_equality": equality,
+        "equality_chain": equality_chain(equality),
+        "local_lemma": {
+            "packet_name": "T01/F09 self-edge local lemma packet",
+            "review_status": "review_pending",
+            "hypothesis_scope": (
+                "Natural cyclic order on labels 0..8 plus the three listed "
+                "selected rows; no claim is made about other n=9 templates."
+            ),
+            "selected_distance_equalities": equality_steps(equality),
+            "strict_inequality_statement": (
+                "Row 0 has witness order [1, 2, 4, 8], so the outer pair "
+                "[1, 8] strictly contains the inner pair [1, 2] in the "
+                "row-0 vertex-circle order."
+            ),
+            "equality_statement": (
+                "Rows 1, 0, and 2 identify [1, 8] with [1, 2] in the "
+                "selected-distance quotient."
+            ),
+            "contradiction": (
+                "The strict graph has a reflexive strict edge after "
+                "selected-distance quotienting."
+            ),
+        },
+        "replay": {
+            "status": replay["status"],
+            "selected_row_count": replay["selected_row_count"],
+            "strict_edge_count": replay["strict_edge_count"],
+            "self_edge_conflict_count": len(replay["self_edge_conflicts"]),
+            "cycle_edge_count": len(replay["cycle_edges"]),
+            "primary_self_edge_conflict": primary,
+            "self_edge_conflicts": replay["self_edge_conflicts"],
+        },
+        "source_template_record": _source_template_summary(template),
+        "source_catalog_record": catalog_record,
+        "interpretation": [
+            "This packet isolates the T01/F09 self-edge motif from existing review-pending n=9 diagnostics.",
+            "The three local rows force the displayed equality chain of ordinary pair distances.",
+            "The row-0 vertex-circle order gives the displayed strict inequality between the same quotient class.",
+            "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": source_artifacts(self_edge_packet, template_catalog),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_t01_self_edge_lemma_packet(payload)
+    return payload
+
+
+def assert_expected_t01_self_edge_lemma_packet(payload: dict[str, Any]) -> None:
+    """Assert stable constants for the focused T01/F09 local lemma packet."""
+
+    if payload["schema"] != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload['schema']}")
+    if payload["status"] != STATUS:
+        raise AssertionError(f"unexpected status: {payload['status']}")
+    if payload["trust"] != TRUST:
+        raise AssertionError(f"unexpected trust: {payload['trust']}")
+    if payload["claim_scope"] != CLAIM_SCOPE:
+        raise AssertionError("claim scope changed")
+    if payload["n"] != n9.N or payload["row_size"] != n9.ROW_SIZE:
+        raise AssertionError("unexpected n or row size")
+    if payload["cyclic_order"] != list(n9.ORDER):
+        raise AssertionError("unexpected cyclic order")
+    if payload["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected template id")
+    if payload["family_id"] != EXPECTED_FAMILY_ID:
+        raise AssertionError("unexpected family id")
+    if payload["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected assignment count")
+    if payload["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("unexpected assignment ids")
+    if payload["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("unexpected family count")
+    if payload["orbit_size"] != EXPECTED_ORBIT_SIZE:
+        raise AssertionError("unexpected orbit size")
+    if payload["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected core size")
+    if payload["core_selected_rows"] != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS):
+        raise AssertionError("unexpected core rows")
+    if payload["strict_inequality"] != EXPECTED_STRICT_INEQUALITY:
+        raise AssertionError("unexpected strict inequality")
+    if payload["distance_equality"] != EXPECTED_DISTANCE_EQUALITY:
+        raise AssertionError("unexpected distance equality")
+    if payload["equality_chain"] != [list(item) for item in EXPECTED_EQUALITY_CHAIN]:
+        raise AssertionError("unexpected equality chain")
+    replay = payload["replay"]
+    if replay["status"] != "self_edge":
+        raise AssertionError("unexpected replay status")
+    if replay["selected_row_count"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected selected row count")
+    if replay["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("unexpected strict edge count")
+    if replay["self_edge_conflict_count"] != EXPECTED_SELF_EDGE_CONFLICT_COUNT:
+        raise AssertionError("unexpected self-edge conflict count")
+    primary = replay["primary_self_edge_conflict"]
+    for key in ("row", "witness_order", "outer_pair", "inner_pair"):
+        if primary[key] != EXPECTED_STRICT_INEQUALITY[key]:
+            raise AssertionError(f"primary conflict {key} mismatch")
+    if payload["provenance"] != PROVENANCE:
+        raise AssertionError("unexpected provenance")

--- a/tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_t01_self_edge_lemma_packet import (
+    assert_expected_t01_self_edge_lemma_packet,
+    t01_self_edge_lemma_packet_payload,
+)
+from scripts.check_n9_vertex_circle_t01_self_edge_lemma_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_t01_self_edge_lemma_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_t01_self_edge_lemma_packet(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "proof-mining scaffolding only" in payload["claim_scope"]
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["template_id"] == "T01"
+    assert payload["family_id"] == "F09"
+    assert payload["assignment_count"] == 6
+    assert payload["assignment_ids"] == ["A014", "A024", "A031", "A140", "A166", "A175"]
+    assert payload["family_count"] == 1
+    assert payload["orbit_size"] == 6
+    assert payload["core_size"] == 3
+
+
+def test_t01_self_edge_lemma_packet_records_expected_local_shape() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert payload["core_selected_rows"] == [
+        [0, 1, 2, 4, 8],
+        [1, 0, 3, 5, 8],
+        [2, 0, 1, 4, 6],
+    ]
+    assert payload["strict_inequality"]["row"] == 0
+    assert payload["strict_inequality"]["witness_order"] == [1, 2, 4, 8]
+    assert payload["strict_inequality"]["outer_pair"] == [1, 8]
+    assert payload["strict_inequality"]["inner_pair"] == [1, 2]
+    assert payload["strict_inequality"]["outer_span"] == 3
+    assert payload["strict_inequality"]["inner_span"] == 1
+    assert payload["distance_equality"] == {
+        "start_pair": [1, 8],
+        "end_pair": [1, 2],
+        "path": [
+            {"row": 1, "next_pair": [0, 1]},
+            {"row": 0, "next_pair": [0, 2]},
+            {"row": 2, "next_pair": [1, 2]},
+        ],
+    }
+    assert payload["equality_chain"] == [[1, 8], [0, 1], [0, 2], [1, 2]]
+    assert payload["local_lemma"]["review_status"] == "review_pending"
+    assert payload["replay"]["status"] == "self_edge"
+    assert payload["replay"]["strict_edge_count"] == 27
+    assert payload["replay"]["self_edge_conflict_count"] == 2
+
+
+def test_t01_self_edge_lemma_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["template_id"] == "T01"
+    assert summary["family_id"] == "F09"
+    assert summary["assignment_count"] == 6
+
+
+def test_t01_self_edge_lemma_packet_rejects_tampered_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["distance_equality"]["path"][0]["next_pair"] = [2, 3]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("equality path mismatch" in error for error in errors)
+    assert any("expected T01 self-edge lemma packet" in error for error in errors)
+
+
+def test_t01_self_edge_lemma_packet_rejects_tampered_core_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["core_selected_rows"][0] = [0, 1, 2, 3, 8]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("core_selected_rows mismatch" in error for error in errors)
+
+
+def test_t01_self_edge_lemma_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_t01_self_edge_lemma_packet_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    sources["self_edge_packet"]["templates"][0]["assignment_ids"][0] = "A999"
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source self-edge template packet invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+def test_t01_self_edge_lemma_packet_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == t01_self_edge_lemma_packet_payload(
+        source_payloads["self_edge_packet"],
+        source_payloads["template_catalog"],
+    )
+
+
+@pytest.mark.artifact
+def test_t01_self_edge_lemma_packet_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["template_id"] == "T01"
+    assert payload["replay_status"] == "self_edge"
+
+
+@pytest.mark.artifact
+def test_t01_self_edge_lemma_packet_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "t01_self_edge_lemma_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_t01_self_edge_lemma_packet_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "t01_self_edge_lemma_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -121,6 +121,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "
         "--spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125"
         in command_texts


### PR DESCRIPTION
## Summary

Adds a focused review-pending T01/F09 self-edge local lemma packet derived from the existing n=9 vertex-circle self-edge template packet and template lemma-candidate catalog.

The packet isolates the six T01 assignments (`A014`, `A024`, `A031`, `A140`, `A166`, `A175`) and records the three-row local core:

- `0 -> {1,2,4,8}`
- `1 -> {0,3,5,8}`
- `2 -> {0,1,4,6}`

It records the row-0 strict inequality `[1,8] > [1,2]`, the selected-distance equality chain `[1,8] -> [0,1] -> [0,2] -> [1,2]`, and a replayed self-edge conflict summary.

This is proof-mining scaffolding only. It does not prove n=9, does not claim a counterexample, does not complete independent review of the n=9 checker, and does not update the official/global status or source-of-truth strongest local result.

## Verification

Passed:

- `python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --assert-expected --write`
- `python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q`
- `python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m artifact`
- `python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -o addopts=`
- `python -m pytest tests/test_n9_vertex_circle_template_lemma_catalog.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m artifact`
- `python -m pytest tests/test_run_artifact_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`498 passed, 75 deselected`)
