### PR TITLE
[codex] Add bridge-first Codex strategy guidance

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -8,6 +8,165 @@ repository claims. No general proof and no counterexample are claimed, and the
 official/global status remains falsifiable/open unless manually rechecked and
 updated from the official source.
 
+For task-selection discipline, read `docs/codex-strategy-instructions.md`.
+Before starting a task, identify which bridge it might strengthen; if it does
+not strengthen a bridge, record the audit, provenance, or negative-control value
+that justifies doing it anyway.
+
+## Recommended next technical PRs
+
+Use this queue when no more specific issue is selected.
+
+1. Extract one `n=9` vertex-circle self-edge local template into a
+   proof-facing lemma candidate and compact verifier. Start with the focused
+   T01/F09 packet unless another packet has a clearer review target.
+2. Extract one `n=9` strict-cycle local template into a proof-facing lemma
+   candidate and compact verifier. The T10/F12 packet is the first natural
+   target.
+3. Strengthen the minimal fragile-cover bridge with one geometric necessary
+   condition and test it against the block-6 negative controls.
+4. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
+   certificates and emit verifier-backed template records.
+5. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
+   with an independent input-data replay.
+
+## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
+
+Issue: none yet.
+
+Read first:
+
+- `docs/codex-strategy-instructions.md`
+- `docs/n9-vertex-circle-template-lemma-catalog.md`
+- `docs/n9-vertex-circle-t01-self-edge-lemma.md`
+- `data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json`
+- `docs/n9-vertex-circle-exhaustive.md`
+
+Commands:
+
+```bash
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```
+
+Expected artifacts:
+
+- a proof-facing lemma note or update that states the exact incidence and
+  cyclic-order hypotheses for the T01/F09 self-edge template;
+- a minimal checker or checker update that verifies the compact template
+  packet independently of the full exhaustive search;
+- documentation that distinguishes the local template from any `n=9`
+  completeness or global Erdos #97 claim.
+
+Acceptance criteria:
+
+- The lemma candidate does not enumerate all `n=9` selected-witness systems.
+- The proof-facing text identifies the selected-distance quotienting and
+  vertex-circle monotonicity used to force a self-edge.
+- The checker treats the packet as input data and reports explicit uncertainty
+  rather than silently accepting unsupported fields.
+- The result remains review-pending unless independently reviewed.
+
+Trust delta: may produce a reusable local obstruction template. It may not
+promote the full `n=9` selected-witness result or alter global status.
+
+Forbidden overclaiming text:
+
+- "n=9 is proved"
+- "the vertex-circle checker is independently reviewed"
+- "this proves Erdos #97"
+
+## Task CB-N9-T10 - Extract Vertex-Circle Strict-Cycle Template
+
+Issue: none yet.
+
+Read first:
+
+- `docs/codex-strategy-instructions.md`
+- `docs/n9-vertex-circle-template-lemma-catalog.md`
+- `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
+- `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
+- `docs/n9-vertex-circle-exhaustive.md`
+
+Commands:
+
+```bash
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+```
+
+Expected artifacts:
+
+- a proof-facing lemma note or update that states the exact incidence and
+  cyclic-order hypotheses for the T10/F12 strict-cycle template;
+- a compact verifier that replays the quotient strict-cycle certificate from
+  stored data;
+- documentation that keeps local-core strict-cycle counts separate from
+  full-assignment obstruction-shape counts.
+
+Acceptance criteria:
+
+- The lemma candidate states the directed quotient cycle and the exact local
+  hypotheses that force it.
+- The verifier is independent of the full exhaustive brancher.
+- The result is scoped as a reusable obstruction template, not an `n=9`
+  completeness proof.
+
+Trust delta: may produce a reusable local strict-cycle obstruction template. It
+may not promote the full `n=9` selected-witness result or alter global status.
+
+Forbidden overclaiming text:
+
+- "all strict cycles are classified" without the review-pending qualifier
+- "n=9 is proved"
+- "this proves Erdos #97"
+
+## Task CB-FRAGILE-GEO - Add One Geometric Fragile-Cover Condition
+
+Issue: none yet.
+
+Read first:
+
+- `docs/codex-strategy-instructions.md`
+- `docs/minimal-fragile-cover-bridge.md`
+- `src/erdos97/fragile_hypergraph.py`
+- `scripts/check_fragile_hypergraph.py`
+- `docs/stuck-set-miner.md`
+
+Commands:
+
+```bash
+python scripts/check_fragile_hypergraph.py --json
+python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json
+python -m pytest tests/test_fragile_hypergraph.py -q
+```
+
+Expected artifacts:
+
+- one documented geometric necessary condition for minimal counterexamples;
+- checker support that can be run against the block-6 family, two disjoint
+  block-6 families, and any current full-row extension survivors;
+- a short report explaining which abstract family is newly rejected and why the
+  condition is geometric rather than an arbitrary SAT filter.
+
+Acceptance criteria:
+
+- The condition is proved necessary for a minimal geometric counterexample.
+- It rejects at least one abstract fragile-cover family that currently passes
+  the pairwise/crossing checks.
+- It remains labeled as a partial bridge unless it proves more.
+
+Trust delta: may strengthen the minimal-counterexample bridge. It may not prove
+Erdos #97 unless paired with a complete reduction and exact obstruction.
+
+Forbidden overclaiming text:
+
+- "fragile covers prove the theorem"
+- "block-6 is impossible geometrically" without the stated new hypothesis
+- "minimal counterexamples are ruled out"
+
 ## Task CB-83 - Decompose C19 Kalmanson Certificate
 
 Issue: <https://github.com/davidiach/erdos97/issues/83>
@@ -52,8 +211,8 @@ Acceptance criteria:
 
 Trust delta: may improve C19 certificate understanding. The all-order
 fixed-pattern obstruction is already exact if the stored Z3 certificate
-replays, but this may not promote any `n >= 9` finite case or Erdos Problem
-#97.
+replays, but this may not promote any `n >= 9` finite case or Erdos
+Problem #97.
 
 Forbidden overclaiming text:
 

--- a/docs/codex-strategy-instructions.md
+++ b/docs/codex-strategy-instructions.md
@@ -1,0 +1,184 @@
+# Codex strategy instructions
+
+Status: strategic planning guidance only; not mathematical evidence.
+
+This document guides Codex task selection in this repository. If it conflicts
+with `AGENTS.md`, `README.md`, `STATE.md`, `RESULTS.md`,
+`metadata/erdos97.yaml`, `docs/claims.md`, or
+`docs/review-priorities.md`, those files control. In particular, no general
+proof and no counterexample are claimed, and the official/global status remains
+falsifiable/open unless it is manually rechecked and updated from the official
+source.
+
+## Mission
+
+Work on Erdos Problem #97 with one goal: make real progress without
+overclaiming.
+
+The repository is already strong at exact obstruction checking for fixed
+selected-witness patterns, fixed cyclic orders, finite slices, and review
+pending finite-case artifacts. The strategic gap is scope. Erdos #97 requires
+ruling out every strictly convex polygon with arbitrary `n`, arbitrary
+per-center radii, and arbitrary selected 4-witness choices.
+
+The highest-value work narrows that scope gap.
+
+## Task selection rule
+
+Before starting a task, name the bridge it might strengthen. If no bridge is
+strengthened, record why the work is still useful, for example independent
+audit, verifier hardening, provenance cleanup, or a negative-control result.
+
+Prefer work that changes this form:
+
+```text
+Given this selected-witness pattern, cyclic order, or finite slice,
+exact constraints imply contradiction.
+```
+
+into this form:
+
+```text
+Every hypothetical counterexample must contain or reduce to
+one of the forbidden structures.
+```
+
+## Scope discipline
+
+Do not claim a general proof of Erdos #97.
+
+Do not claim a counterexample unless there are exact coordinates, exact
+algebraic certificates, interval certificates, SMT certificates, or formal
+proofs verifying the selected equal-distance equations, strict convexity,
+distinct vertices, and selected incidence pattern.
+
+Do not promote `n=9`, `n=10`, C13, C19, C29, B12, P18, P24, or any other
+fixed-pattern, fixed-order, sampled-window, or review-pending result into a
+global theorem.
+
+When choosing a trust label, use the weakest label compatible with the evidence
+and the repository ledgers. Common planning labels include:
+
+- `LEMMA`
+- `EXACT_OBSTRUCTION`
+- `MACHINE_CHECKED_FINITE_CASE_ARTIFACT`
+- `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`
+- `MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING`
+- `NUMERICAL_EVIDENCE`
+- `NUMERICAL_NONLINEAR_DIAGNOSTIC`
+- `FIXED_ORDER_DIAGNOSTIC`
+- `PROVENANCE`
+- `FAILED_ROUTE`
+
+## High-leverage directions
+
+### Reusable vertex-circle lemmas
+
+Treat the `n=9` vertex-circle computation as a source of candidate reusable
+templates until independently audited. Do not cite it as established theorem
+input without its review-pending label.
+
+Useful work:
+
+- extract one compact self-edge local template into proof-facing hypotheses;
+- extract one compact strict-cycle local template into proof-facing hypotheses;
+- write minimal independent checkers for each template packet;
+- document the exact incidence and cyclic-order hypotheses needed for the
+  template, and what the template does not prove.
+
+Good inputs include `docs/n9-vertex-circle-template-lemma-catalog.md`, the
+focused T01/T02/T03 self-edge notes, the focused T10/T11/T12 strict-cycle
+notes, and their checked JSON packets under `data/certificates/`.
+
+### Stronger fragile-cover bridges
+
+The minimal fragile-cover bridge is a proved necessary condition for minimal
+counterexamples, but pure fragile-cover hypergraph constraints are too weak:
+the block-6 abstract family is the standing negative control.
+
+Useful work adds a genuinely geometric necessary condition, such as
+critical-radius ordering, dependency-cycle restrictions for the witness map
+`pi`, row-circle constraints, vertex-circle monotonicity, crossing constraints
+between fragile rows and full selected rows, or interaction with stuck-set /
+ear-orderability failures.
+
+Any strengthened condition should be documented as necessary for a minimal
+geometric counterexample and tested against an abstract family that currently
+passes the fragile-cover checks.
+
+### Kalmanson/Farkas template extraction
+
+The C13 and C19 all-order Kalmanson certificates are fixed-pattern results,
+but their inverse-pair clauses may contain reusable order-search templates.
+
+Useful work classifies repeated ordered-quadrilateral pairs, explains which
+selected-distance quotient structures make the inequalities cancel, and emits
+human-readable template records with verifiers. The output should cover a
+template or family, not merely one more fixed-order certificate.
+
+### Independent trust audits
+
+Audit work is valuable when it treats checked-in JSON and certificates as
+inputs rather than generated truth. The best audit targets remain the `n=8`
+finite-case artifacts, the delicate `n=8` class `14`, the review-pending
+`n=9` vertex-circle checker, and the draft `n=10` singleton-slice package.
+
+## Low-leverage work to avoid
+
+Avoid certificate archaeology unless it produces reusable mathematics.
+
+Examples of low-leverage work:
+
+- making a fixed C29 certificate smaller without extracting a reusable lemma;
+- profiling C19 or C29 rows without producing order-search clauses or bridge
+  constraints;
+- adding numerical near-misses without an exactification plan;
+- killing another hand-picked sparse pattern without explaining why arbitrary
+  counterexamples reduce to that family.
+
+Certificate simplification is useful only when it yields a reusable local
+obstruction lemma, a new exact pruning rule, a bridge condition forced by
+arbitrary counterexamples, or an independently checkable compact proof object
+for an already important result.
+
+## Failed routes
+
+Before reviving a known failed route, read `docs/failed-ideas.md` and identify
+the new ingredient that changes the failure mode. In particular, do not restart
+arguments based only on:
+
+- circumcenter-inside-witness-hull contradictions;
+- middle-neighbor forest assumptions;
+- consecutive-witness assumptions;
+- cube-pattern-only `n=8` proofs;
+- forced indegree-four regularity outside saturated cases;
+- generic Jacobian rank at nonsolutions;
+- common-radius or unit-distance shortcuts;
+- B12 or C13 numerical near-misses as live candidates;
+- pure fragile-cover hypergraph constraints;
+- more fixed-pattern killing without a bridge.
+
+## Preferred report shape
+
+Every proof-facing Codex change should answer:
+
+```text
+What exact mathematical object is being studied?
+Is this a global theorem, finite-case artifact, fixed-pattern obstruction,
+fixed-order obstruction, review-pending diagnostic, numerical artifact,
+or failed-route record?
+What hypotheses are required?
+Which arbitrary-counterexample bridge, if any, does this strengthen?
+What does this rule out?
+What does it not rule out?
+What command verifies it?
+What files changed?
+What trust label applies?
+```
+
+## Validation
+
+After code or documentation changes, run `make verify-fast` or the raw fast
+tier from `AGENTS.md` / `README.md`. For finite-case, certificate, or public
+theorem-style updates, run the relevant artifact checker or record exactly
+which command could not be run and why.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ put detailed reconciliation in the canonical synthesis.
   artifacts and exact certificates.
 - [`review-priorities.md`](review-priorities.md): current independent-review
   priorities; planning guidance only, not mathematical evidence.
+- [`codex-strategy-instructions.md`](codex-strategy-instructions.md):
+  Codex task-selection discipline centered on bridge theorems and
+  non-overclaiming; planning guidance only, not mathematical evidence.
 - [`canonical-synthesis.md`](canonical-synthesis.md): long-form canonical
   synthesis, claim taxonomy, failed-route reconciliation, and source/hash
   inventory.


### PR DESCRIPTION
## Summary

- Add `docs/codex-strategy-instructions.md` as planning guidance for bridge-first Codex task selection.
- Add recommended next technical PRs and concrete backlog entries for n=9 vertex-circle template extraction and fragile-cover geometry work.
- Link the new strategy guide from `docs/index.md`.

## Scope and claim discipline

This is documentation and planning guidance only. It does not change repository status, mathematical claims, source-of-truth metadata, or any generated artifact. It preserves that no general proof and no counterexample are claimed.

## Validation

Locally on the corresponding workspace changes:

- `python scripts/check_text_clean.py` passed
- `python scripts/check_status_consistency.py` passed
- `python scripts/check_artifact_provenance.py` passed
- `git diff --check` passed
- `python -m ruff check .` passed
- `python -m pytest -q` printed `716 passed, 102 deselected`, but the wrapper returned timeout code 124 after the green summary
