### PR TITLE
Add n9 T10 strict-cycle lemma packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
+++ b/data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
@@ -1,0 +1,737 @@
+{
+  "assignment_count": 18,
+  "assignment_ids": [
+    "A020",
+    "A040",
+    "A047",
+    "A071",
+    "A080",
+    "A081",
+    "A083",
+    "A093",
+    "A095",
+    "A111",
+    "A126",
+    "A147",
+    "A151",
+    "A153",
+    "A154",
+    "A157",
+    "A164",
+    "A180"
+  ],
+  "claim_scope": "Focused T10/F12 strict-cycle local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "connector_path_length_counts": {
+    "1": 18,
+    "2": 18
+  },
+  "core_size": 4,
+  "cycle_length": 2,
+  "cycle_length_counts": {
+    "2": 18
+  },
+  "cycle_span_counts": [
+    {
+      "count": 2,
+      "inner_span": 1,
+      "outer_span": 2
+    }
+  ],
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "family_assignment_counts": {
+    "F12": 18
+  },
+  "family_count": 1,
+  "family_ids": [
+    "F12"
+  ],
+  "family_orbit_sizes": {
+    "F12": 18
+  },
+  "family_packets": [
+    {
+      "assignment_count": 18,
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          6,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          8,
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_pair_chain": [
+        {
+          "cycle_step": 0,
+          "equality_chain_to_next_outer_pair": [
+            [
+              0,
+              3
+            ],
+            [
+              3,
+              6
+            ],
+            [
+              1,
+              6
+            ]
+          ],
+          "next_outer_pair": [
+            1,
+            6
+          ],
+          "strict_from_outer_pair": [
+            0,
+            6
+          ],
+          "strict_to_inner_pair": [
+            0,
+            3
+          ]
+        },
+        {
+          "cycle_step": 1,
+          "equality_chain_to_next_outer_pair": [
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              6
+            ]
+          ],
+          "next_outer_pair": [
+            0,
+            6
+          ],
+          "strict_from_outer_pair": [
+            1,
+            6
+          ],
+          "strict_to_inner_pair": [
+            0,
+            1
+          ]
+        }
+      ],
+      "cycle_steps": [
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              1,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  6
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  6
+                ],
+                "row": 6
+              }
+            ],
+            "start_pair": [
+              0,
+              3
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [
+              0,
+              3,
+              6,
+              7
+            ]
+          }
+        },
+        {
+          "equality_to_next_outer_pair": {
+            "end_pair": [
+              0,
+              6
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  6
+                ],
+                "row": 0
+              }
+            ],
+            "start_pair": [
+              0,
+              1
+            ]
+          },
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [
+              4,
+              6,
+              0,
+              1
+            ]
+          }
+        }
+      ],
+      "family_id": "F12",
+      "local_lemma": {
+        "contradiction": "The strict graph has a directed strict cycle of length 2 after selected-distance quotienting.",
+        "cycle_closure_statement": "Each strict edge's inner pair is identified with the next strict edge's outer pair, closing a directed two-edge strict cycle in the selected-distance quotient.",
+        "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the four listed selected rows; no claim is made about other n=9 templates.",
+        "packet_name": "T10/F12 strict-cycle local lemma packet",
+        "review_status": "review_pending",
+        "selected_distance_equalities": [
+          {
+            "cycle_step": 0,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  0,
+                  3
+                ],
+                "right_pair": [
+                  3,
+                  6
+                ],
+                "row": 3
+              },
+              {
+                "left_pair": [
+                  3,
+                  6
+                ],
+                "right_pair": [
+                  1,
+                  6
+                ],
+                "row": 6
+              }
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  0,
+                  1
+                ],
+                "right_pair": [
+                  0,
+                  6
+                ],
+                "row": 0
+              }
+            ]
+          }
+        ],
+        "strict_inequality_statements": [
+          "Step 0: row 8 has witness order [0, 3, 6, 7], so outer pair [0, 6] strictly contains inner pair [0, 3].",
+          "Step 1: row 3 has witness order [4, 6, 0, 1], so outer pair [1, 6] strictly contains inner pair [0, 1]."
+        ]
+      },
+      "orbit_size": 18,
+      "replay": {
+        "cycle_edge_count": 2,
+        "cycle_edges": [
+          {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "row": 8,
+            "witness_order": [
+              0,
+              3,
+              6,
+              7
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "row": 3,
+            "witness_order": [
+              4,
+              6,
+              0,
+              1
+            ]
+          }
+        ],
+        "selected_row_count": 4,
+        "self_edge_conflict_count": 0,
+        "self_edge_conflicts": [],
+        "status": "strict_cycle",
+        "strict_edge_count": 36
+      },
+      "source_family_record": {
+        "assignment_count": 18,
+        "core_size": 4,
+        "cycle_length": 2,
+        "cycle_steps": [
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                1,
+                6
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    3,
+                    6
+                  ],
+                  "row": 3
+                },
+                {
+                  "next_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 6
+                }
+              ],
+              "start_pair": [
+                0,
+                3
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                0,
+                3
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                0,
+                3
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                2
+              ],
+              "outer_pair": [
+                0,
+                6
+              ],
+              "outer_span": 2,
+              "row": 8,
+              "witness_order": [
+                0,
+                3,
+                6,
+                7
+              ]
+            }
+          },
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                0,
+                6
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    0,
+                    6
+                  ],
+                  "row": 0
+                }
+              ],
+              "start_pair": [
+                0,
+                1
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                1
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                3
+              ],
+              "outer_interval": [
+                1,
+                3
+              ],
+              "outer_pair": [
+                1,
+                6
+              ],
+              "outer_span": 2,
+              "row": 3,
+              "witness_order": [
+                4,
+                6,
+                0,
+                1
+              ]
+            }
+          }
+        ],
+        "equality_chains": [
+          [
+            [
+              0,
+              3
+            ],
+            [
+              3,
+              6
+            ],
+            [
+              1,
+              6
+            ]
+          ],
+          [
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              6
+            ]
+          ]
+        ],
+        "family_id": "F12",
+        "orbit_size": 18,
+        "span_signature": "2:1,2:1",
+        "status": "strict_cycle",
+        "strict_edge_count": 36,
+        "template_id": "T10"
+      },
+      "span_signature": "2:1,2:1",
+      "strict_edge_count": 36
+    }
+  ],
+  "interpretation": [
+    "This packet isolates the single-family T10 strict-cycle motif from existing review-pending n=9 diagnostics.",
+    "The F12 record has four local rows and two directed strict inequalities.",
+    "Each strict edge's inner pair is connected by selected-distance equalities to the next strict edge's outer pair.",
+    "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "orbit_size_sum": 18,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+      "role": "source T10/F12 strict-cycle template record",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+      "role": "catalog crosswalk confirming T10 coverage and strict-cycle shape summary",
+      "schema": "erdos97.n9_vertex_circle_template_lemma_catalog.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_catalog_record": {
+    "conclusion_shape": {
+      "certificate_fields": [
+        "cycle_steps",
+        "equality_to_next_outer_pair"
+      ],
+      "kind": "strict_cycle",
+      "strict_graph_obstruction": "directed strict cycle after selected-distance quotienting"
+    },
+    "coverage": {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A020",
+        "A040",
+        "A047",
+        "A071",
+        "A080",
+        "A081",
+        "A083",
+        "A093",
+        "A095",
+        "A111",
+        "A126",
+        "A147",
+        "A151",
+        "A153",
+        "A154",
+        "A157",
+        "A164",
+        "A180"
+      ],
+      "families": [
+        "F12"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18
+    },
+    "family_summaries": [
+      {
+        "assignment_count": 18,
+        "contradiction_kind": "strict_cycle",
+        "core_size": 4,
+        "cycle_length": 2,
+        "cycle_step_count": 2,
+        "family_id": "F12",
+        "orbit_size": 18,
+        "span_signature": "2:1,2:1",
+        "status": "strict_cycle",
+        "strict_edge_count": 36,
+        "template_id": "T10"
+      }
+    ],
+    "hypothesis_shape": {
+      "connector_path_length_counts": {
+        "1": 18,
+        "2": 18
+      },
+      "core_size": 4,
+      "cycle_length": 2,
+      "cycle_length_counts": {
+        "2": 18
+      },
+      "cycle_span_counts": [
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 2
+        }
+      ],
+      "span_signature_counts": {
+        "2:1,2:1": 18
+      },
+      "strict_edge_count": 36
+    },
+    "status": "strict_cycle",
+    "template_id": "T10",
+    "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+  },
+  "source_template_record": {
+    "assignment_count": 18,
+    "assignment_ids": [
+      "A020",
+      "A040",
+      "A047",
+      "A071",
+      "A080",
+      "A081",
+      "A083",
+      "A093",
+      "A095",
+      "A111",
+      "A126",
+      "A147",
+      "A151",
+      "A153",
+      "A154",
+      "A157",
+      "A164",
+      "A180"
+    ],
+    "connector_path_length_counts": {
+      "1": 18,
+      "2": 18
+    },
+    "core_size": 4,
+    "cycle_length": 2,
+    "cycle_length_counts": {
+      "2": 18
+    },
+    "cycle_span_counts": [
+      {
+        "count": 2,
+        "inner_span": 1,
+        "outer_span": 2
+      }
+    ],
+    "families": [
+      "F12"
+    ],
+    "family_count": 1,
+    "orbit_size_sum": 18,
+    "span_signature_counts": {
+      "2:1,2:1": 18
+    },
+    "status": "strict_cycle",
+    "strict_edge_count": 36,
+    "template_id": "T10",
+    "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+  },
+  "span_signature_counts": {
+    "2:1,2:1": 18
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_edge_count": 36,
+  "template_id": "T10",
+  "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t03-self-edge-lemma.md`](n9-vertex-circle-t03-self-edge-lemma.md):
   focused review-pending T03 multi-family self-edge local lemma packet for
   proof mining.
+- [`n9-vertex-circle-t10-strict-cycle-lemma.md`](n9-vertex-circle-t10-strict-cycle-lemma.md):
+  focused review-pending T10/F12 strict-cycle local lemma packet for proof
+  mining.
 - [`n10-vertex-circle-singleton-slices.md`](n10-vertex-circle-singleton-slices.md):
   review-pending `n=10` singleton-slice finite-case draft, including the
   secondary first-five replay cross-check.

--- a/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
@@ -1,0 +1,79 @@
+# n=9 Vertex-circle T10 Strict-cycle Local Lemma Packet
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one focused proof-mining packet for the single-family `T10`
+strict-cycle motif. It does not claim a proof of `n=9`, does not claim a
+counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Packet scope
+
+The checked artifact is
+`data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`.
+It is derived from:
+
+- `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
+
+The packet covers 18 assignment ids in one family:
+
+```text
+F12: 18 assignments
+```
+
+The family has a four-row core and replays to a directed strict cycle with 36
+strict edges, two cycle edges, and no self-edge conflict. The local obstruction
+is a two-step quotient cycle, not a reflexive self-edge.
+
+## Family core
+
+`F12`:
+
+```text
+[0, 1, 2, 5, 6]
+[3, 0, 1, 4, 6]
+[6, 1, 3, 4, 7]
+[8, 0, 3, 6, 7]
+
+strict: [0, 6] > [0, 3] from row 8
+path:   [0, 3] -> [3, 6] -> [1, 6]
+
+strict: [1, 6] > [0, 1] from row 3
+path:   [0, 1] -> [0, 6]
+```
+
+Thus the packet isolates the directed cycle
+
+```text
+[0, 6] > [0, 3] = [3, 6] = [1, 6] > [0, 1] = [0, 6].
+```
+
+## Commands
+
+Generate and check the packet:
+
+```bash
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py -q -m "artifact"
+```
+
+## Review standard
+
+Before treating this as a reusable local lemma, a reviewer should restate the
+incidence and cyclic-order hypotheses without relying on `T10` as a theorem
+name, then prove directly for the `F12` core that the listed rows force the two
+strict inequalities and the two connector chains. The packet is a small replay
+aid for that review, not an independent proof of the `n=9` case.

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -64,6 +64,7 @@ python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -157,6 +157,8 @@ Next steps:
   the next focused review-pending T02 multi-family self-edge local lemma packet;
 - use `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json` as
   the next focused review-pending T03 multi-family self-edge local lemma packet;
+- use `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
+  as the next focused review-pending T10/F12 strict-cycle local lemma packet;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -84,6 +84,7 @@ python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -810,6 +810,56 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_t10_strict_cycle_lemma_packet
+    path: data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+    command: python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+    check_command: python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused T10/F12 strict-cycle local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Focused T10/F12 strict-cycle local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      template_id: T10
+      template_key: strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2
+      assignment_count: 18
+      family_count: 1
+      family_ids:
+        - F12
+      family_assignment_counts.F12: 18
+      family_orbit_sizes.F12: 18
+      orbit_size_sum: 18
+      core_size: 4
+      cycle_length: 2
+      strict_edge_count: 36
+      cycle_length_counts.2: 18
+      connector_path_length_counts.1: 18
+      connector_path_length_counts.2: 18
+      "span_signature_counts.2:1,2:1": 18
+      cycle_span_counts:
+        - count: 2
+          inner_span: 1
+          outer_span: 2
+      provenance.command: python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - T10 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the local lemma packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_groebner_real_root_decoders
     path: data/certificates/n9_groebner_real_root_decoders.json
     kind: algebraic_decoder_artifact

--- a/scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Generate or check the focused T10 n=9 strict-cycle local lemma packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_strict_cycle_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_STRICT_CYCLE_PACKET,
+    validate_payload as validate_strict_cycle_packet,
+)
+from check_n9_vertex_circle_template_lemma_catalog import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATE_CATALOG,
+    validate_payload as validate_template_catalog,
+)
+from erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    EXPECTED_ASSIGNMENT_IDS,
+    EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS,
+    EXPECTED_CORE_SELECTED_ROWS,
+    EXPECTED_CYCLE_LENGTH,
+    EXPECTED_CYCLE_LENGTH_COUNTS,
+    EXPECTED_CYCLE_SPAN_COUNTS,
+    EXPECTED_CYCLE_STEPS,
+    EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+    EXPECTED_FAMILY_IDS,
+    EXPECTED_FAMILY_ORBIT_SIZES,
+    EXPECTED_SPAN_SIGNATURE_COUNTS,
+    EXPECTED_TEMPLATE_KEY,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_t10_strict_cycle_lemma_packet,
+    source_artifacts,
+    t10_strict_cycle_lemma_packet_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_count",
+    "assignment_ids",
+    "claim_scope",
+    "connector_path_length_counts",
+    "core_size",
+    "cycle_length",
+    "cycle_length_counts",
+    "cycle_span_counts",
+    "cyclic_order",
+    "family_assignment_counts",
+    "family_count",
+    "family_ids",
+    "family_orbit_sizes",
+    "family_packets",
+    "interpretation",
+    "n",
+    "orbit_size_sum",
+    "provenance",
+    "row_size",
+    "schema",
+    "source_artifacts",
+    "source_catalog_record",
+    "source_template_record",
+    "span_signature_counts",
+    "status",
+    "strict_edge_count",
+    "template_id",
+    "template_key",
+    "trust",
+}
+EXPECTED_FAMILY_PACKET_KEYS = {
+    "assignment_count",
+    "core_selected_rows",
+    "core_size",
+    "cycle_length",
+    "cycle_pair_chain",
+    "cycle_steps",
+    "family_id",
+    "local_lemma",
+    "orbit_size",
+    "replay",
+    "source_family_record",
+    "span_signature",
+    "strict_edge_count",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    strict_cycle_packet_path: Path = DEFAULT_STRICT_CYCLE_PACKET,
+    template_catalog_path: Path = DEFAULT_TEMPLATE_CATALOG,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the focused T10 packet."""
+
+    return {
+        "strict_cycle_packet": load_artifact(_resolve(strict_cycle_packet_path)),
+        "template_catalog": load_artifact(_resolve(template_catalog_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    strict_cycle = source_payloads.get("strict_cycle_packet")
+    catalog = source_payloads.get("template_catalog")
+    if not isinstance(strict_cycle, dict):
+        errors.append("source strict-cycle template packet must be an object")
+    else:
+        errors.extend(
+            f"source strict-cycle template packet invalid: {error}"
+            for error in validate_strict_cycle_packet(strict_cycle, recompute=False)
+        )
+    if not isinstance(catalog, dict):
+        errors.append("source template lemma catalog must be an object")
+    else:
+        errors.extend(
+            f"source template lemma catalog invalid: {error}"
+            for error in validate_template_catalog(catalog, recompute=False)
+        )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return t10_strict_cycle_lemma_packet_payload(
+            source_payloads["strict_cycle_packet"],
+            source_payloads["template_catalog"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound T10 strict-cycle lemma packet failed: {exc}")
+        return None
+
+
+def _family_packets_by_id(payload: dict[str, Any], errors: list[str]) -> dict[str, dict[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        errors.append("family_packets must be a list")
+        return {}
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, "
+            f"got {len(packets)}"
+        )
+    by_id: dict[str, dict[str, Any]] = {}
+    for packet in packets:
+        if not isinstance(packet, dict):
+            errors.append("family_packets entries must be objects")
+            continue
+        family_id = str(packet.get("family_id"))
+        if family_id in by_id:
+            errors.append(f"duplicate family packet id: {family_id}")
+        by_id[family_id] = packet
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family packet ids mismatch: expected {list(EXPECTED_FAMILY_IDS)!r}, "
+            f"got {sorted(by_id)!r}"
+        )
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS if family_id in by_id}
+
+
+def _validate_local_lemma(packet: dict[str, Any], errors: list[str]) -> None:
+    lemma = packet.get("local_lemma")
+    if not isinstance(lemma, dict):
+        errors.append("F12 local_lemma must be an object")
+        return
+    expect_equal(errors, "F12 local_lemma review_status", lemma.get("review_status"), "review_pending")
+    selected_equalities = lemma.get("selected_distance_equalities")
+    if not isinstance(selected_equalities, list) or len(selected_equalities) != EXPECTED_CYCLE_LENGTH:
+        errors.append("F12 local_lemma selected_distance_equalities must have two cycle steps")
+    strict_statements = lemma.get("strict_inequality_statements")
+    if not isinstance(strict_statements, list) or len(strict_statements) != EXPECTED_CYCLE_LENGTH:
+        errors.append("F12 local_lemma strict_inequality_statements must have two entries")
+    hypothesis = str(lemma.get("hypothesis_scope", ""))
+    if "four listed selected rows" not in hypothesis:
+        errors.append("F12 local_lemma hypothesis must mention four selected rows")
+    closure = str(lemma.get("cycle_closure_statement", ""))
+    if "directed two-edge strict cycle" not in closure:
+        errors.append("F12 local_lemma must describe the directed two-edge strict cycle")
+    contradiction = str(lemma.get("contradiction", ""))
+    if "directed strict cycle" not in contradiction:
+        errors.append("F12 local_lemma contradiction must mention a directed strict cycle")
+    if "reflexive strict edge" in contradiction or "self-edge" in contradiction:
+        errors.append("F12 local_lemma contradiction must not describe a self-edge")
+
+
+def _validate_replay(packet: dict[str, Any], errors: list[str]) -> None:
+    replay = packet.get("replay")
+    if not isinstance(replay, dict):
+        errors.append("F12 replay must be an object")
+        return
+    expect_equal(errors, "F12 replay status", replay.get("status"), "strict_cycle")
+    expect_equal(errors, "F12 replay selected_row_count", replay.get("selected_row_count"), 4)
+    expect_equal(errors, "F12 replay strict_edge_count", replay.get("strict_edge_count"), 36)
+    expect_equal(errors, "F12 replay self_edge_conflict_count", replay.get("self_edge_conflict_count"), 0)
+    expect_equal(errors, "F12 replay cycle_edge_count", replay.get("cycle_edge_count"), 2)
+    if "primary_self_edge_conflict" in replay:
+        errors.append("F12 replay must not include primary_self_edge_conflict")
+    cycle_edges = replay.get("cycle_edges")
+    if not isinstance(cycle_edges, list) or len(cycle_edges) != EXPECTED_CYCLE_LENGTH:
+        errors.append("F12 replay cycle_edges must have two entries")
+        return
+    for index, edge in enumerate(cycle_edges):
+        if not isinstance(edge, dict):
+            errors.append(f"F12 replay cycle_edges[{index}] must be an object")
+            continue
+        strict = EXPECTED_CYCLE_STEPS[index]["strict_inequality"]
+        for key in (
+            "row",
+            "witness_order",
+            "outer_pair",
+            "inner_pair",
+            "outer_interval",
+            "inner_interval",
+            "outer_class",
+            "inner_class",
+        ):
+            expect_equal(errors, f"F12 replay cycle edge {index} {key}", edge.get(key), strict[key])
+        if edge.get("outer_class") == edge.get("inner_class"):
+            errors.append("F12 replay cycle edge quotient classes must be distinct")
+        if "outer_span" in edge or "inner_span" in edge:
+            errors.append("F12 replay cycle edges must not include source-only spans")
+
+
+def _validate_family_packet(packet: dict[str, Any], errors: list[str]) -> None:
+    if set(packet) != EXPECTED_FAMILY_PACKET_KEYS:
+        errors.append(
+            "F12 keys mismatch: "
+            f"expected {sorted(EXPECTED_FAMILY_PACKET_KEYS)!r}, got {sorted(packet)!r}"
+        )
+    expect_equal(errors, "F12 family_id", packet.get("family_id"), "F12")
+    expect_equal(errors, "F12 assignment_count", packet.get("assignment_count"), 18)
+    expect_equal(errors, "F12 orbit_size", packet.get("orbit_size"), 18)
+    expect_equal(errors, "F12 core_size", packet.get("core_size"), 4)
+    expect_equal(errors, "F12 cycle_length", packet.get("cycle_length"), EXPECTED_CYCLE_LENGTH)
+    expect_equal(errors, "F12 strict_edge_count", packet.get("strict_edge_count"), 36)
+    expect_equal(errors, "F12 span_signature", packet.get("span_signature"), "2:1,2:1")
+    expect_equal(
+        errors,
+        "F12 core_selected_rows",
+        packet.get("core_selected_rows"),
+        [list(row) for row in EXPECTED_CORE_SELECTED_ROWS],
+    )
+    expect_equal(errors, "F12 cycle_steps", packet.get("cycle_steps"), EXPECTED_CYCLE_STEPS)
+    _validate_local_lemma(packet, errors)
+    _validate_replay(packet, errors)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a focused T10 local lemma packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "template_id": "T10",
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": 18,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": 1,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": 18,
+        "core_size": 4,
+        "cycle_length": EXPECTED_CYCLE_LENGTH,
+        "strict_edge_count": 36,
+        "cycle_length_counts": EXPECTED_CYCLE_LENGTH_COUNTS,
+        "connector_path_length_counts": EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS,
+        "span_signature_counts": EXPECTED_SPAN_SIGNATURE_COUNTS,
+        "cycle_span_counts": EXPECTED_CYCLE_SPAN_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the no-proof statement")
+        if not any("proof mining" in item for item in interpretation):
+            errors.append("interpretation must preserve the proof-mining scope")
+        if not any("two directed strict inequalities" in item for item in interpretation):
+            errors.append("interpretation must preserve the strict-cycle scope")
+
+    for packet in _family_packets_by_id(payload, errors).values():
+        _validate_family_packet(packet, errors)
+
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            source_artifacts(
+                source_payloads["strict_cycle_packet"],
+                source_payloads["template_catalog"],
+            ),
+        )
+        expect_equal(
+            errors,
+            "source_template_record",
+            payload.get("source_template_record"),
+            expected_payload["source_template_record"],
+        )
+        expect_equal(
+            errors,
+            "source_catalog_record",
+            payload.get("source_catalog_record"),
+            expected_payload["source_catalog_record"],
+        )
+
+    try:
+        assert_expected_t10_strict_cycle_lemma_packet(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected T10 strict-cycle lemma packet counts failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "T10 strict-cycle lemma packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    family_packets = object_payload.get("family_packets")
+    family_packets = family_packets if isinstance(family_packets, list) else []
+    replay_statuses = [
+        packet.get("replay", {}).get("status")
+        for packet in family_packets
+        if isinstance(packet, dict) and isinstance(packet.get("replay"), dict)
+    ]
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "template_id": object_payload.get("template_id"),
+        "assignment_count": object_payload.get("assignment_count"),
+        "family_count": object_payload.get("family_count"),
+        "family_ids": object_payload.get("family_ids"),
+        "core_size": object_payload.get("core_size"),
+        "cycle_length": object_payload.get("cycle_length"),
+        "replay_statuses": replay_statuses,
+        "strict_edge_count": object_payload.get("strict_edge_count"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--strict-cycle-packet", type=Path, default=DEFAULT_STRICT_CYCLE_PACKET)
+    parser.add_argument("--template-catalog", type=Path, default=DEFAULT_TEMPLATE_CATALOG)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            strict_cycle_packet_path=args.strict_cycle_packet,
+            template_catalog_path=args.template_catalog,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = t10_strict_cycle_lemma_packet_payload(
+            sources["strict_cycle_packet"],
+            sources["template_catalog"],
+        )
+        if args.assert_expected:
+            assert_expected_t10_strict_cycle_lemma_packet(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle T10 strict-cycle local lemma packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"assignments: {summary['assignment_count']}")
+        print(f"families: {summary['family_ids']}")
+        print(f"core size: {summary['core_size']}")
+        print(f"cycle length: {summary['cycle_length']}")
+        if args.check or args.assert_expected:
+            print("OK: T10 strict-cycle local lemma packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -276,6 +276,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_t10_strict_cycle_lemma_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused T10/F12 n=9 strict-cycle local lemma packet; "
+            "proof-mining scaffolding only, not a proof of n=9, "
+            "counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(

--- a/src/erdos97/n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t10_strict_cycle_lemma_packet.py
@@ -1,0 +1,682 @@
+"""Build a focused T10 n=9 strict-cycle local lemma packet.
+
+This module is proof-mining scaffolding. It does not prove the full n=9 case,
+does not claim a counterexample, and does not promote the review-pending n=9
+checker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path
+from erdos97.n9_vertex_circle_strict_cycle_template_packet import (
+    SCHEMA as STRICT_CYCLE_TEMPLATE_PACKET_SCHEMA,
+)
+from erdos97.n9_vertex_circle_template_lemma_catalog import (
+    SCHEMA as TEMPLATE_LEMMA_CATALOG_SCHEMA,
+)
+from erdos97.vertex_circle_quotient_replay import (
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused T10/F12 strict-cycle local lemma packet for eighteen n=9 "
+    "frontier assignments; proof-mining scaffolding only, not a proof of n=9, "
+    "not a counterexample, not an independent review of the exhaustive checker, "
+    "and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py "
+        "--assert-expected --write"
+    ),
+}
+
+EXPECTED_TEMPLATE_ID = "T10"
+EXPECTED_TEMPLATE_KEY = "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+EXPECTED_FAMILY_IDS = ("F12",)
+EXPECTED_ASSIGNMENT_IDS = (
+    "A020",
+    "A040",
+    "A047",
+    "A071",
+    "A080",
+    "A081",
+    "A083",
+    "A093",
+    "A095",
+    "A111",
+    "A126",
+    "A147",
+    "A151",
+    "A153",
+    "A154",
+    "A157",
+    "A164",
+    "A180",
+)
+EXPECTED_ASSIGNMENT_COUNT = 18
+EXPECTED_FAMILY_COUNT = 1
+EXPECTED_ORBIT_SIZE_SUM = 18
+EXPECTED_CORE_SIZE = 4
+EXPECTED_CYCLE_LENGTH = 2
+EXPECTED_STRICT_EDGE_COUNT = 36
+EXPECTED_SELF_EDGE_CONFLICT_COUNT = 0
+EXPECTED_CYCLE_EDGE_COUNT = 2
+EXPECTED_FAMILY_ASSIGNMENT_COUNTS = {"F12": 18}
+EXPECTED_FAMILY_ORBIT_SIZES = {"F12": 18}
+EXPECTED_CYCLE_LENGTH_COUNTS = {"2": 18}
+EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS = {"1": 18, "2": 18}
+EXPECTED_SPAN_SIGNATURE_COUNTS = {"2:1,2:1": 18}
+EXPECTED_CYCLE_SPAN_COUNTS = [{"count": 2, "inner_span": 1, "outer_span": 2}]
+EXPECTED_CORE_SELECTED_ROWS = (
+    (0, 1, 2, 5, 6),
+    (3, 0, 1, 4, 6),
+    (6, 1, 3, 4, 7),
+    (8, 0, 3, 6, 7),
+)
+EXPECTED_CYCLE_STEPS: list[dict[str, Any]] = [
+    {
+        "equality_to_next_outer_pair": {
+            "end_pair": [1, 6],
+            "path": [
+                {"next_pair": [3, 6], "row": 3},
+                {"next_pair": [1, 6], "row": 6},
+            ],
+            "start_pair": [0, 3],
+        },
+        "strict_inequality": {
+            "inner_class": [0, 3],
+            "inner_interval": [0, 1],
+            "inner_pair": [0, 3],
+            "inner_span": 1,
+            "outer_class": [0, 1],
+            "outer_interval": [0, 2],
+            "outer_pair": [0, 6],
+            "outer_span": 2,
+            "row": 8,
+            "witness_order": [0, 3, 6, 7],
+        },
+    },
+    {
+        "equality_to_next_outer_pair": {
+            "end_pair": [0, 6],
+            "path": [{"next_pair": [0, 6], "row": 0}],
+            "start_pair": [0, 1],
+        },
+        "strict_inequality": {
+            "inner_class": [0, 1],
+            "inner_interval": [2, 3],
+            "inner_pair": [0, 1],
+            "inner_span": 1,
+            "outer_class": [0, 3],
+            "outer_interval": [1, 3],
+            "outer_pair": [1, 6],
+            "outer_span": 2,
+            "row": 3,
+            "witness_order": [4, 6, 0, 1],
+        },
+    },
+]
+EXPECTED_EQUALITY_CHAINS = (
+    ([0, 3], [3, 6], [1, 6]),
+    ([0, 1], [0, 6]),
+)
+
+
+def _template_record(packet: dict[str, Any]) -> dict[str, Any]:
+    templates = packet.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("strict-cycle template packet must contain templates")
+    for template in templates:
+        if isinstance(template, dict) and template.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return template
+    raise ValueError(f"missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _family_records_by_id(template: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    records = template.get("family_records")
+    if not isinstance(records, list):
+        raise ValueError(f"{EXPECTED_TEMPLATE_ID} must contain family_records")
+    by_id = {
+        str(record["family_id"]): record
+        for record in records
+        if isinstance(record, dict) and "family_id" in record
+    }
+    missing = [family_id for family_id in EXPECTED_FAMILY_IDS if family_id not in by_id]
+    if missing:
+        raise ValueError(f"missing T10 families: {missing!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def _catalog_record(catalog: dict[str, Any]) -> dict[str, Any]:
+    templates = catalog.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template lemma catalog must contain templates")
+    for record in templates:
+        if isinstance(record, dict) and record.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return record
+    raise ValueError(f"catalog missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _normalize_rows(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    return [[int(value) for value in row] for row in rows]
+
+
+def equality_chain(equality: Mapping[str, Any]) -> list[list[int]]:
+    """Return the pair chain traversed by a selected-distance equality path."""
+
+    chain = [[int(value) for value in pair(*equality["start_pair"])]]
+    for step in equality["path"]:
+        chain.append([int(value) for value in pair(*step["next_pair"])])
+    return chain
+
+
+def equality_steps(equality: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return row-labelled equality steps for the local lemma packet."""
+
+    current = [int(value) for value in pair(*equality["start_pair"])]
+    steps = []
+    for step in equality["path"]:
+        next_pair = [int(value) for value in pair(*step["next_pair"])]
+        steps.append(
+            {
+                "row": int(step["row"]),
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+    return steps
+
+
+def source_artifacts(
+    strict_cycle_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the T10 packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+            "role": "source T10/F12 strict-cycle template record",
+            "schema": strict_cycle_packet.get("schema"),
+            "status": strict_cycle_packet.get("status"),
+            "trust": strict_cycle_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+            "role": "catalog crosswalk confirming T10 coverage and strict-cycle shape summary",
+            "schema": template_catalog.get("schema"),
+            "status": template_catalog.get("status"),
+            "trust": template_catalog.get("trust"),
+        },
+    ]
+
+
+def _source_template_summary(template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_id": str(template["template_id"]),
+        "template_key": str(template["template_key"]),
+        "status": str(template["status"]),
+        "assignment_count": int(template["assignment_count"]),
+        "assignment_ids": list(template["assignment_ids"]),
+        "family_count": int(template["family_count"]),
+        "families": list(template["families"]),
+        "orbit_size_sum": int(template["orbit_size_sum"]),
+        "core_size": int(template["core_size"]),
+        "cycle_length": int(template["cycle_length"]),
+        "strict_edge_count": int(template["strict_edge_count"]),
+        "cycle_length_counts": template["cycle_length_counts"],
+        "connector_path_length_counts": template["connector_path_length_counts"],
+        "span_signature_counts": template["span_signature_counts"],
+        "cycle_span_counts": template["cycle_span_counts"],
+    }
+
+
+def _family_source_summary(family: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "family_id": str(family["family_id"]),
+        "template_id": str(family["template_id"]),
+        "status": str(family["status"]),
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "cycle_length": int(family["cycle_length"]),
+        "strict_edge_count": int(family["strict_edge_count"]),
+        "span_signature": str(family["span_signature"]),
+        "cycle_steps": family["cycle_steps"],
+        "equality_chains": [
+            equality_chain(step["equality_to_next_outer_pair"])
+            for step in family["cycle_steps"]
+        ],
+    }
+
+
+def _assert_cycle_steps(rows: Sequence[Sequence[int]], steps: Sequence[dict[str, Any]]) -> None:
+    if len(steps) != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("unexpected T10 cycle-step count")
+    if list(steps) != EXPECTED_CYCLE_STEPS:
+        raise AssertionError("unexpected T10 cycle steps")
+    for index, step in enumerate(steps):
+        edge = step["strict_inequality"]
+        equality = step["equality_to_next_outer_pair"]
+        next_edge = steps[(index + 1) % len(steps)]["strict_inequality"]
+        if pair(*equality["start_pair"]) != pair(*edge["inner_pair"]):
+            raise AssertionError("cycle equality must start at current inner pair")
+        if pair(*equality["end_pair"]) != pair(*next_edge["outer_pair"]):
+            raise AssertionError("cycle equality must end at next outer pair")
+        validate_equality_path(rows, equality)
+
+
+def _assert_source_records(
+    template: dict[str, Any],
+    family: dict[str, Any],
+    catalog_record: dict[str, Any],
+) -> None:
+    if template["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected template id")
+    if template["template_key"] != EXPECTED_TEMPLATE_KEY:
+        raise AssertionError("unexpected T10 template key")
+    if template["status"] != "strict_cycle":
+        raise AssertionError("T10 must remain a strict-cycle template")
+    if template["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("unexpected T10 assignment ids")
+    if template["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected T10 assignment count")
+    if template["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("unexpected T10 family list")
+    if template["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("unexpected T10 family count")
+    if template["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("unexpected T10 orbit-size sum")
+    if template["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected T10 core size")
+    if template["cycle_length"] != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("unexpected T10 cycle length")
+    if template["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("unexpected T10 strict-edge count")
+    if template["cycle_length_counts"] != EXPECTED_CYCLE_LENGTH_COUNTS:
+        raise AssertionError("unexpected T10 cycle-length counts")
+    if template["connector_path_length_counts"] != EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected T10 connector path-length counts")
+    if template["span_signature_counts"] != EXPECTED_SPAN_SIGNATURE_COUNTS:
+        raise AssertionError("unexpected T10 span-signature counts")
+    if template["cycle_span_counts"] != EXPECTED_CYCLE_SPAN_COUNTS:
+        raise AssertionError("unexpected T10 cycle-span counts")
+
+    rows = _normalize_rows(family["core_selected_rows"])
+    if family["family_id"] != "F12":
+        raise AssertionError("unexpected family id")
+    if family["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("family/template mismatch")
+    if family["status"] != "strict_cycle":
+        raise AssertionError("F12 must remain a strict-cycle record")
+    if family["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS["F12"]:
+        raise AssertionError("unexpected F12 assignment count")
+    if family["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES["F12"]:
+        raise AssertionError("unexpected F12 orbit size")
+    if family["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected F12 core size")
+    if family["cycle_length"] != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("unexpected F12 cycle length")
+    if family["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("unexpected F12 strict-edge count")
+    if family["span_signature"] != "2:1,2:1":
+        raise AssertionError("unexpected F12 span signature")
+    if rows != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS):
+        raise AssertionError("unexpected F12 core rows")
+    _assert_cycle_steps(rows, family["cycle_steps"])
+
+    if catalog_record["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected catalog template id")
+    if catalog_record["status"] != "strict_cycle":
+        raise AssertionError("unexpected catalog T10 status")
+    if catalog_record["template_key"] != EXPECTED_TEMPLATE_KEY:
+        raise AssertionError("catalog T10 template-key mismatch")
+    coverage = catalog_record["coverage"]
+    if coverage["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("catalog T10 assignment count mismatch")
+    if coverage["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("catalog T10 assignment ids mismatch")
+    if coverage["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("catalog T10 family mismatch")
+    if coverage["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("catalog T10 family count mismatch")
+    if coverage["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("catalog T10 orbit-size sum mismatch")
+    hypothesis = catalog_record["hypothesis_shape"]
+    if hypothesis["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("catalog T10 core-size mismatch")
+    if hypothesis["cycle_length"] != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("catalog T10 cycle-length mismatch")
+    if hypothesis["cycle_length_counts"] != EXPECTED_CYCLE_LENGTH_COUNTS:
+        raise AssertionError("catalog T10 cycle-length counts mismatch")
+    if hypothesis["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("catalog T10 strict-edge mismatch")
+    if hypothesis["connector_path_length_counts"] != EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS:
+        raise AssertionError("catalog T10 connector path-length mismatch")
+    if hypothesis["span_signature_counts"] != EXPECTED_SPAN_SIGNATURE_COUNTS:
+        raise AssertionError("catalog T10 span-signature mismatch")
+    if hypothesis["cycle_span_counts"] != EXPECTED_CYCLE_SPAN_COUNTS:
+        raise AssertionError("catalog T10 cycle-span mismatch")
+    conclusion = catalog_record["conclusion_shape"]
+    if conclusion["kind"] != "strict_cycle":
+        raise AssertionError("catalog T10 conclusion kind mismatch")
+    if "directed strict cycle" not in conclusion["strict_graph_obstruction"]:
+        raise AssertionError("catalog T10 must describe a directed strict cycle")
+
+    summaries = {
+        str(summary["family_id"]): summary
+        for summary in catalog_record["family_summaries"]
+        if isinstance(summary, dict) and "family_id" in summary
+    }
+    summary = summaries.get("F12")
+    if summary is None:
+        raise AssertionError("catalog missing F12 summary")
+    if summary["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS["F12"]:
+        raise AssertionError("catalog F12 assignment count mismatch")
+    if summary["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES["F12"]:
+        raise AssertionError("catalog F12 orbit size mismatch")
+    if summary["cycle_length"] != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("catalog F12 cycle length mismatch")
+    if summary["cycle_step_count"] != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("catalog F12 cycle-step count mismatch")
+    if summary["contradiction_kind"] != "strict_cycle":
+        raise AssertionError("catalog F12 contradiction kind mismatch")
+
+
+def _cycle_pair_chain(steps: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "cycle_step": index,
+            "strict_from_outer_pair": step["strict_inequality"]["outer_pair"],
+            "strict_to_inner_pair": step["strict_inequality"]["inner_pair"],
+            "equality_chain_to_next_outer_pair": equality_chain(
+                step["equality_to_next_outer_pair"]
+            ),
+            "next_outer_pair": steps[(index + 1) % len(steps)]["strict_inequality"][
+                "outer_pair"
+            ],
+        }
+        for index, step in enumerate(steps)
+    ]
+
+
+def _family_local_lemma(steps: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "packet_name": "T10/F12 strict-cycle local lemma packet",
+        "review_status": "review_pending",
+        "hypothesis_scope": (
+            "Natural cyclic order on labels 0..8 plus the four listed selected "
+            "rows; no claim is made about other n=9 templates."
+        ),
+        "strict_inequality_statements": [
+            (
+                f"Step {index}: row {step['strict_inequality']['row']} has "
+                f"witness order {step['strict_inequality']['witness_order']}, so "
+                f"outer pair {step['strict_inequality']['outer_pair']} strictly "
+                f"contains inner pair {step['strict_inequality']['inner_pair']}."
+            )
+            for index, step in enumerate(steps)
+        ],
+        "selected_distance_equalities": [
+            {
+                "cycle_step": index,
+                "equality_steps": equality_steps(step["equality_to_next_outer_pair"]),
+            }
+            for index, step in enumerate(steps)
+        ],
+        "cycle_closure_statement": (
+            "Each strict edge's inner pair is identified with the next strict "
+            "edge's outer pair, closing a directed two-edge strict cycle in the "
+            "selected-distance quotient."
+        ),
+        "contradiction": (
+            "The strict graph has a directed strict cycle of length 2 after "
+            "selected-distance quotienting."
+        ),
+    }
+
+
+def _cycle_edges(replay: Mapping[str, Any], steps: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    matched = []
+    for step in steps:
+        strict = step["strict_inequality"]
+        for edge in replay["cycle_edges"]:
+            if (
+                edge["row"] == strict["row"]
+                and edge["outer_pair"] == strict["outer_pair"]
+                and edge["inner_pair"] == strict["inner_pair"]
+            ):
+                matched.append(dict(edge))
+                break
+        else:
+            raise AssertionError("T10 strict cycle edge not found in replay")
+    return matched
+
+
+def _family_packet(family: dict[str, Any]) -> dict[str, Any]:
+    family_id = str(family["family_id"])
+    rows = _normalize_rows(family["core_selected_rows"])
+    steps = family["cycle_steps"]
+    replay_result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parse_selected_rows(rows),
+    )
+    replay = result_to_json(replay_result)
+    return {
+        "family_id": family_id,
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "cycle_length": int(family["cycle_length"]),
+        "strict_edge_count": int(family["strict_edge_count"]),
+        "span_signature": str(family["span_signature"]),
+        "core_selected_rows": rows,
+        "cycle_steps": steps,
+        "cycle_pair_chain": _cycle_pair_chain(steps),
+        "local_lemma": _family_local_lemma(steps),
+        "replay": {
+            "status": replay["status"],
+            "selected_row_count": replay["selected_row_count"],
+            "strict_edge_count": replay["strict_edge_count"],
+            "self_edge_conflict_count": len(replay["self_edge_conflicts"]),
+            "cycle_edge_count": len(replay["cycle_edges"]),
+            "cycle_edges": _cycle_edges(replay, steps),
+            "self_edge_conflicts": replay["self_edge_conflicts"],
+        },
+        "source_family_record": _family_source_summary(family),
+    }
+
+
+def t10_strict_cycle_lemma_packet_payload(
+    strict_cycle_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the focused review-pending T10 local lemma packet."""
+
+    if strict_cycle_packet.get("schema") != STRICT_CYCLE_TEMPLATE_PACKET_SCHEMA:
+        raise ValueError("unexpected strict-cycle template packet schema")
+    if template_catalog.get("schema") != TEMPLATE_LEMMA_CATALOG_SCHEMA:
+        raise ValueError("unexpected template lemma catalog schema")
+
+    template = _template_record(strict_cycle_packet)
+    families = _family_records_by_id(template)
+    family = families["F12"]
+    catalog_record = _catalog_record(template_catalog)
+    _assert_source_records(template, family, catalog_record)
+    family_packets = [_family_packet(family)]
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "cycle_length": EXPECTED_CYCLE_LENGTH,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "cycle_length_counts": EXPECTED_CYCLE_LENGTH_COUNTS,
+        "connector_path_length_counts": EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS,
+        "span_signature_counts": EXPECTED_SPAN_SIGNATURE_COUNTS,
+        "cycle_span_counts": EXPECTED_CYCLE_SPAN_COUNTS,
+        "family_packets": family_packets,
+        "source_template_record": _source_template_summary(template),
+        "source_catalog_record": catalog_record,
+        "interpretation": [
+            "This packet isolates the single-family T10 strict-cycle motif from existing review-pending n=9 diagnostics.",
+            "The F12 record has four local rows and two directed strict inequalities.",
+            "Each strict edge's inner pair is connected by selected-distance equalities to the next strict edge's outer pair.",
+            "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": source_artifacts(strict_cycle_packet, template_catalog),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_t10_strict_cycle_lemma_packet(payload)
+    return payload
+
+
+def _family_packets_by_id(payload: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        raise AssertionError("family_packets must be a list")
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        raise AssertionError(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, got {len(packets)}"
+        )
+    by_id = {
+        str(packet["family_id"]): packet
+        for packet in packets
+        if isinstance(packet, dict) and "family_id" in packet
+    }
+    if len(by_id) != len(packets):
+        raise AssertionError("family_packets must not contain duplicate family ids")
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        raise AssertionError(f"unexpected family packet ids: {sorted(by_id)!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def assert_expected_t10_strict_cycle_lemma_packet(payload: Mapping[str, Any]) -> None:
+    """Assert stable constants for the focused T10 local lemma packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "cycle_length": EXPECTED_CYCLE_LENGTH,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "cycle_length_counts": EXPECTED_CYCLE_LENGTH_COUNTS,
+        "connector_path_length_counts": EXPECTED_CONNECTOR_PATH_LENGTH_COUNTS,
+        "span_signature_counts": EXPECTED_SPAN_SIGNATURE_COUNTS,
+        "cycle_span_counts": EXPECTED_CYCLE_SPAN_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}")
+
+    family_packets = _family_packets_by_id(payload)
+    packet = family_packets["F12"]
+    if packet["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS["F12"]:
+        raise AssertionError("F12 assignment count mismatch")
+    if packet["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES["F12"]:
+        raise AssertionError("F12 orbit size mismatch")
+    if packet["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("F12 core size mismatch")
+    if packet["cycle_length"] != EXPECTED_CYCLE_LENGTH:
+        raise AssertionError("F12 cycle length mismatch")
+    if packet["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("F12 strict-edge count mismatch")
+    if packet["span_signature"] != "2:1,2:1":
+        raise AssertionError("F12 span signature mismatch")
+    if packet["core_selected_rows"] != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS):
+        raise AssertionError("F12 core rows mismatch")
+    if packet["cycle_steps"] != EXPECTED_CYCLE_STEPS:
+        raise AssertionError("F12 cycle steps mismatch")
+    expected_pair_chain = _cycle_pair_chain(EXPECTED_CYCLE_STEPS)
+    if packet["cycle_pair_chain"] != expected_pair_chain:
+        raise AssertionError("F12 cycle pair chain mismatch")
+
+    replay = packet["replay"]
+    if replay["status"] != "strict_cycle":
+        raise AssertionError("F12 replay status mismatch")
+    if replay["selected_row_count"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("F12 selected row count mismatch")
+    if replay["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("F12 strict-edge count mismatch")
+    if replay["self_edge_conflict_count"] != EXPECTED_SELF_EDGE_CONFLICT_COUNT:
+        raise AssertionError("F12 self-edge conflict count mismatch")
+    if replay["cycle_edge_count"] != EXPECTED_CYCLE_EDGE_COUNT:
+        raise AssertionError("F12 cycle-edge count mismatch")
+    if "primary_self_edge_conflict" in replay:
+        raise AssertionError("T10 replay must not carry a primary self-edge conflict")
+    cycle_edges = replay["cycle_edges"]
+    if len(cycle_edges) != EXPECTED_CYCLE_EDGE_COUNT:
+        raise AssertionError("F12 replay cycle-edge list mismatch")
+    for index, edge in enumerate(cycle_edges):
+        strict = EXPECTED_CYCLE_STEPS[index]["strict_inequality"]
+        for key in (
+            "row",
+            "witness_order",
+            "outer_pair",
+            "inner_pair",
+            "outer_interval",
+            "inner_interval",
+            "outer_class",
+            "inner_class",
+        ):
+            if edge[key] != strict[key]:
+                raise AssertionError(f"F12 cycle edge {index} {key} mismatch")
+        if edge["outer_class"] == edge["inner_class"]:
+            raise AssertionError("F12 replay cycle edge quotient classes must be distinct")
+        if "outer_span" in edge or "inner_span" in edge:
+            raise AssertionError("F12 replay cycle edges must not include source-only spans")
+
+    lemma = packet["local_lemma"]
+    if lemma["review_status"] != "review_pending":
+        raise AssertionError("F12 local lemma review status mismatch")
+    contradiction = str(lemma["contradiction"])
+    if "directed strict cycle" not in contradiction:
+        raise AssertionError("F12 local lemma must describe a directed strict cycle")
+    if "reflexive strict edge" in contradiction or "self-edge" in contradiction:
+        raise AssertionError("F12 local lemma must not describe a self-edge conflict")
+
+    if "No proof of the n=9 case is claimed." not in payload.get("interpretation", []):
+        raise AssertionError("interpretation must preserve the no-proof statement")

--- a/tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet import (
+    EXPECTED_CYCLE_STEPS,
+    assert_expected_t10_strict_cycle_lemma_packet,
+    t10_strict_cycle_lemma_packet_payload,
+)
+from scripts.check_n9_vertex_circle_t10_strict_cycle_lemma_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _f12(payload: dict[str, object]) -> dict[str, object]:
+    return payload["family_packets"][0]  # type: ignore[index]
+
+
+def _template_record(source_payloads: dict[str, object]) -> dict[str, object]:
+    for template in source_payloads["strict_cycle_packet"]["templates"]:  # type: ignore[index]
+        if template["template_id"] == "T10":
+            return template
+    raise AssertionError("missing T10 template")
+
+
+def _catalog_record(source_payloads: dict[str, object]) -> dict[str, object]:
+    for template in source_payloads["template_catalog"]["templates"]:  # type: ignore[index]
+        if template["template_id"] == "T10":
+            return template
+    raise AssertionError("missing T10 catalog record")
+
+
+def test_t10_strict_cycle_lemma_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_t10_strict_cycle_lemma_packet(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "proof-mining scaffolding only" in payload["claim_scope"]
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["template_id"] == "T10"
+    assert payload["template_key"] == "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+    assert payload["assignment_count"] == 18
+    assert payload["family_count"] == 1
+    assert payload["family_ids"] == ["F12"]
+    assert payload["family_assignment_counts"] == {"F12": 18}
+    assert payload["family_orbit_sizes"] == {"F12": 18}
+    assert payload["orbit_size_sum"] == 18
+    assert payload["core_size"] == 4
+    assert payload["cycle_length"] == 2
+    assert payload["strict_edge_count"] == 36
+    assert payload["cycle_length_counts"] == {"2": 18}
+    assert payload["connector_path_length_counts"] == {"1": 18, "2": 18}
+    assert payload["span_signature_counts"] == {"2:1,2:1": 18}
+    assert payload["cycle_span_counts"] == [{"count": 2, "inner_span": 1, "outer_span": 2}]
+
+
+def test_t10_strict_cycle_lemma_packet_records_expected_directed_cycle() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+
+    assert packet["core_selected_rows"] == [
+        [0, 1, 2, 5, 6],
+        [3, 0, 1, 4, 6],
+        [6, 1, 3, 4, 7],
+        [8, 0, 3, 6, 7],
+    ]
+    assert packet["cycle_steps"] == EXPECTED_CYCLE_STEPS
+    assert packet["cycle_pair_chain"] == [
+        {
+            "cycle_step": 0,
+            "strict_from_outer_pair": [0, 6],
+            "strict_to_inner_pair": [0, 3],
+            "equality_chain_to_next_outer_pair": [[0, 3], [3, 6], [1, 6]],
+            "next_outer_pair": [1, 6],
+        },
+        {
+            "cycle_step": 1,
+            "strict_from_outer_pair": [1, 6],
+            "strict_to_inner_pair": [0, 1],
+            "equality_chain_to_next_outer_pair": [[0, 1], [0, 6]],
+            "next_outer_pair": [0, 6],
+        },
+    ]
+    assert packet["local_lemma"]["review_status"] == "review_pending"  # type: ignore[index]
+    assert "four listed selected rows" in packet["local_lemma"]["hypothesis_scope"]  # type: ignore[index]
+    assert "directed strict cycle" in packet["local_lemma"]["contradiction"]  # type: ignore[index]
+    assert "self-edge" not in packet["local_lemma"]["contradiction"]  # type: ignore[index]
+    assert packet["replay"]["status"] == "strict_cycle"  # type: ignore[index]
+    assert packet["replay"]["selected_row_count"] == 4  # type: ignore[index]
+    assert packet["replay"]["strict_edge_count"] == 36  # type: ignore[index]
+    assert packet["replay"]["self_edge_conflict_count"] == 0  # type: ignore[index]
+    assert packet["replay"]["cycle_edge_count"] == 2  # type: ignore[index]
+    assert "primary_self_edge_conflict" not in packet["replay"]  # type: ignore[operator]
+    for edge in packet["replay"]["cycle_edges"]:  # type: ignore[index]
+        assert "outer_span" not in edge
+        assert "inner_span" not in edge
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_tampered_replay_classes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["replay"]["cycle_edges"][0]["inner_class"] = [0, 1]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F12 replay cycle edge 0 inner_class mismatch" in error for error in errors)
+    assert any("quotient classes must be distinct" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["template_id"] == "T10"
+    assert summary["family_count"] == 1
+    assert summary["assignment_count"] == 18
+    assert summary["cycle_length"] == 2
+    assert summary["replay_statuses"] == ["strict_cycle"]
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_tampered_step0_connector() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["cycle_steps"][0]["equality_to_next_outer_pair"]["end_pair"] = [0, 6]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F12 cycle_steps mismatch" in error for error in errors)
+    assert any("expected T10 strict-cycle lemma packet" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_tampered_step1_closure() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["cycle_steps"][1]["equality_to_next_outer_pair"]["path"][0]["next_pair"] = [3, 6]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F12 cycle_steps mismatch" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_tampered_strict_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["cycle_steps"][0]["strict_inequality"]["row"] = 0  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F12 cycle_steps mismatch" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_tampered_core_rows() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["core_selected_rows"][0] = [0, 1, 2, 4, 6]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F12 core_selected_rows mismatch" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_self_edge_copy_error() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["local_lemma"]["contradiction"] = "The strict graph has a reflexive strict edge."  # type: ignore[index]
+    packet["replay"]["primary_self_edge_conflict"] = {"row": 8}  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("must mention a directed strict cycle" in error for error in errors)
+    assert any("must not include primary_self_edge_conflict" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_missing_family() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["family_packets"] = []
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family packet ids mismatch" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_duplicate_family_packet() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["family_packets"].append(copy.deepcopy(payload["family_packets"][0]))
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family_packets length mismatch" in error for error in errors)
+    assert any("duplicate family packet id: F12" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_extra_family_packet() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    extra = copy.deepcopy(payload["family_packets"][0])
+    extra["family_id"] = "F99"
+    payload["family_packets"].append(extra)
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("family_packets length mismatch" in error for error in errors)
+    assert any("family packet ids mismatch" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    template = _template_record(sources)
+    template["family_records"][0]["cycle_steps"][0]["strict_inequality"]["row"] = 0  # type: ignore[index]
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source strict-cycle template packet invalid" in error
+        or "source-bound T10 strict-cycle lemma packet failed" in error
+        for error in errors
+    )
+
+
+def test_t10_strict_cycle_lemma_packet_detects_catalog_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    catalog = _catalog_record(sources)
+    catalog["hypothesis_shape"]["cycle_length"] = 3  # type: ignore[index]
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source template lemma catalog invalid" in error
+        or "source-bound T10 strict-cycle lemma packet failed" in error
+        for error in errors
+    )
+
+
+@pytest.mark.artifact
+def test_t10_strict_cycle_lemma_packet_artifact_matches_generator() -> None:
+    source_payloads = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == t10_strict_cycle_lemma_packet_payload(
+        source_payloads["strict_cycle_packet"],
+        source_payloads["template_catalog"],
+    )
+
+
+@pytest.mark.artifact
+def test_t10_strict_cycle_lemma_packet_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["template_id"] == "T10"
+    assert payload["family_count"] == 1
+    assert payload["cycle_length"] == 2
+    assert payload["replay_statuses"] == ["strict_cycle"]
+
+
+@pytest.mark.artifact
+def test_t10_strict_cycle_lemma_packet_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "t10_strict_cycle_lemma_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_t10_strict_cycle_lemma_packet_write_check_rejects_mismatched_paths(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "t10_strict_cycle_lemma_packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -136,6 +136,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "
         "--spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125"
         in command_texts


### PR DESCRIPTION
## Summary

- add a focused review-pending T10/F12 strict-cycle local lemma packet and generated JSON artifact
- add a source-bound checker, targeted tests, and audit/manifest hooks
- document the T10 two-edge directed quotient cycle without upgrading the n=9/global claim status

## Verification

- `python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py tests/test_run_artifact_audit.py -q` (`19 passed, 3 deselected`)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- direct `verify-n9-review` commands from `Makefile` (all passed before rebase; `make` is unavailable in this Windows shell)
- `python -m pytest -q` before rebase (`552 passed, 84 deselected`)

## Review fixes

- kept `replay.cycle_edges` literal by removing source-only span fields from the replay block
- tightened lightweight validation to pin replay quotient classes and reject self-edge-like class tampering

## Rebase note

- rebased cleanly onto `origin/main` at `e3139f1`; reran the T10 checker, targeted tests, text/status/provenance, diff, and ruff checks after rebase