### PR TITLE
[codex] Audit n9 MRO branching order

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,9 @@ put detailed reconciliation in the canonical synthesis.
   vertex-circle strict-chord filter.
 - [`n9-vertex-circle-row0-root-audit.md`](n9-vertex-circle-row0-root-audit.md):
   row0-root enumeration audit for the exhaustive `n=9` vertex-circle checker.
+- [`n9-vertex-circle-mro-branching-audit.md`](n9-vertex-circle-mro-branching-audit.md):
+  minimum-remaining-options branching audit for the exhaustive `n=9`
+  vertex-circle checker.
 - [`n9-vertex-circle-template-lemma-catalog.md`](n9-vertex-circle-template-lemma-catalog.md):
   derived 12-template lemma-candidate catalog for proof-mining review.
 - [`n9-vertex-circle-certificate-chain.md`](n9-vertex-circle-certificate-chain.md):

--- a/docs/n9-vertex-circle-mro-branching-audit.md
+++ b/docs/n9-vertex-circle-mro-branching-audit.md
@@ -1,0 +1,112 @@
+# n=9 Vertex-circle MRO Branching Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note audits one narrow control-flow question in the repo-native `n=9`
+vertex-circle exhaustive checker: the dynamic minimum-remaining-options
+choice of the next row changes only search order, conditional on the listed
+partial filters being sound. It does not claim a proof of `n=9`, does not
+claim a counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Minimum-remaining-options Branching Lemma
+
+Let `A` be a partial selected-witness assignment. For each unassigned center
+`c`, define `V_c(A)` to be the list of row masks for `c` that pass the current
+partial pair/crossing/count filters against `A`.
+
+The checker constructs `V_c(A)` with `valid_options_for_center`: it scans all
+literal row masks in `OPTIONS[c]` and appends exactly those not rejected by
+compatibility, selected-indegree capacity, or witness-pair capacity against
+the current partial assignment.
+
+The recursive search then computes `V_c(A)` for every unassigned center and
+chooses a center `c*` with minimum `|V_c(A)|`. If any `V_c(A)` is empty, the
+search returns from that partial assignment. Otherwise it branches over every
+mask in `V_c*(A)`.
+
+Conditional on the partial filters being necessary conditions, this choice
+cannot omit a valid completion:
+
+1. If some `V_c(A)` is empty, no completion extending `A` can exist, because
+   every completion must assign a row to `c`, and that row would have to pass
+   the same current partial filters.
+2. If all `V_c(A)` are nonempty, every completion extending `A` has a unique
+   row value `m` at the selected center `c*`, and by definition
+   `m in V_c*(A)`.
+3. The branch loop iterates over every `m in V_c*(A)`, so the branch
+   containing that completion is visited.
+
+Thus the minimum-remaining-options rule is a variable-ordering heuristic in
+this finite backtracking search. It is not a quotient and not an additional
+mathematical pruning rule.
+
+## Code-shape Audit
+
+The checked source block is
+`src/erdos97/n9_vertex_circle_exhaustive.py`.
+
+The option constructor has the required exhaustive shape:
+
+```python
+out = []
+for m in OPTIONS[center]:
+    ...
+    out.append(m)
+return out
+```
+
+The branch selector has the required variable-ordering shape:
+
+```python
+best_center = None
+best_options = None
+for center in range(N):
+    if center in assign:
+        continue
+    opts = valid_options_for_center(...)
+    if best_options is None or len(opts) < len(best_options):
+        best_center = center
+        best_options = opts
+        if not opts:
+            break
+if not best_options:
+    return
+
+center = best_center
+for m in best_options:
+    assign[center] = m
+    ...
+    search(assign, column_counts, witness_pair_counts)
+```
+
+A one-off static audit reported:
+
+```text
+exhaustive_search functions: 1
+contains best_center: true
+contains best_options: true
+branches over "for m in best_options": true
+zero-options return present: true
+valid_options_for_center present: true
+```
+
+## Scope
+
+This audit isolates the row-order heuristic only. It does not prove the
+geometric necessity of the pair/crossing/count filters, does not audit the
+vertex-circle partial pruning predicate, and does not independently replay the
+184 pre-vertex-circle assignments.
+
+The remaining frontier-soundness audit still needs to check the pruning
+lemmas and the relation between the repo-native checker and archive variants.
+
+## Commands
+
+Run the exhaustive checker and the targeted artifact test:
+
+```bash
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
+
+python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"
+```

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,147 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 633 - MRO Branching Audit
+
+### Mathematical Subquestion
+
+After Cycle 632 separated the row0-root enumeration issue, the next
+frontier-soundness question was:
+
+Does the dynamic minimum-remaining-options choice in the review-pending `n=9`
+vertex-circle exhaustive checker merely choose the next row variable to branch
+on, rather than omitting any possible completion?
+
+### Definitions and Assumptions
+
+Let `A` be a partial selected-witness assignment. For each unassigned center
+`c`, let `V_c(A)` be the list of row masks for `c` that pass the current
+partial pair/crossing/count filters against `A`.
+
+This cycle assumes the current partial filters are necessary conditions. It
+audits only the effect of choosing the next center with minimum `|V_c(A)|`.
+
+### Result Status
+
+Proved conditional control-flow lemma:
+**Minimum-remaining-options Branching Lemma**.
+
+Conditional on the partial filters being sound, selecting an unassigned center
+with the fewest currently valid row masks changes only search order and cannot
+remove a completion.
+
+### Argument
+
+If some unassigned center `c` has `V_c(A)=empty`, then no full completion of
+`A` exists, because every completion needs a row at `c` and that row must pass
+the current partial filters. Returning at that node is therefore sound under
+the necessity assumption.
+
+Otherwise, let `c*` be the selected minimum-options center. Every full
+completion extending `A` has a unique row mask `m` at `c*`, and by definition
+`m in V_c*(A)`. The checker iterates over every `m in V_c*(A)`, so the branch
+containing that completion is visited. The choice of `c*` only changes which
+row variable is expanded next.
+
+### Exact Code-shape Audit
+
+The one-off static audit over
+`src/erdos97/n9_vertex_circle_exhaustive.py` reported:
+
+```text
+exhaustive_search functions: 1
+contains best_center: true
+contains best_options: true
+branches over "for m in best_options": true
+zero-options return present: true
+valid_options_for_center present: true
+```
+
+The inspected source shows that `valid_options_for_center` scans every mask in
+`OPTIONS[center]` and appends every candidate not rejected by current partial
+filters. The recursive search computes this list for every unassigned center,
+chooses a shortest list, returns only if the chosen list is empty, and
+otherwise loops over every mask in that list.
+
+### Exact Scope
+
+This is not a full audit of the `n=9` checker. It does not prove the
+geometric necessity of the pair/crossing/count filters, does not audit the
+vertex-circle partial pruning predicate, does not independently replay the
+184 pre-vertex-circle assignments, and does not prove the full `n=9` finite
+case. It does not prove Erdos Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-mro-branching-audit.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+The frontier-soundness checklist is reduced by one control-flow concern:
+minimum-remaining-options branch selection is a row-order heuristic, not an
+additional quotient or pruning condition. The remaining burden is in the
+mathematical necessity of the filters and in independent replay or archive
+reconciliation.
+
+### Next Lead
+
+Audit vertex-circle partial pruning monotonicity: once a partial assignment
+has a quotient self-edge or directed strict cycle, show that no later selected
+rows can turn it back into a realizable full assignment.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-633`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-633`.
+- The branch was based on `origin/main` at commit
+  `bb7cb682c7e6cfd5ff002a46b13b5ca4291b9de8`, after PR #335 merged Cycle
+  632.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- Source inspection of
+  `src/erdos97/n9_vertex_circle_exhaustive.py` confirmed that
+  `valid_options_for_center` scans every candidate in `OPTIONS[center]`, the
+  recursive search computes options for every unassigned center, and the
+  branch loop iterates over every mask in the selected `best_options` list.
+- One-off static audit confirmed the presence of one `exhaustive_search`
+  function, `best_center`, `best_options`, the `for m in best_options` branch
+  loop, the zero-options return, and `valid_options_for_center`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_exhaustive.py --assert-expected`
+  passed. It reported 70 row0 choices, 0 full assignments with
+  vertex-circle pruning, and 184 full assignments in the cross-check without
+  vertex-circle pruning.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"`
+  passed with 3 tests.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`
+  passed.
+- `git diff --check` passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`
+  passed with 534 passed and 276 deselected.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 632 - Row0 Root Enumeration Audit
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Scope

This PR records Cycle 633 as a documentation/log checkpoint. It adds a reviewer-facing audit page for the `n=9` vertex-circle checker's dynamic minimum-remaining-options branching choice, links it from the docs index, and records the research cycle in the running Codex goal log.

## Files changed

- `docs/n9-vertex-circle-mro-branching-audit.md`
- `docs/index.md`
- `reports/codex_goal_erdos97_log.md`

## Mathematical status

This proves only a conditional control-flow lemma: assuming the current partial filters are necessary conditions, choosing the unassigned center with the fewest currently valid row masks changes only search order and cannot omit a completion. It does not claim a proof of `n=9`, does not claim a proof of Erdos Problem #97, and does not give a counterexample. The overarching proof/counterexample goal remains open.

## Validation

- source inspection of `src/erdos97/n9_vertex_circle_exhaustive.py` confirmed that `valid_options_for_center` scans every candidate in `OPTIONS[center]`, the recursive search computes options for every unassigned center, and the branch loop iterates over every mask in the selected `best_options` list
- one-off static audit confirmed one `exhaustive_search` function, `best_center`, `best_options`, the `for m in best_options` loop, the zero-options return, and `valid_options_for_center`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"` passed with 3 tests
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` passed with 534 passed and 276 deselected

## Remaining limitations

This PR audits only the row-order heuristic. It does not prove the geometric necessity of the pair/crossing/count filters, does not audit vertex-circle partial pruning, does not independently replay the 184 pre-vertex-circle assignments, and does not prove the full `n=9` finite case.