### PR TITLE
Record Erdos97 research cycle 546

### DIFF
--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -91186,3 +91186,196 @@ the two singleton middle/deep orientations already isolated by Cycle 540?
 
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
+
+## 2026-05-07 10:15 EEST - Cycle 546: O01 Placement-Only Explanation Obstruction
+
+### Mathematical Subquestion
+
+Does the sampled `O01` deep-avoidance fact from Cycle 545 follow already
+from the sampled fifth-child placement frontier, before looking at the
+two-row `O01` certificate family?
+
+### Definitions and Assumptions
+
+Use the recorded sampled C19 prefix-window catalog-prefilter sweep over
+windows 288-479. Reconstruct every fifth-pair child from its recorded
+fourth-pair survivor boundary state.
+
+For each possible selected center `c`, define the `O01` partner
+`p=c+7 mod 19`. Record the child positions of `c` and `p` whether or not
+the child has an `O01` certificate. Use the depth labels:
+
+```text
+A  = anchor
+M  = middle
+L1 = left depth 1
+LD = left depth deeper than 1
+R1 = right depth 1
+RD = right depth deeper than 1
+```
+
+The **placement frontier** is the multiset of all ordered
+`(depth(c), depth(c+7))` pairs across all 19 choices of `c` and all sampled
+fifth-pair children. An **`O01` hit** is defined as in Cycle 545 by exact
+quotient-vector equality with the rotated relation `-S_c + P_{c,c+7}`.
+
+### Attempted Proof Route
+
+The hoped-for explanation was:
+
+```text
+The sampled fifth-child placement frontier itself avoids the broad ambiguous
+depth-pair classes that were absent from sampled O01 in Cycle 545.
+```
+
+If true, Cycle 545 would reduce to a simple boundary-placement statement,
+independent of which two-row certificate family closes the child.
+
+### Result
+
+Failed lemma:
+**O01 Placement-Only Explanation Obstruction.**
+
+The placement-only explanation is false. The sampled fifth-child frontier
+contains many placements in every broad ambiguous depth-pair class that
+Cycle 545 found absent from sampled `O01`:
+
+```text
+all sampled center/partner placements 196650
+
+(LD, LD): 6822
+(LD, RD): 10496
+(M, LD):  17296
+(RD, LD): 11144
+(RD, M):  18232
+(RD, RD): 6624
+```
+
+But the sampled `O01` counts in the same six depth-pair classes are all zero:
+
+```text
+(LD, LD): 0
+(LD, RD): 0
+(M, LD):  0
+(RD, LD): 0
+(RD, M):  0
+(RD, RD): 0
+```
+
+Thus Cycle 545's deep-avoidance fact is not merely a property of the sampled
+fifth-child boundary placements. It is a property of which placements support
+the `O01` inverse-pair certificate family.
+
+### Exact Audit
+
+The replay used:
+
+```text
+data/certificates/c19_kalmanson_prefix_window_catalog_prefilter_sweep_288_479.json
+```
+
+The audit returned:
+
+```text
+all_fifth 10350
+all_center_partner_placements 196650
+two_hits 10342
+o01 1594
+o01_label_digest ea8e4657d233b712c068c6f9d4373e637551e6a33fe7ecae6774a14dadfc348d
+all_depth_pair_count 27
+o01_depth_pair_count 17
+witness_all_frontier_count 0
+witness_o01_count 0
+```
+
+The exact broad witness `(center=1, L2, L4)` remains absent even from the
+full sampled placement frontier:
+
+```text
+witness_all_frontier_count 0
+```
+
+However, other placements in the same broad ambiguous depth class `(LD, LD)`
+occur 6,822 times in the sampled placement frontier, so the absence of that
+specific witness is weaker than the `O01` family-level deep avoidance.
+
+The transition summary also shows that the forbidden placement classes include
+both inherited boundary endpoints and newly added fifth-pair endpoints. For
+example:
+
+```text
+LD,LD,cnew=False,pnew=False 3510
+LD,LD,cnew=False,pnew=True  1647
+LD,LD,cnew=True,pnew=False  1665
+LD,RD,cnew=True,pnew=True    497
+RD,LD,cnew=True,pnew=True    497
+```
+
+The audit digest was:
+
+```text
+c2afdb98e55ba7c6c414892839e8537651ea1d2089490c0a936447387cbf71d7
+```
+
+### Proof
+
+The audit deterministically reconstructs every sampled fifth child and loops
+over all 19 possible centers `c`. This gives exactly
+`10350 * 19 = 196650` center/partner placements. It then independently
+recomputes two-row certificates and identifies the 1,594 sampled `O01` hits
+by exact quotient-vector equality, with the same `O01` label digest as Cycle
+545.
+
+Because the six broad ambiguous depth classes have positive counts in the
+full placement frontier but zero counts in the `O01` subfrontier, placement
+alone cannot explain the sampled `O01` deep avoidance.
+
+### Limitations
+
+- This is a finite audit over sampled windows 288-479 only.
+- It does not classify which non-`O01` certificate families occupy the broad
+  ambiguous depth-pair placements.
+- It does not prove an abstract criterion for when a placement supports the
+  `O01` inverse-pair family.
+- It does not prove an all-order `C19_skew` obstruction, a general proof of
+  Erdos Problem #97, or a counterexample.
+
+### Effect on the Attack
+
+The simplest parent-placement route fails. A proof-oriented explanation of
+sampled `O01` deep avoidance must use the actual Kalmanson row geometry, not
+only the positions of `c` and `c+7` in the child boundary state.
+
+This is useful negative information: it rules out promoting Cycle 545 into a
+pure placement lemma. The next viable abstraction should compare `O01` against
+the other two-row inverse-pair families occupying the forbidden depth classes.
+
+### Next Lead
+
+Classify the two-row certificate families present on the six forbidden
+depth-pair placement classes. A concrete subquestion is whether a small set of
+non-`O01` quotient-vector families accounts for those classes, which would
+turn deep avoidance into a family-selection rule rather than a raw placement
+rule.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-546`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-546`.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- No commit, push, or pull request was made during this cycle.
+
+### Validation
+
+- One-off exact sampled placement-vs-`O01` audit over all 10,350 sampled
+  fifth-pair children and all 196,650 center/partner placements: passed, with
+  digest `c2afdb98e55ba7c6c414892839e8537651ea1d2089490c0a936447387cbf71d7`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.


### PR DESCRIPTION
## Mathematical Scope

Records Cycle 546 in `reports/codex_goal_erdos97_log.md`.

The cycle tests whether the sampled `O01` deep-avoidance fact from Cycle 545 follows from raw sampled fifth-child placement data alone. It records the failed lemma named **O01 Placement-Only Explanation Obstruction**.

The exact finite result is negative: the sampled placement frontier contains many placements in the six broad ambiguous depth-pair classes, while sampled `O01` hits in those classes remain zero. Thus the Cycle 545 avoidance is a certificate-family phenomenon, not a placement-only fact.

## Files Changed

- `reports/codex_goal_erdos97_log.md`

## Validation Run

- One-off exact sampled placement-vs-`O01` audit over all 10,350 sampled fifth-pair children and all 196,650 center/partner placements: passed, digest `c2afdb98e55ba7c6c414892839e8537651ea1d2089490c0a936447387cbf71d7`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`499 passed, 75 deselected in 598.16s`)

## Review

Self-review found no code or documentation issues. The diff is a one-file append at the end of the running research log and preserves the repo's non-overclaiming posture.

## Remaining Limitations

- This is a finite audit over sampled windows 288-479 only.
- It does not classify which non-`O01` certificate families occupy the broad ambiguous depth-pair placements.
- It does not prove an abstract criterion for when a placement supports the `O01` inverse-pair family.
- It does not prove an all-order `C19_skew` obstruction, a general proof of Erdos Problem #97, or a counterexample.

## Draft Workaround

This PR is opened non-draft because the connector's draft mark-ready mutation is still hitting the known GraphQL `htmlUrl` field error.