### PR TITLE
[codex] Record self-edge criterion page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,9 @@ put detailed reconciliation in the canonical synthesis.
   vertex-circle strict-chord filter.
 - [`n9-vertex-circle-template-lemma-catalog.md`](n9-vertex-circle-template-lemma-catalog.md):
   derived 12-template lemma-candidate catalog for proof-mining review.
+- [`n9-vertex-circle-self-edge-criterion.md`](n9-vertex-circle-self-edge-criterion.md):
+  selected-path self-edge criterion unifying the T01 through T09 local
+  self-edge packets.
 - [`n9-vertex-circle-t01-self-edge-lemma.md`](n9-vertex-circle-t01-self-edge-lemma.md):
   focused review-pending T01/F09 self-edge local lemma packet for proof
   mining.

--- a/docs/n9-vertex-circle-self-edge-criterion.md
+++ b/docs/n9-vertex-circle-self-edge-criterion.md
@@ -1,0 +1,167 @@
+# n=9 Vertex-circle Selected-path Self-edge Criterion
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records the common local contradiction behind the `T01` through
+`T09` vertex-circle self-edge packets. It does not claim a proof of `n=9`,
+does not claim a counterexample, does not complete independent review of the
+exhaustive checker, and does not update the official/global status.
+
+## Criterion
+
+Let `P` be a strictly convex polygon with labelled vertices, and let selected
+rows be written
+
+```text
+S_c = {a,b,d,e}.
+```
+
+The row `S_c` means that the four spoke distances
+
+```text
+d(c,a), d(c,b), d(c,d), d(c,e)
+```
+
+are equal. These selected-row equalities generate an equivalence relation on
+unordered vertex pairs. Write `D([x,y])` for the common distance value of the
+selected-distance quotient class containing `{x,y}`.
+
+A selected-distance equality path from an unordered pair `p` to an unordered
+pair `q` is a finite sequence
+
+```text
+p = p_0, p_1, ..., p_k = q
+```
+
+where each equality `D(p_j) = D(p_{j+1})` is forced by one selected row.
+
+A certified strict edge `p > q` is a separately checked vertex-circle
+inequality saying that every realization of the displayed local row core has
+
+```text
+D(p) > D(q).
+```
+
+In the `n=9` self-edge packets, the strict edge comes from the usual
+vertex-circle monotonicity lemma: on one selected circle, a chord whose
+witness interval properly contains another witness interval is strictly
+longer.
+
+**Selected-path self-edge criterion.** If a local row core contains both
+
+```text
+p > q
+```
+
+and a selected-distance equality path from `p` to `q`, then that local core is
+unrealizable.
+
+Indeed, the equality path gives
+
+```text
+D(p) = D(q),
+```
+
+while the strict edge gives
+
+```text
+D(p) > D(q),
+```
+
+a contradiction.
+
+Equivalently, after quotienting ordinary pair distances by the selected-row
+equalities, the local row core has a reflexive strict edge.
+
+## Current Packet Audit
+
+The checked source artifact is
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json`. It is
+derived into the combined template catalog
+`data/certificates/n9_vertex_circle_template_lemma_catalog.json`.
+
+The current self-edge packet records:
+
+```text
+self-edge templates:       9
+self-edge family records: 13
+covered assignments:     158
+```
+
+The criterion applies exactly to every family record in that packet: in each
+record, the strict outer pair is the equality-path start pair, and the strict
+inner pair is the equality-path end pair.
+
+```text
+T01/F09: assignments=6  path=3  strict [1,8] > [1,2]
+T02/F01: assignments=18 path=3  strict [1,8] > [1,2]
+T02/F04: assignments=18 path=3  strict [0,2] > [2,3]
+T02/F08: assignments=2  path=3  strict [1,8] > [1,2]
+T02/F14: assignments=2  path=3  strict [1,8] > [1,2]
+T03/F05: assignments=18 path=3  strict [3,7] > [1,7]
+T03/F15: assignments=2  path=3  strict [1,4] > [3,4]
+T04/F13: assignments=2  path=3  strict [1,5] > [1,2]
+T05/F10: assignments=18 path=3  strict [1,8] > [1,2]
+T06/F11: assignments=18 path=4  strict [3,8] > [3,5]
+T07/F06: assignments=18 path=4  strict [1,4] > [1,2]
+T08/F02: assignments=18 path=5  strict [1,3] > [1,2]
+T09/F03: assignments=18 path=6  strict [1,3] > [1,2]
+```
+
+The audit counts are:
+
+```text
+family-record path lengths:       {3: 9, 4: 2, 5: 1, 6: 1}
+assignment-weighted path lengths: {3: 86, 4: 36, 5: 18, 6: 18}
+mismatch count:                   0
+audit digest: c76e76eea27c61eca04a755ef0c7f15d4cf77f9513f55697da5ad1aa105172b4
+```
+
+## Scope
+
+This criterion is a local final-contradiction lemma. It applies only after
+the local selected-row equalities and the local vertex-circle strict edge have
+already been checked.
+
+It does not prove the full `n=9` finite case, because the exhaustive checker
+and assignment-to-template crosswalk are still needed to show that every
+frontier assignment contains one of the recorded local obstruction templates.
+It does not prove Erdos Problem #97 and does not give a counterexample.
+
+## Commands
+
+Check the source packet and the combined template catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+The family-record audit can be reproduced by parsing
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json` and
+checking:
+
+```text
+strict_inequality.outer_pair == distance_equality.start_pair
+strict_inequality.inner_pair == distance_equality.end_pair
+```
+
+for every family record.
+
+## Review Standard
+
+Before using this criterion in a proof, a reviewer should independently check
+the two local inputs for the particular row core under discussion:
+
+1. the selected rows really force the displayed equality path; and
+2. the vertex-circle witness order really forces the displayed strict edge.
+
+Once those two inputs are established, the contradiction in this note is just
+the incompatibility of `D(p) = D(q)` with `D(p) > D(q)`.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,184 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 629 - Selected-Path Self-Edge Criterion Page
+
+### Mathematical Subquestion
+
+After the focused `T07`, `T08`, and `T09` self-edge notes were promoted, the
+next narrow question was:
+
+Can the repeated `T01` through `T09` self-edge mechanism be stated as one
+reviewer-facing local criterion, with an exact audit that the current
+self-edge packet records all satisfy it?
+
+### Definitions and Assumptions
+
+For a selected row `S_c`, all distances `d(c,x)` with `x in S_c` are equal.
+These equalities generate a selected-distance quotient relation on unordered
+vertex pairs. Write `D(p)` for the distance value of a pair or quotient class
+`p`.
+
+A selected-distance equality path from `p` to `q` is a sequence
+
+```text
+p = p_0, p_1, ..., p_k = q
+```
+
+where each equality `D(p_j)=D(p_{j+1})` is forced by one selected row.
+
+A certified strict edge `p > q` is a local vertex-circle inequality already
+proved from a selected row's witness order, usually by nested chord
+monotonicity on that row circle.
+
+### Result Status
+
+Proved local criterion plus exact current-packet audit:
+**Selected-Path Self-Edge Criterion**.
+
+If a local row core has both a certified strict edge `p > q` and a
+selected-distance equality path from `p` to `q`, then the local row core is
+unrealizable.
+
+### Argument
+
+The equality path gives
+
+```text
+D(p)=D(q).
+```
+
+The certified strict edge gives
+
+```text
+D(p)>D(q).
+```
+
+These two statements are incompatible for real distances. Equivalently, after
+selected-distance quotienting, the local core has a reflexive strict edge.
+
+### Exact Current-Packet Audit
+
+A one-off exact JSON audit over
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json` checked
+every self-edge family record for:
+
+```text
+strict_inequality.outer_pair == distance_equality.start_pair
+strict_inequality.inner_pair == distance_equality.end_pair
+```
+
+The audit found:
+
+```text
+family_records: 13
+assignments: 158
+path_counts: {3: 9, 4: 2, 5: 1, 6: 1}
+assignment_weighted_path_counts: {3: 86, 4: 36, 5: 18, 6: 18}
+mismatch_count: 0
+digest: c76e76eea27c61eca04a755ef0c7f15d4cf77f9513f55697da5ad1aa105172b4
+```
+
+The family records are:
+
+```text
+T01/F09: assignments=6 path=3 strict=[1,8] > [1,2]
+T02/F01: assignments=18 path=3 strict=[1,8] > [1,2]
+T02/F04: assignments=18 path=3 strict=[0,2] > [2,3]
+T02/F08: assignments=2 path=3 strict=[1,8] > [1,2]
+T02/F14: assignments=2 path=3 strict=[1,8] > [1,2]
+T03/F05: assignments=18 path=3 strict=[3,7] > [1,7]
+T03/F15: assignments=2 path=3 strict=[1,4] > [3,4]
+T04/F13: assignments=2 path=3 strict=[1,5] > [1,2]
+T05/F10: assignments=18 path=3 strict=[1,8] > [1,2]
+T06/F11: assignments=18 path=4 strict=[3,8] > [3,5]
+T07/F06: assignments=18 path=4 strict=[1,4] > [1,2]
+T08/F02: assignments=18 path=5 strict=[1,3] > [1,2]
+T09/F03: assignments=18 path=6 strict=[1,3] > [1,2]
+```
+
+### Exact Scope
+
+This is a local final-contradiction criterion. It does not independently
+prove the selected-distance equality paths or the vertex-circle strict edges;
+those remain the inputs checked in the individual focused packet notes and
+packet artifacts.
+
+It does not prove the full `n=9` finite case, because the review-pending
+exhaustive checker is still needed to show that every `n=9` frontier
+assignment contains a recorded local obstruction template. It does not prove
+Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-self-edge-criterion.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+The self-edge side of the `n=9` vertex-circle catalog now has one explicit
+reviewer-facing final-contradiction criterion. The remaining proof pressure is
+not the last algebraic step of the self-edge contradiction; it is certifying
+the local inputs and proving the finite-to-local bridge from arbitrary
+frontier assignments to cataloged obstruction templates.
+
+### Next Lead
+
+Apply the same reviewer-facing consolidation to the strict-cycle templates,
+or attack the bridge: explain why the review-pending `n=9` exhaustive checker
+forces every frontier assignment into one of the 12 recorded local templates.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-629`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-629`.
+- The branch was based on `origin/main` at commit
+  `b76cff13c742bed78c9c44a92dca71727c3aa914`, after PR #327 merged Cycle
+  628.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_self_edge_template_packet.py --check
+  --assert-expected --json`
+  passed. The packet checker reported `ok: true`, 158 self-edge
+  assignments, 13 families, 9 templates, and no validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`
+  passed. The catalog checker reported `ok: true`, 184 covered assignments,
+  12 templates, and no validation errors.
+- One-off exact family-record audit over
+  `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
+  passed. It checked all 13 family records, found mismatch count `0`, and
+  produced digest
+  `c76e76eea27c61eca04a755ef0c7f15d4cf77f9513f55697da5ad1aa105172b4`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`
+  passed.
+- `git diff --check` passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`
+  passed with 534 passed and 275 deselected.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 628 - T09/F03 Focused Self-Edge Proof Note
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

Records Cycle 629 as a focused reviewer-facing page for the selected-path self-edge criterion behind the review-pending `n=9` vertex-circle `T01` through `T09` self-edge packets.

The criterion is local: if a row core has both a certified strict edge `p > q` and a selected-distance equality path from `p` to `q`, then it is unrealizable because it forces both `D(p) > D(q)` and `D(p) = D(q)`.

It does not claim a proof of Erdos Problem #97, does not claim a counterexample, and does not claim the full `n=9` finite case outside the existing review-pending checker pipeline.

## Files changed

- `docs/n9-vertex-circle-self-edge-criterion.md`
- `docs/index.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- One-off exact family-record audit over `data/certificates/n9_vertex_circle_self_edge_template_packet.json`: 13 family records, 158 assignments, mismatch count 0, digest `c76e76eea27c61eca04a755ef0c7f15d4cf77f9513f55697da5ad1aa105172b4`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`534 passed, 275 deselected`)

## Remaining limitations

The overarching proof/counterexample goal remains open. This PR only promotes one local final-contradiction criterion and current packet audit into independently reviewable prose.