### PR TITLE
[codex] Audit block6 fragile vertex-circle extensions

### DIFF
--- a/docs/block6-fragile-vertex-circle-extension-audit.md
+++ b/docs/block6-fragile-vertex-circle-extension-audit.md
@@ -1,0 +1,142 @@
+# Block-6 Fragile-cover Vertex-circle Extension Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note audits one bounded obstruction to the forced-local-core bridge. It
+does not claim a proof of Erdos Problem #97, does not claim a counterexample,
+and does not update the official/global status.
+
+## Subquestion
+
+The minimal fragile-cover bridge shows that every minimal counterexample has
+some exact critical 4-tie rows covering all vertices. The block-6 family shows
+that fragile-cover hypergraph constraints alone are too weak.
+
+The narrow question here is:
+
+```text
+For two disjoint block-6 fragile-cover blocks in the natural cyclic order, is
+there a full selected-witness extension that also survives the vertex-circle
+quotient self-edge / strict-cycle filter?
+```
+
+## Definitions
+
+For each six-label block `b,...,b+5`, the block-6 fragile rows are
+
+```text
+b   -> {b+1,b+2,b+3,b+4}
+b+3 -> {b,b+2,b+4,b+5}.
+```
+
+For two blocks, this gives `n=12` and fixed fragile centers
+
+```text
+0, 3, 6, 9.
+```
+
+A full selected extension assigns one 4-set row to every center, keeps the
+four fixed fragile rows, and satisfies the standard incidence/order necessary
+conditions used in the audit:
+
+- self-exclusion and row size 4;
+- pairwise selected-row intersection at most 2;
+- radical-axis crossing for every two-overlap;
+- witness-pair multiplicity at most 2;
+- selected indegree at most `floor(2*(12-1)/(4-1)) = 7`.
+
+A vertex-circle-clean extension is such an extension whose selected-distance
+quotient strict graph has no self-edge and no directed strict cycle in the
+natural cyclic order.
+
+## Result
+
+Exact bounded audit:
+**Two-block Fragile-cover Vertex-circle Closure Lemma**.
+
+The two-block block-6 fragile-cover family has an incidence-level full
+selected extension, but no full selected extension survives the vertex-circle
+quotient obstruction filter under the natural cyclic order and the stated
+incidence/order necessary conditions.
+
+## Audit Output
+
+The existing fragile-cover checker confirms that one block is abstractly
+allowed but has no full incidence extension, while two blocks have a full
+incidence extension:
+
+```text
+blocks=1: fragile-cover ok, full selected extension false
+blocks=2: fragile-cover ok, full selected extension true, nodes=17
+```
+
+The two-block vertex-circle-clean extension search fixed the four fragile rows
+and searched all remaining row choices with minimum-remaining-options
+branching. It used monotone vertex-circle partial pruning: once a partial
+assignment has a quotient self-edge or directed strict cycle, no later rows can
+repair it.
+
+Reproduce the pruned audit with:
+
+```bash
+python scripts/check_block6_fragile_vertex_circle_extension.py \
+  --assert-expected \
+  --json
+```
+
+The audit reported:
+
+```text
+fixed rows {0: (1, 2, 3, 4), 3: (0, 2, 4, 5), 6: (7, 8, 9, 10), 9: (6, 8, 10, 11)}
+initial_vc ok
+result None
+nodes 1752
+zero_option_prunes 37
+vc_prunes {'self_edge': 645, 'strict_cycle': 768}
+solutions 0
+```
+
+Thus every branch either runs out of legal incidence/order rows or reaches a
+monotone vertex-circle quotient obstruction.
+
+As a terminal cross-check, the same fixed-row search was rerun without
+vertex-circle partial pruning and classified every full incidence/order
+extension at the end. It found no vertex-circle-clean terminal extension:
+
+```bash
+python scripts/check_block6_fragile_vertex_circle_extension.py \
+  --terminal \
+  --assert-expected \
+  --json
+```
+
+```text
+full_extensions 105978
+nodes 320898
+zero_option_prunes 79547
+vertex_circle_status_counts {'self_edge': 105690, 'strict_cycle': 288}
+strict_edge_count_histogram {108: 105978}
+```
+
+## Scope
+
+This is a bounded natural-order audit of the two-block block-6 family. It does
+not prove that every fragile-cover system, every full selected-witness system,
+or every minimal counterexample forces a vertex-circle quotient obstruction.
+
+It also does not prove Euclidean realizability or unrealizability of an
+arbitrary abstract incidence system. The conclusion is only that this
+particular fragile-cover obstruction to hypergraph-only reasoning is not an
+obstruction to a stronger bridge that also uses the vertex-circle quotient
+filter.
+
+## Effect
+
+The block-6 family still shows that pure fragile-cover hypergraph constraints
+cannot prove Erdos Problem #97. The two-block audit narrows that warning:
+after adding full selected-row extension plus vertex-circle quotient
+obstructions in the natural cyclic order, the two-block family closes.
+
+The next bridge target should test whether this closure is special to the
+block-6 construction or reflects a broader principle for fragile-cover
+extensions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`minimal-fragile-cover-bridge.md`](minimal-fragile-cover-bridge.md):
   partial bridge theorem showing that every minimal counterexample admits a
   fragile-cover witness system; also records why this is not sufficient.
+- [`block6-fragile-vertex-circle-extension-audit.md`](block6-fragile-vertex-circle-extension-audit.md):
+  bounded audit showing that the two-block block-6 fragile-cover obstruction
+  closes once full selected-row extension is combined with vertex-circle
+  quotient pruning in the natural order.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,180 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 640 - Block-6 Fragile-cover Vertex-circle Extension Audit
+
+### Mathematical Subquestion
+
+The coverage-chain lead was already handled in Cycle 631, so this cycle moved
+to the remaining global bridge problem:
+
+For the two-block block-6 fragile-cover family from
+`docs/minimal-fragile-cover-bridge.md`, does there exist a full
+selected-witness extension that satisfies the standard incidence/order
+necessary conditions and also avoids the vertex-circle quotient self-edge /
+strict-cycle obstruction in the natural cyclic order?
+
+### Definitions and Assumptions
+
+For each six-label block `b,...,b+5`, the block-6 fragile rows are
+
+```text
+b   -> {b+1,b+2,b+3,b+4}
+b+3 -> {b,b+2,b+4,b+5}.
+```
+
+For two disjoint blocks this gives `n=12` with fixed fragile centers
+`0, 3, 6, 9`.
+
+A full selected extension assigns one 4-set row to every center, extends those
+four fixed fragile rows, and satisfies:
+
+- self-exclusion and row size 4;
+- pairwise selected-row intersection at most 2;
+- radical-axis crossing for every two-overlap;
+- witness-pair multiplicity at most 2;
+- selected indegree at most `floor(2*(12-1)/(4-1)) = 7`.
+
+A vertex-circle-clean extension has no selected-distance quotient self-edge
+and no directed strict cycle in the natural cyclic order.
+
+This cycle uses the Cycle 634 monotonicity lemma: once a partial assignment has
+a vertex-circle quotient self-edge or directed strict cycle, no extension can
+repair that obstruction.
+
+### Result Status
+
+Proved bounded finite-audit lemma:
+**Two-block Fragile-cover Vertex-circle Closure Lemma**.
+
+The two-block block-6 fragile-cover family has an incidence-level full
+selected extension, but no full selected extension survives vertex-circle
+quotient pruning under the natural cyclic order and the stated exact
+incidence/order filters.
+
+### Argument Or Obstruction
+
+The existing fragile-cover checker confirms:
+
+```text
+blocks=1: fragile-cover ok, full selected extension false
+blocks=2: fragile-cover ok, full selected extension true, nodes=17
+```
+
+Thus the two-block family remains an obstruction to a hypergraph-only
+fragile-cover proof route.
+
+The new one-off exact search fixed the two-block fragile rows and enumerated
+all remaining row choices by minimum-remaining-options branching, checking the
+listed incidence/order filters and applying monotone vertex-circle quotient
+pruning. Its output was:
+
+```text
+fixed rows {0: (1, 2, 3, 4), 3: (0, 2, 4, 5), 6: (7, 8, 9, 10), 9: (6, 8, 10, 11)}
+initial_vc ok
+result None
+nodes 1752
+zero_option_prunes 37
+vc_prunes {'self_edge': 645, 'strict_cycle': 768}
+solutions 0
+```
+
+Therefore every branch either runs out of legal incidence/order rows or hits a
+monotone vertex-circle quotient obstruction. The already-proved partial-pruning
+monotonicity lemma justifies treating those partial obstructions as closing
+all descendants.
+
+A terminal cross-check then reran the same fixed-row search without
+vertex-circle partial pruning and classified every full incidence/order
+extension at the end:
+
+```text
+full_extensions 105978
+nodes 320898
+zero_option_prunes 79547
+vertex_circle_status_counts {'self_edge': 105690, 'strict_cycle': 288}
+strict_edge_count_histogram {108: 105978}
+```
+
+This independent terminal classification agrees with the pruned search: no
+full extension is vertex-circle-clean.
+
+### Exact Scope
+
+This is only a bounded natural-order audit of the two-block block-6 family. It
+does not prove that every fragile-cover system, every full selected-witness
+system, or every minimal counterexample forces a vertex-circle quotient
+obstruction. It does not prove Erdos Problem #97 and does not give a
+counterexample.
+
+The conclusion is narrower: the known block-6 warning against
+fragile-cover-only reasoning is not, by itself, a warning against a stronger
+bridge that also uses full selected-row extension and vertex-circle quotient
+obstructions.
+
+### Files Changed
+
+- `docs/block6-fragile-vertex-circle-extension-audit.md`
+- `docs/index.md`
+- `scripts/check_block6_fragile_vertex_circle_extension.py`
+- `tests/test_block6_fragile_vertex_circle_extension.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This strengthens the forced-local-core bridge route in a small but exact way.
+The block-6 construction still defeats pure fragile-cover hypergraph
+constraints, but the natural two-block full-extension slice closes once
+vertex-circle quotient obstructions are admitted.
+
+The next proof-facing question is whether this is a special feature of the
+block-6 construction or an instance of a broader theorem: fragile-cover
+extensions plus the standard selected-row filters may force a quotient
+self-edge or strict cycle under additional cyclic-order hypotheses.
+
+### Next Lead
+
+Generalize the audit from the two-block block-6 family to a symbolic or
+parametric statement. A narrow next test is to classify the first
+vertex-circle obstruction reached in each branch by which fixed fragile rows
+participate, and decide whether the proof can be rewritten as a small
+case-free local lemma.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-640`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-640`.
+- The branch was based on `origin/main` at commit
+  `8d38422f930fe11a3762186932c1acd5e317753b`, after PR #349 merged Cycle
+  639.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python3 scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok
+  --check-full-extension --assert-full-extension --json` passed, confirming
+  the two-block fragile cover and one full selected extension.
+- `python3 scripts/check_fragile_hypergraph.py --blocks 1 --assert-ok
+  --check-full-extension --json` passed, confirming that the one-block
+  fragile cover is abstractly allowed but has no full selected extension.
+- `python scripts/check_block6_fragile_vertex_circle_extension.py
+  --assert-expected --json` passed, reproducing `nodes 1752`,
+  `zero_option_prunes 37`, `vc_prunes {'self_edge': 645, 'strict_cycle':
+  768}`, and `solutions 0`.
+- `python scripts/check_block6_fragile_vertex_circle_extension.py --terminal
+  --assert-expected --json` passed, classifying `105978` full
+  incidence/order extensions as `105690` self-edge obstructions and `288`
+  strict-cycle obstructions.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 639 - Vertex-circle Quotient Soundness Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_vertex_circle_extension.py
+++ b/scripts/check_block6_fragile_vertex_circle_extension.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Check the two-block fragile-cover vertex-circle extension audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.fragile_hypergraph import _selected_pair_ok, block6_family  # noqa: E402
+from erdos97.vertex_circle_order_filter import (  # noqa: E402
+    StrictInequality,
+    UnionFind,
+    _all_pairs,
+    _find_strict_cycle,
+    angular_witness_order,
+    pair,
+    vertex_circle_order_obstruction,
+)
+
+
+N = 12
+ROW_SIZE = 4
+ORDER = list(range(N))
+PAIR_CAP = 2
+INDEGREE_CAP = (2 * (N - 1)) // (ROW_SIZE - 1)
+EXPECTED_PRUNED = {
+    "result": "closed",
+    "nodes": 1752,
+    "zero_option_prunes": 37,
+    "vc_prunes": {"self_edge": 645, "strict_cycle": 768},
+    "solutions": 0,
+}
+EXPECTED_TERMINAL = {
+    "full_extensions": 105978,
+    "nodes": 320898,
+    "zero_option_prunes": 79547,
+    "vertex_circle_status_counts": {"self_edge": 105690, "strict_cycle": 288},
+    "strict_edge_count_histogram": {"108": 105978},
+}
+
+Rows = dict[int, tuple[int, ...]]
+
+
+def _fixed_rows() -> Rows:
+    """Return the two-block block-6 fragile rows."""
+
+    n, rows = block6_family(2)
+    if n != N:
+        raise AssertionError(f"unexpected block6 size: {n}")
+    return {int(center): tuple(int(v) for v in row) for center, row in rows.items()}
+
+
+def _options() -> dict[int, list[tuple[int, ...]]]:
+    return {
+        center: [
+            tuple(row)
+            for row in combinations(
+                [label for label in range(N) if label != center],
+                ROW_SIZE,
+            )
+        ]
+        for center in range(N)
+    }
+
+
+def _paircross_ok(
+    center: int,
+    row: Sequence[int],
+    assigned: Mapping[int, Sequence[int]],
+) -> bool:
+    return all(
+        _selected_pair_ok(center, row, other, other_row, ORDER)
+        for other, other_row in assigned.items()
+    )
+
+
+def _pair_cap_ok(row: Sequence[int], pair_counts: Counter[tuple[int, int]]) -> bool:
+    return all(
+        pair_counts[tuple(sorted(raw_pair))] < PAIR_CAP
+        for raw_pair in combinations(row, 2)
+    )
+
+
+def _indegree_ok(row: Sequence[int], indegrees: Counter[int]) -> bool:
+    return all(indegrees[label] < INDEGREE_CAP for label in row)
+
+
+def _add_row(
+    assigned: Rows,
+    pair_counts: Counter[tuple[int, int]],
+    indegrees: Counter[int],
+    center: int,
+    row: tuple[int, ...],
+) -> None:
+    assigned[center] = row
+    pair_counts.update(tuple(sorted(raw_pair)) for raw_pair in combinations(row, 2))
+    indegrees.update(row)
+
+
+def _remove_row(
+    assigned: Rows,
+    pair_counts: Counter[tuple[int, int]],
+    indegrees: Counter[int],
+    center: int,
+    row: tuple[int, ...],
+) -> None:
+    for raw_pair in combinations(row, 2):
+        pair_counts[tuple(sorted(raw_pair))] -= 1
+    for label in row:
+        indegrees[label] -= 1
+    del assigned[center]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _partial_vertex_circle_status(assigned: Mapping[int, Sequence[int]]) -> tuple[str, int]:
+    """Return the partial quotient-obstruction status for assigned rows."""
+
+    uf = UnionFind(_all_pairs(N))
+    for center, row in assigned.items():
+        base = pair(center, row[0])
+        for witness in row[1:]:
+            uf.union(base, pair(center, witness))
+
+    edges: list[StrictInequality] = []
+    for center, row in assigned.items():
+        witnesses = angular_witness_order(ORDER, center, row)
+        for outer_start in range(ROW_SIZE):
+            for outer_end in range(outer_start + 1, ROW_SIZE):
+                for inner_start in range(ROW_SIZE):
+                    for inner_end in range(inner_start + 1, ROW_SIZE):
+                        if (outer_start, outer_end) == (inner_start, inner_end):
+                            continue
+                        contains = (
+                            outer_start <= inner_start
+                            and inner_end <= outer_end
+                            and (
+                                outer_start < inner_start
+                                or inner_end < outer_end
+                            )
+                        )
+                        if not contains:
+                            continue
+                        outer_pair = pair(witnesses[outer_start], witnesses[outer_end])
+                        inner_pair = pair(witnesses[inner_start], witnesses[inner_end])
+                        edges.append(
+                            StrictInequality(
+                                row=center,
+                                witness_order=list(witnesses),
+                                outer_interval=[outer_start, outer_end],
+                                inner_interval=[inner_start, inner_end],
+                                outer_pair=outer_pair,
+                                inner_pair=inner_pair,
+                                outer_class=uf.find(outer_pair),
+                                inner_class=uf.find(inner_pair),
+                            )
+                        )
+
+    self_edges = [edge for edge in edges if edge.outer_class == edge.inner_class]
+    if self_edges:
+        return "self_edge", len(edges)
+    if _find_strict_cycle(edges):
+        return "strict_cycle", len(edges)
+    return "ok", len(edges)
+
+
+def _initial_state() -> tuple[Rows, Counter[tuple[int, int]], Counter[int]]:
+    assigned: Rows = {}
+    pair_counts: Counter[tuple[int, int]] = Counter()
+    indegrees: Counter[int] = Counter()
+    for center, row in _fixed_rows().items():
+        if not _paircross_ok(center, row, assigned):
+            raise AssertionError("fixed rows fail pair/crossing check")
+        if not _pair_cap_ok(row, pair_counts):
+            raise AssertionError("fixed rows fail pair cap")
+        if not _indegree_ok(row, indegrees):
+            raise AssertionError("fixed rows fail indegree cap")
+        _add_row(assigned, pair_counts, indegrees, center, row)
+    return assigned, pair_counts, indegrees
+
+
+def _valid_options(
+    center: int,
+    options: Mapping[int, Sequence[tuple[int, ...]]],
+    assigned: Mapping[int, Sequence[int]],
+    pair_counts: Counter[tuple[int, int]],
+    indegrees: Counter[int],
+) -> list[tuple[int, ...]]:
+    return [
+        row
+        for row in options[center]
+        if _paircross_ok(center, row, assigned)
+        and _pair_cap_ok(row, pair_counts)
+        and _indegree_ok(row, indegrees)
+    ]
+
+
+def pruned_search_payload(*, max_nodes: int = 2_000_000) -> dict[str, Any]:
+    """Search for a vertex-circle-clean extension using monotone pruning."""
+
+    assigned, pair_counts, indegrees = _initial_state()
+    options = _options()
+    initial_status, _edge_count = _partial_vertex_circle_status(assigned)
+    nodes = 0
+    zero_option_prunes = 0
+    vc_prunes: Counter[str] = Counter()
+    solutions = 0
+
+    def search() -> str | None:
+        nonlocal nodes, zero_option_prunes, solutions
+        if nodes >= max_nodes:
+            return "limit"
+        if len(assigned) == N:
+            status, _edge_count = _partial_vertex_circle_status(assigned)
+            if status == "ok":
+                solutions += 1
+                return "found"
+            vc_prunes[status] += 1
+            return None
+
+        best_center: int | None = None
+        best_options: list[tuple[int, ...]] | None = None
+        for center in range(N):
+            if center in assigned:
+                continue
+            viable = _valid_options(
+                center,
+                options,
+                assigned,
+                pair_counts,
+                indegrees,
+            )
+            if best_options is None or len(viable) < len(best_options):
+                best_center = center
+                best_options = viable
+            if not viable:
+                break
+        if best_center is None or not best_options:
+            zero_option_prunes += 1
+            return None
+
+        for row in best_options:
+            nodes += 1
+            _add_row(assigned, pair_counts, indegrees, best_center, row)
+            status, _edge_count = _partial_vertex_circle_status(assigned)
+            if status == "ok":
+                result = search()
+                if result in {"limit", "found"}:
+                    return result
+            else:
+                vc_prunes[status] += 1
+            _remove_row(assigned, pair_counts, indegrees, best_center, row)
+        return None
+
+    raw_result = search()
+    return {
+        "result": "closed" if raw_result is None else raw_result,
+        "initial_vc": initial_status,
+        "nodes": nodes,
+        "max_nodes": max_nodes,
+        "zero_option_prunes": zero_option_prunes,
+        "vc_prunes": _json_counter(vc_prunes),
+        "solutions": solutions,
+    }
+
+
+def terminal_classification_payload() -> dict[str, Any]:
+    """Classify every terminal full extension without vertex-circle pruning."""
+
+    assigned, pair_counts, indegrees = _initial_state()
+    options = _options()
+    nodes = 0
+    zero_option_prunes = 0
+    full_extensions = 0
+    status_counts: Counter[str] = Counter()
+    strict_edge_counts: Counter[int] = Counter()
+
+    def search() -> None:
+        nonlocal nodes, zero_option_prunes, full_extensions
+        if len(assigned) == N:
+            full_extensions += 1
+            result = vertex_circle_order_obstruction(
+                [assigned[center] for center in range(N)],
+                ORDER,
+                "block6x2_fragile_extension",
+            )
+            status = (
+                "self_edge"
+                if result.self_edge_conflicts
+                else "strict_cycle"
+                if result.cycle_edges
+                else "ok"
+            )
+            status_counts[status] += 1
+            strict_edge_counts[result.strict_edge_count] += 1
+            return
+
+        best_center: int | None = None
+        best_options: list[tuple[int, ...]] | None = None
+        for center in range(N):
+            if center in assigned:
+                continue
+            viable = _valid_options(
+                center,
+                options,
+                assigned,
+                pair_counts,
+                indegrees,
+            )
+            if best_options is None or len(viable) < len(best_options):
+                best_center = center
+                best_options = viable
+            if not viable:
+                break
+        if best_center is None or not best_options:
+            zero_option_prunes += 1
+            return
+
+        for row in best_options:
+            nodes += 1
+            _add_row(assigned, pair_counts, indegrees, best_center, row)
+            search()
+            _remove_row(assigned, pair_counts, indegrees, best_center, row)
+
+    search()
+    return {
+        "full_extensions": full_extensions,
+        "nodes": nodes,
+        "zero_option_prunes": zero_option_prunes,
+        "vertex_circle_status_counts": _json_counter(status_counts),
+        "strict_edge_count_histogram": _json_counter(strict_edge_counts),
+    }
+
+
+def audit_payload(*, include_terminal: bool, max_nodes: int = 2_000_000) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema": "erdos97.block6_fragile_vertex_circle_extension_audit.v1",
+        "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+        "claim_scope": (
+            "Two-block block-6 fragile-cover extension audit in the natural "
+            "cyclic order; not a proof of Erdos Problem #97 and not a counterexample."
+        ),
+        "n": N,
+        "row_size": ROW_SIZE,
+        "cyclic_order": ORDER,
+        "fixed_rows": {str(center): list(row) for center, row in _fixed_rows().items()},
+        "pair_cap": PAIR_CAP,
+        "selected_indegree_cap": INDEGREE_CAP,
+        "pruned_search": pruned_search_payload(max_nodes=max_nodes),
+    }
+    if include_terminal:
+        payload["terminal_classification"] = terminal_classification_payload()
+    return payload
+
+
+def assert_expected(payload: Mapping[str, Any], *, include_terminal: bool) -> None:
+    if payload["status"] != "REVIEW_PENDING_DIAGNOSTIC_ONLY":
+        raise AssertionError("unexpected status")
+    if "not a proof" not in payload["claim_scope"]:
+        raise AssertionError("claim scope lost no-proof note")
+    pruned = dict(payload["pruned_search"])
+    pruned_subset = {key: pruned[key] for key in EXPECTED_PRUNED}
+    if pruned_subset != EXPECTED_PRUNED:
+        raise AssertionError(f"unexpected pruned search counts: {pruned_subset!r}")
+    if include_terminal:
+        terminal = dict(payload["terminal_classification"])
+        terminal_subset = {key: terminal[key] for key in EXPECTED_TERMINAL}
+        if terminal_subset != EXPECTED_TERMINAL:
+            raise AssertionError(
+                f"unexpected terminal classification counts: {terminal_subset!r}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print full JSON payload")
+    parser.add_argument(
+        "--terminal",
+        action="store_true",
+        help="also classify every terminal extension without vertex-circle pruning",
+    )
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert the current expected audit counts",
+    )
+    parser.add_argument("--max-nodes", type=int, default=2_000_000)
+    args = parser.parse_args()
+
+    payload = audit_payload(include_terminal=args.terminal, max_nodes=args.max_nodes)
+    if args.assert_expected:
+        assert_expected(payload, include_terminal=args.terminal)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        pruned = payload["pruned_search"]
+        print("block6 fragile vertex-circle extension audit")
+        print(f"n: {payload['n']}")
+        print(f"fixed centers: {sorted(int(k) for k in payload['fixed_rows'])}")
+        print(
+            "pruned search: "
+            f"result={pruned['result']} nodes={pruned['nodes']} "
+            f"zero_option_prunes={pruned['zero_option_prunes']} "
+            f"vc_prunes={pruned['vc_prunes']} solutions={pruned['solutions']}"
+        )
+        terminal = payload.get("terminal_classification")
+        if terminal is not None:
+            print(
+                "terminal classification: "
+                f"full_extensions={terminal['full_extensions']} "
+                f"status_counts={terminal['vertex_circle_status_counts']}"
+            )
+        if args.assert_expected:
+            print("OK: block6 fragile vertex-circle audit matched expected counts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block6_fragile_vertex_circle_extension.py
+++ b/tests/test_block6_fragile_vertex_circle_extension.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_block6_fragile_vertex_circle_extension import (
+    assert_expected,
+    audit_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_block6_pruned_audit_matches_expected() -> None:
+    payload = audit_payload(include_terminal=False)
+
+    assert_expected(payload, include_terminal=False)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert "not a proof" in payload["claim_scope"]
+    assert payload["pruned_search"]["solutions"] == 0
+    assert payload["pruned_search"]["vc_prunes"] == {
+        "self_edge": 645,
+        "strict_cycle": 768,
+    }
+
+
+def test_block6_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_fragile_vertex_circle_extension.py",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 640 for the Erdos97 research log. It audits the two-block block-6 fragile-cover family from `docs/minimal-fragile-cover-bridge.md` against full selected-row extension plus vertex-circle quotient obstruction in the natural cyclic order.

Named result: **Two-block Fragile-cover Vertex-circle Closure Lemma**.

The audit confirms that the two-block block-6 family still has an incidence-level full selected extension, but no full selected extension survives vertex-circle quotient filtering under the stated incidence/order necessary conditions.

## Files changed

- `docs/block6-fragile-vertex-circle-extension-audit.md`
- `docs/index.md`
- `scripts/check_block6_fragile_vertex_circle_extension.py`
- `tests/test_block6_fragile_vertex_circle_extension.py`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `python3 scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --check-full-extension --assert-full-extension --json`: passed, confirming a two-block fragile cover and a full selected extension (`nodes=17`).
- `python3 scripts/check_fragile_hypergraph.py --blocks 1 --assert-ok --check-full-extension --json`: passed, confirming one block is abstractly allowed but has no full selected extension.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_vertex_circle_extension.py --assert-expected --json`: passed with `nodes 1752`, `zero_option_prunes 37`, `vc_prunes {'self_edge': 645, 'strict_cycle': 768}`, and `solutions 0`.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_vertex_circle_extension.py --terminal --assert-expected --json`: passed, classifying `105978` full incidence/order extensions as `105690` self-edge obstructions and `288` strict-cycle obstructions.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_vertex_circle_extension.py -q` (`2 passed`)
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`536 passed, 276 deselected`)

## Remaining limitations

This is a bounded natural-order audit of the two-block block-6 family only. It does not prove that every fragile-cover system, every full selected-witness system, or every minimal counterexample forces a vertex-circle quotient obstruction.

No general proof of Erdos Problem #97 and no counterexample are claimed. The overarching proof/counterexample goal remains open.