### PR TITLE
[codex] Record T10 strict-cycle local lemma

### DIFF
--- a/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
@@ -49,6 +49,97 @@ Thus the packet isolates the directed cycle
 [0, 6] > [0, 3] = [3, 6] = [1, 6] > [0, 1] = [0, 6].
 ```
 
+## Local lemma
+
+The following local obstruction is independent of the exhaustive `n=9`
+brancher once the four displayed rows are assumed.
+
+Assume a strictly convex polygon has labels appearing in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8
+```
+
+and contains the four selected rows
+
+```text
+S_0 = {1,2,5,6}
+S_3 = {0,1,4,6}
+S_6 = {1,3,4,7}
+S_8 = {0,3,6,7}
+```
+
+Then these four rows cannot be realized.
+
+Indeed, row `8` has witness order
+
+```text
+0,3,6,7.
+```
+
+In a strictly convex polygon, the rays from a vertex to the other vertices
+occur in the polygon's cyclic order inside an angle smaller than `pi`. Since
+the row-`8` witnesses lie on one circle centered at vertex `8`, chord length
+on that circle is strictly increasing with the enclosed central angle in this
+range. The chord `[0,6]` strictly contains `[0,3]` in the row-`8` witness
+order, so
+
+```text
+d(0,6) > d(0,3).                         (1)
+```
+
+The selected-distance equalities from rows `3` and `6` give
+
+```text
+d(0,3) = d(3,6)      from row 3,
+d(3,6) = d(1,6)      from row 6.
+```
+
+Thus (1) implies
+
+```text
+d(0,6) > d(1,6).                         (2)
+```
+
+Next, row `3` has witness order
+
+```text
+4,6,0,1.
+```
+
+The chord `[1,6]` strictly contains `[0,1]` in this row-`3` witness order, so
+
+```text
+d(1,6) > d(0,1).                         (3)
+```
+
+Row `0` identifies the inner chord from (3) with the first outer chord:
+
+```text
+d(0,1) = d(0,6)      from row 0.
+```
+
+Combining this equality with (3) gives
+
+```text
+d(1,6) > d(0,6).                         (4)
+```
+
+The inequalities (2) and (4) form the impossible strict cycle
+
+```text
+d(0,6) > d(1,6) > d(0,6).
+```
+
+Equivalently, after quotienting ordinary pair distances by the selected
+distance equalities, rows `8` and `3` create a directed strict cycle of length
+two.
+
+The lemma is local: it rules out any selected-witness system containing these
+four rows in the stated cyclic order. It does not prove the full `n=9` finite
+case, because the exhaustive checker is still needed to show that every
+frontier assignment contains one of the recorded local obstruction templates.
+
 ## Commands
 
 Generate and check the packet:

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,184 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 618 - T10/F12 Local Strict-Cycle Proof Note
+
+### Mathematical Subquestion
+
+The `n=9` vertex-circle strict-cycle packet already records the `T10/F12`
+four-row obstruction and the running log had a human-readable derivation, but
+the canonical packet note was still mostly a packet summary. The narrow
+question for this cycle was:
+
+Can the T10/F12 strict-cycle packet be restated in its proof-facing note as a
+standalone local lemma whose contradiction follows directly from two
+vertex-circle strict inequalities and selected-distance quotienting, without
+invoking the exhaustive `n=9` brancher?
+
+### Definitions and Assumptions
+
+For a selected row `S_c`, all distances `d(c,x)` with `x in S_c` are equal.
+Work in a strictly convex polygon with labels in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8.
+```
+
+The T10/F12 local core consists of the four selected rows
+
+```text
+S_0 = {1,2,5,6}
+S_3 = {0,1,4,6}
+S_6 = {1,3,4,7}
+S_8 = {0,3,6,7}.
+```
+
+Use the standard vertex-circle monotonicity fact: if several selected
+witnesses lie on one circle centered at a polygon vertex, then nested witness
+chords in the radial order around that center have strictly increasing
+ordinary length.
+
+### Result Status
+
+Proved local lemma:
+**T10/F12 Two-Edge Strict-Cycle Lemma**.
+
+The four displayed rows are impossible in the stated cyclic order.
+
+### Argument
+
+Row `8` has witness order
+
+```text
+0,3,6,7.
+```
+
+The chord `[0,6]` strictly contains `[0,3]` in this row-`8` witness order.
+Thus vertex-circle monotonicity gives
+
+```text
+d(0,6) > d(0,3).                         (1)
+```
+
+Rows `3` and `6` give the selected-distance equality chain
+
+```text
+d(0,3) = d(3,6)      from row 3,
+d(3,6) = d(1,6)      from row 6.
+```
+
+Therefore
+
+```text
+d(0,6) > d(1,6).                         (2)
+```
+
+Row `3` has witness order
+
+```text
+4,6,0,1.
+```
+
+The chord `[1,6]` strictly contains `[0,1]` in this row-`3` witness order, so
+
+```text
+d(1,6) > d(0,1).                         (3)
+```
+
+Row `0` identifies the inner chord with the first outer chord:
+
+```text
+d(0,1) = d(0,6)      from row 0.
+```
+
+Combining this with (3) gives
+
+```text
+d(1,6) > d(0,6).                         (4)
+```
+
+The strict inequalities (2) and (4) produce the impossible cycle
+
+```text
+d(0,6) > d(1,6) > d(0,6).
+```
+
+Equivalently, after quotienting ordinary pair distances by the selected
+distance equalities, rows `8` and `3` create a directed strict cycle of length
+two.
+
+### Exact Scope
+
+This is a local obstruction lemma for the four displayed selected rows in the
+stated cyclic order. It is independent of the exhaustive brancher once those
+rows are given.
+
+It does not prove the full `n=9` finite case, because the review-pending
+exhaustive checker is still needed to show that every `n=9` frontier
+assignment contains a recorded local obstruction template. It does not prove
+Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+This turns the first review-pending strict-cycle packet into a reusable
+proof-facing local lemma in the same style as the T01/F09 self-edge note. It
+strengthens the proof-mining library of local obstructions, but only locally:
+future work must still prove that arbitrary or finite frontier assignments
+force one of these local cores.
+
+### Next Lead
+
+Apply the same proof-note consolidation to the remaining strict-cycle packet
+notes, preferably T11/F07 next. The useful subquestion is whether its
+three-edge cycle can be displayed as a compact cyclic chain of vertex-circle
+strict inequalities plus selected-distance connector chains.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-618`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-618`.
+- The branch was based on `origin/main` at commit
+  `6d30d6ff6af0646910b7b5b1b6faedcae5741ae6`, after PR #304 merged Cycle
+  617.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check
+  --assert-expected --json`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check
+  --assert-expected --json`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 617 - T01/F09 Local Self-Edge Lemma
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Scope

Ready replacement for draft PR #305, using the same branch and head commit `b54010ef1ccb4142c6e181eed0eca71fedfe30aa`. Draft PR #305 had green hosted CI but could not be marked ready because the connector hit the known GraphQL `htmlUrl` field error.

This PR records Cycle 618 of the Erdos97 research log. It promotes the T10/F12 strict-cycle packet note from a packet summary into a proof-facing local lemma: the four displayed selected rows force two vertex-circle strict inequalities, and selected-distance equalities close them into the impossible cycle `d(0,6) > d(1,6) > d(0,6)`.

## Files Changed

- `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

Local validation:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`530 passed, 275 deselected`)

Hosted validation on draft PR #305:

- `tests / pytest (3.10)`: passed
- `tests / pytest (3.11)`: passed
- `tests / pytest (3.12)`: passed

## Limitations

This is a local obstruction lemma for the displayed T10/F12 row core only. It does not prove the full `n=9` finite case, does not prove Erdos Problem #97, and does not give a counterexample.