### PR TITLE
[codex] Record strict-cycle criterion page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-self-edge-criterion.md`](n9-vertex-circle-self-edge-criterion.md):
   selected-path self-edge criterion unifying the T01 through T09 local
   self-edge packets.
+- [`n9-vertex-circle-strict-cycle-criterion.md`](n9-vertex-circle-strict-cycle-criterion.md):
+  directed strict-cycle criterion unifying the T10 through T12 local
+  strict-cycle packets.
 - [`n9-vertex-circle-t01-self-edge-lemma.md`](n9-vertex-circle-t01-self-edge-lemma.md):
   focused review-pending T01/F09 self-edge local lemma packet for proof
   mining.

--- a/docs/n9-vertex-circle-strict-cycle-criterion.md
+++ b/docs/n9-vertex-circle-strict-cycle-criterion.md
@@ -1,0 +1,140 @@
+# n=9 Vertex-circle Directed Strict-cycle Criterion
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records the common local contradiction behind the `T10` through
+`T12` vertex-circle strict-cycle packets. It does not claim a proof of `n=9`,
+does not claim a counterexample, does not complete independent review of the
+exhaustive checker, and does not update the official/global status.
+
+## Criterion
+
+Let selected rows generate a selected-distance quotient relation on unordered
+vertex pairs, as in the self-edge criterion. Write `D(p)` for the common
+distance value of a pair or quotient class `p`.
+
+A strict-cycle packet consists of a cyclic list of pairs
+
+```text
+p_0, p_1, ..., p_{k-1}
+```
+
+and, for each index `i` modulo `k`,
+
+1. a certified vertex-circle strict edge
+
+   ```text
+   p_i > q_i,
+   ```
+
+2. a selected-distance equality path from `q_i` to `p_{i+1}`.
+
+Then the local row core is unrealizable.
+
+Indeed, each equality path gives
+
+```text
+D(q_i) = D(p_{i+1}),
+```
+
+while each strict edge gives
+
+```text
+D(p_i) > D(q_i).
+```
+
+Combining around the cycle yields
+
+```text
+D(p_0) > D(p_1) > ... > D(p_{k-1}) > D(p_0),
+```
+
+which is impossible for real distances.
+
+Equivalently, after quotienting ordinary pair distances by the selected-row
+equalities, the local row core has a directed strict cycle.
+
+## Current Packet Audit
+
+The checked source artifact is
+`data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`. It is
+derived into the combined template catalog
+`data/certificates/n9_vertex_circle_template_lemma_catalog.json`.
+
+The current strict-cycle packet records:
+
+```text
+strict-cycle templates:       3
+strict-cycle family records:  3
+covered assignments:        26
+```
+
+The criterion applies exactly to every family record in that packet: in each
+cycle step, the strict inner pair is the connector start pair, and the
+connector end pair is the next strict outer pair.
+
+```text
+T10/F12: assignments=18 cycle=2 connectors=[2,1]
+T11/F07: assignments=6  cycle=3 connectors=[0,1,2]
+T12/F16: assignments=2  cycle=3 connectors=[1,2,1]
+```
+
+The audit counts are:
+
+```text
+family-record cycle lengths:       {2: 1, 3: 2}
+assignment-weighted cycle lengths: {2: 18, 3: 8}
+connector path lengths:            {0: 1, 1: 4, 2: 3}
+mismatch count:                    0
+audit digest: 49363955d3efebad841d4898d0d4695696fc4016dbad2a4c6d532edf15b667ab
+```
+
+## Scope
+
+This criterion is a local final-contradiction lemma. It applies only after
+the local selected-row equality connectors and the local vertex-circle strict
+edges have already been checked.
+
+It does not prove the full `n=9` finite case, because the exhaustive checker
+and assignment-to-template crosswalk are still needed to show that every
+frontier assignment contains one of the recorded local obstruction templates.
+It does not prove Erdos Problem #97 and does not give a counterexample.
+
+## Commands
+
+Check the source packet and the combined template catalog:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py \
+  --check \
+  --assert-expected \
+  --json
+
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+The family-record audit can be reproduced by parsing
+`data/certificates/n9_vertex_circle_strict_cycle_template_packet.json` and
+checking, for every cycle step:
+
+```text
+strict_inequality.inner_pair == equality_to_next_outer_pair.start_pair
+equality_to_next_outer_pair.end_pair == next strict_inequality.outer_pair
+```
+
+with the next strict outer pair taken cyclically.
+
+## Review Standard
+
+Before using this criterion in a proof, a reviewer should independently check
+the two local inputs for the particular row core under discussion:
+
+1. every displayed connector path is forced by selected rows; and
+2. every displayed strict edge is forced by the stated vertex-circle witness
+   order.
+
+Once those inputs are established, the contradiction in this note is just the
+impossibility of a strict cycle among real distance values.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,182 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 630 - Directed Strict-Cycle Criterion Page
+
+### Mathematical Subquestion
+
+After Cycle 629 promoted the selected-path self-edge criterion, the matching
+strict-cycle side still existed only in individual `T10`, `T11`, and `T12`
+notes plus the long research log. The narrow question for this cycle was:
+
+Can the repeated `T10` through `T12` strict-cycle mechanism be stated as one
+reviewer-facing local criterion, with an exact audit that the current
+strict-cycle packet records all satisfy it?
+
+### Definitions and Assumptions
+
+For a selected row `S_c`, all distances `d(c,x)` with `x in S_c` are equal.
+These equalities generate a selected-distance quotient relation on unordered
+vertex pairs. Write `D(p)` for the distance value of a pair or quotient class
+`p`.
+
+A strict-cycle packet consists of a cyclic list of outer pairs
+
+```text
+p_0, p_1, ..., p_{k-1}
+```
+
+where each step has a certified vertex-circle strict edge `p_i > q_i` and a
+selected-distance equality path from `q_i` to `p_{i+1}`.
+
+### Result Status
+
+Proved local criterion plus exact current-packet audit:
+**Directed Strict-Cycle Criterion**.
+
+If a local row core has such a cyclic list of strict edges and equality
+connectors, then the local row core is unrealizable.
+
+### Argument
+
+Each equality connector gives
+
+```text
+D(q_i)=D(p_{i+1}).
+```
+
+Each certified strict edge gives
+
+```text
+D(p_i)>D(q_i).
+```
+
+Combining around the cycle yields
+
+```text
+D(p_0)>D(p_1)>...>D(p_{k-1})>D(p_0),
+```
+
+which is impossible for real distances. Equivalently, after
+selected-distance quotienting, the local core has a directed strict cycle.
+
+### Exact Current-Packet Audit
+
+A one-off exact JSON audit over
+`data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+checked every strict-cycle family record for:
+
+```text
+strict_inequality.inner_pair == equality_to_next_outer_pair.start_pair
+equality_to_next_outer_pair.end_pair == next strict_inequality.outer_pair
+```
+
+where the next strict outer pair is taken cyclically.
+
+The audit found:
+
+```text
+family_records: 3
+assignments: 26
+cycle_counts: {2: 1, 3: 2}
+assignment_weighted_cycle_counts: {2: 18, 3: 8}
+connector_path_length_counts: {0: 1, 1: 4, 2: 3}
+mismatch_count: 0
+digest: 49363955d3efebad841d4898d0d4695696fc4016dbad2a4c6d532edf15b667ab
+```
+
+The family records are:
+
+```text
+T10/F12: assignments=18 cycle=2 connectors=[2,1]
+T11/F07: assignments=6 cycle=3 connectors=[0,1,2]
+T12/F16: assignments=2 cycle=3 connectors=[1,2,1]
+```
+
+### Exact Scope
+
+This is a local final-contradiction criterion. It does not independently
+prove the selected-distance equality connectors or the vertex-circle strict
+edges; those remain the inputs checked in the individual focused packet notes
+and packet artifacts.
+
+It does not prove the full `n=9` finite case, because the review-pending
+exhaustive checker is still needed to show that every `n=9` frontier
+assignment contains a recorded local obstruction template. It does not prove
+Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-strict-cycle-criterion.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+Together with Cycle 629, the two local final-contradiction mechanisms in the
+`n=9` vertex-circle catalog now have reviewer-facing criterion pages. The
+remaining proof pressure is no longer the final real-number contradiction in
+the local packets; it is certifying the local inputs and proving the
+finite-to-local bridge from arbitrary frontier assignments to cataloged
+obstruction templates.
+
+### Next Lead
+
+Attack the bridge directly: explain why the review-pending `n=9` exhaustive
+checker forces every frontier assignment into one of the 12 recorded local
+templates, or look for an exact obstruction to globalizing that local-template
+route beyond `n=9`.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-630`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-630`.
+- The branch was based on `origin/main` at commit
+  `65d6c42ab2490d8b8a9c64e34aed187e9bc9d035`, after PR #329 merged Cycle
+  629.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check
+  --assert-expected --json`
+  passed. The packet checker reported `ok: true`, 26 strict-cycle
+  assignments, 3 families, 3 templates, and no validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`
+  passed. The catalog checker reported `ok: true`, 184 covered assignments,
+  12 templates, and no validation errors.
+- One-off exact family-record audit over
+  `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+  passed. It checked all 3 family records, found mismatch count `0`, and
+  produced digest
+  `49363955d3efebad841d4898d0d4695696fc4016dbad2a4c6d532edf15b667ab`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`
+  passed.
+- `git diff --check` passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`
+  passed with 534 passed and 275 deselected.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 629 - Selected-Path Self-Edge Criterion Page
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Scope

This PR records Cycle 630 as a documentation/log checkpoint. It adds a reviewer-facing page for the local directed strict-cycle contradiction criterion behind the current `T10` through `T12` vertex-circle strict-cycle packets, links it from the docs index, and records the research cycle in the running Codex goal log.

## Files changed

- `docs/n9-vertex-circle-strict-cycle-criterion.md`
- `docs/index.md`
- `reports/codex_goal_erdos97_log.md`

## Mathematical status

This is a local final-contradiction criterion plus an audit of the current strict-cycle packet. It does not claim a proof of `n=9`, does not claim a proof of Erdos Problem #97, and does not give a counterexample. The overarching proof/counterexample goal remains open.

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- one-off exact family-record audit over `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`, digest `49363955d3efebad841d4898d0d4695696fc4016dbad2a4c6d532edf15b667ab`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` passed with 534 passed and 275 deselected

## Remaining limitations

The page assumes the local selected-row equality connectors and vertex-circle strict edges have already been checked in the packet artifacts. The finite-to-local bridge from arbitrary `n=9` frontier assignments to the recorded local obstruction templates remains review-pending.