### PR TITLE
[codex] Catalog block6 fragile fifth-row obstructions

### DIFF
--- a/docs/block6-fragile-fifth-row-obstruction-catalog.md
+++ b/docs/block6-fragile-fifth-row-obstruction-catalog.md
@@ -1,0 +1,116 @@
+# Block-6 Fragile-cover Fifth-row Obstruction Catalog
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one bounded proof-mining audit for the two-block block-6
+fragile-cover family. It does not claim a proof of Erdos Problem #97, does
+not claim a counterexample, and does not update the official/global status.
+
+## Subquestion
+
+Cycle 640 showed that the two-block block-6 fragile-cover family has no full
+selected-witness extension surviving the vertex-circle quotient filter in the
+natural cyclic order.
+
+The narrow follow-up question is whether that closure can already be reduced
+to a one-step local lemma:
+
+```text
+After fixing the four block-6 fragile rows, does every legal fifth selected
+row immediately force a vertex-circle quotient self-edge or strict cycle?
+```
+
+## Definitions
+
+Use the same two-block fixed rows as the extension audit:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+A legal fifth row is a four-set at one remaining center that satisfies, with
+respect to the four fixed rows:
+
+- self-exclusion and row size 4;
+- pairwise selected-row intersection at most 2;
+- radical-axis crossing for every two-overlap;
+- witness-pair multiplicity at most 2;
+- selected indegree at most `floor(2*(12-1)/(4-1)) = 7`.
+
+Its vertex-circle status is computed from the selected-distance quotient and
+proper-interval strict edges of just those five selected rows in the natural
+cyclic order.
+
+## Result
+
+Counterexample to the one-step local-closure subclaim:
+**Block-6 Fifth-row Survivor Catalog**.
+
+There are exactly `342` legal fifth rows. Of these, `176` already force a
+vertex-circle quotient obstruction, but `166` remain vertex-circle-clean at
+the five-row level.
+
+```text
+total legal fifth rows: 342
+vertex-circle-clean:   166
+self-edge obstruction:  82
+strict-cycle obstruction: 94
+```
+
+Thus the Cycle 640 closure cannot be rewritten as the statement that every
+legal fifth row already closes. Later rows are genuinely needed for the
+surviving fifth-row states.
+
+## Center Counts
+
+```text
+center  legal  ok  self_edge  strict_cycle
+1       38     21  7          10
+2       64     41  13         10
+4       38     7   14         17
+5       31     14  7          10
+7       38     21  7          10
+8       64     41  13         10
+10      38     7   14         17
+11      31     14  7          10
+```
+
+One explicit legal fifth-row survivor is:
+
+```text
+5 -> {0,1,6,7}
+```
+
+With the four fixed rows above, this row satisfies the listed incidence/order
+necessary conditions and has vertex-circle status `ok` at the five-row level.
+It is only a counterexample to the one-step local-closure subclaim, not to
+Erdos Problem #97.
+
+## Reproduction
+
+Run:
+
+```bash
+python scripts/check_block6_fragile_fifth_row_obstructions.py \
+  --assert-expected \
+  --json
+```
+
+The checker enumerates all legal fifth rows from the fixed two-block state and
+asserts the center counts and totals above. To print every row classification,
+add `--include-rows`.
+
+## Effect
+
+This audit sharpens the Cycle 640 bridge lead. It shows that a proof-facing
+block-6 closure lemma cannot stop at the first connector row. However, it also
+shows that more than half of the legal fifth rows already close by the same
+quotient-obstruction mechanism, giving a small exact catalog for the next
+normal-form step.
+
+The next useful reduction is to classify the `166` clean fifth-row states by
+symmetry and then ask whether every clean state closes after a sixth row, or
+whether a small family of clean normal forms persists deeper into the search.

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,10 @@ put detailed reconciliation in the canonical synthesis.
   bounded audit showing that the two-block block-6 fragile-cover obstruction
   closes once full selected-row extension is combined with vertex-circle
   quotient pruning in the natural order.
+- [`block6-fragile-fifth-row-obstruction-catalog.md`](block6-fragile-fifth-row-obstruction-catalog.md):
+  one-step catalog showing that many legal fifth rows already hit the
+  vertex-circle quotient obstruction, while 166 remain clean and block a
+  fifth-row-only closure lemma.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,153 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 641 - Block-6 Fifth-row Obstruction Catalog
+
+### Mathematical Subquestion
+
+Cycle 640 showed that the two-block block-6 fragile-cover family has no full
+selected-witness extension surviving the vertex-circle quotient filter in the
+natural cyclic order. The next proof-facing question was whether that closure
+can be reduced to a one-step local lemma:
+
+```text
+After fixing the four block-6 fragile rows, does every legal fifth selected
+row immediately force a vertex-circle quotient self-edge or strict cycle?
+```
+
+### Definitions and Assumptions
+
+The fixed two-block fragile rows are:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+A legal fifth row is a four-set at one remaining center that satisfies the
+same one-row incidence/order necessary conditions used in Cycle 640 relative
+to the fixed rows: self-exclusion, row size 4, selected-row pairwise
+intersection at most 2, radical-axis crossing for every two-overlap,
+witness-pair multiplicity at most 2, and selected indegree at most
+`floor(2*(12-1)/(4-1)) = 7`.
+
+The vertex-circle status is computed from the selected-distance quotient and
+proper-interval strict edges of just the five selected rows in the natural
+cyclic order.
+
+### Result Status
+
+Counterexample to the one-step local-closure subclaim:
+**Block-6 Fifth-row Survivor Catalog**.
+
+There are exactly `342` legal fifth rows. Of these, `176` already force a
+vertex-circle quotient obstruction, but `166` remain vertex-circle-clean at
+the five-row level. Therefore the two-block closure from Cycle 640 cannot be
+rewritten as a fifth-row-only local lemma.
+
+### Argument Or Obstruction
+
+The exact catalog checker enumerates every legal fifth row from the fixed
+two-block state and classifies its five-row vertex-circle quotient status.
+The totals are:
+
+```text
+total legal fifth rows: 342
+vertex-circle-clean:   166
+self-edge obstruction:  82
+strict-cycle obstruction: 94
+```
+
+The center-by-center counts are:
+
+```text
+center  legal  ok  self_edge  strict_cycle
+1       38     21  7          10
+2       64     41  13         10
+4       38     7   14         17
+5       31     14  7          10
+7       38     21  7          10
+8       64     41  13         10
+10      38     7   14         17
+11      31     14  7          10
+```
+
+One explicit obstruction to the proposed fifth-row-only lemma is:
+
+```text
+5 -> {0,1,6,7}
+```
+
+With the four fixed rows, this fifth row is legal under the stated filters
+and has vertex-circle status `ok` at the five-row level.
+
+### Exact Scope
+
+This is a bounded one-row extension catalog for the two-block block-6 family
+in the natural cyclic order. It is not a proof of Erdos Problem #97 and is not
+a counterexample. The clean fifth-row states are not Euclidean realizability
+claims; they are only states not yet killed by the listed five-row
+incidence/order and vertex-circle quotient checks.
+
+### Files Changed
+
+- `docs/block6-fragile-fifth-row-obstruction-catalog.md`
+- `docs/index.md`
+- `scripts/check_block6_fragile_fifth_row_obstructions.py`
+- `tests/test_block6_fragile_fifth_row_obstructions.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This sharpens the block-6 bridge route by ruling out a tempting but false
+local reduction. The proof cannot simply say that any connector row between
+the two fragile blocks closes immediately. However, the same audit gives a
+small exact catalog for the next normal-form step: more than half of the legal
+fifth rows already close, and the remaining `166` clean rows are now a
+manageable target.
+
+### Next Lead
+
+Quotient the `166` clean fifth-row states by the block-swap and reversal
+symmetries, then test whether every clean normal form closes after a sixth
+row. If not, record the smallest exact clean sixth-row obstruction to that
+stronger subclaim.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-641`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-641`.
+- The branch was based on `origin/main` at commit
+  `fb0aa3f4a77e2be1f41c5163f698ab1d5aeea3b7`, after PR #351 merged Cycle
+  640.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python scripts/check_block6_fragile_fifth_row_obstructions.py
+  --assert-expected --json`: passed, reproducing `342` legal fifth rows,
+  with `166` vertex-circle-clean, `82` self-edge, and `94` strict-cycle
+  one-row statuses.
+- `python scripts/check_text_clean.py`: passed.
+- `python scripts/check_status_consistency.py`: passed.
+- `python scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `python -m ruff check .`: passed.
+- `python -m pytest tests/test_block6_fragile_fifth_row_obstructions.py -q`:
+  passed, `2 passed`.
+- `python -m pytest -q`: passed, `538 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 640 - Block-6 Fragile-cover Vertex-circle Extension Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_fifth_row_obstructions.py
+++ b/scripts/check_block6_fragile_fifth_row_obstructions.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Catalog one-row vertex-circle obstructions for the block-6 fragile audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.check_block6_fragile_vertex_circle_extension import (  # noqa: E402
+    _add_row,
+    _initial_state,
+    _options,
+    _partial_vertex_circle_status,
+    _remove_row,
+    _valid_options,
+)
+
+EXPECTED_CENTER_COUNTS = {
+    "1": {"valid": 38, "ok": 21, "self_edge": 7, "strict_cycle": 10},
+    "2": {"valid": 64, "ok": 41, "self_edge": 13, "strict_cycle": 10},
+    "4": {"valid": 38, "ok": 7, "self_edge": 14, "strict_cycle": 17},
+    "5": {"valid": 31, "ok": 14, "self_edge": 7, "strict_cycle": 10},
+    "7": {"valid": 38, "ok": 21, "self_edge": 7, "strict_cycle": 10},
+    "8": {"valid": 64, "ok": 41, "self_edge": 13, "strict_cycle": 10},
+    "10": {"valid": 38, "ok": 7, "self_edge": 14, "strict_cycle": 17},
+    "11": {"valid": 31, "ok": 14, "self_edge": 7, "strict_cycle": 10},
+}
+EXPECTED_TOTALS = {
+    "valid": 342,
+    "ok": 166,
+    "self_edge": 82,
+    "strict_cycle": 94,
+}
+STATUSES = ("ok", "self_edge", "strict_cycle")
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def catalog_payload(*, include_rows: bool = False) -> dict[str, Any]:
+    """Classify every legal one-row extension of the fixed block-6 rows."""
+
+    assigned, pair_counts, indegrees = _initial_state()
+    options = _options()
+    fixed_centers = sorted(assigned)
+    center_payload: dict[str, dict[str, Any]] = {}
+    totals: Counter[str] = Counter()
+
+    for center in range(len(options)):
+        if center in assigned:
+            continue
+        valid_rows = _valid_options(
+            center,
+            options,
+            assigned,
+            pair_counts,
+            indegrees,
+        )
+        status_counts: Counter[str] = Counter()
+        edge_counts: Counter[int] = Counter()
+        examples: dict[str, list[int]] = {}
+        row_records: list[dict[str, Any]] = []
+
+        for row in valid_rows:
+            _add_row(assigned, pair_counts, indegrees, center, row)
+            status, edge_count = _partial_vertex_circle_status(assigned)
+            _remove_row(assigned, pair_counts, indegrees, center, row)
+
+            status_counts[status] += 1
+            edge_counts[edge_count] += 1
+            examples.setdefault(status, list(row))
+            if include_rows:
+                row_records.append(
+                    {
+                        "row": list(row),
+                        "vertex_circle_status": status,
+                        "strict_edge_count": edge_count,
+                    }
+                )
+
+        center_record: dict[str, Any] = {
+            "valid": len(valid_rows),
+            "ok": int(status_counts["ok"]),
+            "self_edge": int(status_counts["self_edge"]),
+            "strict_cycle": int(status_counts["strict_cycle"]),
+            "strict_edge_count_histogram": _json_counter(edge_counts),
+            "first_examples": examples,
+        }
+        if include_rows:
+            center_record["rows"] = row_records
+        center_payload[str(center)] = center_record
+        totals.update({"valid": len(valid_rows)})
+        for status in STATUSES:
+            totals.update({status: status_counts[status]})
+
+    return {
+        "schema": "erdos97.block6_fragile_fifth_row_obstruction_catalog.v1",
+        "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+        "claim_scope": (
+            "Legal one-row extensions of the two-block block-6 fragile rows "
+            "in the natural cyclic order; not a proof of Erdos Problem #97 "
+            "and not a counterexample."
+        ),
+        "fixed_centers": fixed_centers,
+        "fixed_rows": {str(center): list(assigned[center]) for center in fixed_centers},
+        "center_counts": center_payload,
+        "totals": {key: int(totals[key]) for key in ("valid", *STATUSES)},
+    }
+
+
+def assert_expected(payload: Mapping[str, Any]) -> None:
+    if payload["status"] != "REVIEW_PENDING_DIAGNOSTIC_ONLY":
+        raise AssertionError("unexpected status")
+    if "not a proof" not in payload["claim_scope"]:
+        raise AssertionError("claim scope lost no-proof note")
+    if payload["totals"] != EXPECTED_TOTALS:
+        raise AssertionError(f"unexpected totals: {payload['totals']!r}")
+    actual_centers = {
+        center: {
+            key: record[key]
+            for key in ("valid", "ok", "self_edge", "strict_cycle")
+        }
+        for center, record in payload["center_counts"].items()
+    }
+    if actual_centers != EXPECTED_CENTER_COUNTS:
+        raise AssertionError(f"unexpected center counts: {actual_centers!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print full JSON payload")
+    parser.add_argument(
+        "--include-rows",
+        action="store_true",
+        help="include every legal fifth-row classification in the JSON payload",
+    )
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert the current expected catalog counts",
+    )
+    args = parser.parse_args()
+
+    payload = catalog_payload(include_rows=args.include_rows)
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        totals = payload["totals"]
+        print("block6 fragile fifth-row obstruction catalog")
+        print(f"fixed centers: {payload['fixed_centers']}")
+        print(
+            "totals: "
+            f"valid={totals['valid']} ok={totals['ok']} "
+            f"self_edge={totals['self_edge']} "
+            f"strict_cycle={totals['strict_cycle']}"
+        )
+        if args.assert_expected:
+            print("OK: block6 fifth-row catalog matched expected counts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block6_fragile_fifth_row_obstructions.py
+++ b/tests/test_block6_fragile_fifth_row_obstructions.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_block6_fragile_fifth_row_obstructions import (
+    assert_expected,
+    catalog_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_block6_fifth_row_catalog_matches_expected() -> None:
+    payload = catalog_payload()
+
+    assert_expected(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert "not a proof" in payload["claim_scope"]
+    assert payload["totals"] == {
+        "valid": 342,
+        "ok": 166,
+        "self_edge": 82,
+        "strict_cycle": 94,
+    }
+    assert payload["center_counts"]["5"]["first_examples"]["ok"] == [0, 1, 6, 7]
+
+
+def test_block6_fifth_row_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_fragile_fifth_row_obstructions.py",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""


### PR DESCRIPTION
## Mathematical scope

This ready PR replaces draft PR #352 from the same branch/SHA after the connector hit the known draft-ready GraphQL response bug.

This PR records Cycle 641 for the Erdos97 research log. It tests whether the Cycle 640 two-block block-6 fragile-cover closure can be reduced to a one-step local lemma: after the four fixed fragile rows are set, does every legal fifth selected row immediately force a vertex-circle quotient self-edge or strict cycle?

Named result: **Block-6 Fifth-row Survivor Catalog**.

The exact catalog gives a counterexample to that fifth-row-only local-closure subclaim: among 342 legal fifth rows, 176 already force a vertex-circle quotient obstruction, but 166 remain vertex-circle-clean at the five-row level.

This is only a counterexample to the one-step reduction, not to Erdos Problem #97.

## Files changed

- `docs/block6-fragile-fifth-row-obstruction-catalog.md`
- `docs/index.md`
- `scripts/check_block6_fragile_fifth_row_obstructions.py`
- `tests/test_block6_fragile_fifth_row_obstructions.py`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `python3 scripts/check_block6_fragile_fifth_row_obstructions.py --assert-expected --json`: passed, reproducing 342 legal fifth rows, with 166 vertex-circle-clean, 82 self-edge, and 94 strict-cycle one-row statuses.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`: passed.
- `git diff --check`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_fifth_row_obstructions.py -q`: passed (`2 passed`).
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`: passed (`538 passed, 276 deselected`).
- Draft PR #352 hosted CI run `25620536094`: passed on Python 3.10, 3.11, and 3.12 for the same head commit `841b3b10b2210bf6054943611be2b1e5973e4285`.

## Remaining limitations

This is a bounded one-row extension catalog for the two-block block-6 family in the natural cyclic order. Clean fifth-row states are not Euclidean realization claims; they are only states not killed by the five-row incidence/order and vertex-circle quotient checks.

No general proof of Erdos Problem #97 and no counterexample are claimed. The overarching proof/counterexample goal remains open.