### PR TITLE
[codex] Catalog block6 six-row center-pair normal forms

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -38,6 +38,48 @@ are `6047` distinct clean six-row states. Under the block-swap symmetry
 `i -> i+6 mod 12`, these form `3056` orbits: `2991` two-element orbits and
 `65` fixed orbits.
 
+## Center-pair Normal Forms
+
+The clean six-row states are not concentrated in a small set of added-center
+pairs. Every one of the `28` unordered pairs of nonfixed centers supports at
+least one clean six-row state. Under block-swap, these `28` pairs form `16`
+center-pair orbits, and every orbit has positive clean support.
+
+```text
+center pair  clean states
+1,2          350
+1,4          98
+1,5          126
+1,7          256
+1,8          508
+1,10         69
+1,11         105
+2,4          182
+2,5          238
+2,7          508
+2,8          1074
+2,10         176
+2,11         325
+4,5          28
+4,7          69
+4,8          176
+4,10         36
+4,11         71
+5,7          105
+5,8          325
+5,10         71
+5,11         129
+7,8          350
+7,10         98
+7,11         126
+8,10         182
+8,11         238
+10,11        28
+```
+
+Thus no proof can close the two-block family at six rows using only the
+unordered pair of added centers. The obstruction depends on finer row content.
+
 ## Center Counts
 
 ```text
@@ -83,8 +125,10 @@ orbits for the clean fifth-row and clean six-row states.
 This rules out the next tempting local bridge reduction. The Cycle 640 closure
 cannot be made into a fifth-row-only or sixth-row-only obstruction theorem.
 The obstruction is still real, but it occurs deeper in the selected-row
-extension tree.
+extension tree. The center-pair normal-form audit also rules out a still
+coarser six-row proof based only on which two nonfixed centers have been
+selected.
 
 The next useful step is to mine the `6047` clean six-row states for a smaller
-normal-form family or to ask for the first row depth at which every branch is
-forced into a quotient obstruction.
+row-content normal-form family or to ask for the first row depth at which
+every branch is forced into a quotient obstruction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,8 @@ put detailed reconciliation in the canonical synthesis.
   fifth-row-only closure lemma.
 - [`block6-fragile-sixth-row-survivor-catalog.md`](block6-fragile-sixth-row-survivor-catalog.md):
   follow-up catalog showing that every clean fifth-row state still has a clean
-  legal sixth-row continuation, so the block-6 closure is not sixth-row-local.
+  legal sixth-row continuation, and that all added-center pairs support clean
+  states, so the block-6 closure is not sixth-row-local.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,163 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 643 - Block-6 Six-row Center-pair Normal Forms
+
+### Mathematical Subquestion
+
+Cycle 642 showed that `6047` distinct six-row states remain
+vertex-circle-clean after adding two nonfixed rows to the two-block block-6
+fragile rows. The next smaller normal-form question was:
+
+```text
+Can the six-row survivors be excluded using only the unordered pair of
+nonfixed centers selected by the two added rows?
+```
+
+Equivalently, is there some unordered pair of nonfixed centers for which every
+legal pair of added rows already forces a vertex-circle quotient self-edge or
+strict cycle?
+
+### Definitions and Assumptions
+
+The four fixed rows are still:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+A clean six-row state is a pair of additional legal rows at two distinct
+nonfixed centers whose six-row selected-distance quotient has no
+vertex-circle self-edge and no directed strict cycle in the natural cyclic
+order. Row order is ignored for the center-pair counts.
+
+The only symmetry used here is the block-swap `i -> i+6 mod 12`, which
+preserves the four fixed fragile rows.
+
+### Result Status
+
+Counterexample to the center-pair closure subclaim:
+**Block-6 Six-row Center-pair Survivor Catalog**.
+
+Every one of the `28` unordered pairs of nonfixed centers supports at least
+one clean six-row state. Under block-swap, these `28` center pairs form `16`
+orbits, and every orbit has positive clean support.
+
+### Argument Or Obstruction
+
+The exact checker from Cycle 642 was extended to project the `6047` clean
+six-row states to their unordered added-center pair. The clean counts are:
+
+```text
+center pair  clean states
+1,2          350
+1,4          98
+1,5          126
+1,7          256
+1,8          508
+1,10         69
+1,11         105
+2,4          182
+2,5          238
+2,7          508
+2,8          1074
+2,10         176
+2,11         325
+4,5          28
+4,7          69
+4,8          176
+4,10         36
+4,11         71
+5,7          105
+5,8          325
+5,10         71
+5,11         129
+7,8          350
+7,10         98
+7,11         126
+8,10         182
+8,11         238
+10,11        28
+```
+
+The minimum clean support is still positive: pairs `4,5` and `10,11` each
+support `28` clean six-row states. The maximum is the block-swap fixed pair
+`2,8`, which supports `1074` clean six-row states.
+
+Therefore a six-row proof cannot close the block-6 family by choosing, or
+forbidding, only an unordered pair of added centers. The actual obstruction
+must depend on row content or on deeper extension data.
+
+### Exact Scope
+
+This is a bounded center-pair projection of the two-block block-6 six-row
+survivor catalog in the natural cyclic order. It is not a proof of Erdos
+Problem #97 and is not a counterexample. Clean six-row states remain abstract
+states not yet killed by the listed six-row incidence/order and
+vertex-circle quotient checks; they are not Euclidean realizability claims.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `docs/index.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This sharpens the negative information from Cycles 641 and 642. The block-6
+two-block closure is not fifth-row-local, not sixth-row-local, and not even
+six-row center-pair-local. A useful proof-facing normal form now has to
+include row content, not just which centers have been added.
+
+### Next Lead
+
+Classify the low-support center-pair families, especially `4,5` and `10,11`,
+by row-content signatures. If those `28` clean states collapse to a very small
+row-content normal form, they may give a tractable next exact subclaim.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-643`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-643`.
+- The branch was based on `origin/main` at commit
+  `076d12ef109c8d39aa561e9ee303aaf816ac2d6b`, after PR #355 merged Cycle
+  642.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python3 scripts/check_block6_fragile_sixth_row_survivors.py
+  --assert-expected --json`: passed; reported `6047` unique clean six-row
+  states, `28` clean center pairs, and `16` clean center-pair block-swap
+  orbits.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 642 - Block-6 Sixth-row Survivor Catalog
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -35,8 +35,58 @@ EXPECTED_TOTALS = {
     "clean_fifth_rows_with_clean_sixth": 166,
     "unique_clean_six_row_states": 6047,
     "unique_clean_six_row_block_swap_orbits": 3056,
+    "clean_center_pairs": 28,
+    "clean_center_pair_block_swap_orbits": 16,
 }
 EXPECTED_CLEAN_SIX_ORBIT_SIZES = {"1": 65, "2": 2991}
+EXPECTED_CLEAN_BY_CENTER_PAIR = {
+    "1,2": 350,
+    "1,4": 98,
+    "1,5": 126,
+    "1,7": 256,
+    "1,8": 508,
+    "1,10": 69,
+    "1,11": 105,
+    "2,4": 182,
+    "2,5": 238,
+    "2,7": 508,
+    "2,8": 1074,
+    "2,10": 176,
+    "2,11": 325,
+    "4,5": 28,
+    "4,7": 69,
+    "4,8": 176,
+    "4,10": 36,
+    "4,11": 71,
+    "5,7": 105,
+    "5,8": 325,
+    "5,10": 71,
+    "5,11": 129,
+    "7,8": 350,
+    "7,10": 98,
+    "7,11": 126,
+    "8,10": 182,
+    "8,11": 238,
+    "10,11": 28,
+}
+EXPECTED_CLEAN_BY_CENTER_PAIR_ORBIT = {
+    "1,2|7,8": 700,
+    "1,4|7,10": 196,
+    "1,5|7,11": 252,
+    "1,7": 256,
+    "1,8|2,7": 1016,
+    "1,10|4,7": 138,
+    "1,11|5,7": 210,
+    "2,4|8,10": 364,
+    "2,5|8,11": 476,
+    "2,8": 1074,
+    "2,10|4,8": 352,
+    "2,11|5,8": 650,
+    "4,5|10,11": 56,
+    "4,10": 36,
+    "4,11|5,10": 142,
+    "5,11": 129,
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -98,6 +148,7 @@ EXPECTED_BY_FIFTH_CENTER = {
 
 RowRecord = tuple[int, tuple[int, ...]]
 SixState = tuple[RowRecord, RowRecord]
+CenterPair = tuple[int, int]
 
 
 def _json_counter(counter: Counter[Any]) -> dict[str, int]:
@@ -111,6 +162,19 @@ def _swap_label(label: int) -> int:
 def _block_swap_row(record: RowRecord) -> RowRecord:
     center, row = record
     return (_swap_label(center), tuple(sorted(_swap_label(label) for label in row)))
+
+
+def _center_pair_key(pair: CenterPair) -> str:
+    return f"{pair[0]},{pair[1]}"
+
+
+def _block_swap_center_pair(pair: CenterPair) -> CenterPair:
+    return tuple(sorted((_swap_label(pair[0]), _swap_label(pair[1]))))  # type: ignore[return-value]
+
+
+def _center_pair_orbit_key(pair: CenterPair) -> str:
+    orbit = sorted({pair, _block_swap_center_pair(pair)})
+    return "|".join(_center_pair_key(item) for item in orbit)
 
 
 def _block_swap_six_state(state: SixState) -> SixState:
@@ -220,6 +284,12 @@ def survivor_payload() -> dict[str, Any]:
 
     clean_fifth_orbits, clean_fifth_orbit_sizes = _orbit_count(clean_fifth_rows)
     clean_six_orbits, clean_six_orbit_sizes = _orbit_count(clean_six_states)
+    clean_by_center_pair: Counter[CenterPair] = Counter(
+        tuple(sorted((state[0][0], state[1][0]))) for state in clean_six_states
+    )
+    clean_by_center_pair_orbit: Counter[str] = Counter()
+    for center_pair, count in clean_by_center_pair.items():
+        clean_by_center_pair_orbit[_center_pair_orbit_key(center_pair)] += count
     totals = {
         "clean_fifth_rows": len(clean_fifth_rows),
         "clean_fifth_block_swap_orbits": clean_fifth_orbits,
@@ -232,6 +302,8 @@ def survivor_payload() -> dict[str, Any]:
         "clean_fifth_rows_with_clean_sixth": clean_fifth_with_clean_sixth,
         "unique_clean_six_row_states": len(clean_six_states),
         "unique_clean_six_row_block_swap_orbits": clean_six_orbits,
+        "clean_center_pairs": len(clean_by_center_pair),
+        "clean_center_pair_block_swap_orbits": len(clean_by_center_pair_orbit),
     }
 
     return {
@@ -251,6 +323,14 @@ def survivor_payload() -> dict[str, Any]:
             clean_fifth_orbit_sizes
         ),
         "clean_six_block_swap_orbit_sizes": _json_counter(clean_six_orbit_sizes),
+        "clean_by_center_pair": {
+            _center_pair_key(center_pair): int(clean_by_center_pair[center_pair])
+            for center_pair in sorted(clean_by_center_pair)
+        },
+        "clean_by_center_pair_orbit": {
+            key: int(clean_by_center_pair_orbit[key])
+            for key in sorted(clean_by_center_pair_orbit)
+        },
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
             for center, counter in sorted(by_fifth_center.items(), key=lambda item: int(item[0]))
@@ -270,6 +350,18 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(
             "unexpected clean-six orbit sizes: "
             f"{payload['clean_six_block_swap_orbit_sizes']!r}"
+        )
+    if payload["clean_by_center_pair"] != EXPECTED_CLEAN_BY_CENTER_PAIR:
+        raise AssertionError(
+            f"unexpected clean center-pair counts: {payload['clean_by_center_pair']!r}"
+        )
+    if (
+        payload["clean_by_center_pair_orbit"]
+        != EXPECTED_CLEAN_BY_CENTER_PAIR_ORBIT
+    ):
+        raise AssertionError(
+            "unexpected center-pair orbit counts: "
+            f"{payload['clean_by_center_pair_orbit']!r}"
         )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -22,6 +22,12 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
     assert payload["totals"]["clean_fifth_rows"] == 166
     assert payload["totals"]["clean_fifth_rows_with_clean_sixth"] == 166
     assert payload["totals"]["unique_clean_six_row_states"] == 6047
+    assert payload["totals"]["clean_center_pairs"] == 28
+    assert payload["totals"]["clean_center_pair_block_swap_orbits"] == 16
+    assert payload["clean_by_center_pair"]["4,5"] == 28
+    assert payload["clean_by_center_pair"]["2,8"] == 1074
+    assert payload["clean_by_center_pair_orbit"]["4,5|10,11"] == 56
+    assert payload["clean_by_center_pair_orbit"]["2,8"] == 1074
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 643 asks whether the remaining block-6 clean six-row states can be excluded using only the unordered pair of nonfixed centers selected by the two added rows.

Result: no. The exact checker now projects the 6047 clean six-row states to added-center pairs and records that all 28 unordered nonfixed center pairs have positive clean support. Under the block-swap symmetry, these form 16 center-pair orbits, all with positive support.

Named result: Block-6 Six-row Center-pair Survivor Catalog.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: records expected clean counts by center pair and block-swap center-pair orbit.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts the new totals and representative counts.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the center-pair normal forms and their obstruction role.
- `docs/index.md`: updates the catalog summary.
- `reports/codex_goal_erdos97_log.md`: records Cycle 643 with scope, limitations, validation, and next lead.

## Validation run

- `python3 scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`540 passed, 276 deselected`)
- Hosted GitHub Actions `tests` on commit `276717b8121328550e50a963a7d355e176c53e34`: success on Python 3.10, 3.11, and 3.12.

## Remaining limitations

This is a bounded projection of the two-block block-6 six-row survivor catalog in the natural cyclic order. It is not a proof of Erdos Problem #97 and is not a counterexample. It rules out only a center-pair-local six-row closure route; remaining clean states are abstract states, not Euclidean realizability claims.

Replaces draft PR #356, which was closed after the connector hit the known `markPullRequestReadyForReview` GraphQL `htmlUrl` bug.