### PR TITLE
Add n9 T03 self-edge lemma packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json
+++ b/data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json
@@ -1,0 +1,934 @@
+{
+  "assignment_count": 20,
+  "assignment_ids": [
+    "A005",
+    "A021",
+    "A042",
+    "A048",
+    "A054",
+    "A068",
+    "A074",
+    "A077",
+    "A079",
+    "A104",
+    "A110",
+    "A116",
+    "A117",
+    "A124",
+    "A131",
+    "A148",
+    "A155",
+    "A156",
+    "A181",
+    "A183"
+  ],
+  "claim_scope": "Focused T03 multi-family self-edge local lemma packet for twenty n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "core_size": 4,
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "family_assignment_counts": {
+    "F05": 18,
+    "F15": 2
+  },
+  "family_count": 2,
+  "family_ids": [
+    "F05",
+    "F15"
+  ],
+  "family_orbit_sizes": {
+    "F05": 18,
+    "F15": 2
+  },
+  "family_packets": [
+    {
+      "assignment_count": 18,
+      "core_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          3,
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          6,
+          1,
+          3,
+          5,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          7
+        ],
+        "path": [
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          }
+        ],
+        "start_pair": [
+          3,
+          7
+        ]
+      },
+      "equality_chain": [
+        [
+          3,
+          7
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          7
+        ]
+      ],
+      "family_id": "F05",
+      "local_lemma": {
+        "contradiction": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "equality_statement": "Rows [3, 2, 1] identify [3, 7] with [1, 7] in the selected-distance quotient.",
+        "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the four listed selected rows; no claim is made about other n=9 templates.",
+        "packet_name": "T03/F05 self-edge local lemma packet",
+        "review_status": "review_pending",
+        "selected_distance_equalities": [
+          {
+            "left_pair": [
+              3,
+              7
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "left_pair": [
+              2,
+              3
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "left_pair": [
+              1,
+              2
+            ],
+            "right_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          }
+        ],
+        "strict_inequality_statement": "Row 6 has witness order [7, 1, 3, 5], so the outer pair [3, 7] strictly contains the inner pair [1, 7] in that row's vertex-circle order."
+      },
+      "orbit_size": 18,
+      "replay": {
+        "cycle_edge_count": 0,
+        "primary_self_edge_conflict": {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            7
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            3,
+            7
+          ],
+          "outer_span": 2,
+          "row": 6,
+          "witness_order": [
+            7,
+            1,
+            3,
+            5
+          ]
+        },
+        "selected_row_count": 4,
+        "self_edge_conflict_count": 1,
+        "self_edge_conflicts": [
+          {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "row": 6,
+            "witness_order": [
+              7,
+              1,
+              3,
+              5
+            ]
+          }
+        ],
+        "status": "self_edge",
+        "strict_edge_count": 36
+      },
+      "source_family_record": {
+        "assignment_count": 18,
+        "core_size": 4,
+        "distance_equality": {
+          "end_pair": [
+            1,
+            7
+          ],
+          "path": [
+            {
+              "next_pair": [
+                2,
+                3
+              ],
+              "row": 3
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            },
+            {
+              "next_pair": [
+                1,
+                7
+              ],
+              "row": 1
+            }
+          ],
+          "start_pair": [
+            3,
+            7
+          ]
+        },
+        "equality_chain": [
+          [
+            3,
+            7
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            7
+          ]
+        ],
+        "family_id": "F05",
+        "orbit_size": 18,
+        "path_length": 3,
+        "status": "self_edge",
+        "strict_inequality": {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            7
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            3,
+            7
+          ],
+          "outer_span": 2,
+          "row": 6,
+          "witness_order": [
+            7,
+            1,
+            3,
+            5
+          ]
+        },
+        "template_id": "T03"
+      },
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          3
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          3
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          5
+        ]
+      }
+    },
+    {
+      "assignment_count": 2,
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          1,
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          3,
+          2,
+          4,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          3,
+          4
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "start_pair": [
+          1,
+          4
+        ]
+      },
+      "equality_chain": [
+        [
+          1,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "family_id": "F15",
+      "local_lemma": {
+        "contradiction": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "equality_statement": "Rows [1, 2, 3] identify [1, 4] with [3, 4] in the selected-distance quotient.",
+        "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the four listed selected rows; no claim is made about other n=9 templates.",
+        "packet_name": "T03/F15 self-edge local lemma packet",
+        "review_status": "review_pending",
+        "selected_distance_equalities": [
+          {
+            "left_pair": [
+              1,
+              4
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              1,
+              2
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "left_pair": [
+              2,
+              3
+            ],
+            "right_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "strict_inequality_statement": "Row 0 has witness order [1, 3, 4, 8], so the outer pair [1, 4] strictly contains the inner pair [3, 4] in that row's vertex-circle order."
+      },
+      "orbit_size": 2,
+      "replay": {
+        "cycle_edge_count": 0,
+        "primary_self_edge_conflict": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            3,
+            4
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            4
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        "selected_row_count": 4,
+        "self_edge_conflict_count": 1,
+        "self_edge_conflicts": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              4,
+              8
+            ]
+          }
+        ],
+        "status": "self_edge",
+        "strict_edge_count": 36
+      },
+      "source_family_record": {
+        "assignment_count": 2,
+        "core_size": 4,
+        "distance_equality": {
+          "end_pair": [
+            3,
+            4
+          ],
+          "path": [
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                2,
+                3
+              ],
+              "row": 2
+            },
+            {
+              "next_pair": [
+                3,
+                4
+              ],
+              "row": 3
+            }
+          ],
+          "start_pair": [
+            1,
+            4
+          ]
+        },
+        "equality_chain": [
+          [
+            1,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "family_id": "F15",
+        "orbit_size": 2,
+        "path_length": 3,
+        "status": "self_edge",
+        "strict_inequality": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            3,
+            4
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            4
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        "template_id": "T03"
+      },
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          4,
+          8
+        ]
+      }
+    }
+  ],
+  "interpretation": [
+    "This packet isolates the multi-family T03 self-edge motif from existing review-pending n=9 diagnostics.",
+    "Each family record has four local rows that force the displayed equality chain.",
+    "Each family record has one vertex-circle strict inequality between the same quotient class.",
+    "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "orbit_size_sum": 20,
+  "path_length_counts": {
+    "3": 20
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_t03_self_edge_lemma_packet.v1",
+  "selected_path_shape_counts": {
+    "2:1:1:path=3": 20
+  },
+  "shared_endpoint_counts": {
+    "1": 20
+  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "source T03 multi-family self-edge template record",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+      "role": "catalog crosswalk confirming T03 coverage and shape summary",
+      "schema": "erdos97.n9_vertex_circle_template_lemma_catalog.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_catalog_record": {
+    "conclusion_shape": {
+      "certificate_fields": [
+        "strict_inequality",
+        "distance_equality"
+      ],
+      "kind": "self_edge",
+      "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+    },
+    "coverage": {
+      "assignment_count": 20,
+      "assignment_ids": [
+        "A005",
+        "A021",
+        "A042",
+        "A048",
+        "A054",
+        "A068",
+        "A074",
+        "A077",
+        "A079",
+        "A104",
+        "A110",
+        "A116",
+        "A117",
+        "A124",
+        "A131",
+        "A148",
+        "A155",
+        "A156",
+        "A181",
+        "A183"
+      ],
+      "families": [
+        "F05",
+        "F15"
+      ],
+      "family_count": 2,
+      "orbit_size_sum": 20
+    },
+    "family_summaries": [
+      {
+        "assignment_count": 18,
+        "contradiction_kind": "self_edge",
+        "core_size": 4,
+        "equality_path_length": 3,
+        "family_id": "F05",
+        "inner_pair": [
+          1,
+          7
+        ],
+        "inner_span": 1,
+        "orbit_size": 18,
+        "outer_pair": [
+          3,
+          7
+        ],
+        "outer_span": 2,
+        "path_length": 3,
+        "status": "self_edge",
+        "template_id": "T03"
+      },
+      {
+        "assignment_count": 2,
+        "contradiction_kind": "self_edge",
+        "core_size": 4,
+        "equality_path_length": 3,
+        "family_id": "F15",
+        "inner_pair": [
+          3,
+          4
+        ],
+        "inner_span": 1,
+        "orbit_size": 2,
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 2,
+        "path_length": 3,
+        "status": "self_edge",
+        "template_id": "T03"
+      }
+    ],
+    "hypothesis_shape": {
+      "core_size": 4,
+      "path_length_counts": {
+        "3": 20
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=3": 20
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 20
+      },
+      "strict_edge_count": 36
+    },
+    "status": "self_edge",
+    "template_id": "T03",
+    "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+  },
+  "source_template_record": {
+    "assignment_count": 20,
+    "assignment_ids": [
+      "A005",
+      "A021",
+      "A042",
+      "A048",
+      "A054",
+      "A068",
+      "A074",
+      "A077",
+      "A079",
+      "A104",
+      "A110",
+      "A116",
+      "A117",
+      "A124",
+      "A131",
+      "A148",
+      "A155",
+      "A156",
+      "A181",
+      "A183"
+    ],
+    "core_size": 4,
+    "families": [
+      "F05",
+      "F15"
+    ],
+    "family_count": 2,
+    "orbit_size_sum": 20,
+    "path_length_counts": {
+      "3": 20
+    },
+    "selected_path_shape_counts": {
+      "2:1:1:path=3": 20
+    },
+    "self_edge_shape_counts": [
+      {
+        "count": 1,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoint_count": 1
+      }
+    ],
+    "shared_endpoint_counts": {
+      "1": 20
+    },
+    "status": "self_edge",
+    "strict_edge_count": 36,
+    "template_id": "T03",
+    "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_edge_count": 36,
+  "template_id": "T03",
+  "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t02-self-edge-lemma.md`](n9-vertex-circle-t02-self-edge-lemma.md):
   focused review-pending T02 multi-family self-edge local lemma packet for
   proof mining.
+- [`n9-vertex-circle-t03-self-edge-lemma.md`](n9-vertex-circle-t03-self-edge-lemma.md):
+  focused review-pending T03 multi-family self-edge local lemma packet for
+  proof mining.
 - [`n10-vertex-circle-singleton-slices.md`](n10-vertex-circle-singleton-slices.md):
   review-pending `n=10` singleton-slice finite-case draft, including the
   secondary first-five replay cross-check.

--- a/docs/n9-vertex-circle-t03-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t03-self-edge-lemma.md
@@ -1,0 +1,85 @@
+# n=9 Vertex-circle T03 Self-edge Local Lemma Packet
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one focused proof-mining packet for the multi-family `T03`
+self-edge motif. It does not claim a proof of `n=9`, does not claim a
+counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Packet scope
+
+The checked artifact is
+`data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json`.
+It is derived from:
+
+- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
+- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
+
+The packet covers 20 assignment ids across two families:
+
+```text
+F05: 18 assignments
+F15:  2 assignments
+```
+
+Each family has a four-row core and replays to a single self-edge conflict
+with 36 strict edges and no strict cycle. The selected-distance equality path
+still has three steps, so reviewers should keep the four selected rows separate
+from the three equality edges.
+
+## Family cores
+
+`F05`:
+
+```text
+[1, 2, 5, 7, 8]
+[2, 1, 3, 4, 8]
+[3, 0, 2, 4, 7]
+[6, 1, 3, 5, 7]
+strict: [3, 7] > [1, 7] from row 6
+path:   [3, 7] -> [2, 3] -> [1, 2] -> [1, 7]
+```
+
+`F15`:
+
+```text
+[0, 1, 3, 4, 8]
+[1, 0, 2, 4, 5]
+[2, 1, 3, 5, 6]
+[3, 2, 4, 6, 7]
+strict: [1, 4] > [3, 4] from row 0
+path:   [1, 4] -> [1, 2] -> [2, 3] -> [3, 4]
+```
+
+Thus the packet isolates a reusable-looking local self-edge shape: each family
+forces a strict edge from a selected-distance quotient class back to itself.
+
+## Commands
+
+Generate and check the packet:
+
+```bash
+python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py -q -m "artifact"
+```
+
+## Review standard
+
+Before treating this as a reusable local lemma, a reviewer should restate the
+incidence and cyclic-order hypotheses without relying on `T03` as a theorem
+name, then prove directly for each of the two family cores that the listed
+rows force the displayed equality path and strict inequality. The packet is a
+small replay aid for that review, not an independent proof of the `n=9` case.

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -63,6 +63,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -155,6 +155,8 @@ Next steps:
   the first focused review-pending T01/F09 self-edge local lemma packet;
 - use `data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json` as
   the next focused review-pending T02 multi-family self-edge local lemma packet;
+- use `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json` as
+  the next focused review-pending T03 multi-family self-edge local lemma packet;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -83,6 +83,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -763,6 +763,53 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_t03_self_edge_lemma_packet
+    path: data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py
+    command: python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py
+    check_command: python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused T03 multi-family self-edge local lemma packet for twenty n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_t03_self_edge_lemma_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Focused T03 multi-family self-edge local lemma packet for twenty n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      template_id: T03
+      template_key: self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1
+      assignment_count: 20
+      family_count: 2
+      family_ids:
+        - F05
+        - F15
+      family_assignment_counts.F05: 18
+      family_assignment_counts.F15: 2
+      family_orbit_sizes.F05: 18
+      family_orbit_sizes.F15: 2
+      orbit_size_sum: 20
+      core_size: 4
+      strict_edge_count: 36
+      path_length_counts.3: 20
+      shared_endpoint_counts.1: 20
+      "selected_path_shape_counts.2:1:1:path=3": 20
+      provenance.command: python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - T03 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the local lemma packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Generate or check the focused T03 n=9 self-edge local lemma packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_self_edge_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_SELF_EDGE_PACKET,
+    validate_payload as validate_self_edge_packet,
+)
+from check_n9_vertex_circle_template_lemma_catalog import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATE_CATALOG,
+    validate_payload as validate_template_catalog,
+)
+from erdos97.n9_vertex_circle_t03_self_edge_lemma_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    EXPECTED_ASSIGNMENT_IDS,
+    EXPECTED_CORE_SELECTED_ROWS,
+    EXPECTED_DISTANCE_EQUALITIES,
+    EXPECTED_EQUALITY_CHAINS,
+    EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+    EXPECTED_FAMILY_IDS,
+    EXPECTED_FAMILY_ORBIT_SIZES,
+    EXPECTED_PATH_LENGTH_COUNTS,
+    EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+    EXPECTED_SHARED_ENDPOINT_COUNTS,
+    EXPECTED_STRICT_INEQUALITIES,
+    EXPECTED_TEMPLATE_KEY,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_t03_self_edge_lemma_packet,
+    source_artifacts,
+    t03_self_edge_lemma_packet_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t03_self_edge_lemma_packet.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_count",
+    "assignment_ids",
+    "claim_scope",
+    "core_size",
+    "cyclic_order",
+    "family_assignment_counts",
+    "family_count",
+    "family_ids",
+    "family_orbit_sizes",
+    "family_packets",
+    "interpretation",
+    "n",
+    "orbit_size_sum",
+    "path_length_counts",
+    "provenance",
+    "row_size",
+    "schema",
+    "selected_path_shape_counts",
+    "shared_endpoint_counts",
+    "source_artifacts",
+    "source_catalog_record",
+    "source_template_record",
+    "status",
+    "strict_edge_count",
+    "template_id",
+    "template_key",
+    "trust",
+}
+EXPECTED_FAMILY_PACKET_KEYS = {
+    "assignment_count",
+    "core_selected_rows",
+    "core_size",
+    "distance_equality",
+    "equality_chain",
+    "family_id",
+    "local_lemma",
+    "orbit_size",
+    "replay",
+    "source_family_record",
+    "strict_inequality",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
+    template_catalog_path: Path = DEFAULT_TEMPLATE_CATALOG,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the focused T03 packet."""
+
+    return {
+        "self_edge_packet": load_artifact(_resolve(self_edge_packet_path)),
+        "template_catalog": load_artifact(_resolve(template_catalog_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    self_edge = source_payloads.get("self_edge_packet")
+    catalog = source_payloads.get("template_catalog")
+    if not isinstance(self_edge, dict):
+        errors.append("source self-edge template packet must be an object")
+    else:
+        errors.extend(
+            f"source self-edge template packet invalid: {error}"
+            for error in validate_self_edge_packet(self_edge, recompute=False)
+        )
+    if not isinstance(catalog, dict):
+        errors.append("source template lemma catalog must be an object")
+    else:
+        errors.extend(
+            f"source template lemma catalog invalid: {error}"
+            for error in validate_template_catalog(catalog, recompute=False)
+        )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return t03_self_edge_lemma_packet_payload(
+            source_payloads["self_edge_packet"],
+            source_payloads["template_catalog"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound T03 self-edge lemma packet failed: {exc}")
+        return None
+
+
+def _family_packets_by_id(payload: dict[str, Any], errors: list[str]) -> dict[str, dict[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        errors.append("family_packets must be a list")
+        return {}
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, "
+            f"got {len(packets)}"
+        )
+    by_id: dict[str, dict[str, Any]] = {}
+    for packet in packets:
+        if not isinstance(packet, dict):
+            errors.append("family_packets entries must be objects")
+            continue
+        family_id = str(packet.get("family_id"))
+        if family_id in by_id:
+            errors.append(f"duplicate family packet id: {family_id}")
+        by_id[family_id] = packet
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family packet ids mismatch: expected {list(EXPECTED_FAMILY_IDS)!r}, "
+            f"got {sorted(by_id)!r}"
+        )
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS if family_id in by_id}
+
+
+def _validate_local_lemma(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    lemma = packet.get("local_lemma")
+    if not isinstance(lemma, dict):
+        errors.append(f"{family_id} local_lemma must be an object")
+        return
+    expect_equal(errors, f"{family_id} local_lemma review_status", lemma.get("review_status"), "review_pending")
+    selected_equalities = lemma.get("selected_distance_equalities")
+    if not isinstance(selected_equalities, list) or len(selected_equalities) != 3:
+        errors.append(f"{family_id} local_lemma selected_distance_equalities must have three steps")
+    strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+    statement = str(lemma.get("strict_inequality_statement", ""))
+    for pair_value in (strict["outer_pair"], strict["inner_pair"]):
+        if str(pair_value) not in statement:
+            errors.append(f"{family_id} strict inequality statement must name {pair_value}")
+    hypothesis = str(lemma.get("hypothesis_scope", ""))
+    if "four listed selected rows" not in hypothesis:
+        errors.append(f"{family_id} local_lemma hypothesis must mention four selected rows")
+    contradiction = str(lemma.get("contradiction", ""))
+    if "reflexive strict edge" not in contradiction:
+        errors.append(f"{family_id} local_lemma contradiction must mention a reflexive strict edge")
+
+
+def _validate_replay(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    replay = packet.get("replay")
+    if not isinstance(replay, dict):
+        errors.append(f"{family_id} replay must be an object")
+        return
+    expect_equal(errors, f"{family_id} replay status", replay.get("status"), "self_edge")
+    expect_equal(errors, f"{family_id} replay selected_row_count", replay.get("selected_row_count"), 4)
+    expect_equal(errors, f"{family_id} replay strict_edge_count", replay.get("strict_edge_count"), 36)
+    expect_equal(
+        errors,
+        f"{family_id} replay self_edge_conflict_count",
+        replay.get("self_edge_conflict_count"),
+        1,
+    )
+    expect_equal(errors, f"{family_id} replay cycle_edge_count", replay.get("cycle_edge_count"), 0)
+    primary = replay.get("primary_self_edge_conflict")
+    if not isinstance(primary, dict):
+        errors.append(f"{family_id} replay primary_self_edge_conflict must be an object")
+        return
+    strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+    for key in ("row", "witness_order", "outer_pair", "inner_pair", "outer_interval", "inner_interval"):
+        expect_equal(errors, f"{family_id} primary {key}", primary.get(key), strict[key])
+
+
+def _validate_family_packet(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    if set(packet) != EXPECTED_FAMILY_PACKET_KEYS:
+        errors.append(
+            f"{family_id} keys mismatch: expected {sorted(EXPECTED_FAMILY_PACKET_KEYS)!r}, "
+            f"got {sorted(packet)!r}"
+        )
+    expect_equal(errors, f"{family_id} family_id", packet.get("family_id"), family_id)
+    expect_equal(
+        errors,
+        f"{family_id} assignment_count",
+        packet.get("assignment_count"),
+        EXPECTED_FAMILY_ASSIGNMENT_COUNTS[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} orbit_size",
+        packet.get("orbit_size"),
+        EXPECTED_FAMILY_ORBIT_SIZES[family_id],
+    )
+    expect_equal(errors, f"{family_id} core_size", packet.get("core_size"), 4)
+    expect_equal(
+        errors,
+        f"{family_id} core_selected_rows",
+        packet.get("core_selected_rows"),
+        [list(row) for row in EXPECTED_CORE_SELECTED_ROWS[family_id]],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} strict_inequality",
+        packet.get("strict_inequality"),
+        EXPECTED_STRICT_INEQUALITIES[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} distance_equality",
+        packet.get("distance_equality"),
+        EXPECTED_DISTANCE_EQUALITIES[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} equality_chain",
+        packet.get("equality_chain"),
+        [list(item) for item in EXPECTED_EQUALITY_CHAINS[family_id]],
+    )
+    _validate_local_lemma(family_id, packet, errors)
+    _validate_replay(family_id, packet, errors)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a focused T03 local lemma packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "template_id": "T03",
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": 20,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": 2,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": 20,
+        "core_size": 4,
+        "strict_edge_count": 36,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the no-proof statement")
+        if not any("proof mining" in item for item in interpretation):
+            errors.append("interpretation must preserve the proof-mining scope")
+
+    for family_id, packet in _family_packets_by_id(payload, errors).items():
+        _validate_family_packet(family_id, packet, errors)
+
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            source_artifacts(
+                source_payloads["self_edge_packet"],
+                source_payloads["template_catalog"],
+            ),
+        )
+        expect_equal(
+            errors,
+            "source_template_record",
+            payload.get("source_template_record"),
+            expected_payload["source_template_record"],
+        )
+        expect_equal(
+            errors,
+            "source_catalog_record",
+            payload.get("source_catalog_record"),
+            expected_payload["source_catalog_record"],
+        )
+
+    try:
+        assert_expected_t03_self_edge_lemma_packet(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected T03 self-edge lemma packet counts failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "T03 self-edge lemma packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    family_packets = object_payload.get("family_packets")
+    family_packets = family_packets if isinstance(family_packets, list) else []
+    replay_statuses = [
+        packet.get("replay", {}).get("status")
+        for packet in family_packets
+        if isinstance(packet, dict) and isinstance(packet.get("replay"), dict)
+    ]
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "template_id": object_payload.get("template_id"),
+        "assignment_count": object_payload.get("assignment_count"),
+        "family_count": object_payload.get("family_count"),
+        "family_ids": object_payload.get("family_ids"),
+        "core_size": object_payload.get("core_size"),
+        "replay_statuses": replay_statuses,
+        "strict_edge_count": object_payload.get("strict_edge_count"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--self-edge-packet", type=Path, default=DEFAULT_SELF_EDGE_PACKET)
+    parser.add_argument("--template-catalog", type=Path, default=DEFAULT_TEMPLATE_CATALOG)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            self_edge_packet_path=args.self_edge_packet,
+            template_catalog_path=args.template_catalog,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = t03_self_edge_lemma_packet_payload(
+            sources["self_edge_packet"],
+            sources["template_catalog"],
+        )
+        if args.assert_expected:
+            assert_expected_t03_self_edge_lemma_packet(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle T03 self-edge local lemma packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"assignments: {summary['assignment_count']}")
+        print(f"families: {summary['family_ids']}")
+        print(f"core size: {summary['core_size']}")
+        if args.check or args.assert_expected:
+            print("OK: T03 self-edge local lemma packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -261,6 +261,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_t03_self_edge_lemma_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused T03 multi-family n=9 self-edge local lemma packet; "
+            "proof-mining scaffolding only, not a proof of n=9, "
+            "counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_t03_self_edge_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t03_self_edge_lemma_packet.py
@@ -1,0 +1,602 @@
+"""Build a focused T03 n=9 self-edge local lemma packet.
+
+This module is proof-mining scaffolding. It does not prove the full n=9 case,
+does not claim a counterexample, and does not promote the review-pending n=9
+checker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path
+from erdos97.n9_vertex_circle_self_edge_template_packet import (
+    SCHEMA as SELF_EDGE_TEMPLATE_PACKET_SCHEMA,
+)
+from erdos97.n9_vertex_circle_template_lemma_catalog import (
+    SCHEMA as TEMPLATE_LEMMA_CATALOG_SCHEMA,
+)
+from erdos97.vertex_circle_quotient_replay import (
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_t03_self_edge_lemma_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused T03 multi-family self-edge local lemma packet for twenty n=9 "
+    "frontier assignments; proof-mining scaffolding only, not a proof of n=9, "
+    "not a counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py "
+        "--assert-expected --write"
+    ),
+}
+
+EXPECTED_TEMPLATE_ID = "T03"
+EXPECTED_TEMPLATE_KEY = "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+EXPECTED_FAMILY_IDS = ("F05", "F15")
+EXPECTED_ASSIGNMENT_IDS = (
+    "A005",
+    "A021",
+    "A042",
+    "A048",
+    "A054",
+    "A068",
+    "A074",
+    "A077",
+    "A079",
+    "A104",
+    "A110",
+    "A116",
+    "A117",
+    "A124",
+    "A131",
+    "A148",
+    "A155",
+    "A156",
+    "A181",
+    "A183",
+)
+EXPECTED_ASSIGNMENT_COUNT = 20
+EXPECTED_FAMILY_COUNT = 2
+EXPECTED_ORBIT_SIZE_SUM = 20
+EXPECTED_CORE_SIZE = 4
+EXPECTED_STRICT_EDGE_COUNT = 36
+EXPECTED_SELF_EDGE_CONFLICT_COUNT = 1
+EXPECTED_CYCLE_EDGE_COUNT = 0
+EXPECTED_FAMILY_ASSIGNMENT_COUNTS = {"F05": 18, "F15": 2}
+EXPECTED_FAMILY_ORBIT_SIZES = {"F05": 18, "F15": 2}
+EXPECTED_PATH_LENGTH_COUNTS = {"3": 20}
+EXPECTED_SHARED_ENDPOINT_COUNTS = {"1": 20}
+EXPECTED_SELECTED_PATH_SHAPE_COUNTS = {"2:1:1:path=3": 20}
+EXPECTED_CORE_SELECTED_ROWS = {
+    "F05": (
+        (1, 2, 5, 7, 8),
+        (2, 1, 3, 4, 8),
+        (3, 0, 2, 4, 7),
+        (6, 1, 3, 5, 7),
+    ),
+    "F15": (
+        (0, 1, 3, 4, 8),
+        (1, 0, 2, 4, 5),
+        (2, 1, 3, 5, 6),
+        (3, 2, 4, 6, 7),
+    ),
+}
+EXPECTED_STRICT_INEQUALITIES: dict[str, dict[str, Any]] = {
+    "F05": {
+        "row": 6,
+        "witness_order": [7, 1, 3, 5],
+        "outer_interval": [0, 2],
+        "inner_interval": [0, 1],
+        "outer_pair": [3, 7],
+        "inner_pair": [1, 7],
+        "outer_class": [0, 3],
+        "inner_class": [0, 3],
+        "outer_span": 2,
+        "inner_span": 1,
+    },
+    "F15": {
+        "row": 0,
+        "witness_order": [1, 3, 4, 8],
+        "outer_interval": [0, 2],
+        "inner_interval": [1, 2],
+        "outer_pair": [1, 4],
+        "inner_pair": [3, 4],
+        "outer_class": [0, 1],
+        "inner_class": [0, 1],
+        "outer_span": 2,
+        "inner_span": 1,
+    },
+}
+EXPECTED_DISTANCE_EQUALITIES: dict[str, dict[str, Any]] = {
+    "F05": {
+        "start_pair": [3, 7],
+        "end_pair": [1, 7],
+        "path": [
+            {"row": 3, "next_pair": [2, 3]},
+            {"row": 2, "next_pair": [1, 2]},
+            {"row": 1, "next_pair": [1, 7]},
+        ],
+    },
+    "F15": {
+        "start_pair": [1, 4],
+        "end_pair": [3, 4],
+        "path": [
+            {"row": 1, "next_pair": [1, 2]},
+            {"row": 2, "next_pair": [2, 3]},
+            {"row": 3, "next_pair": [3, 4]},
+        ],
+    },
+}
+EXPECTED_EQUALITY_CHAINS = {
+    "F05": ([3, 7], [2, 3], [1, 2], [1, 7]),
+    "F15": ([1, 4], [1, 2], [2, 3], [3, 4]),
+}
+
+
+def _template_record(packet: dict[str, Any]) -> dict[str, Any]:
+    templates = packet.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("self-edge template packet must contain templates")
+    for template in templates:
+        if isinstance(template, dict) and template.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return template
+    raise ValueError(f"missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _family_records_by_id(template: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    records = template.get("family_records")
+    if not isinstance(records, list):
+        raise ValueError(f"{EXPECTED_TEMPLATE_ID} must contain family_records")
+    by_id = {
+        str(record["family_id"]): record
+        for record in records
+        if isinstance(record, dict) and "family_id" in record
+    }
+    missing = [family_id for family_id in EXPECTED_FAMILY_IDS if family_id not in by_id]
+    if missing:
+        raise ValueError(f"missing T03 families: {missing!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def _catalog_record(catalog: dict[str, Any]) -> dict[str, Any]:
+    templates = catalog.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template lemma catalog must contain templates")
+    for record in templates:
+        if isinstance(record, dict) and record.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return record
+    raise ValueError(f"catalog missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _normalize_rows(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    return [[int(value) for value in row] for row in rows]
+
+
+def equality_chain(equality: Mapping[str, Any]) -> list[list[int]]:
+    """Return the pair chain traversed by a selected-distance equality path."""
+
+    chain = [[int(value) for value in pair(*equality["start_pair"])]]
+    for step in equality["path"]:
+        chain.append([int(value) for value in pair(*step["next_pair"])])
+    return chain
+
+
+def equality_steps(equality: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return row-labelled equality steps for the local lemma packet."""
+
+    current = [int(value) for value in pair(*equality["start_pair"])]
+    steps = []
+    for step in equality["path"]:
+        next_pair = [int(value) for value in pair(*step["next_pair"])]
+        steps.append(
+            {
+                "row": int(step["row"]),
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+    return steps
+
+
+def source_artifacts(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the T03 packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+            "role": "source T03 multi-family self-edge template record",
+            "schema": self_edge_packet.get("schema"),
+            "status": self_edge_packet.get("status"),
+            "trust": self_edge_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+            "role": "catalog crosswalk confirming T03 coverage and shape summary",
+            "schema": template_catalog.get("schema"),
+            "status": template_catalog.get("status"),
+            "trust": template_catalog.get("trust"),
+        },
+    ]
+
+
+def _primary_conflict(replay: dict[str, Any], strict: Mapping[str, Any]) -> dict[str, Any]:
+    for conflict in replay["self_edge_conflicts"]:
+        if (
+            conflict["row"] == strict["row"]
+            and conflict["outer_pair"] == strict["outer_pair"]
+            and conflict["inner_pair"] == strict["inner_pair"]
+        ):
+            return {
+                **conflict,
+                "outer_span": strict["outer_span"],
+                "inner_span": strict["inner_span"],
+            }
+    raise AssertionError("primary T03 self-edge conflict not found in replay")
+
+
+def _source_template_summary(template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_id": str(template["template_id"]),
+        "template_key": str(template["template_key"]),
+        "status": str(template["status"]),
+        "assignment_count": int(template["assignment_count"]),
+        "assignment_ids": list(template["assignment_ids"]),
+        "family_count": int(template["family_count"]),
+        "families": list(template["families"]),
+        "orbit_size_sum": int(template["orbit_size_sum"]),
+        "core_size": int(template["core_size"]),
+        "strict_edge_count": int(template["strict_edge_count"]),
+        "path_length_counts": template["path_length_counts"],
+        "shared_endpoint_counts": template["shared_endpoint_counts"],
+        "selected_path_shape_counts": template["selected_path_shape_counts"],
+        "self_edge_shape_counts": template["self_edge_shape_counts"],
+    }
+
+
+def _family_source_summary(family: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "family_id": str(family["family_id"]),
+        "template_id": str(family["template_id"]),
+        "status": str(family["status"]),
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "path_length": int(family["path_length"]),
+        "strict_inequality": family["strict_inequality"],
+        "distance_equality": family["distance_equality"],
+        "equality_chain": equality_chain(family["distance_equality"]),
+    }
+
+
+def _assert_source_records(
+    template: dict[str, Any],
+    families: Mapping[str, dict[str, Any]],
+    catalog_record: dict[str, Any],
+) -> None:
+    if template["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected template id")
+    if template["template_key"] != EXPECTED_TEMPLATE_KEY:
+        raise AssertionError("unexpected T03 template key")
+    if template["status"] != "self_edge":
+        raise AssertionError("T03 must remain a self-edge template")
+    if template["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("unexpected T03 assignment ids")
+    if template["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected T03 assignment count")
+    if template["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("unexpected T03 family list")
+    if template["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("unexpected T03 family count")
+    if template["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("unexpected T03 orbit-size sum")
+    if template["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected T03 core size")
+    if template["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("unexpected T03 strict-edge count")
+    if template["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected T03 path-length counts")
+    if template["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("unexpected T03 shared-endpoint counts")
+    if template["selected_path_shape_counts"] != EXPECTED_SELECTED_PATH_SHAPE_COUNTS:
+        raise AssertionError("unexpected T03 selected-path shape counts")
+
+    for family_id in EXPECTED_FAMILY_IDS:
+        family = families[family_id]
+        rows = _normalize_rows(family["core_selected_rows"])
+        equality = family["distance_equality"]
+        strict = family["strict_inequality"]
+        validate_equality_path(rows, equality)
+        if family["family_id"] != family_id:
+            raise AssertionError("unexpected family id")
+        if family["template_id"] != EXPECTED_TEMPLATE_ID:
+            raise AssertionError("family/template mismatch")
+        if family["status"] != "self_edge":
+            raise AssertionError(f"{family_id} must remain a self-edge record")
+        if family["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[family_id]:
+            raise AssertionError(f"unexpected {family_id} assignment count")
+        if family["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[family_id]:
+            raise AssertionError(f"unexpected {family_id} orbit size")
+        if family["core_size"] != EXPECTED_CORE_SIZE:
+            raise AssertionError(f"unexpected {family_id} core size")
+        if rows != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS[family_id]):
+            raise AssertionError(f"unexpected {family_id} core rows")
+        if strict != EXPECTED_STRICT_INEQUALITIES[family_id]:
+            raise AssertionError(f"unexpected {family_id} strict inequality")
+        if equality != EXPECTED_DISTANCE_EQUALITIES[family_id]:
+            raise AssertionError(f"unexpected {family_id} equality path")
+        if equality_chain(equality) != [list(item) for item in EXPECTED_EQUALITY_CHAINS[family_id]]:
+            raise AssertionError(f"unexpected {family_id} equality chain")
+        if strict["outer_pair"] != equality["start_pair"]:
+            raise AssertionError(f"{family_id} strict outer pair must start equality path")
+        if strict["inner_pair"] != equality["end_pair"]:
+            raise AssertionError(f"{family_id} strict inner pair must end equality path")
+
+    if catalog_record["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected catalog template id")
+    if catalog_record["status"] != "self_edge":
+        raise AssertionError("unexpected catalog T03 status")
+    coverage = catalog_record["coverage"]
+    if coverage["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("catalog T03 assignment count mismatch")
+    if coverage["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("catalog T03 assignment ids mismatch")
+    if coverage["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("catalog T03 family mismatch")
+    if coverage["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("catalog T03 family count mismatch")
+    if coverage["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("catalog T03 orbit-size sum mismatch")
+    hypothesis = catalog_record["hypothesis_shape"]
+    if hypothesis["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("catalog T03 core-size mismatch")
+    if hypothesis["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("catalog T03 strict-edge mismatch")
+    if hypothesis["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("catalog T03 path-length mismatch")
+    if hypothesis["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("catalog T03 shared-endpoint mismatch")
+    if hypothesis["selected_path_shape_counts"] != EXPECTED_SELECTED_PATH_SHAPE_COUNTS:
+        raise AssertionError("catalog T03 selected-path shape mismatch")
+
+    summaries = {
+        str(summary["family_id"]): summary
+        for summary in catalog_record["family_summaries"]
+        if isinstance(summary, dict) and "family_id" in summary
+    }
+    for family_id in EXPECTED_FAMILY_IDS:
+        summary = summaries.get(family_id)
+        if summary is None:
+            raise AssertionError(f"catalog missing {family_id} summary")
+        strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+        if summary["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[family_id]:
+            raise AssertionError(f"catalog {family_id} assignment count mismatch")
+        if summary["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[family_id]:
+            raise AssertionError(f"catalog {family_id} orbit size mismatch")
+        if summary["outer_pair"] != strict["outer_pair"]:
+            raise AssertionError(f"catalog {family_id} outer pair mismatch")
+        if summary["inner_pair"] != strict["inner_pair"]:
+            raise AssertionError(f"catalog {family_id} inner pair mismatch")
+
+
+def _family_local_lemma(family_id: str, strict: Mapping[str, Any], equality: Mapping[str, Any]) -> dict[str, Any]:
+    path_rows = [int(step["row"]) for step in equality["path"]]
+    return {
+        "packet_name": f"T03/{family_id} self-edge local lemma packet",
+        "review_status": "review_pending",
+        "hypothesis_scope": (
+            "Natural cyclic order on labels 0..8 plus the four listed selected "
+            "rows; no claim is made about other n=9 templates."
+        ),
+        "selected_distance_equalities": equality_steps(equality),
+        "strict_inequality_statement": (
+            f"Row {strict['row']} has witness order {strict['witness_order']}, "
+            f"so the outer pair {strict['outer_pair']} strictly contains the "
+            f"inner pair {strict['inner_pair']} in that row's vertex-circle order."
+        ),
+        "equality_statement": (
+            f"Rows {path_rows} identify {equality['start_pair']} with "
+            f"{equality['end_pair']} in the selected-distance quotient."
+        ),
+        "contradiction": (
+            "The strict graph has a reflexive strict edge after selected-distance "
+            "quotienting."
+        ),
+    }
+
+
+def _family_packet(family: dict[str, Any]) -> dict[str, Any]:
+    family_id = str(family["family_id"])
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    strict = family["strict_inequality"]
+    replay_result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parse_selected_rows(rows),
+    )
+    replay = result_to_json(replay_result)
+    primary = _primary_conflict(replay, strict)
+    return {
+        "family_id": family_id,
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "core_selected_rows": rows,
+        "strict_inequality": strict,
+        "distance_equality": equality,
+        "equality_chain": equality_chain(equality),
+        "local_lemma": _family_local_lemma(family_id, strict, equality),
+        "replay": {
+            "status": replay["status"],
+            "selected_row_count": replay["selected_row_count"],
+            "strict_edge_count": replay["strict_edge_count"],
+            "self_edge_conflict_count": len(replay["self_edge_conflicts"]),
+            "cycle_edge_count": len(replay["cycle_edges"]),
+            "primary_self_edge_conflict": primary,
+            "self_edge_conflicts": replay["self_edge_conflicts"],
+        },
+        "source_family_record": _family_source_summary(family),
+    }
+
+
+def t03_self_edge_lemma_packet_payload(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the focused review-pending T03 local lemma packet."""
+
+    if self_edge_packet.get("schema") != SELF_EDGE_TEMPLATE_PACKET_SCHEMA:
+        raise ValueError("unexpected self-edge template packet schema")
+    if template_catalog.get("schema") != TEMPLATE_LEMMA_CATALOG_SCHEMA:
+        raise ValueError("unexpected template lemma catalog schema")
+
+    template = _template_record(self_edge_packet)
+    families = _family_records_by_id(template)
+    catalog_record = _catalog_record(template_catalog)
+    _assert_source_records(template, families, catalog_record)
+    family_packets = [_family_packet(families[family_id]) for family_id in EXPECTED_FAMILY_IDS]
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "family_packets": family_packets,
+        "source_template_record": _source_template_summary(template),
+        "source_catalog_record": catalog_record,
+        "interpretation": [
+            "This packet isolates the multi-family T03 self-edge motif from existing review-pending n=9 diagnostics.",
+            "Each family record has four local rows that force the displayed equality chain.",
+            "Each family record has one vertex-circle strict inequality between the same quotient class.",
+            "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": source_artifacts(self_edge_packet, template_catalog),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_t03_self_edge_lemma_packet(payload)
+    return payload
+
+
+def _family_packets_by_id(payload: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        raise AssertionError("family_packets must be a list")
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        raise AssertionError(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, got {len(packets)}"
+        )
+    by_id = {
+        str(packet["family_id"]): packet
+        for packet in packets
+        if isinstance(packet, dict) and "family_id" in packet
+    }
+    if len(by_id) != len(packets):
+        raise AssertionError("family_packets must not contain duplicate family ids")
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        raise AssertionError(f"unexpected family packet ids: {sorted(by_id)!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def assert_expected_t03_self_edge_lemma_packet(payload: Mapping[str, Any]) -> None:
+    """Assert stable constants for the focused T03 local lemma packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}")
+
+    family_packets = _family_packets_by_id(payload)
+    for family_id, packet in family_packets.items():
+        if packet["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[family_id]:
+            raise AssertionError(f"{family_id} assignment count mismatch")
+        if packet["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[family_id]:
+            raise AssertionError(f"{family_id} orbit size mismatch")
+        if packet["core_size"] != EXPECTED_CORE_SIZE:
+            raise AssertionError(f"{family_id} core size mismatch")
+        if packet["core_selected_rows"] != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS[family_id]):
+            raise AssertionError(f"{family_id} core rows mismatch")
+        if packet["strict_inequality"] != EXPECTED_STRICT_INEQUALITIES[family_id]:
+            raise AssertionError(f"{family_id} strict inequality mismatch")
+        if packet["distance_equality"] != EXPECTED_DISTANCE_EQUALITIES[family_id]:
+            raise AssertionError(f"{family_id} equality path mismatch")
+        if packet["equality_chain"] != [list(item) for item in EXPECTED_EQUALITY_CHAINS[family_id]]:
+            raise AssertionError(f"{family_id} equality chain mismatch")
+
+        replay = packet["replay"]
+        if replay["status"] != "self_edge":
+            raise AssertionError(f"{family_id} replay status mismatch")
+        if replay["selected_row_count"] != EXPECTED_CORE_SIZE:
+            raise AssertionError(f"{family_id} selected row count mismatch")
+        if replay["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+            raise AssertionError(f"{family_id} strict-edge count mismatch")
+        if replay["self_edge_conflict_count"] != EXPECTED_SELF_EDGE_CONFLICT_COUNT:
+            raise AssertionError(f"{family_id} self-edge conflict count mismatch")
+        if replay["cycle_edge_count"] != EXPECTED_CYCLE_EDGE_COUNT:
+            raise AssertionError(f"{family_id} cycle-edge count mismatch")
+        primary = replay["primary_self_edge_conflict"]
+        strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+        for key in ("row", "witness_order", "outer_pair", "inner_pair", "outer_interval", "inner_interval"):
+            if primary[key] != strict[key]:
+                raise AssertionError(f"{family_id} primary conflict {key} mismatch")
+        lemma = packet["local_lemma"]
+        if lemma["review_status"] != "review_pending":
+            raise AssertionError(f"{family_id} local lemma review status mismatch")
+
+    if "No proof of the n=9 case is claimed." not in payload.get("interpretation", []):
+        raise AssertionError("interpretation must preserve the no-proof statement")

--- a/tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_t03_self_edge_lemma_packet import (
+    EXPECTED_FAMILY_IDS,
+    assert_expected_t03_self_edge_lemma_packet,
+    t03_self_edge_lemma_packet_payload,
+)
+from scripts.check_n9_vertex_circle_t03_self_edge_lemma_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _family_packets(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {str(packet["family_id"]): packet for packet in payload["family_packets"]}  # type: ignore[index]
+
+
+def _template_record(source_payloads: dict[str, object]) -> dict[str, object]:
+    for template in source_payloads["self_edge_packet"]["templates"]:  # type: ignore[index]
+        if template["template_id"] == "T03":
+            return template
+    raise AssertionError("missing T03 template")
+
+
+def _catalog_record(source_payloads: dict[str, object]) -> dict[str, object]:
+    for template in source_payloads["template_catalog"]["templates"]:  # type: ignore[index]
+        if template["template_id"] == "T03":
+            return template
+    raise AssertionError("missing T03 catalog record")
+
+
+def test_t03_self_edge_lemma_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_t03_self_edge_lemma_packet(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "proof-mining scaffolding only" in payload["claim_scope"]
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["template_id"] == "T03"
+    assert payload["template_key"] == "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+    assert payload["assignment_count"] == 20
+    assert payload["family_count"] == 2
+    assert payload["family_ids"] == ["F05", "F15"]
+    assert payload["family_assignment_counts"] == {"F05": 18, "F15": 2}
+    assert payload["family_orbit_sizes"] == {"F05": 18, "F15": 2}
+    assert payload["orbit_size_sum"] == 20
+    assert payload["core_size"] == 4
+    assert payload["strict_edge_count"] == 36
+    assert payload["path_length_counts"] == {"3": 20}
+    assert payload["shared_endpoint_counts"] == {"1": 20}
+    assert payload["selected_path_shape_counts"] == {"2:1:1:path=3": 20}
+
+
+def test_t03_self_edge_lemma_packet_records_expected_local_shapes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packets = _family_packets(payload)
+
+    assert set(packets) == set(EXPECTED_FAMILY_IDS)
+    assert packets["F05"]["core_selected_rows"] == [
+        [1, 2, 5, 7, 8],
+        [2, 1, 3, 4, 8],
+        [3, 0, 2, 4, 7],
+        [6, 1, 3, 5, 7],
+    ]
+    assert packets["F05"]["strict_inequality"]["row"] == 6  # type: ignore[index]
+    assert packets["F05"]["strict_inequality"]["witness_order"] == [7, 1, 3, 5]  # type: ignore[index]
+    assert packets["F05"]["strict_inequality"]["outer_pair"] == [3, 7]  # type: ignore[index]
+    assert packets["F05"]["strict_inequality"]["inner_pair"] == [1, 7]  # type: ignore[index]
+    assert packets["F05"]["equality_chain"] == [[3, 7], [2, 3], [1, 2], [1, 7]]
+
+    assert packets["F15"]["core_selected_rows"] == [
+        [0, 1, 3, 4, 8],
+        [1, 0, 2, 4, 5],
+        [2, 1, 3, 5, 6],
+        [3, 2, 4, 6, 7],
+    ]
+    assert packets["F15"]["strict_inequality"]["row"] == 0  # type: ignore[index]
+    assert packets["F15"]["strict_inequality"]["witness_order"] == [1, 3, 4, 8]  # type: ignore[index]
+    assert packets["F15"]["strict_inequality"]["outer_pair"] == [1, 4]  # type: ignore[index]
+    assert packets["F15"]["strict_inequality"]["inner_pair"] == [3, 4]  # type: ignore[index]
+    assert packets["F15"]["strict_inequality"]["inner_interval"] == [1, 2]  # type: ignore[index]
+    assert packets["F15"]["equality_chain"] == [[1, 4], [1, 2], [2, 3], [3, 4]]
+
+    for family_id, packet in packets.items():
+        assert packet["local_lemma"]["review_status"] == "review_pending"  # type: ignore[index]
+        assert "four listed selected rows" in packet["local_lemma"]["hypothesis_scope"]  # type: ignore[index]
+        assert packet["replay"]["status"] == "self_edge"  # type: ignore[index]
+        assert packet["replay"]["selected_row_count"] == 4  # type: ignore[index]
+        assert packet["replay"]["strict_edge_count"] == 36  # type: ignore[index]
+        assert packet["replay"]["self_edge_conflict_count"] == 1  # type: ignore[index]
+        assert packet["replay"]["cycle_edge_count"] == 0  # type: ignore[index]
+        assert packet["replay"]["primary_self_edge_conflict"]["row"] == packet["strict_inequality"]["row"]  # type: ignore[index]
+        assert family_id in {"F05", "F15"}
+
+
+def test_t03_self_edge_lemma_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["template_id"] == "T03"
+    assert summary["family_count"] == 2
+    assert summary["assignment_count"] == 20
+    assert summary["replay_statuses"] == ["self_edge", "self_edge"]
+
+
+def test_t03_self_edge_lemma_packet_rejects_tampered_f05_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packets = _family_packets(payload)
+    packets["F05"]["distance_equality"]["path"][0]["next_pair"] = [2, 4]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F05 distance_equality mismatch" in error for error in errors)
+    assert any("expected T03 self-edge lemma packet" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_tampered_f15_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packets = _family_packets(payload)
+    packets["F15"]["distance_equality"]["path"][1]["next_pair"] = [2, 4]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F15 distance_equality mismatch" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_tampered_f05_strict_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packets = _family_packets(payload)
+    packets["F05"]["strict_inequality"]["row"] = 0  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F05 strict_inequality mismatch" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_tampered_f15_inner_interval() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packets = _family_packets(payload)
+    packets["F15"]["strict_inequality"]["inner_interval"] = [0, 1]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F15 strict_inequality mismatch" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_core_size_three_copy_error() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["core_size"] = 3
+    packets = _family_packets(payload)
+    packets["F05"]["replay"]["selected_row_count"] = 3  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("core_size mismatch" in error for error in errors)
+    assert any("F05 replay selected_row_count mismatch" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_missing_family() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["family_packets"] = [
+        packet for packet in payload["family_packets"] if packet["family_id"] != "F15"
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family packet ids mismatch" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_duplicate_family_packet() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["family_packets"].append(copy.deepcopy(payload["family_packets"][0]))
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family_packets length mismatch" in error for error in errors)
+    assert any("duplicate family packet id: F05" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_t03_self_edge_lemma_packet_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    template = _template_record(sources)
+    template["family_records"][0]["strict_inequality"]["row"] = 0  # F05 is the first T03 family.
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source self-edge template packet invalid" in error
+        or "source-bound T03 self-edge lemma packet failed" in error
+        for error in errors
+    )
+
+
+def test_t03_self_edge_lemma_packet_detects_catalog_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    catalog = _catalog_record(sources)
+    catalog["coverage"]["families"] = ["F05"]
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source template lemma catalog invalid" in error
+        or "source-bound T03 self-edge lemma packet failed" in error
+        for error in errors
+    )
+
+
+@pytest.mark.artifact
+def test_t03_self_edge_lemma_packet_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == t03_self_edge_lemma_packet_payload(
+        source_payloads["self_edge_packet"],
+        source_payloads["template_catalog"],
+    )
+
+
+@pytest.mark.artifact
+def test_t03_self_edge_lemma_packet_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["template_id"] == "T03"
+    assert payload["family_count"] == 2
+    assert payload["replay_statuses"] == ["self_edge", "self_edge"]
+
+
+@pytest.mark.artifact
+def test_t03_self_edge_lemma_packet_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "t03_self_edge_lemma_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_t03_self_edge_lemma_packet_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "t03_self_edge_lemma_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -131,6 +131,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "
         "--spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125"
         in command_texts


### PR DESCRIPTION
## Summary
- add a focused review-pending T03 multi-family n=9 self-edge local lemma packet
- replay the T03 family cores (`F05`, `F15`) with four selected rows, per-family equality chains, strict inequalities, and self-edge conflicts
- register the generated artifact in provenance metadata, audit commands, review docs, and targeted tests

## Scope
Proof-mining diagnostic only. This does not prove `n=9`, does not claim a counterexample, does not complete independent review of the exhaustive checker, and does not update official/global status.

## Verification
- `python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --assert-expected --write --json`
- `python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py tests/test_run_artifact_audit.py -q` (`16 passed, 3 deselected`)
- `python -m pytest tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py tests/test_run_artifact_audit.py -q -m artifact` (`3 passed, 16 deselected`)
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`535 passed, 81 deselected`)