### PR TITLE
Harden n9 base-apex ledger validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
 	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
+	$(PYTHON) scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
+	$(PYTHON) scripts/check_n9_d3_escape_slice.py --check --json
 
 verify-n10-review:
 	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125

--- a/README.md
+++ b/README.md
@@ -355,6 +355,12 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json
@@ -366,6 +372,7 @@ python scripts/check_n9_base_apex_escape_budget.py --check --json
 python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
 python scripts/check_n9_d3_escape_slice.py --check --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
+python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json
 ```
 
 Useful exploratory commands:

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -998,15 +998,18 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
-    claim_scope: Focused n=9 base-apex low-excess bookkeeping; not a proof of n=9 and not a global status update.
+    claim_scope: Focused n=9 base-apex low-excess bookkeeping; not a proof of n=9, not a counterexample, and not a global status update.
     json_top_level_type: object
     expected_json:
       schema: erdos97.n9_base_apex_low_excess_ledgers.v1
       status: EXPLORATORY_LEDGER_ONLY
       trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      claim_scope: Focused n=9 base-apex low-excess bookkeeping; not a proof of n=9, not a counterexample, and not a global status update.
       n: 9
       witness_size: 4
       base_apex_slack: 9
+      provenance.generator: scripts/explore_n9_base_apex.py
+      provenance.command: python scripts/explore_n9_base_apex.py --low-excess-report --out data/certificates/n9_base_apex_low_excess_ledgers.json
       strict_unresolved_profile_ledger_count: 30
     forbidden_claims:
       - n=9 is proved

--- a/scripts/check_n9_base_apex_low_excess_ledgers.py
+++ b/scripts/check_n9_base_apex_low_excess_ledgers.py
@@ -15,6 +15,42 @@ from typing import Any, Iterable, Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_base_apex_low_excess_ledgers.json"
+EXPECTED_TOP_LEVEL_KEYS = {
+    "base_apex_slack",
+    "claim_scope",
+    "conservative_minimum_escape_motif_classes",
+    "conservative_turn_cover_summary",
+    "n",
+    "notes",
+    "provenance",
+    "schema",
+    "status",
+    "strict_minimum_escape_motif_classes",
+    "strict_turn_cover_summary",
+    "strict_unresolved_count_by_capacity_deficit",
+    "strict_unresolved_count_by_total_profile_excess",
+    "strict_unresolved_profile_ledger_count",
+    "strict_unresolved_profile_ledgers",
+    "trust",
+    "witness_size",
+}
+EXPECTED_CLAIM_SCOPE = (
+    "Focused n=9 base-apex low-excess bookkeeping; not a proof of n=9, "
+    "not a counterexample, and not a global status update."
+)
+EXPECTED_NOTES = [
+    "No proof of the n=9 case is claimed.",
+    "These are exactly the profile ledgers not closed by the strict turn-cover diagnostic.",
+    "For the strict threshold, unresolved ledgers have E <= 6 and D >= 3.",
+    "The motif classes only record length-2/length-3 saturation deficits relevant to this diagnostic.",
+]
+EXPECTED_PROVENANCE = {
+    "generator": "scripts/explore_n9_base_apex.py",
+    "command": (
+        "python scripts/explore_n9_base_apex.py --low-excess-report "
+        "--out data/certificates/n9_base_apex_low_excess_ledgers.json"
+    ),
+}
 
 
 def binom2(value: int) -> int:
@@ -401,6 +437,13 @@ def validate_payload(payload: Any) -> list[str]:
         return ["artifact top level must be a JSON object"]
 
     errors: list[str] = []
+    top_level_keys = set(payload)
+    if top_level_keys != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(top_level_keys)!r}"
+        )
+
     n = payload.get("n")
     witness_size = payload.get("witness_size")
     if not isinstance(n, int) or not isinstance(witness_size, int):
@@ -418,38 +461,44 @@ def validate_payload(payload: Any) -> list[str]:
         expect_equal(errors, key, payload.get(key), expected)
 
     claim_scope = payload.get("claim_scope")
-    if not isinstance(claim_scope, str):
-        errors.append("claim_scope must be a string")
-    else:
+    expect_equal(errors, "claim_scope", claim_scope, EXPECTED_CLAIM_SCOPE)
+    if isinstance(claim_scope, str):
         lowered = claim_scope.lower()
         for phrase in ("not a proof", "not a counterexample", "not a global status update"):
             if phrase not in lowered:
                 errors.append(f"claim_scope must include {phrase!r}")
+    else:
+        errors.append("claim_scope must be a string")
 
     notes = payload.get("notes")
-    if not isinstance(notes, list) or "No proof of the n=9 case is claimed." not in notes:
-        errors.append("notes must preserve the explicit no-proof statement")
+    expect_equal(errors, "notes", notes, EXPECTED_NOTES)
+    if not isinstance(notes, list) or not all(isinstance(note, str) for note in notes):
+        errors.append("notes must be the expected list of public nonclaiming notes")
 
     provenance = payload.get("provenance")
+    expect_equal(errors, "provenance", provenance, EXPECTED_PROVENANCE)
     if not isinstance(provenance, dict):
         errors.append("provenance must be an object")
-    else:
-        expect_equal(
-            errors,
-            "provenance.generator",
-            provenance.get("generator"),
-            "scripts/explore_n9_base_apex.py",
-        )
-        command = provenance.get("command")
-        if not isinstance(command, str) or "--low-excess-report" not in command:
-            errors.append("provenance.command must name the low-excess generator command")
 
     computed_profiles = distance_profiles(n, witness_size)
+    actual_rows = payload.get("strict_unresolved_profile_ledgers")
+    row_excess_sources: list[dict[str, Any]] = []
+    if not isinstance(actual_rows, list):
+        errors.append("strict_unresolved_profile_ledgers must be a list")
+    else:
+        for index, row in enumerate(actual_rows):
+            if not isinstance(row, dict):
+                errors.append(f"strict_unresolved_profile_ledgers[{index}] must be an object")
+                continue
+            excesses = row.get("excesses")
+            if not isinstance(excesses, list) or not all(type(excess) is int for excess in excesses):
+                errors.append(f"strict_unresolved_profile_ledgers[{index}].excesses must be a list of integers")
+                continue
+            row_excess_sources.append(row)
     used_profile_excesses = {
         excess
-        for row in payload.get("strict_unresolved_profile_ledgers", [])
-        if isinstance(row, dict)
-        for excess in row.get("excesses", [])
+        for row in row_excess_sources
+        for excess in row["excesses"]
     }
     available_excesses = {excess for excess, _parts in computed_profiles}
     if not used_profile_excesses.issubset(available_excesses):
@@ -479,7 +528,6 @@ def validate_payload(payload: Any) -> list[str]:
     )
 
     expected_rows = unresolved_ledger_rows(n, witness_size, contradiction_threshold=3)
-    actual_rows = payload.get("strict_unresolved_profile_ledgers")
     expect_equal(errors, "strict_unresolved_profile_ledgers", actual_rows, expected_rows)
     expect_equal(
         errors,

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -324,16 +324,17 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ident="n9_base_apex_low_excess_ledgers",
         command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
         claim_scope=(
-            "Exploratory n=9 base-apex low-excess bookkeeping; "
-            "not a proof of n=9 or official/global status update."
+            "Focused n=9 base-apex low-excess bookkeeping; "
+            "not a proof of n=9, not a counterexample, "
+            "and not a global status update."
         ),
     ),
     AuditCommand(
         ident="n9_base_apex_escape_budget",
         command=("python", "scripts/check_n9_base_apex_escape_budget.py", "--check", "--json"),
         claim_scope=(
-            "Exploratory n=9 base-apex escape-budget bookkeeping; "
-            "not a proof of n=9, counterexample, or official/global status update."
+            "Focused n=9 base-apex escape-budget bookkeeping; "
+            "not a proof of n=9, not a counterexample, and not a global status update."
         ),
     ),
     AuditCommand(
@@ -345,16 +346,18 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--json",
         ),
         claim_scope=(
-            "Exploratory n=9 selected-baseline escape-budget overlay bookkeeping; "
-            "not a proof of n=9, counterexample, or official/global status update."
+            "Focused n=9 selected-baseline escape-budget overlay bookkeeping; "
+            "not a proof of n=9, not a counterexample, not a geometric "
+            "realizability test, and not a global status update."
         ),
     ),
     AuditCommand(
         ident="n9_base_apex_d3_escape_slice",
         command=("python", "scripts/check_n9_d3_escape_slice.py", "--check", "--json"),
         claim_scope=(
-            "Exploratory n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; "
-            "not a proof of n=9, counterexample, or official/global status update."
+            "Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; "
+            "not a proof of n=9, not a counterexample, not a geometric "
+            "realizability test, and not a global status update."
         ),
     ),
     AuditCommand(

--- a/tests/test_n9_base_apex_low_excess_ledgers.py
+++ b/tests/test_n9_base_apex_low_excess_ledgers.py
@@ -45,6 +45,64 @@ def test_low_excess_ledger_checker_rejects_tampered_count() -> None:
     assert any("strict_unresolved_profile_ledger_count" in error for error in errors)
 
 
+def test_low_excess_ledger_checker_rejects_unknown_top_level_key() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["unchecked_schema_drift"] = True
+
+    errors = validate_payload(payload)
+
+    assert any("top-level keys" in error for error in errors)
+
+
+def test_low_excess_ledger_checker_rejects_tampered_claim_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["claim_scope"] = (
+        "Focused n=9 base-apex low-excess bookkeeping; not a proof of n=9 "
+        "and not a global status update."
+    )
+
+    errors = validate_payload(payload)
+
+    assert any("claim_scope mismatch" in error for error in errors)
+    assert any("not a counterexample" in error for error in errors)
+
+
+def test_low_excess_ledger_checker_rejects_shortened_provenance() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["provenance"]["command"] = "python scripts/explore_n9_base_apex.py --low-excess-report"
+
+    errors = validate_payload(payload)
+
+    assert any("provenance mismatch" in error for error in errors)
+
+
+def test_low_excess_ledger_checker_rejects_appended_overclaiming_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["notes"].append("This proves the n=9 case.")
+
+    errors = validate_payload(payload)
+
+    assert any("notes mismatch" in error for error in errors)
+
+
+def test_low_excess_ledger_checker_reports_malformed_row_excesses() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["strict_unresolved_profile_ledgers"][0]["excesses"] = None
+
+    errors = validate_payload(payload)
+
+    assert any("excesses must be a list of integers" in error for error in errors)
+
+
+def test_low_excess_ledger_checker_rejects_boolean_row_excess() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["strict_unresolved_profile_ledgers"][0]["excesses"][0] = False
+
+    errors = validate_payload(payload)
+
+    assert any("excesses must be a list of integers" in error for error in errors)
+
+
 def test_low_excess_ledger_checker_cli_json() -> None:
     result = subprocess.run(
         [


### PR DESCRIPTION
## Summary

- make the n=9 base-apex low-excess checker reject top-level schema drift, exact claim-scope drift, exact public-note drift, strict integer-shape drift, and shortened provenance commands
- pin the low-excess manifest claim scope and provenance fields to the embedded artifact wording
- align `verify-n9-review`, the raw README audit command list, and audit-sidecar claim scopes with the already-audited base-apex/vertex-circle/n10 checkers

## Verification

- `python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json`
- `python scripts/check_n9_base_apex_escape_budget.py --check --json`
- `python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json`
- `python scripts/check_n9_d3_escape_slice.py --check --json`
- `python -m pytest tests/test_n9_base_apex_low_excess_ledgers.py tests/test_run_artifact_audit.py -q` (`13 passed`)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`592 passed, 90 deselected`)

## Review notes

- no n=9 proof, counterexample, geometric realizability result, source-of-truth promotion, or official/global status update is claimed
- sidecar review requested aligning the audit claim scope, pinning `provenance.generator`, exact-matching public notes, robust malformed-row validation, rejecting boolean row excesses, and completing the README raw audit command list; these are included
- `make` is unavailable in this Windows shell, so raw commands above were run directly