### PR TITLE
[codex] Audit n9 two-overlap crossing filter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-partial-pruning-audit.md`](n9-vertex-circle-partial-pruning-audit.md):
   monotonicity audit for vertex-circle partial self-edge and strict-cycle
   pruning.
+- [`n9-vertex-circle-two-overlap-crossing-audit.md`](n9-vertex-circle-two-overlap-crossing-audit.md):
+  row-level audit of the two-overlap radical-axis crossing filter in the
+  exhaustive `n=9` vertex-circle checker.
 - [`n9-vertex-circle-template-lemma-catalog.md`](n9-vertex-circle-template-lemma-catalog.md):
   derived 12-template lemma-candidate catalog for proof-mining review.
 - [`n9-vertex-circle-certificate-chain.md`](n9-vertex-circle-certificate-chain.md):

--- a/docs/n9-vertex-circle-two-overlap-crossing-audit.md
+++ b/docs/n9-vertex-circle-two-overlap-crossing-audit.md
@@ -1,0 +1,109 @@
+# n=9 Two-overlap Crossing Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note audits one row-level filter in the repo-native `n=9` vertex-circle
+exhaustive checker: when two selected-witness rows share exactly two
+witnesses, the checker requires the center-center chord and shared-witness
+chord to cross in the fixed cyclic order. It does not claim a proof of `n=9`,
+does not claim a counterexample, does not complete independent review of the
+exhaustive checker, and does not update the official/global status.
+
+## Radical-axis Crossing Lemma
+
+Let `P` be a strictly convex polygon in cyclic order. Suppose distinct centers
+`x,y` have selected witness sets `S_x,S_y` with
+
+```text
+S_x cap S_y = {a,b}.
+```
+
+Because both `x` and `y` are equidistant from `a` and `b`, the line `xy` is
+the perpendicular bisector of segment `ab`. The midpoint `m` of `ab` lies in
+the relative interior of the chord `ab` and in the convex hull of `P`. If
+`xy` were a polygon edge, its line would support the strictly convex polygon,
+but the perpendicular-bisector line has `a` and `b` on opposite sides. Hence
+`xy` is not a polygon edge. The line through two nonadjacent vertices of a
+strictly convex polygon meets the polygon in exactly the chord segment
+`[x,y]`, so `m in [x,y]`. Hence the chords `{x,y}` and `{a,b}` cross at `m`,
+which in a cyclic order is equivalent to their endpoints alternating.
+
+Equivalently, a two-overlap on adjacent centers is impossible. Thus the same
+crossing test also rejects adjacent-center two-overlaps.
+
+## Checker Equivalence
+
+The checked source block is
+`src/erdos97/n9_vertex_circle_exhaustive.py`.
+
+For centers `i < j`, the checker precomputes a compatibility table over all
+row masks:
+
+```python
+common = row_i & set(MASK_BITS[mj])
+ok = True
+if len(common) > PAIR_CAP:
+    ok = False
+elif len(common) == PAIR_CAP:
+    target = pair(*tuple(common))
+    ok = chords_cross(source, target)
+if ok:
+    allowed.add(mj)
+```
+
+Here `PAIR_CAP = 2`. Thus a row pair is accepted by this filter exactly when:
+
+- the two rows share at most two witnesses; and
+- if they share exactly two witnesses, the source chord `{i,j}` crosses the
+  shared-witness chord in the natural cyclic order `0,1,...,8`.
+
+The helper `rows_compatible` uses the same table symmetrically for either row
+order, and `valid_options_for_center` tests a candidate row against every
+already assigned row through `rows_compatible`.
+
+The crossing predicate is:
+
+```python
+return in_open_arc(a, b, c) != in_open_arc(a, b, d)
+```
+
+for disjoint chords `{a,b}` and `{c,d}`. This is exactly the alternating
+endpoints criterion in the natural cyclic order. In the selected-row setting,
+the source and shared-witness chords are automatically disjoint: label `i`
+cannot lie in `S_i`, and label `j` cannot lie in `S_j`, so neither center can
+belong to `S_i cap S_j`.
+
+## One-off Audit
+
+A one-off predicate audit compared the checker with the shared
+`incidence_filters.chords_cross_in_order` implementation on all nonagon chord
+pairs and recomputed the row-pair compatibility rule for every pair of centers
+and every pair of row masks.
+
+```text
+chord_cross equivalence mismatches: 0
+compatibility errors: 0
+row-pair candidate overlap histogram:
+  0 common witnesses: 7560
+  1 common witness:   57960
+  2 common witnesses: 83160
+  3 common witnesses: 26460
+  4 common witnesses: 1260
+two-overlap crossing accepted: 27720
+two-overlap noncrossing rejected: 55440
+```
+
+The audit is not an independent implementation of the full exhaustive search.
+It only checks that this row-level crossing filter matches the radical-axis
+crossing lemma and the repository's standard cyclic crossing predicate.
+
+## Scope
+
+This audit covers only the two-overlap crossing filter in the fixed natural
+cyclic order used by the `n=9` checker.
+
+It does not audit the witness-pair cap, indegree cap, vertex-circle strict-edge
+lemma, vertex-circle quotient obstruction, row0 coverage, archive
+reconciliation, or the 184 frontier assignments. It does not prove the full
+`n=9` finite case, does not prove Erdos Problem #97, and does not give a
+counterexample.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,167 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 635 - Two-overlap Crossing Filter Audit
+
+### Mathematical Subquestion
+
+After Cycle 634 reduced the vertex-circle partial-pruning concern, the next
+frontier-soundness question was:
+
+Does the repo-native `n=9` vertex-circle checker implement exactly the
+radical-axis two-overlap crossing rule for selected rows, without silently
+using a stronger or different row-pair condition?
+
+### Definitions and Assumptions
+
+Let `P` be a strictly convex polygon in cyclic order. A selected-witness row
+`S_i` is a 4-set of labels different from its center `i`.
+
+For distinct centers `x,y`, write
+
+```text
+S_x cap S_y = {a,b}
+```
+
+when the two rows share exactly two selected witnesses. The source chord is
+`{x,y}` and the common-witness chord is `{a,b}`.
+
+This cycle assumes the standard selected-distance interpretation: each center
+is equidistant from all labels in its selected row.
+
+### Result Status
+
+Proved implementation-audit lemma:
+**N9 Two-overlap Crossing Equivalence Lemma**.
+
+For every pair of centers and every pair of candidate selected rows in the
+repo-native `n=9` checker, the precomputed compatibility table accepts exactly
+the row pairs satisfying:
+
+1. at most two common selected witnesses; and
+2. when there are exactly two common selected witnesses, alternating endpoints
+   of the source chord and common-witness chord in the fixed natural cyclic
+   order.
+
+### Argument
+
+The geometric necessity is the radical-axis crossing lemma. If
+`S_x cap S_y = {a,b}`, then both centers lie on the perpendicular bisector of
+segment `ab`, so the center line `xy` is that perpendicular bisector. The
+midpoint of `ab` lies in the relative interior of chord `ab` and in the convex
+hull. If `xy` were a polygon edge, its line would support the strictly convex
+polygon, but `a` and `b` lie on opposite sides of that line. Thus `xy` is not
+a polygon edge. The line through two nonadjacent vertices of a strictly convex
+polygon meets the polygon in exactly the chord segment `[x,y]`, so the
+midpoint of `ab` lies on `[x,y]`. Therefore the two chords cross,
+equivalently their cyclic-order endpoints alternate.
+
+The code-shape audit over
+`src/erdos97/n9_vertex_circle_exhaustive.py` found that the `COMPATIBLE` table
+sets `ok = False` when `len(common) > PAIR_CAP`, and when
+`len(common) == PAIR_CAP == 2` it sets
+`ok = chords_cross(source, target)`. The helper `rows_compatible` reads this
+table symmetrically, and `valid_options_for_center` applies it against every
+assigned row before any count or vertex-circle pruning.
+
+The crossing helper returns
+
+```text
+in_open_arc(a,b,c) != in_open_arc(a,b,d)
+```
+
+for disjoint chords, which is exactly the alternating-endpoints condition in
+the natural cyclic order. In the selected-row setting the source and
+common-witness chords are automatically disjoint, because `i notin S_i` and
+`j notin S_j`.
+
+### Exact Audit
+
+A one-off predicate audit compared `chords_cross` with the shared
+`incidence_filters.chords_cross_in_order` implementation on all nonagon chord
+pairs and recomputed expected row-pair compatibility for every center pair
+and candidate row-mask pair.
+
+```text
+chord_cross equivalence mismatches: 0
+compatibility errors: 0
+row-pair candidate overlap histogram:
+  0 common witnesses: 7560
+  1 common witness:   57960
+  2 common witnesses: 83160
+  3 common witnesses: 26460
+  4 common witnesses: 1260
+two-overlap crossing accepted: 27720
+two-overlap noncrossing rejected: 55440
+```
+
+### Exact Scope
+
+This is not a full audit of the `n=9` checker. It does not audit the
+witness-pair cap, indegree cap, vertex-circle strict-edge lemma,
+vertex-circle quotient obstruction, row0 coverage, archive reconciliation, or
+the 184 pre-vertex-circle assignments. It does not prove the full `n=9`
+finite case. It does not prove Erdos Problem #97 and does not give a
+counterexample.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-two-overlap-crossing-audit.md`
+- `docs/index.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect on the Attack
+
+The frontier-soundness checklist is reduced by one row-level filter concern:
+the checker's two-overlap row compatibility condition matches the
+proof-facing radical-axis crossing lemma and the standard cyclic crossing
+predicate. The remaining review burden is concentrated on the witness-pair
+cap, indegree cap, vertex-circle strict-edge geometry, and independent replay
+or archive reconciliation for the 184-assignment frontier.
+
+### Next Lead
+
+Audit the witness-pair cap used by the `n=9` checker: for any unordered pair
+of witness labels `{a,b}`, prove that at most two selected rows can contain
+both labels, and confirm that the partial `witness_pair_counts[pidx] >= 2`
+prune is monotone under adding rows.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-635`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-635`.
+- The branch was based on `origin/main` at commit
+  `9bfde4340a4c290a26023d9db5b43a9c8f75d595`, after PR #339 merged Cycle
+  634.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- One-off predicate audit with `PYTHONPATH=src` passed, with zero crossing
+  predicate mismatches and zero compatibility-table errors across all nonagon
+  row-pair candidates.
+- `python scripts/check_text_clean.py` passed.
+- `python scripts/check_status_consistency.py` passed.
+- `python scripts/check_artifact_provenance.py` passed.
+- `git diff --check` passed.
+- `python -m ruff check .` passed.
+- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
+  --json` passed, reproducing `16752` main-search nodes, `0` full assignments
+  with vertex-circle pruning, and `184` cross-check full assignments without
+  vertex-circle pruning.
+- `python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m artifact`
+  passed: `3 passed`.
+- `python -m pytest -q` passed: `534 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 634 - Vertex-circle Partial-pruning Monotonicity Audit
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

This PR replaces draft #340 after the connector failed to mark that draft ready. It uses the same branch and head commit: `4c67457b2114e4ed397811e5e558b5737a98a497`.

This records Cycle 635 of the Erdos97 research log: a narrow row-level audit of the review-pending `n=9` vertex-circle checker's two-overlap crossing filter.

It proves the implementation-audit **N9 Two-overlap Crossing Equivalence Lemma**: for every pair of centers and every pair of candidate selected rows in the checker, the precomputed compatibility table accepts exactly the row pairs with at most two common witnesses, and for exactly two common witnesses requires alternating endpoints of the source chord and common-witness chord in the fixed natural cyclic order.

## Files changed

- `docs/n9-vertex-circle-two-overlap-crossing-audit.md` documents the radical-axis crossing lemma, checker equivalence, one-off predicate audit, and scope limits.
- `docs/index.md` adds the new audit note to the docs index.
- `reports/codex_goal_erdos97_log.md` records Cycle 635 with definitions, argument, limitations, validation, and next lead.

## Validation run

Local validation:

- One-off predicate audit with `PYTHONPATH=src` over all nonagon chord pairs and row-pair candidates: `0` crossing predicate mismatches, `0` compatibility-table errors.
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m artifact` (`3 passed`)
- `python -m pytest -q` (`534 passed, 276 deselected`)

Hosted validation on draft #340 for the same commit:

- `tests` workflow run `25618326817` succeeded on Python 3.10, 3.11, and 3.12.
- `artifact-review` skipped as expected.

## Limitations

This PR does not audit the witness-pair cap, indegree cap, vertex-circle strict-edge lemma, vertex-circle quotient obstruction, row0 coverage, archive reconciliation, or the 184 pre-vertex-circle assignments. It does not prove the full `n=9` finite case, Erdos Problem #97, or a counterexample. The overarching proof/counterexample goal remains open.