### PR TITLE
Summarize C19 Z3 inverse vector pairs

### DIFF
--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -134,6 +134,14 @@ artifacts:
       template_summary.clause_count: 7981
       template_summary.translation_family_count: 1946
       distance_quotient_table_summary.unique_inverse_vector_pairs_used_by_stored_clauses: 285
+      inverse_vector_pair_support_summary.used_inverse_vector_pair_count: 285
+      inverse_vector_pair_support_summary.pair_support_size_mismatch_count: 0
+      inverse_vector_pair_support_summary.unique_pair_support_size_distribution.2: 266
+      inverse_vector_pair_support_summary.unique_pair_support_size_distribution.4: 19
+      inverse_vector_pair_support_summary.clause_count_by_inverse_vector_pair_support_size.2: 7780
+      inverse_vector_pair_support_summary.clause_count_by_inverse_vector_pair_support_size.4: 201
+      inverse_vector_pair_support_summary.clause_count_per_inverse_vector_pair_min: 4
+      inverse_vector_pair_support_summary.clause_count_per_inverse_vector_pair_max: 86
       provenance.command: python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --out reports/c19_kalmanson_z3_clause_diagnostics.json
     forbidden_claims:
       - C19_skew proves Erdos Problem #97

--- a/reports/c19_kalmanson_z3_clause_diagnostics.json
+++ b/reports/c19_kalmanson_z3_clause_diagnostics.json
@@ -36,6 +36,344 @@
     "vector_id_note": "Vector-id counts are deterministic for the current table builder, but individual ids are not a mathematical invariant."
   },
   "interpretation_note": "This report makes the stored C19_skew Z3 clause set easier to inspect. It does not add clauses, search new cyclic orders, or transfer the obstruction to any other selected-witness pattern.",
+  "inverse_vector_pair_support_summary": {
+    "clause_count_by_inverse_vector_pair_support_size": {
+      "2": 7780,
+      "4": 201
+    },
+    "clause_count_per_inverse_vector_pair_max": 86,
+    "clause_count_per_inverse_vector_pair_min": 4,
+    "kind_pattern_count_per_inverse_vector_pair_distribution": {
+      "2": 4,
+      "3": 14,
+      "4": 267
+    },
+    "note": "Vector ids are deterministic for this diagnostic generator, but they are implementation identifiers rather than mathematical invariants.",
+    "oriented_clause_support_size_distribution": {
+      "2,2": 7780,
+      "4,4": 201
+    },
+    "pair_support_size_mismatch_count": 0,
+    "top_inverse_vector_pairs_by_clause_count": [
+      {
+        "clause_count": 86,
+        "inverse_vector_pair": [
+          7001,
+          7037
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 81,
+        "inverse_vector_pair": [
+          5517,
+          5671
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 80,
+        "inverse_vector_pair": [
+          11130,
+          11484
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 78,
+        "inverse_vector_pair": [
+          9829,
+          10553
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 74,
+        "inverse_vector_pair": [
+          7663,
+          8620
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 73,
+        "inverse_vector_pair": [
+          6025,
+          6903
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 73,
+        "inverse_vector_pair": [
+          6706,
+          7526
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 66,
+        "inverse_vector_pair": [
+          11149,
+          11208
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 63,
+        "inverse_vector_pair": [
+          6206,
+          6295
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 63,
+        "inverse_vector_pair": [
+          10498,
+          11939
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 62,
+        "inverse_vector_pair": [
+          7595,
+          8040
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      },
+      {
+        "clause_count": 61,
+        "inverse_vector_pair": [
+          6675,
+          7781
+        ],
+        "kind_patterns": [
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K1_diag_gt_sides",
+            "right_kind": "K2_diag_gt_other"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K1_diag_gt_sides"
+          },
+          {
+            "left_kind": "K2_diag_gt_other",
+            "right_kind": "K2_diag_gt_other"
+          }
+        ],
+        "support_size": 2
+      }
+    ],
+    "unique_pair_support_size_distribution": {
+      "2": 266,
+      "4": 19
+    },
+    "used_inverse_vector_pair_count": 285
+  },
   "label_frequencies": [
     {
       "clause_touch_count": 1530,

--- a/scripts/analyze_kalmanson_z3_clauses.py
+++ b/scripts/analyze_kalmanson_z3_clauses.py
@@ -115,6 +115,30 @@ def inverse_vector_matches(
     return tuple(sorted(matches))
 
 
+def inverse_vector_match_details(
+    clause: Clause,
+    quad_ids: Mapping[Quad, tuple[int, int]],
+    inverse_id: Sequence[int],
+) -> tuple[tuple[int, int, str, str], ...]:
+    """Return vector-id and kind pairs that justify the clause."""
+
+    left_ids = quad_ids[clause[0]]
+    right_ids = quad_ids[clause[1]]
+    details = []
+    for left_kind, left_vector_id in enumerate(left_ids):
+        for right_kind, right_vector_id in enumerate(right_ids):
+            if inverse_id[left_vector_id] == right_vector_id:
+                details.append(
+                    (
+                        left_vector_id,
+                        right_vector_id,
+                        KINDS[left_kind],
+                        KINDS[right_kind],
+                    )
+                )
+    return tuple(sorted(details))
+
+
 def clause_literals(clause: Clause) -> list[tuple[int, int]]:
     literals = []
     for quad in clause:
@@ -171,6 +195,68 @@ def distance_quotient_summary(
         "vector_id_note": (
             "Vector-id counts are deterministic for the current table builder, "
             "but individual ids are not a mathematical invariant."
+        ),
+    }
+
+
+def inverse_vector_pair_support_summary(
+    vector_pair_clause_counts: Counter[tuple[int, int]],
+    pair_kind_patterns: Mapping[tuple[int, int], set[tuple[str, str]]],
+    pair_support_size_by_pair: Mapping[tuple[int, int], int],
+    pair_support_size_mismatches: set[tuple[int, int]],
+    oriented_clause_support_counts: Counter[tuple[int, int]],
+    *,
+    top: int,
+) -> dict[str, object]:
+    """Return compact support data for inverse vector pairs used by clauses."""
+
+    unique_support_counts = Counter(pair_support_size_by_pair.values())
+    kind_pattern_count_distribution = Counter(
+        len(pair_kind_patterns[pair]) for pair in vector_pair_clause_counts
+    )
+    clause_counts = list(vector_pair_clause_counts.values())
+    return {
+        "used_inverse_vector_pair_count": len(vector_pair_clause_counts),
+        "pair_support_size_mismatch_count": len(pair_support_size_mismatches),
+        "unique_pair_support_size_distribution": {
+            str(key): unique_support_counts[key] for key in sorted(unique_support_counts)
+        },
+        "clause_count_by_inverse_vector_pair_support_size": {
+            str(key): sum(
+                count
+                for pair, count in vector_pair_clause_counts.items()
+                if pair_support_size_by_pair[pair] == key
+            )
+            for key in sorted(unique_support_counts)
+        },
+        "oriented_clause_support_size_distribution": {
+            f"{left},{right}": oriented_clause_support_counts[(left, right)]
+            for left, right in sorted(oriented_clause_support_counts)
+        },
+        "clause_count_per_inverse_vector_pair_min": min(clause_counts),
+        "clause_count_per_inverse_vector_pair_max": max(clause_counts),
+        "kind_pattern_count_per_inverse_vector_pair_distribution": {
+            str(key): kind_pattern_count_distribution[key]
+            for key in sorted(kind_pattern_count_distribution)
+        },
+        "top_inverse_vector_pairs_by_clause_count": [
+            {
+                "inverse_vector_pair": list(pair),
+                "clause_count": count,
+                "support_size": pair_support_size_by_pair[pair],
+                "kind_patterns": [
+                    {"left_kind": left, "right_kind": right}
+                    for left, right in sorted(pair_kind_patterns[pair])
+                ],
+            }
+            for pair, count in sorted(
+                vector_pair_clause_counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )[:top]
+        ],
+        "note": (
+            "Vector ids are deterministic for this diagnostic generator, but they are "
+            "implementation identifiers rather than mathematical invariants."
         ),
     }
 
@@ -258,17 +344,39 @@ def diagnostic_payload(
     label_occurrences: Counter[int] = Counter()
     label_clause_touches: Counter[int] = Counter()
     used_vector_pairs: set[tuple[int, int]] = set()
+    vector_pair_clause_counts: Counter[tuple[int, int]] = Counter()
+    vector_pair_kind_patterns: dict[tuple[int, int], set[tuple[str, str]]] = {}
+    pair_support_size_by_pair: dict[tuple[int, int], int] = {}
+    pair_support_size_mismatches: set[tuple[int, int]] = set()
+    oriented_clause_support_counts: Counter[tuple[int, int]] = Counter()
 
     for clause in clauses:
         family_counts[translation_family(clause, n)] += 1
         step_signature_counts[clause_step_signature(clause, n)] += 1
-        kind_matches = inverse_kind_pairs(clause, quad_ids, inverse_id)
-        vector_matches = inverse_vector_matches(clause, quad_ids, inverse_id)
+        match_details = inverse_vector_match_details(clause, quad_ids, inverse_id)
+        kind_matches = tuple(
+            sorted((left_kind, right_kind) for _, _, left_kind, right_kind in match_details)
+        )
+        vector_matches = tuple(
+            sorted(
+                (left_vector_id, right_vector_id)
+                for left_vector_id, right_vector_id, _, _ in match_details
+            )
+        )
         kind_pair_counts[kind_matches] += 1
         matches_per_clause_counts[len(vector_matches)] += 1
-        for left_vector_id, right_vector_id in vector_matches:
-            used_vector_pairs.add(tuple(sorted((left_vector_id, right_vector_id))))
-            matched_vector_support_counts[support_sizes[left_vector_id]] += 1
+        for left_vector_id, right_vector_id, left_kind, right_kind in match_details:
+            vector_pair = tuple(sorted((left_vector_id, right_vector_id)))
+            left_support_size = support_sizes[left_vector_id]
+            right_support_size = support_sizes[right_vector_id]
+            used_vector_pairs.add(vector_pair)
+            vector_pair_clause_counts[vector_pair] += 1
+            vector_pair_kind_patterns.setdefault(vector_pair, set()).add((left_kind, right_kind))
+            pair_support_size_by_pair[vector_pair] = left_support_size
+            if left_support_size != right_support_size:
+                pair_support_size_mismatches.add(vector_pair)
+            oriented_clause_support_counts[(left_support_size, right_support_size)] += 1
+            matched_vector_support_counts[left_support_size] += 1
         shared_label_counts[len(set(clause[0]) & set(clause[1]))] += 1
         union_label_counts[len(set(clause[0]) | set(clause[1]))] += 1
         quads_with_label0_counts[sum(1 for quad in clause if 0 in quad)] += 1
@@ -375,6 +483,14 @@ def diagnostic_payload(
             "label_clause_touch_min": min(label_clause_touches.values()),
             "label_clause_touch_max": max(label_clause_touches.values()),
         },
+        "inverse_vector_pair_support_summary": inverse_vector_pair_support_summary(
+            vector_pair_clause_counts,
+            vector_pair_kind_patterns,
+            pair_support_size_by_pair,
+            pair_support_size_mismatches,
+            oriented_clause_support_counts,
+            top=top,
+        ),
         "rotation_quotient_literal_summary": {
             "quads_containing_label0_per_clause": {
                 str(key): quads_with_label0_counts[key] for key in sorted(quads_with_label0_counts)
@@ -558,6 +674,47 @@ def assert_expected(payload: Mapping[str, object]) -> None:
         observed_kind_counts[(str(pair["left_kind"]), str(pair["right_kind"]))] = int(row["count"])
     if observed_kind_counts != expected_kind_counts:
         raise AssertionError(f"unexpected kind-pair distribution: {observed_kind_counts!r}")
+
+    support = payload.get("inverse_vector_pair_support_summary")
+    if not isinstance(support, Mapping):
+        raise AssertionError("inverse_vector_pair_support_summary must be an object")
+    expected_support = {
+        "used_inverse_vector_pair_count": 285,
+        "pair_support_size_mismatch_count": 0,
+        "unique_pair_support_size_distribution": {"2": 266, "4": 19},
+        "clause_count_by_inverse_vector_pair_support_size": {"2": 7780, "4": 201},
+        "oriented_clause_support_size_distribution": {"2,2": 7780, "4,4": 201},
+        "clause_count_per_inverse_vector_pair_min": 4,
+        "clause_count_per_inverse_vector_pair_max": 86,
+        "kind_pattern_count_per_inverse_vector_pair_distribution": {
+            "2": 4,
+            "3": 14,
+            "4": 267,
+        },
+    }
+    for key, expected in expected_support.items():
+        if support.get(key) != expected:
+            raise AssertionError(
+                f"inverse_vector_pair_support_summary[{key!r}] is {support.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+    top_pairs = support.get("top_inverse_vector_pairs_by_clause_count")
+    if not isinstance(top_pairs, list) or not top_pairs:
+        raise AssertionError("top inverse-vector-pair rows changed")
+    first_pair = top_pairs[0]
+    if not isinstance(first_pair, Mapping):
+        raise AssertionError("top inverse-vector-pair rows must be objects")
+    expected_first_pair = {
+        "inverse_vector_pair": [7001, 7037],
+        "clause_count": 86,
+        "support_size": 2,
+    }
+    for key, expected in expected_first_pair.items():
+        if first_pair.get(key) != expected:
+            raise AssertionError(
+                f"top_inverse_vector_pairs_by_clause_count[0][{key!r}] is "
+                f"{first_pair.get(key)!r}, expected {expected!r}"
+            )
 
     rotation = payload.get("rotation_quotient_literal_summary")
     if not isinstance(rotation, Mapping):

--- a/tests/test_kalmanson_z3_clause_diagnostics.py
+++ b/tests/test_kalmanson_z3_clause_diagnostics.py
@@ -42,6 +42,51 @@ def test_c19_z3_clause_diagnostic_matches_artifact() -> None:
     assert payload["distance_quotient_table_summary"][
         "unique_inverse_vector_pairs_used_by_stored_clauses"
     ] == 285
+    support_summary = payload["inverse_vector_pair_support_summary"]
+    assert support_summary["used_inverse_vector_pair_count"] == 285
+    assert support_summary["pair_support_size_mismatch_count"] == 0
+    assert support_summary["unique_pair_support_size_distribution"] == {
+        "2": 266,
+        "4": 19,
+    }
+    assert support_summary["clause_count_by_inverse_vector_pair_support_size"] == {
+        "2": 7780,
+        "4": 201,
+    }
+    assert support_summary["oriented_clause_support_size_distribution"] == {
+        "2,2": 7780,
+        "4,4": 201,
+    }
+    assert support_summary["clause_count_per_inverse_vector_pair_min"] == 4
+    assert support_summary["clause_count_per_inverse_vector_pair_max"] == 86
+    assert support_summary["kind_pattern_count_per_inverse_vector_pair_distribution"] == {
+        "2": 4,
+        "3": 14,
+        "4": 267,
+    }
+    assert support_summary["top_inverse_vector_pairs_by_clause_count"][0] == {
+        "inverse_vector_pair": [7001, 7037],
+        "clause_count": 86,
+        "support_size": 2,
+        "kind_patterns": [
+            {
+                "left_kind": "K1_diag_gt_sides",
+                "right_kind": "K1_diag_gt_sides",
+            },
+            {
+                "left_kind": "K1_diag_gt_sides",
+                "right_kind": "K2_diag_gt_other",
+            },
+            {
+                "left_kind": "K2_diag_gt_other",
+                "right_kind": "K1_diag_gt_sides",
+            },
+            {
+                "left_kind": "K2_diag_gt_other",
+                "right_kind": "K2_diag_gt_other",
+            },
+        ],
+    }
     assert payload["rotation_quotient_literal_summary"][
         "label0_non_first_occurrences"
     ] == 0
@@ -96,3 +141,30 @@ def test_c19_z3_clause_diagnostic_cli_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["trust"] == "EXACT_CERTIFICATE_DIAGNOSTIC"
     assert payload["status"] == "ALL_ORDER_C19_Z3_CLAUSE_DIAGNOSTIC_ONLY"
+
+
+def test_c19_z3_clause_diagnostic_cli_assert_expected_with_short_top() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/analyze_kalmanson_z3_clauses.py",
+            "--assert-expected",
+            "--top",
+            "3",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert len(payload["inverse_vector_pair_support_summary"][
+        "top_inverse_vector_pairs_by_clause_count"
+    ]) == 3
+    assert payload["inverse_vector_pair_support_summary"][
+        "used_inverse_vector_pair_count"
+    ] == 285


### PR DESCRIPTION
## Summary
- add an inverse-vector-pair support summary to the C19 Z3 clause diagnostic
- regenerate the stored diagnostic report with the 285 used inverse vector pairs broken down by support size, clause coverage, kind-pattern coverage, and top pairs
- pin the new invariants in tests and generated-artifact metadata

## Scope
Diagnostic only for the checked fixed abstract `C19_skew` all-order Z3 Kalmanson certificate. This does not claim a proof of Erdos Problem #97, a counterexample, or transfer to other selected-witness patterns.

## Verification
- `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --top 3 --json`
- `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json`
- `python -m pytest tests/test_kalmanson_z3_clause_diagnostics.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
- `python -m pytest -q` (`499 passed, 75 deselected`)