### PR TITLE
[codex] Catalog block6 low-support row-content normal forms

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -80,6 +80,41 @@ center pair  clean states
 Thus no proof can close the two-block family at six rows using only the
 unordered pair of added centers. The obstruction depends on finer row content.
 
+## Minimum-support Row-content Normal Forms
+
+The two minimum center pairs, `4,5` and `10,11`, do have a compact exact
+row-content description. For `4,5`, the `28` clean states are exactly:
+
+```text
+4 -> {0,3} union A
+5 -> {0,t} union B, where t in {1,4}
+```
+
+where `A` and `B` are ordered disjoint pairs from
+
+```text
+{6,7}, {6,9}, {6,10}, {7,11}, {8,11}, {9,11}.
+```
+
+This six-pair pool has `14` ordered disjoint pair edges, and the binary choice
+of `t` gives `14 * 2 = 28` clean states.
+
+By block-swap, the `10,11` family is exactly:
+
+```text
+10 -> {6,9} union A
+11 -> {6,t} union B, where t in {7,10}
+```
+
+where `A` and `B` are ordered disjoint pairs from
+
+```text
+{0,1}, {0,3}, {0,4}, {1,5}, {2,5}, {3,5}.
+```
+
+Again all `14` ordered disjoint pair edges occur, with the binary choice of
+`t`, giving `28` clean states.
+
 ## Center Counts
 
 ```text
@@ -127,7 +162,9 @@ cannot be made into a fifth-row-only or sixth-row-only obstruction theorem.
 The obstruction is still real, but it occurs deeper in the selected-row
 extension tree. The center-pair normal-form audit also rules out a still
 coarser six-row proof based only on which two nonfixed centers have been
-selected.
+selected. The minimum-support row-content audit gives a compact target for the
+next step: explain, or extend, the disjoint-pair pool normal form rather than
+working with an unstructured list of `56` block-swap-related survivors.
 
 The next useful step is to mine the `6047` clean six-row states for a smaller
 row-content normal-form family or to ask for the first row depth at which

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`block6-fragile-sixth-row-survivor-catalog.md`](block6-fragile-sixth-row-survivor-catalog.md):
   follow-up catalog showing that every clean fifth-row state still has a clean
   legal sixth-row continuation, and that all added-center pairs support clean
-  states, so the block-6 closure is not sixth-row-local.
+  states, with compact row-content normal forms for the two minimum-support
+  center pairs, so the block-6 closure is not sixth-row-local.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,153 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 644 - Block-6 Low-support Row-content Normal Forms
+
+### Mathematical Subquestion
+
+Cycle 643 showed that every unordered pair of nonfixed centers has at least
+one clean six-row survivor, but the pairs `4,5` and `10,11` have the minimum
+support: only `28` clean states each. The next precise question was:
+
+```text
+Do these two minimum-support center-pair families collapse to a compact
+row-content normal form?
+```
+
+### Definitions and Assumptions
+
+The four fixed two-block block-6 fragile rows are still:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+A clean six-row state is a pair of additional legal rows at two distinct
+nonfixed centers whose selected-distance quotient has no vertex-circle
+self-edge and no directed strict cycle in the natural cyclic order.
+
+For a row at a center in one six-block, its row content is split into the two
+selected labels in the same six-block and the two selected labels in the
+opposite six-block.
+
+### Result Status
+
+Proved exact normal form:
+**Block-6 Low-support Disjoint-pair Normal Form**.
+
+The two minimum-support center-pair families are not arbitrary 28-state lists.
+Each is exactly a binary same-block choice times the ordered disjoint edges of
+a six-pair opposite-block pool.
+
+### Argument Or Obstruction
+
+For center pair `4,5`, the clean states are exactly:
+
+```text
+4 -> {0,3} union A
+5 -> {0,t} union B, where t in {1,4}
+```
+
+where `A` and `B` range over ordered disjoint pairs from
+
+```text
+{6,7}, {6,9}, {6,10}, {7,11}, {8,11}, {9,11}.
+```
+
+This pool has exactly `14` ordered disjoint pair edges, and the binary choice
+of `t` gives `14 * 2 = 28` clean states.
+
+By the block-swap `i -> i+6 mod 12`, the pair `10,11` has the corresponding
+normal form:
+
+```text
+10 -> {6,9} union A
+11 -> {6,t} union B, where t in {7,10}
+```
+
+where `A` and `B` range over ordered disjoint pairs from
+
+```text
+{0,1}, {0,3}, {0,4}, {1,5}, {2,5}, {3,5}.
+```
+
+Again all `14` ordered disjoint pair edges occur, with the binary choice of
+`t`, giving `28` clean states.
+
+The checker now asserts these normal forms directly: the actual opposite-pair
+edges equal all ordered disjoint edges from the listed six-pair pool, and all
+actual opposite-pair edges are disjoint.
+
+### Exact Scope
+
+This is an exact finite row-content classification for the two minimum-support
+center pairs in the two-block block-6 six-row survivor catalog, under the
+natural cyclic order and existing incidence/order plus vertex-circle filters.
+It is not a proof of Erdos Problem #97 and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `docs/index.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This is the first compact row-content normal form extracted from the block-6
+six-row survivors. It does not close the two-block family, but it replaces the
+least-supported `56` block-swap-related survivors with one reusable
+disjoint-pair template. A proof route can now ask why this disjoint-pair pool
+is forced, or whether every seventh-row extension of this template is killed.
+
+### Next Lead
+
+Run a seventh-row extension audit restricted to the disjoint-pair normal form,
+or prove a local lemma explaining why these six opposite-block pairs and only
+their ordered disjoint pairings survive the vertex-circle quotient.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-644`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-644`.
+- The branch was based on `origin/main` at commit
+  `59d9a3dedf73b241b63eda3a3e86fdd28c347682`, after PR #357 merged Cycle
+  643.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python3 scripts/check_block6_fragile_sixth_row_survivors.py
+  --assert-expected --json`: passed; reported the `4,5` and `10,11`
+  low-support row-content forms with `28` clean states each, `14` ordered
+  disjoint opposite-pair edges each, and all disjoint pool edges present.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 643 - Block-6 Six-row Center-pair Normal Forms
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -87,6 +87,76 @@ EXPECTED_CLEAN_BY_CENTER_PAIR_ORBIT = {
     "4,11|5,10": 142,
     "5,11": 129,
 }
+EXPECTED_LOW_SUPPORT_ROW_CONTENT_FORMS = {
+    "4,5": {
+        "clean_states": 28,
+        "same_block_pair_counts": {
+            "0,3|0,1": 14,
+            "0,3|0,4": 14,
+        },
+        "opposite_pair_pool": [
+            "6,7",
+            "6,9",
+            "6,10",
+            "7,11",
+            "8,11",
+            "9,11",
+        ],
+        "opposite_pair_edge_counts": {
+            "6,7|8,11": 2,
+            "6,7|9,11": 2,
+            "6,9|7,11": 2,
+            "6,9|8,11": 2,
+            "6,10|7,11": 2,
+            "6,10|8,11": 2,
+            "6,10|9,11": 2,
+            "7,11|6,9": 2,
+            "7,11|6,10": 2,
+            "8,11|6,7": 2,
+            "8,11|6,9": 2,
+            "8,11|6,10": 2,
+            "9,11|6,7": 2,
+            "9,11|6,10": 2,
+        },
+        "ordered_disjoint_opposite_pair_edges": 14,
+        "all_edges_disjoint": True,
+        "all_disjoint_pool_edges_present": True,
+    },
+    "10,11": {
+        "clean_states": 28,
+        "same_block_pair_counts": {
+            "6,9|6,7": 14,
+            "6,9|6,10": 14,
+        },
+        "opposite_pair_pool": [
+            "0,1",
+            "0,3",
+            "0,4",
+            "1,5",
+            "2,5",
+            "3,5",
+        ],
+        "opposite_pair_edge_counts": {
+            "0,1|2,5": 2,
+            "0,1|3,5": 2,
+            "0,3|1,5": 2,
+            "0,3|2,5": 2,
+            "0,4|1,5": 2,
+            "0,4|2,5": 2,
+            "0,4|3,5": 2,
+            "1,5|0,3": 2,
+            "1,5|0,4": 2,
+            "2,5|0,1": 2,
+            "2,5|0,3": 2,
+            "2,5|0,4": 2,
+            "3,5|0,1": 2,
+            "3,5|0,4": 2,
+        },
+        "ordered_disjoint_opposite_pair_edges": 14,
+        "all_edges_disjoint": True,
+        "all_disjoint_pool_edges_present": True,
+    },
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -149,6 +219,7 @@ EXPECTED_BY_FIFTH_CENTER = {
 RowRecord = tuple[int, tuple[int, ...]]
 SixState = tuple[RowRecord, RowRecord]
 CenterPair = tuple[int, int]
+LabelPair = tuple[int, int]
 
 
 def _json_counter(counter: Counter[Any]) -> dict[str, int]:
@@ -168,6 +239,22 @@ def _center_pair_key(pair: CenterPair) -> str:
     return f"{pair[0]},{pair[1]}"
 
 
+def _pair_edge_key(left: LabelPair, right: LabelPair) -> str:
+    return f"{_center_pair_key(left)}|{_center_pair_key(right)}"
+
+
+def _parse_label_pair(text: str) -> LabelPair:
+    left, right = text.split(",")
+    return (int(left), int(right))
+
+
+def _pair_edge_is_disjoint(key: str) -> bool:
+    left_text, right_text = key.split("|")
+    left = _parse_label_pair(left_text)
+    right = _parse_label_pair(right_text)
+    return set(left).isdisjoint(right)
+
+
 def _block_swap_center_pair(pair: CenterPair) -> CenterPair:
     return tuple(sorted((_swap_label(pair[0]), _swap_label(pair[1]))))  # type: ignore[return-value]
 
@@ -179,6 +266,73 @@ def _center_pair_orbit_key(pair: CenterPair) -> str:
 
 def _block_swap_six_state(state: SixState) -> SixState:
     return tuple(sorted(_block_swap_row(record) for record in state))  # type: ignore[return-value]
+
+
+def _split_row_by_center_block(center: int, row: tuple[int, ...]) -> tuple[LabelPair, LabelPair]:
+    block_start = 0 if center < N // 2 else N // 2
+    block = set(range(block_start, block_start + N // 2))
+    same = tuple(label for label in row if label in block)
+    opposite = tuple(label for label in row if label not in block)
+    if len(same) != 2 or len(opposite) != 2:
+        raise AssertionError(
+            f"row at center {center} does not split into two-and-two: {row!r}"
+        )
+    return same, opposite  # type: ignore[return-value]
+
+
+def _low_support_row_content_forms(
+    clean_six_states: set[SixState],
+) -> dict[str, dict[str, Any]]:
+    forms: dict[str, dict[str, Any]] = {}
+    for center_pair in ((4, 5), (10, 11)):
+        matching_states = [
+            state
+            for state in clean_six_states
+            if tuple(record[0] for record in state) == center_pair
+        ]
+        same_block_counts: Counter[str] = Counter()
+        opposite_edge_counts: Counter[str] = Counter()
+        opposite_pool: set[LabelPair] = set()
+
+        for (left_center, left_row), (right_center, right_row) in matching_states:
+            left_same, left_opposite = _split_row_by_center_block(
+                left_center,
+                left_row,
+            )
+            right_same, right_opposite = _split_row_by_center_block(
+                right_center,
+                right_row,
+            )
+            same_block_counts[_pair_edge_key(left_same, right_same)] += 1
+            opposite_edge_counts[
+                _pair_edge_key(left_opposite, right_opposite)
+            ] += 1
+            opposite_pool.add(left_opposite)
+            opposite_pool.add(right_opposite)
+
+        disjoint_edge_keys = {
+            _pair_edge_key(left, right)
+            for left in opposite_pool
+            for right in opposite_pool
+            if set(left).isdisjoint(right)
+        }
+        actual_edge_keys = set(opposite_edge_counts)
+        forms[_center_pair_key(center_pair)] = {
+            "clean_states": len(matching_states),
+            "same_block_pair_counts": dict(sorted(same_block_counts.items())),
+            "opposite_pair_pool": [
+                _center_pair_key(pair) for pair in sorted(opposite_pool)
+            ],
+            "opposite_pair_edge_counts": dict(
+                sorted(opposite_edge_counts.items())
+            ),
+            "ordered_disjoint_opposite_pair_edges": len(disjoint_edge_keys),
+            "all_edges_disjoint": all(
+                _pair_edge_is_disjoint(key) for key in actual_edge_keys
+            ),
+            "all_disjoint_pool_edges_present": actual_edge_keys == disjoint_edge_keys,
+        }
+    return forms
 
 
 def _orbit_count(states: set[RowRecord] | set[SixState]) -> tuple[int, Counter[int]]:
@@ -331,6 +485,9 @@ def survivor_payload() -> dict[str, Any]:
             key: int(clean_by_center_pair_orbit[key])
             for key in sorted(clean_by_center_pair_orbit)
         },
+        "low_support_row_content_forms": _low_support_row_content_forms(
+            clean_six_states
+        ),
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
             for center, counter in sorted(by_fifth_center.items(), key=lambda item: int(item[0]))
@@ -362,6 +519,14 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(
             "unexpected center-pair orbit counts: "
             f"{payload['clean_by_center_pair_orbit']!r}"
+        )
+    if (
+        payload["low_support_row_content_forms"]
+        != EXPECTED_LOW_SUPPORT_ROW_CONTENT_FORMS
+    ):
+        raise AssertionError(
+            "unexpected low-support row-content normal forms: "
+            f"{payload['low_support_row_content_forms']!r}"
         )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -28,6 +28,15 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
     assert payload["clean_by_center_pair"]["2,8"] == 1074
     assert payload["clean_by_center_pair_orbit"]["4,5|10,11"] == 56
     assert payload["clean_by_center_pair_orbit"]["2,8"] == 1074
+    low_support_forms = payload["low_support_row_content_forms"]
+    assert low_support_forms["4,5"]["clean_states"] == 28
+    assert low_support_forms["4,5"]["all_disjoint_pool_edges_present"] is True
+    assert low_support_forms["10,11"]["clean_states"] == 28
+    assert low_support_forms["10,11"]["all_disjoint_pool_edges_present"] is True
+    assert low_support_forms["4,5"]["same_block_pair_counts"] == {
+        "0,3|0,1": 14,
+        "0,3|0,4": 14,
+    }
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 644 asks whether the two minimum-support block-6 six-row center-pair families, `4,5` and `10,11`, collapse to a compact row-content normal form.

Result: yes, within the bounded natural-order two-block block-6 survivor catalog. Each 28-state family is exactly a binary same-block choice times all ordered disjoint edges of a six-pair opposite-block pool.

Named result: Block-6 Low-support Disjoint-pair Normal Form.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds checker-backed low-support row-content forms for `4,5` and `10,11`.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts representative normal-form fields.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the normal forms.
- `docs/index.md`: updates the catalog summary.
- `reports/codex_goal_erdos97_log.md`: records Cycle 644 with scope, validation, and next lead.

## Validation run

- `python3 scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`540 passed, 276 deselected`)

## Remaining limitations

This is an exact finite row-content classification for two minimum-support center pairs in the two-block block-6 six-row survivor catalog. It is not a proof of Erdos Problem #97 and not a counterexample. It does not close the two-block family; it creates a smaller target for a seventh-row extension audit or a proof of the disjoint-pair pool template.