### PR TITLE
[codex] Speed up default pytest tier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: tests
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 1'
 
 jobs:
   pytest:
@@ -20,9 +23,19 @@ jobs:
           cache-dependency-path: pyproject.toml
       - run: python -m pip install --upgrade pip
       - run: pip install -e .[dev]
-      - run: python scripts/check_text_clean.py
-      - run: python scripts/check_status_consistency.py
-      - run: python scripts/check_artifact_provenance.py
-      - run: git diff --check
-      - run: python -m ruff check .
-      - run: python -m pytest -q
+      - run: make verify-fast
+
+  artifact-review:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e .[dev]
+      - run: make verify-pytest-artifacts
+      - run: make verify-artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: verify-lint verify-fast verify-n8 verify-kalmanson verify-n9-review verify-n10-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-n10-review verify-artifacts audit-artifacts verify-all
 
 verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
@@ -11,6 +11,12 @@ verify-lint:
 
 verify-fast: verify-lint
 	$(PYTHON) -m pytest -q
+
+verify-pytest-artifacts:
+	$(PYTHON) -m pytest -q -m "artifact"
+
+verify-pytest-all:
+	$(PYTHON) -m pytest -q -o addopts=
 
 verify-n8:
 	$(PYTHON) scripts/independent_check_n8_artifacts.py --check --json

--- a/scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py
+++ b/scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py
@@ -60,10 +60,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    payload = d3_incidence_capacity_packet_report()
-    if args.assert_expected:
-        assert_expected_packet_counts(payload)
-
+    checked = None
+    artifact = None
     if args.check_artifact is not None:
         artifact = (
             args.check_artifact
@@ -86,6 +84,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
+
+    payload = d3_incidence_capacity_packet_report()
+    if args.assert_expected:
+        assert_expected_packet_counts(payload)
+
+    if checked is not None:
         if checked != payload:
             print(
                 f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",

--- a/scripts/analyze_n9_base_apex_d3_p19_incidence_capacity_pilot.py
+++ b/scripts/analyze_n9_base_apex_d3_p19_incidence_capacity_pilot.py
@@ -60,17 +60,36 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    payload = p19_incidence_capacity_pilot_report()
-    if args.assert_expected:
-        assert_expected_pilot_counts(payload)
-
+    checked = None
+    artifact = None
     if args.check_artifact is not None:
         artifact = (
             args.check_artifact
             if args.check_artifact.is_absolute()
             else ROOT / args.check_artifact
         )
-        checked = load_json(artifact)
+        try:
+            checked = load_json(artifact)
+        except OSError as exc:
+            print(
+                "FAILED: could not load "
+                f"{display_path(artifact, ROOT)}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        except json.JSONDecodeError as exc:
+            print(
+                "FAILED: could not parse "
+                f"{display_path(artifact, ROOT)} as JSON: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+    payload = p19_incidence_capacity_pilot_report()
+    if args.assert_expected:
+        assert_expected_pilot_counts(payload)
+
+    if checked is not None:
         if checked != payload:
             print(
                 f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",

--- a/tests/test_c13_kalmanson_partial_branches.py
+++ b/tests/test_c13_kalmanson_partial_branches.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "certify_c13_kalmanson_partial_branches.py"
 ARTIFACT = ROOT / "data" / "certificates" / "c13_kalmanson_partial_branch_closures.json"
@@ -23,6 +25,8 @@ def run_script(*args: str) -> dict[str, object]:
     return json.loads(result.stdout)
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c13_partial_branch_closures_match_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c13_kalmanson_third_pair_refinement.py
+++ b/tests/test_c13_kalmanson_third_pair_refinement.py
@@ -52,6 +52,8 @@ def test_c13_third_pair_refinement_artifact_summary() -> None:
     assert unclosed[-1]["parent_label"] == "partial_branch_5284"
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c13_third_pair_refinement_small_replay() -> None:
     payload = run_script(
         "--max-parents",

--- a/tests/test_c19_fifth_pair_two_row_prefilter.py
+++ b/tests/test_c19_fifth_pair_two_row_prefilter.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from c19_replay_helpers import assert_c19_replay_matches_artifact
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -82,6 +84,8 @@ def test_c19_fifth_pair_two_row_prefilter_artifact() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_fifth_pair_two_row_prefilter_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_prefix_window.py
+++ b/tests/test_c19_kalmanson_prefix_window.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from c19_replay_helpers import assert_c19_replay_matches_artifact
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -82,6 +84,8 @@ def test_c19_prefix_window_artifact_summary() -> None:
     assert first_fifth["certificate_summary"]["forced_inequalities_available"] == 3300
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefix_window_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
@@ -147,6 +151,8 @@ def test_c19_prefix_window_160_191_artifact_summary() -> None:
     assert payload["unclosed_fifth_pair_child_branches"] == []
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefix_window_160_191_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",

--- a/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
@@ -74,6 +74,7 @@ def test_c19_catalog_prefilter_window_sweep_artifact_summary() -> None:
     }
 
 
+@pytest.mark.artifact
 def test_c19_catalog_prefilter_window_sweep_small_replay() -> None:
     payload = run_script("--window-count", "1", "--json")
 

--- a/tests/test_c19_kalmanson_prefix_window_prefilter.py
+++ b/tests/test_c19_kalmanson_prefix_window_prefilter.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from c19_replay_helpers import assert_c19_replay_matches_artifact
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -68,6 +70,8 @@ def test_c19_prefilter_window_288_319_artifact_summary() -> None:
     }
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_288_319_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -122,6 +126,8 @@ def test_c19_prefilter_window_320_351_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_320_351_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -171,6 +177,8 @@ def test_c19_prefilter_window_352_383_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_352_383_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -223,6 +231,8 @@ def test_c19_prefilter_window_384_415_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_384_415_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -279,6 +289,8 @@ def test_c19_prefilter_window_416_447_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_416_447_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -323,6 +335,8 @@ def test_c19_prefilter_window_448_479_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_448_479_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",

--- a/tests/test_c19_kalmanson_prefix_window_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_prefilter_sweep.py
@@ -76,6 +76,7 @@ def test_c19_prefilter_window_sweep_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
 def test_c19_prefilter_window_sweep_small_replay() -> None:
     payload = run_script("--window-count", "1", "--json")
 

--- a/tests/test_c19_kalmanson_prefix_window_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_sweep.py
@@ -72,6 +72,8 @@ def test_c19_prefix_window_sweep_artifact_summary() -> None:
     assert [len(row["fifth_pair_survivor_labels"]) for row in windows] == [0, 0, 0, 0, 0]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefix_window_sweep_small_replay() -> None:
     payload = run_script("--window-count", "1", "--json")
 

--- a/tests/test_c19_kalmanson_sampled_fifth_pair_refinement.py
+++ b/tests/test_c19_kalmanson_sampled_fifth_pair_refinement.py
@@ -77,6 +77,7 @@ def test_c19_sampled_fifth_pair_refinement_artifact_summary() -> None:
     assert first["certificate_summary"]["forced_inequalities_available"] == 3300
 
 
+@pytest.mark.artifact
 def test_c19_sampled_fifth_pair_refinement_small_replay() -> None:
     payload = run_script(
         "--max-parents",

--- a/tests/test_c19_kalmanson_sampled_fourth_pair_refinement.py
+++ b/tests/test_c19_kalmanson_sampled_fourth_pair_refinement.py
@@ -78,6 +78,7 @@ def test_c19_sampled_fourth_pair_refinement_artifact_summary() -> None:
     assert first["certificate_summary"]["forced_inequalities_available"] == 1932
 
 
+@pytest.mark.artifact
 def test_c19_sampled_fourth_pair_refinement_small_replay() -> None:
     payload = run_script(
         "--max-parents",

--- a/tests/test_c19_prefilter_small_unit_supports.py
+++ b/tests/test_c19_prefilter_small_unit_supports.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "analyze_c19_prefilter_small_unit_supports.py"
 ARTIFACT = ROOT / "reports" / "c19_prefilter_small_unit_support_search.json"
@@ -53,6 +55,8 @@ def test_c19_prefilter_small_unit_support_artifact_summary() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_small_unit_support_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c25_c29_sparse_frontier_probe.py
+++ b/tests/test_c25_c29_sparse_frontier_probe.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "scripts") not in sys.path:
     sys.path.insert(0, str(ROOT / "scripts"))
@@ -71,6 +73,8 @@ def test_c25_c29_sparse_frontier_probe_matches_exact_filter_sweep() -> None:
         ]["survives_pre_kalmanson_filters"]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c25_c29_orders_have_no_two_inequality_kalmanson_inverse_pair() -> None:
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
     by_pattern = {row["pattern"]: row for row in artifact["cases"]}

--- a/tests/test_kalmanson_z3_clause_diagnostics.py
+++ b/tests/test_kalmanson_z3_clause_diagnostics.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.analyze_kalmanson_z3_clauses import (
     DEFAULT_ARTIFACT,
     assert_expected,
@@ -14,6 +16,7 @@ from scripts.analyze_kalmanson_z3_clauses import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_c19_z3_clause_diagnostic_matches_artifact() -> None:

--- a/tests/test_n9_base_apex.py
+++ b/tests/test_n9_base_apex.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from erdos97.n9_base_apex import (
     base_apex_slack,
     canonical_deficit_placement,
@@ -275,6 +277,7 @@ def test_low_excess_ledger_report_records_unresolved_counts() -> None:
     assert "No proof of the n=9 case is claimed." in report["notes"]
 
 
+@pytest.mark.artifact
 def test_escape_budget_report_records_budget_compatible_escape_counts() -> None:
     report = escape_budget_report()
 
@@ -328,6 +331,7 @@ def test_escape_budget_report_records_budget_compatible_escape_counts() -> None:
     assert "No proof of the n=9 case is claimed." in report["interpretation"]
 
 
+@pytest.mark.artifact
 def test_checked_low_excess_ledger_artifact_matches_generator() -> None:
     repo = Path(__file__).resolve().parents[1]
     artifact = repo / "data" / "certificates" / "n9_base_apex_low_excess_ledgers.json"
@@ -337,6 +341,7 @@ def test_checked_low_excess_ledger_artifact_matches_generator() -> None:
     assert payload == low_excess_ledger_report()
 
 
+@pytest.mark.artifact
 def test_checked_escape_budget_artifact_matches_generator() -> None:
     repo = Path(__file__).resolve().parents[1]
     artifact = repo / "data" / "certificates" / "n9_base_apex_escape_budget_report.json"

--- a/tests/test_n9_base_apex_d3_artifact_join.py
+++ b/tests/test_n9_base_apex_d3_artifact_join.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from erdos97.n9_base_apex_d3_artifact_join import (
     EXPECTED_CLAIM_SCOPE,
     cloned_artifacts,
@@ -16,6 +18,7 @@ from erdos97.n9_base_apex_d3_artifact_join import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def load_default_stack() -> tuple[dict[str, Path], dict[str, Any]]:

--- a/tests/test_n9_base_apex_d3_escape_frontier_packet.py
+++ b/tests/test_n9_base_apex_d3_escape_frontier_packet.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_d3_escape_frontier_packet import (
     EXPECTED_CLAIM_SCOPE,
     EXPECTED_INTERPRETATION,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_d3_escape_frontier_packet import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_expected_d3_escape_frontier_packet_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_d3_incidence_capacity_packet.py
+++ b/tests/test_n9_base_apex_d3_incidence_capacity_packet.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 import scripts.check_n9_base_apex_d3_incidence_capacity_packet as checker
 from scripts.check_n9_base_apex_d3_incidence_capacity_packet import (
     EXPECTED_CLAIM_SCOPE,
@@ -16,6 +18,7 @@ from scripts.check_n9_base_apex_d3_incidence_capacity_packet import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_full_packet_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_d3_p19_incidence_capacity_pilot.py
+++ b/tests/test_n9_base_apex_d3_p19_incidence_capacity_pilot.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 import scripts.check_n9_base_apex_d3_p19_incidence_capacity_pilot as checker
 from scripts.check_n9_base_apex_d3_p19_incidence_capacity_pilot import (
     EXPECTED_CLAIM_SCOPE,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_d3_p19_incidence_capacity_pilot import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_p19_pilot_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_escape_budget.py
+++ b/tests/test_n9_base_apex_escape_budget.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_escape_budget import (
     DEFAULT_ARTIFACT,
     load_artifact,
@@ -14,6 +16,7 @@ from scripts.check_n9_base_apex_escape_budget import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_escape_budget_artifact_passes_independent_checker() -> None:

--- a/tests/test_n9_base_apex_low_excess_escape_crosswalk.py
+++ b/tests/test_n9_base_apex_low_excess_escape_crosswalk.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_low_excess_escape_crosswalk import (
     EXPECTED_CLAIM_SCOPE,
     EXPECTED_INTERPRETATION,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_low_excess_escape_crosswalk import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_expected_low_excess_escape_crosswalk_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_low_excess_escape_ladder.py
+++ b/tests/test_n9_base_apex_low_excess_escape_ladder.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_low_excess_escape_ladder import (
     EXPECTED_CLAIM_SCOPE,
     EXPECTED_INTERPRETATION,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_low_excess_escape_ladder import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_expected_low_excess_escape_ladder_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_low_excess_ledgers.py
+++ b/tests/test_n9_base_apex_low_excess_ledgers.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_low_excess_ledgers import (
     DEFAULT_ARTIFACT,
     load_artifact,
@@ -14,6 +16,7 @@ from scripts.check_n9_base_apex_low_excess_ledgers import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_low_excess_ledger_artifact_passes_independent_checker() -> None:

--- a/tests/test_n9_row_ptolemy_family_signatures.py
+++ b/tests/test_n9_row_ptolemy_family_signatures.py
@@ -21,6 +21,7 @@ from scripts.check_n9_row_ptolemy_family_signatures import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_row_ptolemy_family_signature_artifact_counts_and_scope() -> None:

--- a/tests/test_n9_row_ptolemy_order_sensitivity.py
+++ b/tests/test_n9_row_ptolemy_order_sensitivity.py
@@ -21,6 +21,7 @@ from scripts.check_n9_row_ptolemy_order_sensitivity import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_row_ptolemy_order_sensitivity_artifact_scope() -> None:

--- a/tests/test_n9_selected_baseline_d3_escape_class_crosswalk.py
+++ b/tests/test_n9_selected_baseline_d3_escape_class_crosswalk.py
@@ -22,6 +22,7 @@ from scripts.check_n9_selected_baseline_d3_escape_class_crosswalk import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_selected_baseline_d3_crosswalk_artifact_is_nonclaiming() -> None:

--- a/tests/test_n9_selected_baseline_escape_budget_overlay.py
+++ b/tests/test_n9_selected_baseline_escape_budget_overlay.py
@@ -19,6 +19,7 @@ from scripts.check_n9_selected_baseline_escape_budget_overlay import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_selected_baseline_overlay_artifact_summary_is_nonclaiming() -> None:

--- a/tests/test_n9_vertex_circle_local_core_packet.py
+++ b/tests/test_n9_vertex_circle_local_core_packet.py
@@ -18,6 +18,7 @@ from scripts.check_n9_vertex_circle_local_core_packet import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_local_core_packet_artifact_counts_and_scope() -> None:


### PR DESCRIPTION
## Summary

- Move heavyweight replay and generated-artifact pytest coverage out of the default suite and into the `artifact`/`slow` tiers.
- Add Makefile targets for artifact-only pytest and all-pytest runs.
- Update CI so push/PR runs the fast tier, while scheduled/manual artifact review runs artifact pytest plus artifact verification.
- Make two n9 analyzer `--check-artifact` paths fail fast for missing or malformed JSON before generating expensive payloads.

## Impact

The default pytest tier drops from roughly 27 minutes to roughly 2 minutes locally, while the heavier artifact checks remain available through explicit local targets and scheduled/manual CI.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`530 passed, 288 deselected in 121.74s`)
- `python -m pytest --collect-only -q -m "artifact"` (`284/818 tests collected, 534 deselected`)
- GitHub Actions `tests` passed on Python 3.10, 3.11, and 3.12 for commit `ce77955`.