### PR TITLE
[codex] Record T11 strict-cycle local lemma

### DIFF
--- a/docs/n9-vertex-circle-t11-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t11-strict-cycle-lemma.md
@@ -52,6 +52,97 @@ Thus the packet isolates the directed cycle
 [0, 2] > [0, 3] = [0, 3] > [0, 5] = [5, 7] > [1, 5] = [0, 1] = [0, 2].
 ```
 
+## Local lemma
+
+The following local obstruction is independent of the exhaustive `n=9`
+brancher once the four displayed rows are assumed.
+
+Assume a strictly convex polygon has labels appearing in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8
+```
+
+and contains the four selected rows
+
+```text
+S_0 = {1,2,4,8}
+S_1 = {0,2,3,5}
+S_5 = {0,3,4,7}
+S_6 = {1,5,7,8}
+```
+
+Then these four rows cannot be realized.
+
+First use row `1`. Its selected witnesses occur in cyclic order
+
+```text
+2,3,5,0.
+```
+
+In a strictly convex polygon, the rays from a vertex to the other vertices
+occur in the polygon's cyclic order inside an angle smaller than `pi`. Since
+the row-`1` witnesses lie on one circle centered at vertex `1`, chord length
+on that circle is strictly increasing with the enclosed central angle in this
+range. The chord `[0,2]` strictly contains `[0,3]`, and `[0,3]` strictly
+contains `[0,5]`, in the row-`1` witness order. Hence
+
+```text
+d(0,2) > d(0,3) > d(0,5).                (1)
+```
+
+Row `5` identifies the last chord in (1) with the next outer chord:
+
+```text
+d(0,5) = d(5,7)      from row 5.
+```
+
+Thus
+
+```text
+d(0,2) > d(0,3) > d(5,7).                (2)
+```
+
+Next use row `6`. Its selected witnesses occur in cyclic order
+
+```text
+7,8,1,5.
+```
+
+The chord `[5,7]` strictly contains `[1,5]` in this row-`6` witness order, so
+
+```text
+d(5,7) > d(1,5).                         (3)
+```
+
+Rows `1` and `0` identify this inner chord with the first outer chord:
+
+```text
+d(1,5) = d(0,1)      from row 1,
+d(0,1) = d(0,2)      from row 0.
+```
+
+Therefore
+
+```text
+d(5,7) > d(0,2).                         (4)
+```
+
+Combining (2) and (4) gives the impossible strict cycle
+
+```text
+d(0,2) > d(0,3) > d(5,7) > d(0,2).
+```
+
+Equivalently, after quotienting ordinary pair distances by the selected
+distance equalities, rows `1`, `5`, and `6` create a directed strict cycle of
+length three.
+
+The lemma is local: it rules out any selected-witness system containing these
+four rows in the stated cyclic order. It does not prove the full `n=9` finite
+case, because the exhaustive checker is still needed to show that every
+frontier assignment contains one of the recorded local obstruction templates.
+
 ## Commands
 
 Generate and check the packet:

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,183 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 619 - T11/F07 Local Strict-Cycle Proof Note
+
+### Mathematical Subquestion
+
+The `n=9` vertex-circle strict-cycle packet already records the `T11/F07`
+four-row obstruction and the running log had a human-readable derivation, but
+the canonical packet note was still mostly a packet summary. The narrow
+question for this cycle was:
+
+Can the T11/F07 strict-cycle packet be restated in its proof-facing note as a
+standalone local lemma whose contradiction follows directly from
+vertex-circle strict inequalities and selected-distance quotienting, without
+invoking the exhaustive `n=9` brancher?
+
+### Definitions and Assumptions
+
+For a selected row `S_c`, all distances `d(c,x)` with `x in S_c` are equal.
+Work in a strictly convex polygon with labels in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8.
+```
+
+The T11/F07 local core consists of the four selected rows
+
+```text
+S_0 = {1,2,4,8}
+S_1 = {0,2,3,5}
+S_5 = {0,3,4,7}
+S_6 = {1,5,7,8}.
+```
+
+Use the standard vertex-circle monotonicity fact: if several selected
+witnesses lie on one circle centered at a polygon vertex, then nested witness
+chords in the radial order around that center have strictly increasing
+ordinary length.
+
+### Result Status
+
+Proved local lemma:
+**T11/F07 Three-Edge Strict-Cycle Lemma**.
+
+The four displayed rows are impossible in the stated cyclic order.
+
+### Argument
+
+Row `1` has witness order
+
+```text
+2,3,5,0.
+```
+
+The chord `[0,2]` strictly contains `[0,3]`, and `[0,3]` strictly contains
+`[0,5]`, in this row-`1` witness order. Thus vertex-circle monotonicity gives
+
+```text
+d(0,2) > d(0,3) > d(0,5).                (1)
+```
+
+Row `5` identifies the last chord in (1) with the next outer chord:
+
+```text
+d(0,5) = d(5,7)      from row 5.
+```
+
+Therefore
+
+```text
+d(0,2) > d(0,3) > d(5,7).                (2)
+```
+
+Row `6` has witness order
+
+```text
+7,8,1,5.
+```
+
+The chord `[5,7]` strictly contains `[1,5]` in this row-`6` witness order, so
+
+```text
+d(5,7) > d(1,5).                         (3)
+```
+
+Rows `1` and `0` identify this inner chord with the first outer chord:
+
+```text
+d(1,5) = d(0,1)      from row 1,
+d(0,1) = d(0,2)      from row 0.
+```
+
+Combining these equalities with (3) gives
+
+```text
+d(5,7) > d(0,2).                         (4)
+```
+
+The strict inequalities (2) and (4) produce the impossible cycle
+
+```text
+d(0,2) > d(0,3) > d(5,7) > d(0,2).
+```
+
+Equivalently, after quotienting ordinary pair distances by the selected
+distance equalities, rows `1`, `5`, and `6` create a directed strict cycle of
+length three.
+
+### Exact Scope
+
+This is a local obstruction lemma for the four displayed selected rows in the
+stated cyclic order. It is independent of the exhaustive brancher once those
+rows are given.
+
+It does not prove the full `n=9` finite case, because the review-pending
+exhaustive checker is still needed to show that every `n=9` frontier
+assignment contains a recorded local obstruction template. It does not prove
+Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+This turns the second review-pending strict-cycle packet into a reusable
+proof-facing local lemma in the same style as the T10/F12 note. It strengthens
+the proof-mining library of local obstructions, but only locally: future work
+must still prove that arbitrary or finite frontier assignments force one of
+these local cores.
+
+### Next Lead
+
+Apply the same proof-note consolidation to `T12/F16`, then consider a
+single quotient-graph meta-lemma covering both local self-edge and local
+strict-cycle packets.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-619`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-619`.
+- The branch was based on `origin/main` at commit
+  `b7cb0238d2a58cb181e6f67f0a1421ab00325beb`, after PR #306 merged Cycle
+  618.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check
+  --assert-expected --json`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check
+  --assert-expected --json`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 618 - T10/F12 Local Strict-Cycle Proof Note
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Scope

Ready replacement for draft PR #307, using the same branch and head commit `a258f0b5b9d0e942c38d3fcbdde29417ce7382fe`. Draft PR #307 had green hosted CI but could not be marked ready because the connector hit the known GraphQL `htmlUrl` field error.

This PR records Cycle 619 of the Erdos97 research log. It promotes the T11/F07 strict-cycle packet note from a packet summary into a proof-facing local lemma: the four displayed selected rows force a three-edge directed strict cycle after selected-distance quotienting:

```text
d(0,2) > d(0,3) > d(5,7) > d(0,2)
```

## Files Changed

- `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

Local validation:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`530 passed, 275 deselected`)

Hosted validation on draft PR #307:

- `tests / pytest (3.10)`: passed
- `tests / pytest (3.11)`: passed
- `tests / pytest (3.12)`: passed

## Limitations

This is a local obstruction lemma for the displayed T11/F07 row core only. It does not prove the full `n=9` finite case, does not prove Erdos Problem #97, and does not give a counterexample.