### PR TITLE
[codex] Audit n9 vertex-circle partial pruning

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-mro-branching-audit.md`](n9-vertex-circle-mro-branching-audit.md):
   minimum-remaining-options branching audit for the exhaustive `n=9`
   vertex-circle checker.
+- [`n9-vertex-circle-partial-pruning-audit.md`](n9-vertex-circle-partial-pruning-audit.md):
+  monotonicity audit for vertex-circle partial self-edge and strict-cycle
+  pruning.
 - [`n9-vertex-circle-template-lemma-catalog.md`](n9-vertex-circle-template-lemma-catalog.md):
   derived 12-template lemma-candidate catalog for proof-mining review.
 - [`n9-vertex-circle-certificate-chain.md`](n9-vertex-circle-certificate-chain.md):

--- a/docs/n9-vertex-circle-partial-pruning-audit.md
+++ b/docs/n9-vertex-circle-partial-pruning-audit.md
@@ -1,0 +1,107 @@
+# n=9 Vertex-circle Partial-pruning Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note audits one narrow pruning question in the repo-native `n=9`
+vertex-circle exhaustive checker: once a partial assignment already has a
+vertex-circle quotient self-edge or directed strict cycle, later selected rows
+cannot repair that obstruction. It does not claim a proof of `n=9`, does not
+claim a counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status.
+
+## Partial-pruning Monotonicity Lemma
+
+Let `A` be a partial selected-witness assignment and let `B` be an extension of
+`A`. The selected rows in `A` generate an equivalence relation `~_A` on
+ordinary unordered vertex pairs: selected distances in the same row are
+identified. The rows in `B` generate a coarser relation `~_B`, because `B`
+contains every row of `A` and may add more equality identifications.
+
+Likewise, every vertex-circle strict edge produced by a row of `A` is still a
+strict edge in `B`; later rows may add strict edges but do not remove old ones.
+
+If `A` has a quotient self-edge, then some strict edge `p > q` has
+`p ~_A q`. Since `~_B` is coarser, `p ~_B q` too. The same strict edge remains
+present, so `B` has a quotient self-edge.
+
+If `A` has a directed strict cycle among `~_A`-classes, map every class in
+that cycle to its `~_B`-class. The image is a closed directed walk in the
+`B` quotient graph. If any cycle edge has both endpoints mapped to the same
+`~_B`-class, then `B` has a quotient self-edge. Otherwise the closed directed
+walk has length at least two and contains a directed cycle. Hence `B` has a
+strict-cycle obstruction.
+
+Thus vertex-circle partial pruning is monotone: once the checker sees
+`self_edge` or `strict_cycle` on a partial assignment, no extension can become
+realizable by adding more selected rows.
+
+## Code-shape Audit
+
+The checked source block is
+`src/erdos97/n9_vertex_circle_exhaustive.py`.
+
+The quotient construction recomputes the selected-distance union-find from
+the currently assigned rows:
+
+```python
+for center, m in assign.items():
+    selected_pairs = SELECTED_PAIR_INDICES[(center, m)]
+    base = selected_pairs[0]
+    for pidx in selected_pairs[1:]:
+        uf.union(base, pidx)
+```
+
+The strict graph also scans the currently assigned rows:
+
+```python
+for center, m in assign.items():
+    for outer, inner in STRICT_EDGES[(center, m)]:
+        outer_root = uf.find(outer)
+        inner_root = uf.find(inner)
+        if outer_root == inner_root:
+            return "self_edge"
+        graph[outer_root].append(inner_root)
+```
+
+The recursive search applies vertex-circle partial pruning immediately after
+adding one row:
+
+```python
+status = vertex_circle_status(assign) if use_vertex_circle else "ok"
+if status == "ok":
+    search(assign, column_counts, witness_pair_counts)
+else:
+    counts[f"partial_{status}"] += 1
+```
+
+A one-off static audit reported:
+
+```text
+vertex_circle_status lines: 192-226
+self_edge return present: true
+strict_cycle return present: true
+uf union selected pairs present: true
+strict edges from assigned rows present: true
+partial prune call present: true
+```
+
+## Scope
+
+This audit proves monotonicity of the quotient-graph obstruction under adding
+rows. It assumes that selected-row equalities and vertex-circle strict edges
+are valid necessary conditions for any realizable assignment.
+
+It does not prove the geometric vertex-circle strict-chord lemma, does not
+audit the pair/crossing/count filters, does not independently replay the 184
+pre-vertex-circle assignments, and does not prove the full `n=9` finite case.
+
+## Commands
+
+Run the exhaustive checker and the targeted artifact test:
+
+```bash
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
+
+python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"
+```
+

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,150 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 634 - Vertex-circle Partial-pruning Monotonicity Audit
+
+### Mathematical Subquestion
+
+After Cycle 633 isolated the minimum-remaining-options row-order heuristic,
+the next frontier-soundness question was:
+
+Once a partial `n=9` selected-witness assignment already has a vertex-circle
+quotient self-edge or directed strict cycle, can later selected rows repair
+that obstruction, or is the partial prune monotone?
+
+### Definitions and Assumptions
+
+Let `A` be a partial selected-witness assignment and `B` an extension of `A`.
+The selected rows of `A` generate an equivalence relation `~_A` on ordinary
+unordered vertex pairs by identifying the selected distances in each row. The
+extension `B` generates `~_B`.
+
+The strict graph has directed edges between selected-distance classes induced
+by vertex-circle strict chord containment in assigned rows.
+
+This cycle assumes the selected-row equalities and vertex-circle strict edges
+are valid necessary conditions. It audits only whether an already-detected
+quotient-graph contradiction can disappear after adding rows.
+
+### Result Status
+
+Proved conditional pruning lemma:
+**Vertex-circle Partial-pruning Monotonicity Lemma**.
+
+If a partial assignment has status `self_edge` or `strict_cycle`, then every
+extension has status `self_edge` or `strict_cycle` after recomputing the
+selected-distance quotient and strict graph.
+
+### Argument
+
+Adding rows only adds equality identifications, so `~_B` is coarser than
+`~_A`. Adding rows also only adds vertex-circle strict edges; it does not
+remove strict edges from rows already present in `A`.
+
+If `A` has a self-edge, some strict edge `p > q` satisfies `p ~_A q`. Since
+`~_B` is coarser, `p ~_B q`; the same strict edge is still present, so `B`
+has a self-edge.
+
+If `A` has a directed strict cycle among `~_A`-classes, map the classes in
+that cycle to their `~_B`-classes. The image is a closed directed walk in the
+`B` quotient graph. If any edge collapses to one `~_B`-class, `B` has a
+self-edge. Otherwise the closed directed walk has length at least two and
+contains a directed cycle. Thus `B` has a strict-cycle obstruction.
+
+### Exact Code-shape Audit
+
+The one-off static audit over
+`src/erdos97/n9_vertex_circle_exhaustive.py` reported:
+
+```text
+vertex_circle_status lines: 192-226
+self_edge return present: true
+strict_cycle return present: true
+uf union selected pairs present: true
+strict edges from assigned rows present: true
+partial prune call present: true
+```
+
+The inspected source recomputes the union-find quotient from currently
+assigned rows, scans strict edges from currently assigned rows, returns
+`self_edge` when a strict edge collapses inside one quotient class, detects
+directed strict cycles by DFS, and prunes a recursive branch immediately when
+the status is not `ok`.
+
+### Exact Scope
+
+This is not a full audit of the `n=9` checker. It does not prove the
+geometric vertex-circle strict-chord lemma, does not audit pair/crossing/count
+filters, does not independently replay the 184 pre-vertex-circle assignments,
+and does not prove the full `n=9` finite case. It does not prove Erdos
+Problem #97 and does not give a counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-partial-pruning-audit.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+The frontier-soundness checklist is reduced by one pruning concern:
+vertex-circle self-edge and strict-cycle partial prunes are monotone under
+adding rows. The remaining burden is now concentrated on the geometric
+necessity of the row-level filters and a second independent replay or archive
+reconciliation for the full 184-assignment frontier.
+
+### Next Lead
+
+Audit the pair/crossing/count filters one at a time, starting with the
+two-overlap crossing rule: if two selected rows share exactly two witnesses,
+prove the center-center chord and shared-witness chord must cross in cyclic
+order.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-634`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-634`.
+- The branch was based on `origin/main` at commit
+  `38fde816d460d686b9dc3fc99bb6514e1fde36f5`, after PR #337 merged Cycle
+  633.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- Source inspection of
+  `src/erdos97/n9_vertex_circle_exhaustive.py` confirmed that
+  `vertex_circle_status` recomputes the union-find quotient and strict graph
+  from assigned rows, returns `self_edge` when a strict edge collapses, and
+  detects directed strict cycles by DFS.
+- One-off static audit confirmed the `vertex_circle_status` source range,
+  `self_edge` return, `strict_cycle` return, selected-pair union-find unions,
+  strict-edge scan over assigned rows, and the partial-prune call in the
+  recursive search.
+- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected`
+  passed, with the expected review-pending counts:
+  `nodes visited: 16752`, `counts: {'partial_self_edge': 11271,
+  'partial_strict_cycle': 11011}` for the main search; the cross-check without
+  vertex-circle pruning visited `100817` nodes and found `184` full
+  assignments with final counts `{'self_edge': 158, 'strict_cycle': 26}`.
+- Targeted artifact pytest passed:
+  `python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"`
+  with result `3 passed`.
+- `python scripts/check_text_clean.py` passed.
+- `python scripts/check_status_consistency.py` passed.
+- `python scripts/check_artifact_provenance.py` passed.
+- `git diff --check` passed.
+- `python -m ruff check .` passed.
+- `python -m pytest -q` passed: `534 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 633 - MRO Branching Audit
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

This PR replaces draft #338 after the connector failed to mark that draft ready. It uses the same branch and head commit: `87813f5f939390c87c79e31c574c98ecb3f61f22`.

This records Cycle 634 of the Erdos97 research log: a narrow audit of the `n=9` vertex-circle checker's partial-pruning step.

It proves the conditional **Vertex-circle Partial-pruning Monotonicity Lemma**: once a partial selected-witness assignment has a quotient `self_edge` or directed `strict_cycle` obstruction, any extension still has a `self_edge` or `strict_cycle` obstruction after recomputing the quotient and strict graph.

## Files changed

- `docs/n9-vertex-circle-partial-pruning-audit.md` documents the lemma, code-shape audit, scope, and commands.
- `docs/index.md` adds the new audit note to the docs index.
- `reports/codex_goal_erdos97_log.md` records Cycle 634 with definitions, argument, limitations, validation, and next lead.

## Validation run

Local validation:

- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected`
- `python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`534 passed, 276 deselected`)

Hosted validation on draft #338 for the same commit:

- `tests` workflow run `25618012955` succeeded on Python 3.10, 3.11, and 3.12.
- `artifact-review` skipped as expected.

## Limitations

This PR does not prove the geometric vertex-circle strict-chord lemma, does not audit the pair/crossing/count filters, does not independently replay the 184 pre-vertex-circle assignments, and does not prove Erdos Problem #97 or provide a counterexample. The overarching proof/counterexample goal remains open.