### PR TITLE
[codex] Record cycle 564 F06 self-edge lemma

### DIFF
--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,179 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-08 - Cycle 564 - F06 Five-Row Nested-Chord Self-Edge Lemma
+
+### Mathematical Subquestion
+
+Can the `T07/F06` self-edge entry in the review-pending `n=9`
+vertex-circle template catalog be proved directly as a small local lemma,
+continuing the single-family self-edge proof extraction through the next
+five-row template?
+
+### Definitions and Assumptions
+
+Work in a strictly convex polygon with cyclic order agreeing on the displayed
+labels with
+
+```text
+0,1,2,3,4,5,6,7,8.
+```
+
+For a center `i`, a selected row
+
+```text
+i: {a,b,c,d}
+```
+
+means the four selected witnesses lie on one circle centered at vertex `i`,
+so all four distances from `i` to those witnesses are equal. Use `d(u,v)` for
+ordinary Euclidean distance.
+
+The local rows are the five `F06` core rows recorded by the `T07` self-edge
+template:
+
+```text
+0: {1,2,4,7}
+2: {0,1,4,6}
+4: {1,3,5,7}
+5: {3,4,6,8}
+6: {0,2,5,7}
+```
+
+Use the vertex-circle nesting lemma as in Cycles 561-563: on a selected
+circle around a center in a strictly convex polygon, a properly containing
+witness interval determines a strictly longer chord.
+
+### Result Status
+
+Proved local lemma:
+**F06 Five-Row Nested-Chord Self-Edge Lemma**.
+
+Under the five displayed selected rows and cyclic-order hypothesis, no
+strictly convex realization exists.
+
+### Argument
+
+In row `0`, the selected witnesses occur in cyclic order
+
+```text
+1,2,4,7.
+```
+
+The witness interval from `1` to `4` properly contains the witness interval
+from `1` to `2`. Therefore the vertex-circle nesting lemma gives
+
+```text
+d(1,4) > d(1,2).                         (1)
+```
+
+The other selected rows identify the outer and inner chord distances:
+
+```text
+row 4: d(1,4) = d(4,5),
+row 5: d(4,5) = d(5,6),
+row 6: d(5,6) = d(2,6),
+row 2: d(2,6) = d(1,2).
+```
+
+Thus
+
+```text
+d(1,4) = d(1,2),
+```
+
+contradicting (1). Equivalently, the selected-distance quotient graph has a
+reflexive strict edge.
+
+### Exact Artifact Scope
+
+The rows and equality path are the `T07/F06` record in
+
+```text
+data/certificates/n9_vertex_circle_self_edge_template_packet.json
+data/certificates/n9_vertex_circle_template_lemma_catalog.json
+```
+
+The exact packet records that this template covers 18 labelled assignments
+
+```text
+A007, A028, A037, A039, A052, A055, A064, A066, A075,
+A089, A091, A098, A102, A113, A125, A128, A171, A177
+```
+
+all in family `F06`, with outer pair `[1,4]`, inner pair `[1,2]`, and path
+length `4`.
+
+### Limitations
+
+- This is a local row-core obstruction only.
+- It proves the `F06` core contradiction, not the full `n=9` exhaustive
+  checker.
+- It does not prove that arbitrary `n=9` selected-witness assignments must
+  contain this core.
+- It does not address remaining self-edge templates `T08` and `T09`.
+- It does not prove a general theorem for Erdos Problem #97 and does not give
+  a counterexample.
+
+### Effect on the Attack
+
+Cycles 561-563 handled `T04/F13`, `T05/F10`, and `T06/F11`; this cycle handles
+`T07/F06`. The same nested-chord self-edge mechanism still persists despite
+the richer conflict-shape summary for `T07`: one selected row supplies a
+strict outer-greater-than-inner chord inequality, and selected-distance
+equalities chain the outer chord back to the inner chord.
+
+The proof-mining route now has direct human-readable nested-chord proofs for
+four consecutive single-family self-edge templates.
+
+### Next Lead
+
+Extract the analogous proof for `T08/F02`. Since `T08` has six core rows, the
+key question is whether a single strict nested-chord inequality still closes
+through one equality path, or whether a genuinely longer local mechanism is
+needed.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-564`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-564`.
+- The branch was based on merged `origin/main` at
+  `7d051804e0ee032326104a4eb98bdddb52357b4e`.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- No commit, push, or pull request was made before recording this cycle.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_self_edge_template_packet.py --check
+  --assert-expected --json`: passed; the packet reports `T07: 18`
+  assignments and zero validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed; the catalog reports 12 templates covering
+  184 assignments and zero validation errors.
+- Repository validation after recording the cycle:
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+    scripts/check_text_clean.py`: passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+    scripts/check_status_consistency.py`: passed.
+  - `git diff --check`: passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+    scripts/check_artifact_provenance.py`: passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+    passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+    passed, `641 passed, 90 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-08 - Cycle 563 - F11 Five-Row Nested-Chord Self-Edge Lemma
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

Records Cycle 564 in the running Erdos97 research log.

The cycle extracts a direct local proof from the review-pending n=9 vertex-circle template catalog: the `T07/F06` local core forces a five-row nested-chord self-edge contradiction.

Main local lemma recorded: under the displayed selected rows

```text
0: {1,2,4,7}
2: {0,1,4,6}
4: {1,3,5,7}
5: {3,4,6,8}
6: {0,2,5,7}
```

and the natural cyclic order on labels 0 through 8, row 0 gives the strict vertex-circle inequality `d(1,4) > d(1,2)`, while rows 4, 5, 6, and 2 give `d(1,4)=d(4,5)=d(5,6)=d(2,6)=d(1,2)`. This is a local contradiction, not a proof of the full n=9 checker and not a proof of Erdos97.

## Files changed

- `reports/codex_goal_erdos97_log.md`

## Validation run

Local validation from `/private/tmp/erdos97-cycle-564`:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `641 passed, 90 deselected`

## PR lineage

- Replaces draft PR #219, which was closed unmerged after the connector failed while marking it ready for review with the known GraphQL `htmlUrl` field error.
- Same reviewed branch/head: `codex/erdos97-cycle-564` at `0cffe18b1752f8543e2a96e2eaba8ce41962db89`.

## Remaining limitations

- This is a local row-core obstruction only.
- It does not prove the full n=9 exhaustive checker.
- It does not prove that arbitrary n=9 selected-witness assignments contain this core.
- It does not address remaining self-edge templates T08 and T09.
- It does not prove a general theorem for Erdos Problem #97.
- It does not give an exact counterexample.
- The overarching proof/counterexample goal remains open.