### PR TITLE
[codex] Add reciprocal-radial budget packet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,9 @@ put detailed reconciliation in the canonical synthesis.
   crossing CSP for two-overlap patterns.
 - [`vertex-circle-order-filter.md`](vertex-circle-order-filter.md): exact
   row-wise convexity-distance filter for cyclic orders.
+- [`reciprocal-radial-budget.md`](reciprocal-radial-budget.md): local
+  middle-witness reciprocal-radial budget packet; a research packet, not a
+  global obstruction.
 - [`metric-order-lp.md`](metric-order-lp.md): combined fixed-order LP
   diagnostic using Altman gaps, vertex-circle inequalities, and triangle
   inequalities; records a relaxation miss on the registered sparse orders.

--- a/docs/reciprocal-radial-budget.md
+++ b/docs/reciprocal-radial-budget.md
@@ -1,0 +1,269 @@
+# Reciprocal Radial Budget
+
+Status: `RESEARCH_PACKET`.
+
+This note records a local necessary inequality for one selected row of four
+equal-distance witnesses in a strictly convex polygon. It is not a proof of
+Erdos Problem #97, and it is not a counterexample search result. The missing
+ingredient remains a global budget or cycle theorem that prevents all rows of a
+hypothetical counterexample from satisfying these local inequalities
+simultaneously.
+
+## Scope
+
+This packet sharpens the existing middle-witness angle constraint in
+`docs/claims.md`. The older lemma uses only the angles between consecutive
+equal-distance witnesses. The reciprocal-radial budget also sees the local edge
+directions at a middle witness.
+
+It is not a distance-unimodality or squared-distance Monge claim. The radial
+function below may oscillate, and equal-level vertices need not form a
+consecutive block on the boundary.
+
+## Setup
+
+Let `P = (p_0, ..., p_{n-1})` be a strictly convex polygon in counterclockwise
+cyclic order. Write
+
+```text
+e_j = p_{j+1} - p_j
+[u,v] = det(u,v)
+```
+
+with indices modulo `n`. Fix a center `i`, and list vertices on the visible
+chain
+
+```text
+p_{i+1}, p_{i+2}, ..., p_{i-1}
+```
+
+in that boundary order. Suppose four distinct witnesses `a,b,c,d` occur in this
+order and satisfy
+
+```text
+|p_i - p_a| = |p_i - p_b| = |p_i - p_c| = |p_i - p_d| = r.
+```
+
+Set
+
+```text
+x_t = p_t - p_i.
+```
+
+The middle witnesses `b` and `c` are non-adjacent to `i`. The determinant
+orientation convention is the one induced by the visible chain, so for adjacent
+edge vectors at a middle witness,
+
+```text
+[x_t,e_{t-1}] > 0,
+[x_t,e_t] > 0,
+[e_{t-1},e_t] > 0.
+```
+
+## Local Budget Lemma
+
+For the middle witness `b`,
+
+```text
+r^2 [e_{b-1},e_b]
+-------------------------------
+[x_b,e_{b-1}] [x_b,e_b]
+
+<=
+
+[x_a,x_b]                 [x_b,x_c]
+-------------------   +   -------------------
+r^2 + x_a . x_b           r^2 + x_b . x_c
+```
+
+and for the middle witness `c`,
+
+```text
+r^2 [e_{c-1},e_c]
+-------------------------------
+[x_c,e_{c-1}] [x_c,e_c]
+
+<=
+
+[x_b,x_c]                 [x_c,x_d]
+-------------------   +   -------------------
+r^2 + x_b . x_c           r^2 + x_c . x_d.
+```
+
+All displayed denominators are positive. The two `r^2 + dot` denominators are
+positive because consecutive equal-radius witness rays lie in an angular span
+less than `pi`.
+
+Equivalently, define `beta_t^-` and `beta_t^+` as oriented angles from the ray
+`p_i -> p_t` counterclockwise to the incoming and outgoing edge directions
+`e_{t-1}` and `e_t`. Then
+
+```text
+0 < beta_t^- < beta_t^+ < pi
+```
+
+and the left side is
+
+```text
+cot(beta_t^-) - cot(beta_t^+)
+  = sin(tau_t) / (sin(beta_t^-) sin(beta_t^+)),
+```
+
+where `tau_t` is the exterior turn at `p_t`.
+
+## Proof
+
+Relabel locally so the center is `p_0`, and consider the opposite chain
+
+```text
+p_1, p_2, ..., p_{n-1}.
+```
+
+For rays inside the open incident cone at `p_0`, strict convexity gives a
+unique intersection with this chain. Let `theta` be polar angle around `p_0`,
+let `rho(theta)` be the intersection distance, and set
+
+```text
+q(theta) = 1 / rho(theta).
+```
+
+On the edge from `p_j` to `p_{j+1}`, write `v_j = p_j - p_0`. A point
+`lambda u(theta)`, where `u(theta) = (cos theta, sin theta)`, lies on the
+supporting line of that edge exactly when
+
+```text
+[lambda u(theta) - v_j, e_j] = 0.
+```
+
+Thus
+
+```text
+lambda = [v_j,e_j] / [u(theta),e_j],
+q(theta) = [u(theta),e_j] / [v_j,e_j].
+```
+
+It follows that `q'' + q = 0` on each open edge interval.
+
+At a visible non-adjacent vertex `p_t`, the one-sided derivatives are
+
+```text
+q'_-(theta_t) = [R u,e_{t-1}] / [x_t,e_{t-1}],
+q'_+(theta_t) = [R u,e_t]     / [x_t,e_t],
+```
+
+where `u = x_t / |x_t|` and `R` is counterclockwise rotation by `pi/2`.
+Therefore
+
+```text
+J_{0,t} = q'_+(theta_t) - q'_-(theta_t)
+        = |x_t| [e_{t-1},e_t] / ([x_t,e_{t-1}] [x_t,e_t]) > 0.
+```
+
+So, in the distributional sense,
+
+```text
+q'' + q = sum_t J_{0,t} delta_{theta_t},
+```
+
+with positive atomic mass at the visible non-adjacent vertices.
+
+Now take two equal-level vertices `u < v` in angular order:
+
+```text
+q(theta_u) = q(theta_v) = s = 1/r,
+delta = theta_v - theta_u in (0,pi).
+```
+
+Solving from the left gives
+
+```text
+q(theta_v)
+  = q(theta_u) cos(delta)
+  + q'_+(theta_u) sin(delta)
+  + integral_(theta_u,theta_v) sin(theta_v - phi) dmu(phi).
+```
+
+Since `mu >= 0`,
+
+```text
+q'_+(theta_u) <= s tan(delta/2).
+```
+
+Solving backward gives
+
+```text
+q'_-(theta_v) >= -s tan(delta/2).
+```
+
+Apply the backward bound to the pair `(a,b)` and the forward bound to the pair
+`(b,c)`. Then
+
+```text
+J_{0,b} <= s (tan(delta_ab/2) + tan(delta_bc/2)).
+```
+
+Multiplying by `r` and substituting the jump formula gives the determinant
+inequality for `b`. The proof for `c` is identical.
+
+Finally, for equal-length vectors `x` and `y` spanning an angle in `(0,pi)`,
+
+```text
+tan(angle(x,y)/2) = [x,y] / (r^2 + x . y).
+```
+
+This gives the displayed algebraic form.
+
+## Cleared Polynomial Form
+
+For the middle witness `b`, clearing positive denominators gives:
+
+```text
+r^2 [e_{b-1},e_b]
+(r^2 + x_a . x_b)
+(r^2 + x_b . x_c)
+
+<=
+
+[x_b,e_{b-1}] [x_b,e_b]
+(
+  [x_a,x_b] (r^2 + x_b . x_c)
+  + [x_b,x_c] (r^2 + x_a . x_b)
+).
+```
+
+The corresponding formula for `c` is obtained by replacing `(a,b,c)` with
+`(b,c,d)`.
+
+## Negative Control
+
+The local lemma cannot rule out a single bad vertex. In the pentagon
+
+```text
+p_0 = (0,0),
+p_1 = (cos 20 deg,  sin 20 deg),
+p_2 = (cos 60 deg,  sin 60 deg),
+p_3 = (cos 120 deg, sin 120 deg),
+p_4 = (cos 160 deg, sin 160 deg),
+```
+
+the center `p_0` sees the other four vertices at unit distance, and both middle
+budget inequalities are tight. This is consistent with the known local
+counterexample to single-vertex obstruction arguments in
+`docs/canonical-synthesis.md`.
+
+## Next Use
+
+The useful next test is not whether this packet alone kills an existing finite
+frontier. It should first be used as an exact local filter:
+
+1. sort a selected row's four witnesses along the visible chain from the
+   center;
+2. emit the two middle-witness inequalities;
+3. clear the listed positive denominators;
+4. test whether these nonlinear inequalities create reusable obstruction
+   motifs that are not already vertex-circle, Kalmanson, Altman, or Ptolemy
+   certificates.
+
+Any future promotion requires a separate global budget theorem or a checked
+finite certificate that combines these inequalities with other exact
+constraints.

--- a/scripts/check_reciprocal_radial_budget.py
+++ b/scripts/check_reciprocal_radial_budget.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Check the reciprocal-radial middle-witness budget packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.reciprocal_radial_budget import smoke_report  # noqa: E402
+
+
+def assert_expected(report: dict[str, object], tolerance: float) -> None:
+    pentagon = report["pentagon_tight_example"]
+    if not isinstance(pentagon, dict):
+        raise AssertionError("malformed pentagon section")
+    max_abs_margin = float(pentagon["max_abs_margin"])
+    if max_abs_margin > tolerance:
+        raise AssertionError(
+            f"pentagon tightness drifted: {max_abs_margin} > {tolerance}"
+        )
+
+    jump = report["jump_formula_affine_circle"]
+    if not isinstance(jump, dict):
+        raise AssertionError("malformed jump-formula section")
+    max_abs_error = float(jump["max_abs_error"])
+    if max_abs_error > tolerance:
+        raise AssertionError(
+            f"jump formula error too large: {max_abs_error} > {tolerance}"
+        )
+    if float(jump["min_visible_denominator"]) <= 0:
+        raise AssertionError("expected positive visible denominators")
+    if float(jump["min_exterior_turn_cross"]) <= 0:
+        raise AssertionError("expected positive exterior turns")
+    if float(jump["min_convex_left_turn"]) <= 0:
+        raise AssertionError("affine-circle control is not strictly convex")
+
+
+def print_summary(report: dict[str, object]) -> None:
+    pentagon = report["pentagon_tight_example"]
+    jump = report["jump_formula_affine_circle"]
+    if not isinstance(pentagon, dict) or not isinstance(jump, dict):
+        raise TypeError("malformed reciprocal-radial smoke report")
+
+    print("reciprocal-radial budget smoke check")
+    print(f"trust: {report['trust']}")
+    print(f"scope: {report['claim_scope']}")
+    print(
+        "pentagon tight example max |rhs-lhs|: "
+        f"{float(pentagon['max_abs_margin']):.3e}"
+    )
+    print(
+        "jump formula affine-circle max error: "
+        f"{float(jump['max_abs_error']):.3e}"
+    )
+    print(
+        "minimum visible denominator / turn: "
+        f"{float(jump['min_visible_denominator']):.3e} / "
+        f"{float(jump['min_exterior_turn_cross']):.3e}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON output")
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert the deterministic smoke checks match expectations",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=1e-11,
+        help="floating tolerance for deterministic smoke checks",
+    )
+    args = parser.parse_args()
+
+    report = smoke_report()
+    if args.assert_expected:
+        assert_expected(report, args.tolerance)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_summary(report)
+        if args.assert_expected:
+            print("OK: reciprocal-radial budget smoke checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/reciprocal_radial_budget.py
+++ b/src/erdos97/reciprocal_radial_budget.py
@@ -1,0 +1,345 @@
+"""Local reciprocal-radial budget checks.
+
+This module implements the smoke checks for ``docs/reciprocal-radial-budget.md``.
+The inequalities are local necessary conditions for one equal-distance row;
+they are not a global obstruction by themselves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable
+
+Point = tuple[float, float]
+
+TRUST_LABEL = "RESEARCH_PACKET_LOCAL_NECESSARY_CONDITION"
+
+
+@dataclass(frozen=True)
+class BudgetInequality:
+    """One middle-witness reciprocal-radial budget inequality."""
+
+    center: int
+    ordered_witnesses: tuple[int, int, int, int]
+    middle: int
+    left: int
+    right: int
+    lhs: float
+    rhs: float
+    margin: float
+    positive_denominators: dict[str, float]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "center": self.center,
+            "ordered_witnesses": list(self.ordered_witnesses),
+            "middle": self.middle,
+            "left": self.left,
+            "right": self.right,
+            "lhs": self.lhs,
+            "rhs": self.rhs,
+            "margin_rhs_minus_lhs": self.margin,
+            "positive_denominators": self.positive_denominators,
+            "trust": TRUST_LABEL,
+        }
+
+
+@dataclass(frozen=True)
+class JumpFormulaCheck:
+    """One reciprocal-radial jump formula check."""
+
+    center: int
+    vertex: int
+    qprime_minus: float
+    qprime_plus: float
+    derivative_jump: float
+    closed_form_jump: float
+    error: float
+    incoming_denominator: float
+    outgoing_denominator: float
+    exterior_turn_cross: float
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "center": self.center,
+            "vertex": self.vertex,
+            "qprime_minus": self.qprime_minus,
+            "qprime_plus": self.qprime_plus,
+            "derivative_jump": self.derivative_jump,
+            "closed_form_jump": self.closed_form_jump,
+            "error": self.error,
+            "incoming_denominator": self.incoming_denominator,
+            "outgoing_denominator": self.outgoing_denominator,
+            "exterior_turn_cross": self.exterior_turn_cross,
+        }
+
+
+def cross(u: Point, v: Point) -> float:
+    return u[0] * v[1] - u[1] * v[0]
+
+
+def dot(u: Point, v: Point) -> float:
+    return u[0] * v[0] + u[1] * v[1]
+
+
+def sub(u: Point, v: Point) -> Point:
+    return (u[0] - v[0], u[1] - v[1])
+
+
+def rotate_ccw(u: Point) -> Point:
+    return (-u[1], u[0])
+
+
+def edge_vectors(points: list[Point]) -> list[Point]:
+    n = len(points)
+    return [sub(points[(j + 1) % n], points[j]) for j in range(n)]
+
+
+def visible_chain_offset(n: int, center: int, vertex: int) -> int:
+    offset = (vertex - center) % n
+    if offset == 0:
+        raise ValueError("center cannot be a witness")
+    return offset
+
+
+def order_witnesses_on_visible_chain(
+    n: int,
+    center: int,
+    witnesses: Iterable[int],
+) -> tuple[int, int, int, int]:
+    row = tuple(witnesses)
+    if len(row) != 4:
+        raise ValueError(f"expected four witnesses, got {len(row)}")
+    if len(set(row)) != 4:
+        raise ValueError("witnesses must be distinct")
+    if center in row:
+        raise ValueError("center cannot be included among witnesses")
+    return tuple(sorted(row, key=lambda vertex: visible_chain_offset(n, center, vertex)))
+
+
+def validate_ordered_witnesses(
+    n: int,
+    center: int,
+    ordered_witnesses: tuple[int, int, int, int],
+) -> None:
+    if len(ordered_witnesses) != 4:
+        raise ValueError("ordered_witnesses must have length 4")
+    if len(set(ordered_witnesses)) != 4:
+        raise ValueError("ordered_witnesses must be distinct")
+    offsets = [visible_chain_offset(n, center, vertex) for vertex in ordered_witnesses]
+    if offsets != sorted(offsets):
+        raise ValueError("witnesses are not ordered on the visible chain")
+
+
+def half_tan_equal_radius(x: Point, y: Point, r2: float) -> float:
+    """Return tan(angle(x,y)/2) for equal-length vectors in span < pi."""
+
+    return cross(x, y) / (r2 + dot(x, y))
+
+
+def middle_budget_inequalities(
+    points: list[Point],
+    center: int,
+    ordered_witnesses: tuple[int, int, int, int],
+) -> list[BudgetInequality]:
+    """Evaluate the two middle-witness budget inequalities for one row."""
+
+    n = len(points)
+    validate_ordered_witnesses(n, center, ordered_witnesses)
+    edges = edge_vectors(points)
+    output: list[BudgetInequality] = []
+
+    for left, middle, right in (
+        (ordered_witnesses[0], ordered_witnesses[1], ordered_witnesses[2]),
+        (ordered_witnesses[1], ordered_witnesses[2], ordered_witnesses[3]),
+    ):
+        x_left = sub(points[left], points[center])
+        x_middle = sub(points[middle], points[center])
+        x_right = sub(points[right], points[center])
+        r2 = dot(x_middle, x_middle)
+        incoming = (middle - 1) % n
+        outgoing = middle
+        incoming_den = cross(x_middle, edges[incoming])
+        outgoing_den = cross(x_middle, edges[outgoing])
+        left_dot_den = r2 + dot(x_left, x_middle)
+        right_dot_den = r2 + dot(x_middle, x_right)
+
+        lhs = (
+            r2
+            * cross(edges[incoming], edges[outgoing])
+            / (incoming_den * outgoing_den)
+        )
+        rhs = half_tan_equal_radius(
+            x_left,
+            x_middle,
+            r2,
+        ) + half_tan_equal_radius(x_middle, x_right, r2)
+
+        output.append(
+            BudgetInequality(
+                center=center,
+                ordered_witnesses=ordered_witnesses,
+                middle=middle,
+                left=left,
+                right=right,
+                lhs=lhs,
+                rhs=rhs,
+                margin=rhs - lhs,
+                positive_denominators={
+                    "[x_mid,e_mid-1]": incoming_den,
+                    "[x_mid,e_mid]": outgoing_den,
+                    "r2+x_left.x_mid": left_dot_den,
+                    "r2+x_mid.x_right": right_dot_den,
+                },
+            )
+        )
+
+    return output
+
+
+def jump_formula_check(points: list[Point], center: int, vertex: int) -> JumpFormulaCheck:
+    """Check the derivative-jump formula at one non-adjacent visible vertex."""
+
+    n = len(points)
+    if vertex == center:
+        raise ValueError("center cannot be the visible vertex")
+    offset = visible_chain_offset(n, center, vertex)
+    if offset in (1, n - 1):
+        raise ValueError("jump formula check expects a non-adjacent visible vertex")
+
+    edges = edge_vectors(points)
+    x = sub(points[vertex], points[center])
+    radius = math.hypot(x[0], x[1])
+    unit = (x[0] / radius, x[1] / radius)
+    rotated = rotate_ccw(unit)
+    incoming = (vertex - 1) % n
+    outgoing = vertex
+    incoming_den = cross(x, edges[incoming])
+    outgoing_den = cross(x, edges[outgoing])
+    qprime_minus = cross(rotated, edges[incoming]) / incoming_den
+    qprime_plus = cross(rotated, edges[outgoing]) / outgoing_den
+    derivative_jump = qprime_plus - qprime_minus
+    closed_form_jump = (
+        radius
+        * cross(edges[incoming], edges[outgoing])
+        / (incoming_den * outgoing_den)
+    )
+
+    return JumpFormulaCheck(
+        center=center,
+        vertex=vertex,
+        qprime_minus=qprime_minus,
+        qprime_plus=qprime_plus,
+        derivative_jump=derivative_jump,
+        closed_form_jump=closed_form_jump,
+        error=derivative_jump - closed_form_jump,
+        incoming_denominator=incoming_den,
+        outgoing_denominator=outgoing_den,
+        exterior_turn_cross=cross(edges[incoming], edges[outgoing]),
+    )
+
+
+def pentagon_tight_example() -> list[Point]:
+    """Return the local tight pentagon with one vertex seeing four unit witnesses."""
+
+    angles = [20.0, 60.0, 120.0, 160.0]
+    return [(0.0, 0.0)] + [
+        (math.cos(math.radians(angle)), math.sin(math.radians(angle)))
+        for angle in angles
+    ]
+
+
+def affine_circle_example(n: int = 12) -> list[Point]:
+    """Return a deterministic strictly convex affine image of points on a circle."""
+
+    return [
+        (
+            math.cos(0.17 + 2.0 * math.pi * k / n)
+            + 0.35 * math.sin(0.17 + 2.0 * math.pi * k / n),
+            0.4 * math.cos(0.17 + 2.0 * math.pi * k / n)
+            + 1.4 * math.sin(0.17 + 2.0 * math.pi * k / n),
+        )
+        for k in range(n)
+    ]
+
+
+def convex_left_turn_margins(points: list[Point]) -> list[float]:
+    n = len(points)
+    return [
+        cross(
+            sub(points[(idx + 1) % n], points[idx]),
+            sub(points[(idx + 2) % n], points[(idx + 1) % n]),
+        )
+        for idx in range(n)
+    ]
+
+
+def cleared_polynomial_template() -> dict[str, object]:
+    """Return the denominator-cleared middle-witness inequality template."""
+
+    return {
+        "middle_b_lhs": (
+            "r2*[e_{b-1},e_b]*(r2+x_a.x_b)*(r2+x_b.x_c)"
+        ),
+        "middle_b_rhs": (
+            "[x_b,e_{b-1}]*[x_b,e_b]*("
+            "[x_a,x_b]*(r2+x_b.x_c)+"
+            "[x_b,x_c]*(r2+x_a.x_b))"
+        ),
+        "positive_denominators": [
+            "[x_b,e_{b-1}]",
+            "[x_b,e_b]",
+            "r2+x_a.x_b",
+            "r2+x_b.x_c",
+        ],
+        "middle_c": "replace (a,b,c) by (b,c,d)",
+    }
+
+
+def smoke_report() -> dict[str, object]:
+    """Return deterministic checks for the packet's local formulas."""
+
+    pentagon = pentagon_tight_example()
+    pentagon_row = middle_budget_inequalities(pentagon, 0, (1, 2, 3, 4))
+    affine = affine_circle_example()
+    jump_checks = [
+        jump_formula_check(affine, center, vertex)
+        for center in range(len(affine))
+        for vertex in range(len(affine))
+        if vertex != center
+        and visible_chain_offset(len(affine), center, vertex)
+        not in (1, len(affine) - 1)
+    ]
+    convex_margins = convex_left_turn_margins(affine)
+    jump_errors = [abs(item.error) for item in jump_checks]
+    jump_denominators = [
+        value
+        for item in jump_checks
+        for value in (item.incoming_denominator, item.outgoing_denominator)
+    ]
+
+    return {
+        "schema": "reciprocal_radial_budget_smoke_v1",
+        "trust": TRUST_LABEL,
+        "claim_scope": (
+            "local necessary inequality only; not a proof of Erdos Problem #97"
+        ),
+        "pentagon_tight_example": {
+            "center": 0,
+            "ordered_witnesses": [1, 2, 3, 4],
+            "inequalities": [entry.to_json() for entry in pentagon_row],
+            "max_abs_margin": max(abs(entry.margin) for entry in pentagon_row),
+        },
+        "jump_formula_affine_circle": {
+            "polygon_size": len(affine),
+            "checked_non_adjacent_vertices": len(jump_checks),
+            "max_abs_error": max(jump_errors),
+            "min_visible_denominator": min(jump_denominators),
+            "min_exterior_turn_cross": min(
+                item.exterior_turn_cross for item in jump_checks
+            ),
+            "min_convex_left_turn": min(convex_margins),
+        },
+        "cleared_polynomial_template": cleared_polynomial_template(),
+    }

--- a/tests/test_reciprocal_radial_budget.py
+++ b/tests/test_reciprocal_radial_budget.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from erdos97.reciprocal_radial_budget import (
+    affine_circle_example,
+    jump_formula_check,
+    middle_budget_inequalities,
+    order_witnesses_on_visible_chain,
+    pentagon_tight_example,
+    smoke_report,
+    visible_chain_offset,
+)
+
+
+def test_visible_chain_ordering_sorts_across_modulus() -> None:
+    assert order_witnesses_on_visible_chain(9, 7, [2, 8, 0, 5]) == (8, 0, 2, 5)
+    assert visible_chain_offset(9, 7, 8) == 1
+    assert visible_chain_offset(9, 7, 5) == 7
+
+
+def test_pentagon_tight_example_hits_middle_budget_equalities() -> None:
+    points = pentagon_tight_example()
+    entries = middle_budget_inequalities(points, 0, (1, 2, 3, 4))
+
+    assert [entry.middle for entry in entries] == [2, 3]
+    assert max(abs(entry.margin) for entry in entries) < 1e-12
+    for entry in entries:
+        assert all(value > 0 for value in entry.positive_denominators.values())
+
+
+def test_jump_formula_on_affine_circle_control() -> None:
+    points = affine_circle_example()
+    errors = []
+    denominators = []
+    turns = []
+
+    for center in range(len(points)):
+        for vertex in range(len(points)):
+            if vertex == center:
+                continue
+            offset = visible_chain_offset(len(points), center, vertex)
+            if offset in (1, len(points) - 1):
+                continue
+            check = jump_formula_check(points, center, vertex)
+            errors.append(abs(check.error))
+            denominators.extend(
+                [check.incoming_denominator, check.outgoing_denominator]
+            )
+            turns.append(check.exterior_turn_cross)
+
+    assert max(errors) < 1e-12
+    assert min(denominators) > 0
+    assert min(turns) > 0
+
+
+def test_smoke_report_keeps_non_proof_scope() -> None:
+    report = smoke_report()
+
+    assert report["schema"] == "reciprocal_radial_budget_smoke_v1"
+    assert "not a proof" in str(report["claim_scope"])
+    assert report["trust"] == "RESEARCH_PACKET_LOCAL_NECESSARY_CONDITION"


### PR DESCRIPTION
## Summary

- Add a scoped `RESEARCH_PACKET` note for the reciprocal-radial middle-witness budget lemma.
- Add reusable local smoke-check logic plus a CLI checker for the jump formula and pentagon tightness control.
- Add focused pytest coverage and link the packet from the documentation index.

## Safety / scope

This does not promote a new theorem, counterexample, or global obstruction. The packet is explicitly scoped as a local necessary condition and keeps the global-budget gap visible.

## Validation

- `python scripts\check_reciprocal_radial_budget.py --assert-expected`
- `python -m pytest tests\test_reciprocal_radial_budget.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`