### PR TITLE
[codex] Record speculative circulant frontier obstructions

### DIFF
--- a/data/certificates/speculative_circulant_frontier_obstructions.json
+++ b/data/certificates/speculative_circulant_frontier_obstructions.json
@@ -1,0 +1,488 @@
+{
+  "claim_scope": "Exact cleanup for selected speculative circulant patterns: C45 is killed as a fixed abstract selected-witness incidence pattern by the two-circle cap, while C41, C43, and C49 are fixed-natural-order diagnostics only. No general proof of Erdos Problem #97 and no counterexample are claimed.",
+  "forbidden_claims": [
+    "Erdos Problem #97 is solved.",
+    "No counterexample exists.",
+    "C49 is killed across all cyclic orders.",
+    "The speculative frontier is closed.",
+    "This proves the bridge theorem.",
+    "general proof of Erdos Problem #97",
+    "counterexample to Erdos Problem #97"
+  ],
+  "patterns": [
+    {
+      "claim_scope": "Fixed abstract selected-witness incidence pattern across all cyclic orders; this does not imply any global theorem.",
+      "cyclic_order_scope": "all_orders_not_order_dependent",
+      "n": 45,
+      "offsets": [
+        4,
+        13,
+        25,
+        37
+      ],
+      "pattern": "C45_offsets_4_13_25_37",
+      "row_pair": [
+        0,
+        12
+      ],
+      "rows": {
+        "0": [
+          4,
+          13,
+          25,
+          37
+        ],
+        "12": [
+          16,
+          25,
+          37,
+          4
+        ]
+      },
+      "shared_witness_count": 3,
+      "shared_witnesses": [
+        4,
+        25,
+        37
+      ],
+      "status": "EXACT_ABSTRACT_INCIDENCE_OBSTRUCTION_TWO_CIRCLE_CAP",
+      "verified_reason": "Two distinct Euclidean circles can share at most two points; these two selected rows share three witnesses."
+    },
+    {
+      "claim_scope": "Fixed natural cyclic order only; no all-order obstruction for the abstract selected-witness pattern is claimed.",
+      "common_witness_chord": [
+        24,
+        34
+      ],
+      "cyclic_order_scope": "natural_order_only",
+      "n": 41,
+      "natural_cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40
+      ],
+      "offsets": [
+        5,
+        14,
+        24,
+        34
+      ],
+      "pattern": "C41_offsets_5_14_24_34",
+      "row_pair": [
+        0,
+        10
+      ],
+      "rows": {
+        "0": [
+          5,
+          14,
+          24,
+          34
+        ],
+        "10": [
+          15,
+          24,
+          34,
+          3
+        ]
+      },
+      "shared_witnesses": [
+        24,
+        34
+      ],
+      "source_and_witness_chords_alternate": false,
+      "source_chord": [
+        0,
+        10
+      ],
+      "status": "EXACT_NATURAL_ORDER_CROSSING_OBSTRUCTION",
+      "verified_reason": "A two-witness row overlap in a strictly convex realization forces the source chord and common-witness chord to cross; these chords do not alternate in the natural cyclic order."
+    },
+    {
+      "claim_scope": "Fixed natural cyclic order only; no all-order obstruction for the abstract selected-witness pattern is claimed.",
+      "common_witness_chord": [
+        15,
+        36
+      ],
+      "cyclic_order_scope": "natural_order_only",
+      "n": 43,
+      "natural_cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42
+      ],
+      "offsets": [
+        6,
+        15,
+        27,
+        36
+      ],
+      "pattern": "C43_offsets_6_15_27_36",
+      "row_pair": [
+        0,
+        9
+      ],
+      "rows": {
+        "0": [
+          6,
+          15,
+          27,
+          36
+        ],
+        "9": [
+          15,
+          24,
+          36,
+          2
+        ]
+      },
+      "shared_witnesses": [
+        15,
+        36
+      ],
+      "source_and_witness_chords_alternate": false,
+      "source_chord": [
+        0,
+        9
+      ],
+      "status": "EXACT_NATURAL_ORDER_CROSSING_OBSTRUCTION",
+      "verified_reason": "A two-witness row overlap in a strictly convex realization forces the source chord and common-witness chord to cross; these chords do not alternate in the natural cyclic order."
+    },
+    {
+      "claim_scope": "Fixed natural cyclic order only; no all-order obstruction for the abstract selected-witness pattern is claimed.",
+      "cycle_summary": [
+        "d(10,34) > d(34,47)",
+        "d(34,47) > d(22,47)",
+        "d(22,47) > d(22,35)",
+        "d(22,35) > d(10,46)",
+        "d(10,46) > d(10,34)"
+      ],
+      "cyclic_order_scope": "natural_order_only",
+      "n": 49,
+      "natural_cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48
+      ],
+      "offsets": [
+        5,
+        16,
+        29,
+        41
+      ],
+      "pattern": "C49_offsets_5_16_29_41",
+      "status": "EXACT_NATURAL_ORDER_VERTEX_CIRCLE_STRICT_CYCLE_OBSTRUCTION",
+      "strict_cycle": [
+        {
+          "inequality": "d(10,34) > d(34,47)",
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            34,
+            47
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            10,
+            34
+          ],
+          "properly_contains": true,
+          "row": 18,
+          "row_witnesses_formula_order": [
+            23,
+            34,
+            47,
+            10
+          ],
+          "verified_reason": "In the natural order around this center, the outer witness interval properly contains the inner witness interval on the same selected circle.",
+          "witness_order_around_center": [
+            23,
+            34,
+            47,
+            10
+          ]
+        },
+        {
+          "inequality": "d(34,47) > d(22,47)",
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            22,
+            47
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            34,
+            47
+          ],
+          "properly_contains": true,
+          "row": 42,
+          "row_witnesses_formula_order": [
+            47,
+            9,
+            22,
+            34
+          ],
+          "verified_reason": "In the natural order around this center, the outer witness interval properly contains the inner witness interval on the same selected circle.",
+          "witness_order_around_center": [
+            47,
+            9,
+            22,
+            34
+          ]
+        },
+        {
+          "inequality": "d(22,47) > d(22,35)",
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            22,
+            35
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            22,
+            47
+          ],
+          "properly_contains": true,
+          "row": 6,
+          "row_witnesses_formula_order": [
+            11,
+            22,
+            35,
+            47
+          ],
+          "verified_reason": "In the natural order around this center, the outer witness interval properly contains the inner witness interval on the same selected circle.",
+          "witness_order_around_center": [
+            11,
+            22,
+            35,
+            47
+          ]
+        },
+        {
+          "inequality": "d(22,35) > d(10,46)",
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            10,
+            46
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            22,
+            35
+          ],
+          "properly_contains": true,
+          "row": 30,
+          "row_witnesses_formula_order": [
+            35,
+            46,
+            10,
+            22
+          ],
+          "verified_reason": "In the natural order around this center, the outer witness interval properly contains the inner witness interval on the same selected circle.",
+          "witness_order_around_center": [
+            35,
+            46,
+            10,
+            22
+          ]
+        },
+        {
+          "inequality": "d(10,46) > d(10,34)",
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            10,
+            34
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            10,
+            46
+          ],
+          "properly_contains": true,
+          "row": 5,
+          "row_witnesses_formula_order": [
+            10,
+            21,
+            34,
+            46
+          ],
+          "verified_reason": "In the natural order around this center, the outer witness interval properly contains the inner witness interval on the same selected circle.",
+          "witness_order_around_center": [
+            10,
+            21,
+            34,
+            46
+          ]
+        }
+      ],
+      "verified_reason": "The listed vertex-circle interval containments force a strict cycle of ordinary distance inequalities in the natural order."
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_speculative_circulant_frontier_obstructions.py --write",
+    "generator": "scripts/check_speculative_circulant_frontier_obstructions.py"
+  },
+  "schema": "erdos97.speculative_circulant_frontier_obstructions.v1",
+  "status": "EXACT_SPECULATIVE_FRONTIER_CLEANUP",
+  "summary": {
+    "abstract_incidence_obstruction_count": 1,
+    "counterexample_claimed": false,
+    "fixed_natural_order_diagnostic_count": 3,
+    "global_problem_status_changed": false,
+    "pattern_count": 4
+  },
+  "trust": "EXACT_OBSTRUCTION"
+}

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -47,13 +47,19 @@ These came from the n=39 degeneracy review. They are not claims of geometric
 realizability; they are examples of incidence families designed to avoid the
 row-overlap failure that killed the n=39 branch.[^n39]
 
+The checked cleanup artifact
+`data/certificates/speculative_circulant_frontier_obstructions.json` records
+one exact abstract-incidence kill and three natural-order diagnostics for this
+group. The C41, C43, and C49 observations below are fixed-natural-order only;
+they do not rule out arbitrary cyclic orders for the same abstract selected
+witness patterns.
+
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|
-| 11 | `C41_offsets_5_14_24_34` | 41 | offsets `{5,14,24,34}` | prime cyclic | speculative incidence source |
-| 12 | `C43_offsets_6_15_27_36` | 43 | offsets `{6,15,27,36}` | prime cyclic | speculative incidence source |
-| 13 | `C45_offsets_4_13_25_37` | 45 | offsets `{4,13,25,37}` | Sidon-type cyclic | speculative incidence source |
-| 14 | `C49_offsets_5_16_29_41` | 49 | offsets `{5,16,29,41}` | Sidon-type cyclic | speculative incidence source |
-| 15 | `R44_four_lift_2_4_7_9` | 44 | `S_{4g+r}={4(g+a_t)+((r+t) mod 4): t=0..3}`, `a=(2,4,7,9)` | residue-rotating | speculative incidence source |
+| 11 | `C41_offsets_5_14_24_34` | 41 | offsets `{5,14,24,34}` | prime cyclic | speculative abstract-order incidence source; natural-order status: killed by the two-overlap crossing rule |
+| 12 | `C43_offsets_6_15_27_36` | 43 | offsets `{6,15,27,36}` | prime cyclic | speculative abstract-order incidence source; natural-order status: killed by the two-overlap crossing rule |
+| 13 | `C49_offsets_5_16_29_41` | 49 | offsets `{5,16,29,41}` | Sidon-type cyclic | speculative abstract-order incidence source; natural-order status: killed by the vertex-circle strict-cycle filter |
+| 14 | `R44_four_lift_2_4_7_9` | 44 | `S_{4g+r}={4(g+a_t)+((r+t) mod 4): t=0..3}`, `a=(2,4,7,9)` | residue-rotating | speculative incidence source |
 
 ## Archived / killed patterns
 
@@ -68,6 +74,7 @@ row-overlap failure that killed the n=39 branch.[^n39]
 | A7 | `C16_pm_1_6` | 16 | offsets `{-6,-1,1,6}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; parity collapse |
 | A8 | `C13_pm_3_5` | 13 | offsets `{-5,-3,3,5}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; all labels collapse |
 | A9 | `C9_pm_2_4` | 9 | offsets `{-4,-2,2,4}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; all labels collapse |
+| A10 | `C45_offsets_4_13_25_37` | 45 | offsets `{4,13,25,37}` | Sidon-type cyclic | exactly killed as a fixed abstract selected-witness incidence pattern: rows `0` and `12` share three witnesses `{4,25,37}`, violating the two-circle cap |
 
 [^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
 [^comp]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/04_COMPUTATIONAL_FINDINGS.md`.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1675,6 +1675,38 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: speculative_circulant_frontier_obstructions
+    path: data/certificates/speculative_circulant_frontier_obstructions.json
+    kind: certificate_artifact
+    generator: scripts/check_speculative_circulant_frontier_obstructions.py
+    command: python scripts/check_speculative_circulant_frontier_obstructions.py --write
+    checker: scripts/check_speculative_circulant_frontier_obstructions.py
+    check_command: python scripts/check_speculative_circulant_frontier_obstructions.py --check --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: EXACT_OBSTRUCTION
+    claim_scope: Exact cleanup for selected speculative circulant patterns; C45 is killed as a fixed abstract selected-witness incidence pattern, while C41, C43, and C49 are fixed-natural-order diagnostics only.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.speculative_circulant_frontier_obstructions.v1
+      status: EXACT_SPECULATIVE_FRONTIER_CLEANUP
+      trust: EXACT_OBSTRUCTION
+      summary.pattern_count: 4
+      summary.abstract_incidence_obstruction_count: 1
+      summary.fixed_natural_order_diagnostic_count: 3
+      summary.global_problem_status_changed: false
+      summary.counterexample_claimed: false
+      provenance.generator: scripts/check_speculative_circulant_frontier_obstructions.py
+      provenance.command: python scripts/check_speculative_circulant_frontier_obstructions.py --write
+    forbidden_claims:
+      - Erdos Problem #97 is solved.
+      - No counterexample exists.
+      - C49 is killed across all cyclic orders.
+      - The speculative frontier is closed.
+      - This proves the bridge theorem.
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact

--- a/scripts/check_speculative_circulant_frontier_obstructions.py
+++ b/scripts/check_speculative_circulant_frontier_obstructions.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Generate or check speculative circulant frontier obstruction certificates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "speculative_circulant_frontier_obstructions.json"
+)
+SCHEMA = "erdos97.speculative_circulant_frontier_obstructions.v1"
+STATUS = "EXACT_SPECULATIVE_FRONTIER_CLEANUP"
+TRUST = "EXACT_OBSTRUCTION"
+CLAIM_SCOPE = (
+    "Exact cleanup for selected speculative circulant patterns: C45 is killed "
+    "as a fixed abstract selected-witness incidence pattern by the two-circle "
+    "cap, while C41, C43, and C49 are fixed-natural-order diagnostics only. "
+    "No general proof of Erdos Problem #97 and no counterexample are claimed."
+)
+PROVENANCE = {
+    "generator": "scripts/check_speculative_circulant_frontier_obstructions.py",
+    "command": (
+        "python scripts/check_speculative_circulant_frontier_obstructions.py --write"
+    ),
+}
+FORBIDDEN_CLAIMS = [
+    "Erdos Problem #97 is solved.",
+    "No counterexample exists.",
+    "C49 is killed across all cyclic orders.",
+    "The speculative frontier is closed.",
+    "This proves the bridge theorem.",
+    "general proof of Erdos Problem #97",
+    "counterexample to Erdos Problem #97",
+]
+
+
+def circulant_row(n: int, offsets: Sequence[int], center: int) -> list[int]:
+    """Return the selected witnesses in formula order."""
+
+    return [int((center + offset) % n) for offset in offsets]
+
+
+def validate_circulant_rows(n: int, offsets: Sequence[int]) -> None:
+    """Check that each row is a 4-set avoiding its own center."""
+
+    if len(offsets) != 4:
+        raise ValueError("frontier checks are for 4-offset rows")
+    for center in range(n):
+        row = circulant_row(n, offsets, center)
+        if len(set(row)) != 4:
+            raise AssertionError(f"row {center} has repeated witnesses: {row}")
+        if center in row:
+            raise AssertionError(f"row {center} contains its center")
+
+
+def chord_crosses_in_natural_order(n: int, chord_a: Sequence[int], chord_b: Sequence[int]) -> bool:
+    """Return whether two endpoint-disjoint chords alternate in natural order."""
+
+    del n
+    a, b = sorted(int(endpoint) for endpoint in chord_a)
+    c, d = (int(endpoint) for endpoint in chord_b)
+
+    def inside(endpoint: int) -> bool:
+        return a < endpoint < b
+
+    return inside(c) != inside(d)
+
+
+def natural_witness_order(n: int, center: int, witnesses: Sequence[int]) -> list[int]:
+    """Order witnesses around a center in the natural cyclic order."""
+
+    return sorted((int(witness) for witness in witnesses), key=lambda witness: (witness - center) % n)
+
+
+def interval_in_witness_order(
+    witness_order: Sequence[int],
+    outer_pair: Sequence[int],
+    inner_pair: Sequence[int],
+) -> dict[str, Any]:
+    """Return interval-containment data for two witness-witness chords."""
+
+    positions = {witness: index for index, witness in enumerate(witness_order)}
+    outer = tuple(sorted((positions[int(outer_pair[0])], positions[int(outer_pair[1])])))
+    inner = tuple(sorted((positions[int(inner_pair[0])], positions[int(inner_pair[1])])))
+    contains = (
+        outer[0] <= inner[0]
+        and inner[1] <= outer[1]
+        and (outer[0] < inner[0] or inner[1] < outer[1])
+    )
+    return {
+        "outer_interval": list(outer),
+        "inner_interval": list(inner),
+        "properly_contains": contains,
+    }
+
+
+def pair_key(pair: Sequence[int]) -> tuple[int, int]:
+    """Normalize an unordered pair for cycle checks."""
+
+    a, b = (int(pair[0]), int(pair[1]))
+    if a == b:
+        raise ValueError("loop pair is not allowed")
+    return (a, b) if a < b else (b, a)
+
+
+def two_circle_cap_record() -> dict[str, Any]:
+    n = 45
+    offsets = [4, 13, 25, 37]
+    validate_circulant_rows(n, offsets)
+    row0 = circulant_row(n, offsets, 0)
+    row12 = circulant_row(n, offsets, 12)
+    shared = sorted(set(row0) & set(row12))
+    if row0 != [4, 13, 25, 37]:
+        raise AssertionError(f"unexpected C45 row 0: {row0}")
+    if row12 != [16, 25, 37, 4]:
+        raise AssertionError(f"unexpected C45 row 12: {row12}")
+    if shared != [4, 25, 37]:
+        raise AssertionError(f"unexpected C45 shared witnesses: {shared}")
+    return {
+        "pattern": "C45_offsets_4_13_25_37",
+        "n": n,
+        "offsets": offsets,
+        "status": "EXACT_ABSTRACT_INCIDENCE_OBSTRUCTION_TWO_CIRCLE_CAP",
+        "claim_scope": (
+            "Fixed abstract selected-witness incidence pattern across all "
+            "cyclic orders; this does not imply any global theorem."
+        ),
+        "cyclic_order_scope": "all_orders_not_order_dependent",
+        "row_pair": [0, 12],
+        "rows": {
+            "0": row0,
+            "12": row12,
+        },
+        "shared_witnesses": shared,
+        "shared_witness_count": len(shared),
+        "verified_reason": (
+            "Two distinct Euclidean circles can share at most two points; "
+            "these two selected rows share three witnesses."
+        ),
+    }
+
+
+def natural_crossing_record(
+    *,
+    pattern: str,
+    n: int,
+    offsets: Sequence[int],
+    second_row: int,
+    expected_shared: Sequence[int],
+) -> dict[str, Any]:
+    validate_circulant_rows(n, offsets)
+    row0 = circulant_row(n, offsets, 0)
+    rowj = circulant_row(n, offsets, second_row)
+    shared = sorted(set(row0) & set(rowj))
+    if shared != list(expected_shared):
+        raise AssertionError(f"unexpected {pattern} shared witnesses: {shared}")
+    crosses = chord_crosses_in_natural_order(n, [0, second_row], shared)
+    if crosses:
+        raise AssertionError(f"{pattern} natural-order chords unexpectedly cross")
+    return {
+        "pattern": pattern,
+        "n": n,
+        "offsets": list(offsets),
+        "status": "EXACT_NATURAL_ORDER_CROSSING_OBSTRUCTION",
+        "claim_scope": (
+            "Fixed natural cyclic order only; no all-order obstruction for "
+            "the abstract selected-witness pattern is claimed."
+        ),
+        "cyclic_order_scope": "natural_order_only",
+        "natural_cyclic_order": list(range(n)),
+        "row_pair": [0, second_row],
+        "rows": {
+            "0": row0,
+            str(second_row): rowj,
+        },
+        "shared_witnesses": shared,
+        "source_chord": [0, second_row],
+        "common_witness_chord": shared,
+        "source_and_witness_chords_alternate": crosses,
+        "verified_reason": (
+            "A two-witness row overlap in a strictly convex realization forces "
+            "the source chord and common-witness chord to cross; these chords "
+            "do not alternate in the natural cyclic order."
+        ),
+    }
+
+
+def c49_vertex_circle_record() -> dict[str, Any]:
+    n = 49
+    offsets = [5, 16, 29, 41]
+    validate_circulant_rows(n, offsets)
+    raw_edges = [
+        (18, [10, 34], [34, 47]),
+        (42, [34, 47], [22, 47]),
+        (6, [22, 47], [22, 35]),
+        (30, [22, 35], [10, 46]),
+        (5, [10, 46], [10, 34]),
+    ]
+    strict_cycle = []
+    for center, outer_pair, inner_pair in raw_edges:
+        row = circulant_row(n, offsets, center)
+        witness_order = natural_witness_order(n, center, row)
+        for endpoint in [*outer_pair, *inner_pair]:
+            if endpoint not in row:
+                raise AssertionError(f"endpoint {endpoint} is not in row {center}: {row}")
+        interval = interval_in_witness_order(witness_order, outer_pair, inner_pair)
+        if not interval["properly_contains"]:
+            raise AssertionError(f"C49 row {center} lacks proper interval containment")
+        strict_cycle.append(
+            {
+                "row": center,
+                "row_witnesses_formula_order": row,
+                "witness_order_around_center": witness_order,
+                "outer_pair": outer_pair,
+                "inner_pair": inner_pair,
+                **interval,
+                "inequality": f"d({outer_pair[0]},{outer_pair[1]}) > d({inner_pair[0]},{inner_pair[1]})",
+                "verified_reason": (
+                    "In the natural order around this center, the outer witness "
+                    "interval properly contains the inner witness interval on "
+                    "the same selected circle."
+                ),
+            }
+        )
+
+    for index, edge in enumerate(strict_cycle):
+        next_edge = strict_cycle[(index + 1) % len(strict_cycle)]
+        if pair_key(edge["inner_pair"]) != pair_key(next_edge["outer_pair"]):
+            raise AssertionError("C49 strict inequalities do not form the recorded cycle")
+
+    return {
+        "pattern": "C49_offsets_5_16_29_41",
+        "n": n,
+        "offsets": offsets,
+        "status": "EXACT_NATURAL_ORDER_VERTEX_CIRCLE_STRICT_CYCLE_OBSTRUCTION",
+        "claim_scope": (
+            "Fixed natural cyclic order only; no all-order obstruction for "
+            "the abstract selected-witness pattern is claimed."
+        ),
+        "cyclic_order_scope": "natural_order_only",
+        "natural_cyclic_order": list(range(n)),
+        "strict_cycle": strict_cycle,
+        "cycle_summary": [
+            "d(10,34) > d(34,47)",
+            "d(34,47) > d(22,47)",
+            "d(22,47) > d(22,35)",
+            "d(22,35) > d(10,46)",
+            "d(10,46) > d(10,34)",
+        ],
+        "verified_reason": (
+            "The listed vertex-circle interval containments force a strict "
+            "cycle of ordinary distance inequalities in the natural order."
+        ),
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    patterns = [
+        two_circle_cap_record(),
+        natural_crossing_record(
+            pattern="C41_offsets_5_14_24_34",
+            n=41,
+            offsets=[5, 14, 24, 34],
+            second_row=10,
+            expected_shared=[24, 34],
+        ),
+        natural_crossing_record(
+            pattern="C43_offsets_6_15_27_36",
+            n=43,
+            offsets=[6, 15, 27, 36],
+            second_row=9,
+            expected_shared=[15, 36],
+        ),
+        c49_vertex_circle_record(),
+    ]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "summary": {
+            "pattern_count": len(patterns),
+            "abstract_incidence_obstruction_count": 1,
+            "fixed_natural_order_diagnostic_count": 3,
+            "global_problem_status_changed": False,
+            "counterexample_claimed": False,
+        },
+        "patterns": patterns,
+        "forbidden_claims": FORBIDDEN_CLAIMS,
+        "provenance": PROVENANCE,
+    }
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path)
+
+
+def print_summary(payload: dict[str, Any]) -> None:
+    print("speculative circulant frontier obstruction checks")
+    print(f"  patterns: {payload['summary']['pattern_count']}")
+    for record in payload["patterns"]:
+        scope = record["cyclic_order_scope"]
+        print(f"  {record['pattern']}: {record['status']} ({scope})")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write the generated artifact")
+    parser.add_argument("--check", action="store_true", help="compare --out with regenerated data")
+    parser.add_argument("--json", action="store_true", help="print the generated payload as JSON")
+    args = parser.parse_args(argv)
+
+    out = args.out if args.out.is_absolute() else ROOT / args.out
+    payload = build_payload()
+
+    if args.check:
+        existing = load_json(out)
+        if existing != payload:
+            print(f"{display_path(out)} does not match regenerated payload", file=sys.stderr)
+            return 1
+
+    if args.write:
+        write_json(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print(f"OK: {display_path(out)} matches regenerated payload")
+        if args.write:
+            print(f"wrote {display_path(out)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a reproducible checker and generated certificate for four speculative circulant frontier diagnostics.
- Retire `C45_offsets_4_13_25_37` as a fixed abstract selected-witness incidence pattern by a three-witness/two-circle-cap obstruction.
- Keep `C41`, `C43`, and `C49` explicitly scoped as fixed-natural-order diagnostics only.
- Register the generated artifact in the provenance manifest.

## Impact

This is a small frontier cleanup. It does not change the official/global status, does not claim a general proof, and does not claim a counterexample.

## Validation

- `python scripts/check_speculative_circulant_frontier_obstructions.py --check --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`708 passed, 97 deselected in 1513.97s`)