### PR TITLE
[codex] Catalog block6 fragile sixth-row survivors

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -1,0 +1,90 @@
+# Block-6 Fragile-cover Sixth-row Survivor Catalog
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records one bounded follow-up to the block-6 fifth-row catalog. It
+does not claim a proof of Erdos Problem #97, does not claim a counterexample,
+and does not update the official/global status.
+
+## Subquestion
+
+The fifth-row catalog found `166` legal one-row extensions of the two-block
+block-6 fragile rows that remain vertex-circle-clean. The next narrow question
+is:
+
+```text
+After a clean legal fifth row, does every legal sixth row immediately force a
+vertex-circle quotient self-edge or strict cycle?
+```
+
+## Result
+
+Counterexample to the sixth-row-only closure subclaim:
+**Block-6 Sixth-row Survivor Catalog**.
+
+Every one of the `166` clean fifth-row states has at least one legal sixth row
+that remains vertex-circle-clean. In total, the ordered sixth-row
+continuations from clean fifth-row states split as:
+
+```text
+ordered legal sixth rows after clean fifth rows: 29844
+vertex-circle-clean:                         12094
+self-edge obstruction:                        8108
+strict-cycle obstruction:                     9642
+```
+
+After forgetting the order in which the two nonfixed rows were added, there
+are `6047` distinct clean six-row states. Under the block-swap symmetry
+`i -> i+6 mod 12`, these form `3056` orbits: `2991` two-element orbits and
+`65` fixed orbits.
+
+## Center Counts
+
+```text
+fifth center  clean fifth  legal sixth  ok    self_edge  strict_cycle
+1             21           3973         1512  1185       1276
+2             41           7178         2853  1916       2409
+4             7            1211         660   281        270
+5             14           2560         1022  672        866
+7             21           3973         1512  1185       1276
+8             41           7178         2853  1916       2409
+10            7            1211         660   281        270
+11            14           2560         1022  672        866
+```
+
+One explicit clean six-row state is:
+
+```text
+1 -> {0,2,6,7}
+2 -> {0,1,3,8}
+```
+
+Together with the four fixed block-6 fragile rows, these two rows satisfy the
+listed incidence/order filters and have vertex-circle status `ok` at the
+six-row level. This is only a counterexample to the sixth-row-only closure
+subclaim, not to Erdos Problem #97.
+
+## Reproduction
+
+Run:
+
+```bash
+python scripts/check_block6_fragile_sixth_row_survivors.py \
+  --assert-expected \
+  --json
+```
+
+The checker first reconstructs the `166` clean fifth rows, then enumerates
+every legal sixth row after each of them. It also computes the block-swap
+orbits for the clean fifth-row and clean six-row states.
+
+## Effect
+
+This rules out the next tempting local bridge reduction. The Cycle 640 closure
+cannot be made into a fifth-row-only or sixth-row-only obstruction theorem.
+The obstruction is still real, but it occurs deeper in the selected-row
+extension tree.
+
+The next useful step is to mine the `6047` clean six-row states for a smaller
+normal-form family or to ask for the first row depth at which every branch is
+forced into a quotient obstruction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,9 @@ put detailed reconciliation in the canonical synthesis.
   one-step catalog showing that many legal fifth rows already hit the
   vertex-circle quotient obstruction, while 166 remain clean and block a
   fifth-row-only closure lemma.
+- [`block6-fragile-sixth-row-survivor-catalog.md`](block6-fragile-sixth-row-survivor-catalog.md):
+  follow-up catalog showing that every clean fifth-row state still has a clean
+  legal sixth-row continuation, so the block-6 closure is not sixth-row-local.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,153 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 642 - Block-6 Sixth-row Survivor Catalog
+
+### Mathematical Subquestion
+
+Cycle 641 showed that the Cycle 640 two-block block-6 closure cannot be
+reduced to a fifth-row-only local lemma: `166` legal fifth-row states remain
+vertex-circle-clean. The next precise question was:
+
+```text
+After a clean legal fifth row, does every legal sixth row immediately force a
+vertex-circle quotient self-edge or strict cycle?
+```
+
+### Definitions and Assumptions
+
+The fixed two-block fragile rows remain:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+A clean fifth-row state is one of the `166` legal fifth rows from Cycle 641
+whose five-row selected-distance quotient has no vertex-circle self-edge and
+no directed strict cycle. A legal sixth row is a row at a remaining center
+that satisfies the same incidence/order filters relative to the five assigned
+rows. Its status is computed from the selected-distance quotient and
+proper-interval strict edges of the resulting six rows in the natural cyclic
+order.
+
+### Result Status
+
+Counterexample to the sixth-row-only local-closure subclaim:
+**Block-6 Sixth-row Survivor Catalog**.
+
+Every one of the `166` clean fifth-row states has at least one legal sixth row
+that remains vertex-circle-clean. Thus the Cycle 640 two-block closure cannot
+be rewritten as a sixth-row-only local lemma.
+
+### Argument Or Obstruction
+
+The exact checker reconstructs the `166` clean fifth rows and enumerates every
+legal sixth row after each of them. The ordered sixth-row continuations split
+as:
+
+```text
+ordered legal sixth rows after clean fifth rows: 29844
+vertex-circle-clean:                         12094
+self-edge obstruction:                        8108
+strict-cycle obstruction:                     9642
+```
+
+Every clean fifth row has at least one clean sixth-row continuation. After
+forgetting the order in which the two nonfixed rows were added, there are
+`6047` distinct clean six-row states. The block-swap symmetry `i -> i+6 mod
+12` gives `3056` clean six-row orbits: `2991` two-element orbits and `65`
+fixed orbits.
+
+The center-by-center counts are:
+
+```text
+fifth center  clean fifth  legal sixth  ok    self_edge  strict_cycle
+1             21           3973         1512  1185       1276
+2             41           7178         2853  1916       2409
+4             7            1211         660   281        270
+5             14           2560         1022  672        866
+7             21           3973         1512  1185       1276
+8             41           7178         2853  1916       2409
+10            7            1211         660   281        270
+11            14           2560         1022  672        866
+```
+
+One explicit obstruction to the proposed sixth-row-only lemma is:
+
+```text
+1 -> {0,2,6,7}
+2 -> {0,1,3,8}
+```
+
+Together with the four fixed rows, these two rows are legal under the stated
+filters and have vertex-circle status `ok` at the six-row level.
+
+### Exact Scope
+
+This is a bounded two-row extension catalog for the two-block block-6 family
+in the natural cyclic order. It is not a proof of Erdos Problem #97 and is not
+a counterexample. The clean six-row states are not Euclidean realizability
+claims; they are only states not yet killed by the listed six-row
+incidence/order and vertex-circle quotient checks.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `docs/index.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This rules out the next shallow block-6 bridge reduction. The two-block
+closure from Cycle 640 is not a fifth-row-only or sixth-row-only theorem.
+There is still an exact eventual closure, but it lies deeper in the
+selected-row extension tree than a one- or two-connector local lemma.
+
+### Next Lead
+
+Mine the `6047` clean six-row states for normal forms under block-swap and
+row-order symmetries, or ask for the first row depth at which every branch has
+become vertex-circle obstructed. A useful proof-facing target would be a small
+catalog of clean six-row normal forms rather than another full-depth search.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-642`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-642`.
+- The branch was based on `origin/main` at commit
+  `897467e1d0e1906aeac2b8ba3f2544a9ee973aa8`, after PR #353 merged Cycle
+  641.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python scripts/check_block6_fragile_sixth_row_survivors.py
+  --assert-expected --json`: passed, reproducing `166` clean fifth rows,
+  `12094` ordered clean sixth rows, `6047` unique clean six-row states, and
+  `3056` clean six-row block-swap orbits.
+- `python scripts/check_text_clean.py`: passed.
+- `python scripts/check_status_consistency.py`: passed.
+- `python scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `python -m ruff check .`: passed.
+- `python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`:
+  passed, `2 passed`.
+- `python -m pytest -q`: passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 641 - Block-6 Fifth-row Obstruction Catalog
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Catalog sixth-row survivors after clean block-6 fifth rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.check_block6_fragile_vertex_circle_extension import (  # noqa: E402
+    N,
+    _add_row,
+    _initial_state,
+    _options,
+    _partial_vertex_circle_status,
+    _remove_row,
+    _valid_options,
+)
+
+STATUSES = ("ok", "self_edge", "strict_cycle")
+EXPECTED_TOTALS = {
+    "clean_fifth_rows": 166,
+    "clean_fifth_block_swap_orbits": 83,
+    "ordered_legal_sixth_rows_after_clean_fifth": 29844,
+    "ordered_clean_sixth_rows": 12094,
+    "ordered_self_edge_sixth_rows": 8108,
+    "ordered_strict_cycle_sixth_rows": 9642,
+    "clean_fifth_rows_with_clean_sixth": 166,
+    "unique_clean_six_row_states": 6047,
+    "unique_clean_six_row_block_swap_orbits": 3056,
+}
+EXPECTED_CLEAN_SIX_ORBIT_SIZES = {"1": 65, "2": 2991}
+EXPECTED_BY_FIFTH_CENTER = {
+    "1": {
+        "clean_fifth": 21,
+        "sixth_total": 3973,
+        "sixth_ok": 1512,
+        "sixth_self_edge": 1185,
+        "sixth_strict_cycle": 1276,
+    },
+    "2": {
+        "clean_fifth": 41,
+        "sixth_total": 7178,
+        "sixth_ok": 2853,
+        "sixth_self_edge": 1916,
+        "sixth_strict_cycle": 2409,
+    },
+    "4": {
+        "clean_fifth": 7,
+        "sixth_total": 1211,
+        "sixth_ok": 660,
+        "sixth_self_edge": 281,
+        "sixth_strict_cycle": 270,
+    },
+    "5": {
+        "clean_fifth": 14,
+        "sixth_total": 2560,
+        "sixth_ok": 1022,
+        "sixth_self_edge": 672,
+        "sixth_strict_cycle": 866,
+    },
+    "7": {
+        "clean_fifth": 21,
+        "sixth_total": 3973,
+        "sixth_ok": 1512,
+        "sixth_self_edge": 1185,
+        "sixth_strict_cycle": 1276,
+    },
+    "8": {
+        "clean_fifth": 41,
+        "sixth_total": 7178,
+        "sixth_ok": 2853,
+        "sixth_self_edge": 1916,
+        "sixth_strict_cycle": 2409,
+    },
+    "10": {
+        "clean_fifth": 7,
+        "sixth_total": 1211,
+        "sixth_ok": 660,
+        "sixth_self_edge": 281,
+        "sixth_strict_cycle": 270,
+    },
+    "11": {
+        "clean_fifth": 14,
+        "sixth_total": 2560,
+        "sixth_ok": 1022,
+        "sixth_self_edge": 672,
+        "sixth_strict_cycle": 866,
+    },
+}
+
+RowRecord = tuple[int, tuple[int, ...]]
+SixState = tuple[RowRecord, RowRecord]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _swap_label(label: int) -> int:
+    return (label + 6) % N
+
+
+def _block_swap_row(record: RowRecord) -> RowRecord:
+    center, row = record
+    return (_swap_label(center), tuple(sorted(_swap_label(label) for label in row)))
+
+
+def _block_swap_six_state(state: SixState) -> SixState:
+    return tuple(sorted(_block_swap_row(record) for record in state))  # type: ignore[return-value]
+
+
+def _orbit_count(states: set[RowRecord] | set[SixState]) -> tuple[int, Counter[int]]:
+    seen: set[Any] = set()
+    sizes: Counter[int] = Counter()
+    for state in sorted(states):
+        if state in seen:
+            continue
+        if state and isinstance(state[0], int):
+            orbit = {state, _block_swap_row(state)}  # type: ignore[arg-type]
+        else:
+            orbit = {state, _block_swap_six_state(state)}  # type: ignore[arg-type]
+        seen.update(orbit)
+        sizes[len(orbit)] += 1
+    return sum(sizes.values()), sizes
+
+
+def survivor_payload() -> dict[str, Any]:
+    """Classify all legal sixth rows after every clean fifth-row state."""
+
+    assigned, pair_counts, indegrees = _initial_state()
+    options = _options()
+    clean_fifth_rows: set[RowRecord] = set()
+    ordered_sixth_status: Counter[str] = Counter()
+    by_fifth_center: dict[str, Counter[str]] = {}
+    clean_fifth_with_clean_sixth = 0
+    clean_six_states: set[SixState] = set()
+    first_clean_sixth_example: dict[str, Any] | None = None
+
+    for fifth_center in range(N):
+        if fifth_center in assigned:
+            continue
+        for fifth_row in _valid_options(
+            fifth_center,
+            options,
+            assigned,
+            pair_counts,
+            indegrees,
+        ):
+            _add_row(assigned, pair_counts, indegrees, fifth_center, fifth_row)
+            fifth_status, _edge_count = _partial_vertex_circle_status(assigned)
+            if fifth_status == "ok":
+                fifth_record = (fifth_center, tuple(fifth_row))
+                clean_fifth_rows.add(fifth_record)
+                center_counts = by_fifth_center.setdefault(
+                    str(fifth_center),
+                    Counter({"clean_fifth": 0}),
+                )
+                center_counts["clean_fifth"] += 1
+                local_clean_sixth = 0
+
+                for sixth_center in range(N):
+                    if sixth_center in assigned:
+                        continue
+                    for sixth_row in _valid_options(
+                        sixth_center,
+                        options,
+                        assigned,
+                        pair_counts,
+                        indegrees,
+                    ):
+                        _add_row(
+                            assigned,
+                            pair_counts,
+                            indegrees,
+                            sixth_center,
+                            sixth_row,
+                        )
+                        sixth_status, _edge_count = _partial_vertex_circle_status(
+                            assigned
+                        )
+                        _remove_row(
+                            assigned,
+                            pair_counts,
+                            indegrees,
+                            sixth_center,
+                            sixth_row,
+                        )
+
+                        ordered_sixth_status[sixth_status] += 1
+                        center_counts["sixth_total"] += 1
+                        center_counts[f"sixth_{sixth_status}"] += 1
+                        if sixth_status == "ok":
+                            local_clean_sixth += 1
+                            six_state: SixState = tuple(
+                                sorted((fifth_record, (sixth_center, tuple(sixth_row))))
+                            )  # type: ignore[assignment]
+                            clean_six_states.add(six_state)
+                            if first_clean_sixth_example is None:
+                                first_clean_sixth_example = {
+                                    "fifth": {
+                                        "center": fifth_center,
+                                        "row": list(fifth_row),
+                                    },
+                                    "sixth": {
+                                        "center": sixth_center,
+                                        "row": list(sixth_row),
+                                    },
+                                }
+                if local_clean_sixth:
+                    clean_fifth_with_clean_sixth += 1
+            _remove_row(assigned, pair_counts, indegrees, fifth_center, fifth_row)
+
+    clean_fifth_orbits, clean_fifth_orbit_sizes = _orbit_count(clean_fifth_rows)
+    clean_six_orbits, clean_six_orbit_sizes = _orbit_count(clean_six_states)
+    totals = {
+        "clean_fifth_rows": len(clean_fifth_rows),
+        "clean_fifth_block_swap_orbits": clean_fifth_orbits,
+        "ordered_legal_sixth_rows_after_clean_fifth": sum(
+            ordered_sixth_status.values()
+        ),
+        "ordered_clean_sixth_rows": int(ordered_sixth_status["ok"]),
+        "ordered_self_edge_sixth_rows": int(ordered_sixth_status["self_edge"]),
+        "ordered_strict_cycle_sixth_rows": int(ordered_sixth_status["strict_cycle"]),
+        "clean_fifth_rows_with_clean_sixth": clean_fifth_with_clean_sixth,
+        "unique_clean_six_row_states": len(clean_six_states),
+        "unique_clean_six_row_block_swap_orbits": clean_six_orbits,
+    }
+
+    return {
+        "schema": "erdos97.block6_fragile_sixth_row_survivor_catalog.v1",
+        "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+        "claim_scope": (
+            "Legal sixth rows after clean one-row extensions of the two-block "
+            "block-6 fragile rows in the natural cyclic order; not a proof of "
+            "Erdos Problem #97 and not a counterexample."
+        ),
+        "fixed_centers": sorted(assigned),
+        "totals": totals,
+        "ordered_sixth_status_counts": {
+            status: int(ordered_sixth_status[status]) for status in STATUSES
+        },
+        "clean_fifth_block_swap_orbit_sizes": _json_counter(
+            clean_fifth_orbit_sizes
+        ),
+        "clean_six_block_swap_orbit_sizes": _json_counter(clean_six_orbit_sizes),
+        "by_fifth_center": {
+            center: {key: int(counter[key]) for key in sorted(counter)}
+            for center, counter in sorted(by_fifth_center.items(), key=lambda item: int(item[0]))
+        },
+        "first_clean_sixth_example": first_clean_sixth_example,
+    }
+
+
+def assert_expected(payload: Mapping[str, Any]) -> None:
+    if payload["status"] != "REVIEW_PENDING_DIAGNOSTIC_ONLY":
+        raise AssertionError("unexpected status")
+    if "not a proof" not in payload["claim_scope"]:
+        raise AssertionError("claim scope lost no-proof note")
+    if payload["totals"] != EXPECTED_TOTALS:
+        raise AssertionError(f"unexpected totals: {payload['totals']!r}")
+    if payload["clean_six_block_swap_orbit_sizes"] != EXPECTED_CLEAN_SIX_ORBIT_SIZES:
+        raise AssertionError(
+            "unexpected clean-six orbit sizes: "
+            f"{payload['clean_six_block_swap_orbit_sizes']!r}"
+        )
+    if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
+        raise AssertionError(
+            f"unexpected by-fifth-center counts: {payload['by_fifth_center']!r}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print full JSON payload")
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert the current expected survivor counts",
+    )
+    args = parser.parse_args()
+
+    payload = survivor_payload()
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        totals = payload["totals"]
+        print("block6 fragile sixth-row survivor catalog")
+        print(
+            "totals: "
+            f"clean_fifth={totals['clean_fifth_rows']} "
+            f"ordered_sixth={totals['ordered_legal_sixth_rows_after_clean_fifth']} "
+            f"ordered_clean_sixth={totals['ordered_clean_sixth_rows']} "
+            f"unique_clean_six={totals['unique_clean_six_row_states']}"
+        )
+        if args.assert_expected:
+            print("OK: block6 sixth-row survivor catalog matched expected counts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_block6_fragile_sixth_row_survivors import (
+    assert_expected,
+    survivor_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
+    payload = survivor_payload()
+
+    assert_expected(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert "not a proof" in payload["claim_scope"]
+    assert payload["totals"]["clean_fifth_rows"] == 166
+    assert payload["totals"]["clean_fifth_rows_with_clean_sixth"] == 166
+    assert payload["totals"]["unique_clean_six_row_states"] == 6047
+    assert payload["first_clean_sixth_example"] == {
+        "fifth": {"center": 1, "row": [0, 2, 6, 7]},
+        "sixth": {"center": 2, "row": [0, 1, 3, 8]},
+    }
+
+
+def test_block6_sixth_row_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_fragile_sixth_row_survivors.py",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 642 for the Erdos97 research log. It tests the next shallow block-6 bridge reduction: after a clean legal fifth row, does every legal sixth row immediately force a vertex-circle quotient self-edge or strict cycle?

Named result: **Block-6 Sixth-row Survivor Catalog**.

The exact catalog gives a counterexample to that sixth-row-only local-closure subclaim: every one of the 166 clean fifth-row states has at least one clean legal sixth-row continuation. There are 12,094 ordered clean sixth-row continuations and 6,047 distinct clean six-row states, forming 3,056 block-swap orbits.

This is only a counterexample to the shallow local reduction, not to Erdos Problem #97.

## Files changed

- `docs/block6-fragile-sixth-row-survivor-catalog.md`
- `docs/index.md`
- `scripts/check_block6_fragile_sixth_row_survivors.py`
- `tests/test_block6_fragile_sixth_row_survivors.py`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `python3 scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`: passed, reproducing 166 clean fifth rows, 12,094 ordered clean sixth rows, 6,047 unique clean six-row states, and 3,056 clean six-row block-swap orbits.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`: passed.
- `git diff --check`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`: passed.
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`: passed (`2 passed`).
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`: passed (`540 passed, 276 deselected`).

## Remaining limitations

This is a bounded two-row extension catalog for the two-block block-6 family in the natural cyclic order. Clean six-row states are not Euclidean realization claims; they are only states not killed by the six-row incidence/order and vertex-circle quotient checks.

No general proof of Erdos Problem #97 and no counterexample are claimed. The overarching proof/counterexample goal remains open.