### PR TITLE
[codex] Record T09 self-edge local lemma

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -138,6 +138,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t08-self-edge-lemma.md`](n9-vertex-circle-t08-self-edge-lemma.md):
   focused review-pending T08/F02 self-edge local lemma packet for proof
   mining.
+- [`n9-vertex-circle-t09-self-edge-lemma.md`](n9-vertex-circle-t09-self-edge-lemma.md):
+  focused review-pending T09/F03 self-edge local lemma packet for proof
+  mining.
 - [`n9-vertex-circle-t10-strict-cycle-lemma.md`](n9-vertex-circle-t10-strict-cycle-lemma.md):
   focused review-pending T10/F12 strict-cycle local lemma packet for proof
   mining.

--- a/docs/n9-vertex-circle-t09-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t09-self-edge-lemma.md
@@ -1,0 +1,160 @@
+# n=9 Vertex-circle T09/F03 Self-edge Local Lemma
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one focused proof-mining extraction for the `T09/F03`
+self-edge motif. It does not claim a proof of `n=9`, does not claim a
+counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Packet scope
+
+The checked source artifact is
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json`, whose
+`T09` record is derived from:
+
+- `data/certificates/n9_vertex_circle_self_edge_path_join.json`
+- `data/certificates/n9_vertex_circle_core_templates.json`
+- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
+
+The template covers 18 assignment ids:
+
+```text
+A003, A010, A017, A030, A033, A044, A049, A073, A107,
+A108, A123, A130, A135, A142, A144, A160, A161, A169
+```
+
+All assignments belong to family `F03`. The canonical local core is the
+six-row certificate:
+
+```text
+[0, 1, 2, 3, 8]
+[1, 0, 3, 5, 7]
+[2, 1, 3, 4, 6]
+[3, 2, 4, 5, 8]
+[4, 0, 3, 6, 8]
+[8, 0, 1, 4, 7]
+```
+
+Here `[c, a, b, d, e]` means that `a,b,d,e` are the selected witnesses for
+center `c`, hence the four distances from `c` to those witnesses are equal.
+
+## Local lemma
+
+The following local obstruction is independent of the exhaustive `n=9`
+brancher once the displayed rows are given.
+
+Assume a strictly convex polygon has labels appearing in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8
+```
+
+and contains the six selected rows
+
+```text
+S_0 = {1,2,3,8}
+S_1 = {0,3,5,7}
+S_2 = {1,3,4,6}
+S_3 = {2,4,5,8}
+S_4 = {0,3,6,8}
+S_8 = {0,1,4,7}.
+```
+
+Then these six rows cannot be realized.
+
+Indeed, the selected-distance equalities give
+
+```text
+d(1,3) = d(0,1)      from row 1,
+d(0,1) = d(0,8)      from row 0,
+d(0,8) = d(4,8)      from row 8,
+d(4,8) = d(3,4)      from row 4,
+d(3,4) = d(2,3)      from row 3,
+d(2,3) = d(1,2)      from row 2.
+```
+
+Thus
+
+```text
+d(1,3) = d(1,2).
+```
+
+On the other hand, the selected witnesses of row `0` lie on one circle
+centered at vertex `0`, and their radial order is
+
+```text
+1,2,3,8.
+```
+
+In a strictly convex polygon, the rays from a vertex to the other vertices
+occur in polygon cyclic order inside an angle smaller than `pi`. On a fixed
+circle, chord length is strictly increasing with the enclosed central angle in
+this range. The chord `[1,3]` strictly contains the chord `[1,2]` in the
+row-`0` witness order, so
+
+```text
+d(1,3) > d(1,2).
+```
+
+This contradicts the equality above. Equivalently, after quotienting ordinary
+pair distances by the selected-distance equalities, row `0` creates a
+reflexive strict edge for the quotient class of `[1,3]` and `[1,2]`.
+
+The lemma is local: it rules out any selected-witness system containing these
+six rows in the stated cyclic order. It does not prove the full `n=9` finite
+case, because the exhaustive checker is still needed to show that every
+frontier assignment contains one of the recorded local obstruction templates.
+
+## Packet data
+
+For row `0`, the witness order `[1, 2, 3, 8]` gives the strict
+vertex-circle inequality
+
+```text
+[1, 3] > [1, 2]
+```
+
+The selected-distance equality path is:
+
+```text
+[1, 3] -- row 1 --> [0, 1]
+[0, 1] -- row 0 --> [0, 8]
+[0, 8] -- row 8 --> [4, 8]
+[4, 8] -- row 4 --> [3, 4]
+[3, 4] -- row 3 --> [2, 3]
+[2, 3] -- row 2 --> [1, 2]
+```
+
+Thus the packet isolates a six-row local self-edge shape: a strict edge from
+a selected-distance quotient class back to itself.
+
+## Commands
+
+Check the source packet and the combined template catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_self_edge_template_packet.py -q -m "artifact"
+```
+
+## Review standard
+
+Before treating this as a reusable local lemma, a reviewer should restate the
+incidence and cyclic-order hypotheses without relying on `T09` as a theorem
+name, then prove directly that the six rows force the displayed equality path
+and that row `0` gives the displayed strict inequality. The packet is a small
+replay aid for that review, not an independent proof of the `n=9` case.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,166 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 628 - T09/F03 Focused Self-Edge Proof Note
+
+### Mathematical Subquestion
+
+The `T09/F03` self-edge proof was previously recorded in the long research
+log, but it had not been promoted to a focused documentation page indexed with
+the other proof-mined vertex-circle lemmas. The narrow question for this cycle
+was:
+
+Can the `T09/F03` self-edge packet be restated as a standalone local lemma
+page whose contradiction follows directly from selected-distance equalities
+and vertex-circle monotonicity, without invoking the exhaustive `n=9`
+brancher?
+
+### Definitions and Assumptions
+
+For a selected row `S_c`, all distances `d(c,x)` with `x in S_c` are equal.
+Work in a strictly convex polygon with labels in cyclic order
+
+```text
+0,1,2,3,4,5,6,7,8.
+```
+
+Use the standard vertex-circle monotonicity fact: if several selected
+witnesses lie on one circle centered at a polygon vertex, then nested witness
+chords in the radial order around that center have strictly increasing
+ordinary length.
+
+The `T09/F03` local core consists of the six selected rows
+
+```text
+S_0 = {1,2,3,8}
+S_1 = {0,3,5,7}
+S_2 = {1,3,4,6}
+S_3 = {2,4,5,8}
+S_4 = {0,3,6,8}
+S_8 = {0,1,4,7}.
+```
+
+### Result Status
+
+Proved local lemma:
+**T09/F03 Six-Row Self-Edge Lemma**.
+
+The six displayed rows are impossible in the stated cyclic order.
+
+### Argument
+
+The selected rows force the equality chain
+
+```text
+d(1,3) = d(0,1)      from row 1,
+d(0,1) = d(0,8)      from row 0,
+d(0,8) = d(4,8)      from row 8,
+d(4,8) = d(3,4)      from row 4,
+d(3,4) = d(2,3)      from row 3,
+d(2,3) = d(1,2)      from row 2.
+```
+
+Hence
+
+```text
+d(1,3) = d(1,2).
+```
+
+But row `0` has witness order
+
+```text
+1,2,3,8.
+```
+
+In a strictly convex polygon, rays from a vertex to the other vertices occur
+in cyclic order inside an angle smaller than `pi`. Since the row-`0`
+witnesses lie on a common circle centered at `0`, the chord `[1,3]` strictly
+contains `[1,2]` in that witness order. Therefore
+
+```text
+d(1,3) > d(1,2),
+```
+
+contradicting the equality chain. In quotient-graph language, the selected
+distance equalities identify `[1,3]` and `[1,2]`, while row `0` orients a
+strict edge from that quotient class to itself.
+
+### Exact Scope
+
+This is a local obstruction lemma for the six displayed selected rows in the
+stated cyclic order. It is independent of the exhaustive brancher once those
+rows are given.
+
+It does not prove the full `n=9` finite case, because the review-pending
+exhaustive checker is still needed to show that every `n=9` frontier
+assignment contains a recorded local obstruction template. It does not prove
+Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-t09-self-edge-lemma.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+This promotes the last remaining single-family self-edge packet into the
+same focused documentation shape as `T04` through `T08`. The focused notes
+now expose direct human-readable self-edge contradictions for `T01` through
+`T09`; the remaining proof-mining pressure in this catalog is on the
+strict-cycle templates and on the finite-to-local bridge.
+
+### Next Lead
+
+Abstract a schematic selected-path self-edge lemma covering `T01` through
+`T09`, or continue with the already indexed strict-cycle notes and the bridge
+from arbitrary selected-witness assignments to the cataloged local cores.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-628`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-628`.
+- The branch was based on `origin/main` at commit
+  `81e9a39d3c03846318f76edc0d1b31b2abe01254`, after PR #325 merged Cycle
+  627.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_self_edge_template_packet.py --check
+  --assert-expected --json`
+  passed. The packet checker reported `ok: true`, 158 self-edge
+  assignments, 13 families, 9 templates, and `T09: 18` assignments.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`
+  passed. The catalog checker reported `ok: true`, 184 covered assignments,
+  12 templates, and no validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`
+  passed.
+- `git diff --check` passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`
+  passed with 534 passed and 275 deselected.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 627 - T08/F02 Focused Self-Edge Proof Note
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

Records Cycle 628 as a focused proof-mining note for the review-pending `n=9` vertex-circle `T09/F03` self-edge packet.

The new note proves only the local six-row obstruction once the selected rows are given:

- `S_0 = {1,2,3,8}`
- `S_1 = {0,3,5,7}`
- `S_2 = {1,3,4,6}`
- `S_3 = {2,4,5,8}`
- `S_4 = {0,3,6,8}`
- `S_8 = {0,1,4,7}`

It does not claim a proof of Erdos Problem #97, does not claim a counterexample, and does not claim the full `n=9` finite case outside the existing review-pending checker pipeline.

## Files changed

- `docs/n9-vertex-circle-t09-self-edge-lemma.md`
- `docs/index.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`534 passed, 275 deselected`)

## Remaining limitations

The overarching proof/counterexample goal remains open. This PR only promotes one local proof packet into independently reviewable prose.