### PR TITLE
[codex] Record cycle 565 F02 self-edge lemma

### DIFF
--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,181 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-08 - Cycle 565 - F02 Six-Row Nested-Chord Self-Edge Lemma
+
+### Mathematical Subquestion
+
+Can the `T08/F02` self-edge entry in the review-pending `n=9`
+vertex-circle template catalog be proved directly as a small local lemma,
+and does its six-row core still reduce to one nested-chord strict inequality
+closed by selected-distance equalities?
+
+### Definitions and Assumptions
+
+Work in a strictly convex polygon with cyclic order agreeing on the displayed
+labels with
+
+```text
+0,1,2,3,4,5,6,7,8.
+```
+
+For a center `i`, a selected row
+
+```text
+i: {a,b,c,d}
+```
+
+means the four selected witnesses lie on one circle centered at vertex `i`,
+so all four distances from `i` to those witnesses are equal. Use `d(u,v)` for
+ordinary Euclidean distance.
+
+The local rows are the six `F02` core rows recorded by the `T08` self-edge
+template:
+
+```text
+0: {1,2,3,8}
+1: {0,3,4,7}
+2: {1,3,5,6}
+5: {2,4,6,7}
+6: {1,5,7,8}
+7: {0,1,4,6}
+```
+
+Use the vertex-circle nesting lemma as in Cycles 561-564: on a selected
+circle around a center in a strictly convex polygon, a properly containing
+witness interval determines a strictly longer chord.
+
+### Result Status
+
+Proved local lemma:
+**F02 Six-Row Nested-Chord Self-Edge Lemma**.
+
+Under the six displayed selected rows and cyclic-order hypothesis, no strictly
+convex realization exists.
+
+### Argument
+
+In row `0`, the selected witnesses occur in cyclic order
+
+```text
+1,2,3,8.
+```
+
+The witness interval from `1` to `3` properly contains the witness interval
+from `1` to `2`. Therefore the vertex-circle nesting lemma gives
+
+```text
+d(1,3) > d(1,2).                         (1)
+```
+
+The other selected rows identify the outer and inner chord distances:
+
+```text
+row 1: d(1,3) = d(1,7),
+row 7: d(1,7) = d(6,7),
+row 6: d(6,7) = d(5,6),
+row 5: d(5,6) = d(2,5),
+row 2: d(2,5) = d(1,2).
+```
+
+Thus
+
+```text
+d(1,3) = d(1,2),
+```
+
+contradicting (1). Equivalently, the selected-distance quotient graph has a
+reflexive strict edge.
+
+### Exact Artifact Scope
+
+The rows and equality path are the `T08/F02` record in
+
+```text
+data/certificates/n9_vertex_circle_self_edge_template_packet.json
+data/certificates/n9_vertex_circle_template_lemma_catalog.json
+```
+
+The exact packet records that this template covers 18 labelled assignments
+
+```text
+A002, A012, A043, A050, A067, A084, A085, A086, A096,
+A106, A109, A122, A132, A134, A143, A149, A150, A159
+```
+
+all in family `F02`, with outer pair `[1,3]`, inner pair `[1,2]`, and path
+length `5`.
+
+### Limitations
+
+- This is a local row-core obstruction only.
+- It proves the `F02` core contradiction, not the full `n=9` exhaustive
+  checker.
+- It does not prove that arbitrary `n=9` selected-witness assignments must
+  contain this core.
+- It does not address the remaining self-edge template `T09`.
+- It does not prove a general theorem for Erdos Problem #97 and does not give
+  a counterexample.
+
+### Effect on the Attack
+
+Cycles 561-564 handled `T04/F13`, `T05/F10`, `T06/F11`, and `T07/F06`; this
+cycle handles `T08/F02`. The six-row case still needs no new mechanism: one
+selected row supplies the strict nested-chord inequality, and the longer
+selected-distance path identifies the outer chord with the inner chord.
+
+The proof-mining route now has direct human-readable nested-chord proofs for
+five consecutive single-family self-edge templates.
+
+### Next Lead
+
+Extract the analogous proof for `T09`. This is the last self-edge template in
+the packet, so the key question is whether it is another single-family
+nested-chord self-edge or whether it introduces the first non-self-edge
+mechanism needed before moving to the strict-cycle templates.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-565`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-565`.
+- The branch was based on clean cycle-564 content at
+  `0cffe18b1752f8543e2a96e2eaba8ce41962db89`, whose tree was merged to
+  `main` by PR #220 at `dacbd81712ab202435b51ebf9f4e4dd65bc5a06f`.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- No commit, push, or pull request was made before recording this cycle.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_self_edge_template_packet.py --check
+  --assert-expected --json`: passed; the packet reports `T08: 18`
+  assignments and zero validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed; the catalog reports 12 templates covering
+  184 assignments and zero validation errors.
+- Repository validation after recording the cycle:
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+    scripts/check_text_clean.py`: passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+    scripts/check_status_consistency.py`: passed.
+  - `git diff --check`: passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+    scripts/check_artifact_provenance.py`: passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+    passed.
+  - `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+    passed, `641 passed, 90 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-08 - Cycle 564 - F06 Five-Row Nested-Chord Self-Edge Lemma
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

Records Cycle 565 in the running Erdos97 research log.

The cycle extracts a direct local proof from the review-pending n=9 vertex-circle self-edge template packet: the `T08/F02` local core forces a six-row nested-chord self-edge contradiction.

Main local lemma recorded: under the displayed selected rows

```text
0: {1,2,3,8}
1: {0,3,4,7}
2: {1,3,5,6}
5: {2,4,6,7}
6: {1,5,7,8}
7: {0,1,4,6}
```

and the natural cyclic order on labels 0 through 8, row 0 gives the strict vertex-circle inequality `d(1,3) > d(1,2)`, while rows 1, 7, 6, 5, and 2 give `d(1,3)=d(1,7)=d(6,7)=d(5,6)=d(2,5)=d(1,2)`. This is a local contradiction, not a proof of the full n=9 checker and not a proof of Erdos97.

## Files changed

- `reports/codex_goal_erdos97_log.md`

## Validation run

Local validation from `/private/tmp/erdos97-cycle-565`:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `641 passed, 90 deselected`

Hosted CI:

- Replacement lineage uses the same branch/head as draft PR #221: `dc27d2c3ee1c53c86c78859dac189bc7baf92ae9`.
- Draft PR #221 CI run #761 passed on Python 3.10, 3.11, and 3.12 before this replacement was opened.

## PR lineage

- Replaces draft PR #221, which was closed unmerged after the connector failed while marking it ready for review with the known GraphQL `htmlUrl` field error.
- Same reviewed branch/head: `codex/erdos97-cycle-565` at `dc27d2c3ee1c53c86c78859dac189bc7baf92ae9`.

## Remaining limitations

- This is a local row-core obstruction only.
- It does not prove the full n=9 exhaustive checker.
- It does not prove that arbitrary n=9 selected-witness assignments contain this core.
- It does not address the remaining self-edge template T09.
- It does not prove a general theorem for Erdos Problem #97.
- It does not give an exact counterexample.
- The overarching proof/counterexample goal remains open.