### PR TITLE
[codex] Record T04 self-edge local lemma

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t03-self-edge-lemma.md`](n9-vertex-circle-t03-self-edge-lemma.md):
   focused review-pending T03 multi-family self-edge local lemma packet for
   proof mining.
+- [`n9-vertex-circle-t04-self-edge-lemma.md`](n9-vertex-circle-t04-self-edge-lemma.md):
+  focused review-pending T04/F13 self-edge local lemma packet for proof
+  mining.
 - [`n9-vertex-circle-t10-strict-cycle-lemma.md`](n9-vertex-circle-t10-strict-cycle-lemma.md):
   focused review-pending T10/F12 strict-cycle local lemma packet for proof
   mining.

--- a/docs/n9-vertex-circle-t04-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t04-self-edge-lemma.md
@@ -1,0 +1,149 @@
+# n=9 Vertex-circle T04/F13 Self-edge Local Lemma
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one focused proof-mining extraction for the `T04/F13`
+self-edge motif. It does not claim a proof of `n=9`, does not claim a
+counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Packet scope
+
+The checked source artifact is
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json`, whose
+`T04` record is derived from:
+
+- `data/certificates/n9_vertex_circle_self_edge_path_join.json`
+- `data/certificates/n9_vertex_circle_core_templates.json`
+- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
+
+The template covers two assignment ids:
+
+```text
+A023, A174
+```
+
+Both assignments belong to family `F13`. The canonical local core is the
+four-row certificate:
+
+```text
+[0, 1, 2, 5, 7]
+[1, 2, 3, 6, 8]
+[3, 1, 4, 5, 8]
+[5, 1, 3, 6, 7]
+```
+
+Here `[c, a, b, d, e]` means that `a,b,d,e` are the selected witnesses for
+center `c`, hence the four distances from `c` to those witnesses are equal.
+
+## Local lemma
+
+The following local obstruction is independent of the exhaustive `n=9`
+brancher once the displayed rows are given.
+
+Assume a strictly convex polygon has labels appearing in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8
+```
+
+and contains the four selected rows
+
+```text
+S_0 = {1,2,5,7}
+S_1 = {2,3,6,8}
+S_3 = {1,4,5,8}
+S_5 = {1,3,6,7}.
+```
+
+Then these four rows cannot be realized.
+
+Indeed, the selected-distance equalities give
+
+```text
+d(1,5) = d(3,5)      from row 5,
+d(3,5) = d(1,3)      from row 3,
+d(1,3) = d(1,2)      from row 1.
+```
+
+Thus
+
+```text
+d(1,5) = d(1,2).
+```
+
+On the other hand, the selected witnesses of row `0` lie on one circle
+centered at vertex `0`, and their radial order is
+
+```text
+1,2,5,7.
+```
+
+In a strictly convex polygon, the rays from a vertex to the other vertices
+occur in polygon cyclic order inside an angle smaller than `pi`. On a fixed
+circle, chord length is strictly increasing with the enclosed central angle in
+this range. The chord `[1,5]` strictly contains the chord `[1,2]` in the
+row-`0` witness order, so
+
+```text
+d(1,5) > d(1,2).
+```
+
+This contradicts the equality above. Equivalently, after quotienting ordinary
+pair distances by the selected-distance equalities, row `0` creates a
+reflexive strict edge for the quotient class of `[1,5]` and `[1,2]`.
+
+The lemma is local: it rules out any selected-witness system containing these
+four rows in the stated cyclic order. It does not prove the full `n=9` finite
+case, because the exhaustive checker is still needed to show that every
+frontier assignment contains one of the recorded local obstruction templates.
+
+## Packet data
+
+For row `0`, the witness order `[1, 2, 5, 7]` gives the strict
+vertex-circle inequality
+
+```text
+[1, 5] > [1, 2]
+```
+
+The selected-distance equality path is:
+
+```text
+[1, 5] -- row 5 --> [3, 5]
+[3, 5] -- row 3 --> [1, 3]
+[1, 3] -- row 1 --> [1, 2]
+```
+
+Thus the packet isolates a four-row local self-edge shape: a strict edge from
+a selected-distance quotient class back to itself.
+
+## Commands
+
+Check the source packet and the combined template catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_self_edge_template_packet.py -q -m "artifact"
+```
+
+## Review standard
+
+Before treating this as a reusable local lemma, a reviewer should restate the
+incidence and cyclic-order hypotheses without relying on `T04` as a theorem
+name, then prove directly that the four rows force the displayed equality path
+and that row `0` gives the displayed strict inequality. The packet is a small
+replay aid for that review, not an independent proof of the `n=9` case.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,150 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 621 - T04/F13 Local Self-Edge Proof Note
+
+### Mathematical Subquestion
+
+The `n=9` vertex-circle self-edge template packet contains six unpromoted
+self-edge templates after the existing `T01`, `T02`, and `T03` proof notes.
+The smallest remaining packet is `T04/F13`, covering two assignments. The
+narrow question for this cycle was:
+
+Can the T04/F13 self-edge packet be restated as a standalone local lemma whose
+contradiction follows directly from selected-distance equalities and
+vertex-circle monotonicity, without invoking the exhaustive `n=9` brancher?
+
+### Definitions and Assumptions
+
+For a selected row `S_c`, all distances `d(c,x)` with `x in S_c` are equal.
+Work in a strictly convex polygon with labels in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8.
+```
+
+The T04/F13 local core consists of the four selected rows
+
+```text
+S_0 = {1,2,5,7}
+S_1 = {2,3,6,8}
+S_3 = {1,4,5,8}
+S_5 = {1,3,6,7}.
+```
+
+Use the standard vertex-circle monotonicity fact: if several selected
+witnesses lie on one circle centered at a polygon vertex, then nested witness
+chords in the radial order around that center have strictly increasing
+ordinary length.
+
+### Result Status
+
+Proved local lemma:
+**T04/F13 Four-Row Self-Edge Lemma**.
+
+The four displayed rows are impossible in the stated cyclic order.
+
+### Argument
+
+The selected rows force the equality chain
+
+```text
+d(1,5) = d(3,5)      from row 5,
+d(3,5) = d(1,3)      from row 3,
+d(1,3) = d(1,2)      from row 1.
+```
+
+Hence
+
+```text
+d(1,5) = d(1,2).
+```
+
+But row `0` has witness order
+
+```text
+1,2,5,7.
+```
+
+In a strictly convex polygon, rays from a vertex to the other vertices occur
+in cyclic order inside an angle smaller than `pi`. Since the row-`0`
+witnesses lie on a common circle centered at `0`, the chord `[1,5]` strictly
+contains `[1,2]` in that witness order. Therefore
+
+```text
+d(1,5) > d(1,2),
+```
+
+contradicting the equality chain. In quotient-graph language, the selected
+distance equalities identify `[1,5]` and `[1,2]`, while row `0` orients a
+strict edge from that quotient class to itself.
+
+### Exact Scope
+
+This is a local obstruction lemma for the four displayed selected rows in the
+stated cyclic order. It is independent of the exhaustive brancher once those
+rows are given.
+
+It does not prove the full `n=9` finite case, because the review-pending
+exhaustive checker is still needed to show that every `n=9` frontier
+assignment contains a recorded local obstruction template. It does not prove
+Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-t04-self-edge-lemma.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+This extends proof-note consolidation from the first three self-edge templates
+to the next smallest remaining self-edge template. The proof uses the same
+mechanism as the earlier self-edge notes: a selected-distance equality path
+returns an outer and inner row-circle chord to the same quotient class, while
+vertex-circle monotonicity orients a strict self-edge. This strengthens the
+local lemma catalog, but it does not bridge arbitrary selected-witness
+systems to the catalog.
+
+### Next Lead
+
+Continue with one of the 18-assignment self-edge templates `T05` through
+`T09`, or look for a schematic statement covering the repeated four-row
+selected-path self-edge mechanism shared by `T03` and `T04`.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-621`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-621`.
+- The branch was based on `origin/main` at commit
+  `31591afd1d7f8715932d82ca811ff826c733b99a`, after PR #311 merged Cycle
+  620.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check
+  --assert-expected --json`: passed; the packet reports `T04: 2`,
+  self-edge template count `9`, and no validation errors.
+- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed; the catalog reports 184 covered
+  assignments, 12 templates, and no validation errors.
+- `python scripts/check_text_clean.py`: passed.
+- `python scripts/check_status_consistency.py`: passed.
+- `python scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `python -m ruff check .`: passed.
+- `python -m pytest -q`: passed, `534 passed, 275 deselected in 69.65s`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 620 - T12/F16 Local Strict-Cycle Proof Note
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Scope

Ready replacement for draft PR #312, using the same branch and head SHA `a60e7c1ba1ee00e3437c179c98c064b9ce9ce05f`. Draft PR #312 had green hosted CI but could not be marked ready because the connector returned the known GraphQL `htmlUrl` field error.

This PR records Cycle 621 of the Erdos97 research log.

It adds a proof-facing note for the T04/F13 local self-edge motif from the review-pending n=9 vertex-circle template packet. The displayed four selected rows force the equality path

```text
d(1,5) = d(3,5) = d(1,3) = d(1,2)
```

while row 0's vertex-circle order forces

```text
d(1,5) > d(1,2)
```

so the row core is impossible in the stated cyclic order.

## Files Changed

- `docs/n9-vertex-circle-t04-self-edge-lemma.md`
- `docs/index.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

Local validation:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`534 passed, 275 deselected`)

Hosted validation from draft PR #312:

- Workflow run `25614212565`: Python 3.10, 3.11, and 3.12 jobs all completed successfully.

## Limitations

This is a local obstruction lemma for the displayed T04/F13 row core only. It does not prove the full `n=9` finite case, does not prove Erdos Problem #97, and does not give a counterexample.