### PR TITLE
Tighten claim-hygiene wording

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -283,8 +283,9 @@ partial strict-cycle prunes: 5,318,250
 ```
 
 This is a draft audit target only. The repo-native generic checker reproduces
-the n=9 vertex-circle counts and reruns row0 singleton `0`, but the full n=10
-search still needs independent implementation review or a compact replayable
+the n=9 vertex-circle counts and reruns row0 singleton IDs `0`, `63`, and
+`125`, but the full n=10 search still needs independent implementation review
+or a compact replayable
 certificate format before any public theorem-style use. It is not promoted to
 the source-of-truth strongest result. See
 `docs/n10-vertex-circle-singleton-slices.md`.

--- a/STATE.md
+++ b/STATE.md
@@ -129,8 +129,9 @@ A later incoming `n=10` continuation is now recorded as a
 `data/certificates/n10_vertex_circle_singleton_slices.json`. It covers all 126
 row0 singleton slices, reports 4,142,738 total visited nodes, zero full
 assignments, and no aborted slices. The repo-native generic checker reproduces
-the n=9 counts and spot-checks row0 singleton `0`, but the n=10 package is an
-audit target only and is not promoted to the source-of-truth finite-case result.
+the n=9 counts and spot-checks row0 singleton IDs `0`, `63`, and `125`, but the
+n=10 package is an audit target only and is not promoted to the source-of-truth
+finite-case result.
 
 ## Best saved near-miss
 

--- a/docs/erdos97-attack-2026-05-05.md
+++ b/docs/erdos97-attack-2026-05-05.md
@@ -14,6 +14,12 @@ The remaining-F07/F08/F09/F13 language below records the state of the
 2026-05-05 attack report before that follow-up and should be read as
 historical provenance, not current dashboard status.
 
+2026-05-07 supersession note: current source-of-truth wording treats the n = 9
+finite-case package as review-pending and the n = 10 singleton-slice package as
+draft review-pending. Archived phrases below such as "proved-locally" or "audit
+confirms soundness" should not be read as public theorem claims, independent
+review completion, a general proof, or a counterexample.
+
 ## Headline findings
 
 1. **Audit of the review-pending n = 9 vertex-circle exhaustive checker:

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -3,9 +3,10 @@
 Status: `EXACT_CERTIFICATE_DIAGNOSTIC`.
 
 This note records a deterministic support diagnostic for the checked
-fixed-order Kalmanson/Farkas certificates. It does not add a general proof, a
-counterexample, or an all-order obstruction for `C13_sidon_1_2_4_10` or
-`C19_skew`.
+Kalmanson/Farkas certificates. The fixed-order sections remain fixed-order
+diagnostics. The C19 Z3 clause report is an inspection aid for the already
+checked fixed-abstract-pattern all-order certificate. None of these diagnostics
+adds a general proof or a counterexample.
 
 ## Artifact
 

--- a/docs/n9-vertex-circle-frontier-comparison.md
+++ b/docs/n9-vertex-circle-frontier-comparison.md
@@ -37,9 +37,10 @@ matching n=9 strict-cycle span bucket count: 8
 So P18 does not literally contain one of the n=9 local cores, but it does share
 one of the same coarse strict-cycle span shapes.
 
-The recorded `C19_skew` order still passes the vertex-circle filter. This
-remains the guardrail for the proof route: the current quotient-graph
-vertex-circle obstruction is not enough by itself.
+The recorded `C19_skew` order still passes the vertex-circle filter, although
+the fixed abstract pattern is now killed by the separate all-order Z3 Kalmanson
+certificate. This remains the guardrail for the proof route: the current
+quotient-graph vertex-circle obstruction is not enough by itself.
 
 ## Reproduction
 

--- a/docs/n9-vertex-circle-obstruction-shapes.md
+++ b/docs/n9-vertex-circle-obstruction-shapes.md
@@ -58,9 +58,11 @@ a self-edge or directed cycle.
 
 That lemma is not proved here. The existing `C19_skew` caveat in
 `docs/vertex-circle-order-filter.md` shows that the current vertex-circle
-quotient graph alone is not enough for a global solution. The likely proof path
-is to combine this quotient-graph obstruction with stronger order information,
-Altman/Kalmanson inequalities, or radius propagation.
+quotient graph alone is not enough for a global solution. The fixed abstract
+`C19_skew` pattern is now killed by a separate all-order Z3 Kalmanson
+certificate, but that only reinforces the need to combine the quotient-graph
+obstruction with stronger order information, Altman/Kalmanson inequalities, or
+radius propagation.
 
 ## Reproduction
 
@@ -86,6 +88,6 @@ python -m pytest tests/test_n9_vertex_circle_obstruction_shapes.py -q
   cyclic-order templates?
 - Can the 16 dihedral incidence families be replaced by local lemmas that do
   not enumerate all n=9 row systems?
-- Which extra condition rules out the known `C19_skew` vertex-circle survivor:
-  Altman diagonal sums, Kalmanson inequalities, radius propagation, or a
-  sharper vertex-circle inequality?
+- Which extra condition rules out the recorded `C19_skew` vertex-circle-only
+  survivor in a reusable way: Altman diagonal sums, Kalmanson inequalities,
+  radius propagation, or a sharper vertex-circle inequality?

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -93,6 +93,6 @@ full replay and should be reviewed before it changes the source-of-truth local
 finite-case status.
 
 The `n=10` singleton-slice checker is a draft review-pending artifact check.
-The command above validates the imported counts and reruns row0 singleton `0`
-with the repo-native generic checker; it is not a full repo-native replay of
-all 126 singleton slices and does not promote `n=10`.
+The command above validates the imported counts and reruns row0 singleton IDs
+`0`, `63`, and `125` with the repo-native generic checker; it is not a full
+repo-native replay of all 126 singleton slices and does not promote `n=10`.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -154,7 +154,8 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json` as
   the first focused review-pending T01/F09 self-edge local lemma packet;
 - test whether the same motifs appear in the P18 obstruction and fail in the
-  known `C19_skew` vertex-circle survivor;
+  recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
+  fixed abstract pattern by the separate Z3 Kalmanson certificate;
 - use `docs/n9-vertex-circle-frontier-comparison.md` as the current guardrail:
   exact n=9 cores do not embed into P18 or C19, although P18 shares a loose
   strict-cycle span shape;

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -13,6 +13,9 @@
 - It does not claim the `n=8` artifact has had independent external review.
 - It does not claim that the round-two `C19_skew` Kalmanson certificate kills
   all cyclic orders of the abstract pattern.
+- It records a separate Z3 certificate that kills all cyclic orders for the
+  fixed abstract `C19_skew` pattern, but this still is not a proof of Erdos
+  Problem #97.
 - It does not claim that the exact all-order C13 result proves Erdos Problem
   #97; that result is only for one fixed abstract selected-witness pattern.
 
@@ -193,14 +196,15 @@ Check:
 - that the weighted coefficient sum is exactly zero;
 - that the result is recorded only as a fixed-order obstruction.
 
-## Review target F - C13 all-order two-certificate search
+## Review target F - fixed-pattern all-order two-certificate searches
 
 Check:
 
 - that `scripts/check_kalmanson_two_order_search.py` fixes label `0` only by
   translation symmetry for the circulant pattern;
-- that the search result is an all-order statement only for the fixed abstract
-  `C13_sidon_1_2_4_10` selected-witness pattern;
+- that the search/Z3 results are all-order statements only for their fixed
+  abstract selected-witness patterns, such as `C13_sidon_1_2_4_10` and
+  `C19_skew`;
 - that the result is not described as a general proof of Erdos Problem #97.
 
 ## Known weak points / independent review requests


### PR DESCRIPTION
## Summary
- update stale n10 spot-check prose from row0 `0` to row0 IDs `0`, `63`, and `125`
- clarify the distinction between the round-two fixed-order C19 certificate and the separate all-order fixed-abstract-pattern C19 Z3 certificate
- add a supersession note to the archived 2026-05-05 attack report so hotter historical phrases are not read as current public theorem claims

## Scope
Docs/source-of-truth prose only. No generated artifacts, no metadata status promotion, no proof or counterexample claim.

## Verification
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`499 passed, 75 deselected`)