### PR TITLE
[codex] Catalog block6 low-support seventh-row continuations

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -115,6 +115,48 @@ where `A` and `B` are ordered disjoint pairs from
 Again all `14` ordered disjoint pair edges occur, with the binary choice of
 `t`, giving `28` clean states.
 
+## Low-support Seventh-row Continuations
+
+The low-support disjoint-pair normal form still does not close at the next
+row. Across the `56` block-swap-related clean six-row states from the `4,5`
+and `10,11` minimum-support families, every clean six-row state has at least
+one legal seventh row that remains vertex-circle-clean.
+
+```text
+legal seventh rows from low-support six states: 5590
+vertex-circle-clean:                         2252
+self-edge obstruction:                        1560
+strict-cycle obstruction:                     1778
+clean six-row states with clean seventh row:  56 / 56
+```
+
+For center pair `4,5`, the seventh-row split is `1126` clean, `780`
+self-edge, and `889` strict-cycle. The block-swap-related `10,11` family has
+the same aggregate split.
+
+One explicit clean seven-row state extending the `4,5` minimum-support family
+is:
+
+```text
+4 -> {0,3,6,9}
+5 -> {0,4,7,11}
+1 -> {2,5,6,7}
+```
+
+One explicit clean seven-row state extending the `10,11` minimum-support
+family is:
+
+```text
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+1  -> {0,2,7,11}
+```
+
+Together with the four fixed block-6 fragile rows, each displayed state
+satisfies the checker incidence/order filters and has vertex-circle status
+`ok` at the seven-row level. These are abstract selected-row states inside the
+bounded natural-order audit; they are not Euclidean realizability claims.
+
 ## Center Counts
 
 ```text
@@ -153,7 +195,9 @@ python scripts/check_block6_fragile_sixth_row_survivors.py \
 
 The checker first reconstructs the `166` clean fifth rows, then enumerates
 every legal sixth row after each of them. It also computes the block-swap
-orbits for the clean fifth-row and clean six-row states.
+orbits for the clean fifth-row and clean six-row states. Finally, it audits
+every legal seventh row after the `56` low-support clean six-row states in the
+`4,5` and `10,11` minimum-support center-pair families.
 
 ## Effect
 
@@ -163,9 +207,10 @@ The obstruction is still real, but it occurs deeper in the selected-row
 extension tree. The center-pair normal-form audit also rules out a still
 coarser six-row proof based only on which two nonfixed centers have been
 selected. The minimum-support row-content audit gives a compact target for the
-next step: explain, or extend, the disjoint-pair pool normal form rather than
-working with an unstructured list of `56` block-swap-related survivors.
+next step, but the seventh-row continuation audit shows that even this compact
+target is not seventh-row-local.
 
 The next useful step is to mine the `6047` clean six-row states for a smaller
-row-content normal-form family or to ask for the first row depth at which
-every branch is forced into a quotient obstruction.
+row-content normal-form family, or to extend the `56` low-support branches one
+more row to ask where the disjoint-pair survivor family first becomes forced
+into a quotient obstruction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,8 +104,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`block6-fragile-sixth-row-survivor-catalog.md`](block6-fragile-sixth-row-survivor-catalog.md):
   follow-up catalog showing that every clean fifth-row state still has a clean
   legal sixth-row continuation, and that all added-center pairs support clean
-  states, with compact row-content normal forms for the two minimum-support
-  center pairs, so the block-6 closure is not sixth-row-local.
+  states, with compact row-content normal forms plus a seventh-row
+  continuation audit for the two minimum-support center pairs, so the block-6
+  closure is not sixth-row-local.
 - [`sparse-frontier-diagnostic.md`](sparse-frontier-diagnostic.md): exact
   fixed-order witness-pair source diagnostic explaining the sparse/Sidon
   radius-propagation blind spot.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,156 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 645 - Block-6 Low-support Seventh-row Continuations
+
+### Mathematical Subquestion
+
+Cycle 644 gave a compact disjoint-pair normal form for the two
+minimum-support six-row center-pair families, `4,5` and `10,11`. The next
+precise question was:
+
+```text
+Does every legal seventh-row extension of these low-support six-row normal
+forms force a vertex-circle quotient self-edge or directed strict cycle?
+```
+
+### Definitions and Assumptions
+
+The four fixed two-block block-6 fragile rows are still:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+A low-support clean six-row state is one of the `56`
+block-swap-related clean states in the `4,5` and `10,11` minimum-support
+center-pair families classified in Cycle 644. A legal seventh row is any
+valid selected row at a remaining nonfixed center satisfying the same
+incidence/order constraints as the block-6 extension checker. A clean
+seven-row state is one whose selected-distance quotient has no
+vertex-circle self-edge and no directed strict cycle in the natural cyclic
+order.
+
+### Result Status
+
+Counterexample to a subclaim:
+**Block-6 Low-support Seventh-row Survivor Audit**.
+
+The low-support disjoint-pair normal form is not seventh-row-local. Every one
+of the `56` low-support clean six-row states has at least one legal seventh
+row that remains vertex-circle-clean.
+
+### Argument Or Obstruction
+
+The checker enumerates every legal seventh row after each of the `56`
+low-support clean six-row states. The ordered seventh-row continuations split
+as:
+
+```text
+legal seventh rows from low-support six states: 5590
+vertex-circle-clean:                         2252
+self-edge obstruction:                        1560
+strict-cycle obstruction:                     1778
+clean six-row states with clean seventh row:  56 / 56
+```
+
+For the `4,5` family the split is `1126` clean, `780` self-edge, and `889`
+strict-cycle. The block-swap-related `10,11` family has the same aggregate
+split.
+
+One explicit clean continuation of a `4,5` low-support six-row state is:
+
+```text
+4 -> {0,3,6,9}
+5 -> {0,4,7,11}
+1 -> {2,5,6,7}
+```
+
+One explicit clean continuation of a `10,11` low-support six-row state is:
+
+```text
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+1  -> {0,2,7,11}
+```
+
+Together with the four fixed block-6 rows, each displayed state has
+vertex-circle status `ok` at the seven-row level.
+
+### Exact Scope
+
+This is an exact finite audit inside the two-block block-6 natural-order
+selected-row extension tree. It covers only legal seventh rows after the
+`56` low-support clean six-row states from the `4,5` and `10,11` families. It
+does not establish Euclidean realizability of any clean abstract state, is not
+a proof of Erdos Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `docs/index.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This rules out the next tempting bridge theorem: the compact low-support
+disjoint-pair template cannot be closed by adding just one more row. The
+template remains useful because it is small and exact, but any proof route
+through this block-6 branch must either extend the selected-row tree deeper,
+find a stronger geometric invariant than the current vertex-circle quotient,
+or explain the disjoint-pair normal form structurally before applying a deeper
+closure argument.
+
+### Next Lead
+
+Extend the `56` low-support branches one more row, or search within the
+`2252` clean seven-row states for a smaller row-content or center-sequence
+normal form that explains where the obstruction begins.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-645`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-645`.
+- The branch was based on `origin/main` at commit
+  `2c38030fd07132dd0ce574dde4c2ee2ac7e0ce9c`, after PR #359 merged Cycle
+  644.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python3 scripts/check_block6_fragile_sixth_row_survivors.py
+  --assert-expected --json`: passed; reported `5590` legal seventh rows after
+  the `56` low-support six-row states, with `2252` clean, `1560` self-edge,
+  `1778` strict-cycle, and all `56` clean six-row states admitting at least
+  one clean seventh row.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 644 - Block-6 Low-support Row-content Normal Forms
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Catalog sixth-row survivors after clean block-6 fifth rows."""
+"""Catalog block-6 sixth-row survivors and low-support seventh-row extensions."""
 
 from __future__ import annotations
 
@@ -155,6 +155,65 @@ EXPECTED_LOW_SUPPORT_ROW_CONTENT_FORMS = {
         "ordered_disjoint_opposite_pair_edges": 14,
         "all_edges_disjoint": True,
         "all_disjoint_pool_edges_present": True,
+    },
+}
+EXPECTED_LOW_SUPPORT_SEVENTH_AUDIT = {
+    "clean_six_states": 56,
+    "clean_six_states_with_clean_seventh": 56,
+    "ordered_legal_seventh_rows": 5590,
+    "ordered_clean_seventh_rows": 2252,
+    "ordered_self_edge_seventh_rows": 1560,
+    "ordered_strict_cycle_seventh_rows": 1778,
+    "unique_clean_seven_states": 2252,
+    "by_center_pair": {
+        "4,5": {
+            "clean_six_states": 28,
+            "clean_six_states_with_clean_seventh": 28,
+            "seventh_status_counts": {
+                "ok": 1126,
+                "self_edge": 780,
+                "strict_cycle": 889,
+            },
+            "by_seventh_center": {
+                "1": {"ok": 160, "self_edge": 0, "strict_cycle": 216},
+                "2": {"ok": 283, "self_edge": 280, "strict_cycle": 99},
+                "7": {"ok": 71, "self_edge": 117, "strict_cycle": 126},
+                "8": {"ok": 362, "self_edge": 120, "strict_cycle": 229},
+                "10": {"ok": 95, "self_edge": 163, "strict_cycle": 124},
+                "11": {"ok": 155, "self_edge": 100, "strict_cycle": 95},
+            },
+            "first_clean_seventh_example": {
+                "six_state": [
+                    {"center": 4, "row": [0, 3, 6, 9]},
+                    {"center": 5, "row": [0, 4, 7, 11]},
+                ],
+                "seventh": {"center": 1, "row": [2, 5, 6, 7]},
+            },
+        },
+        "10,11": {
+            "clean_six_states": 28,
+            "clean_six_states_with_clean_seventh": 28,
+            "seventh_status_counts": {
+                "ok": 1126,
+                "self_edge": 780,
+                "strict_cycle": 889,
+            },
+            "by_seventh_center": {
+                "1": {"ok": 71, "self_edge": 117, "strict_cycle": 126},
+                "2": {"ok": 362, "self_edge": 120, "strict_cycle": 229},
+                "4": {"ok": 95, "self_edge": 163, "strict_cycle": 124},
+                "5": {"ok": 155, "self_edge": 100, "strict_cycle": 95},
+                "7": {"ok": 160, "self_edge": 0, "strict_cycle": 216},
+                "8": {"ok": 283, "self_edge": 280, "strict_cycle": 99},
+            },
+            "first_clean_seventh_example": {
+                "six_state": [
+                    {"center": 10, "row": [0, 4, 6, 9]},
+                    {"center": 11, "row": [3, 5, 6, 7]},
+                ],
+                "seventh": {"center": 1, "row": [0, 2, 7, 11]},
+            },
+        },
     },
 }
 EXPECTED_BY_FIFTH_CENTER = {
@@ -335,6 +394,124 @@ def _low_support_row_content_forms(
     return forms
 
 
+def _status_counts(counter: Counter[str]) -> dict[str, int]:
+    return {status: int(counter[status]) for status in STATUSES}
+
+
+def _record_payload(record: RowRecord) -> dict[str, Any]:
+    center, row = record
+    return {"center": center, "row": list(row)}
+
+
+def _low_support_seventh_extension_audit(
+    clean_six_states: set[SixState],
+) -> dict[str, Any]:
+    options = _options()
+    overall_status: Counter[str] = Counter()
+    clean_six_with_clean_seventh = 0
+    unique_clean_seven_states: set[tuple[RowRecord, ...]] = set()
+    by_center_pair: dict[str, dict[str, Any]] = {}
+
+    for center_pair in ((4, 5), (10, 11)):
+        matching_states = [
+            state
+            for state in clean_six_states
+            if tuple(record[0] for record in state) == center_pair
+        ]
+        pair_status: Counter[str] = Counter()
+        by_seventh_center: dict[str, Counter[str]] = {}
+        pair_clean_six_with_clean = 0
+        first_clean_seventh_example: dict[str, Any] | None = None
+
+        for state in matching_states:
+            assigned, pair_counts, indegrees = _initial_state()
+            for center, row in state:
+                _add_row(assigned, pair_counts, indegrees, center, row)
+
+            local_clean_seventh = 0
+            for seventh_center in range(N):
+                if seventh_center in assigned:
+                    continue
+                center_counter = by_seventh_center.setdefault(
+                    str(seventh_center),
+                    Counter(),
+                )
+                for seventh_row in _valid_options(
+                    seventh_center,
+                    options,
+                    assigned,
+                    pair_counts,
+                    indegrees,
+                ):
+                    _add_row(
+                        assigned,
+                        pair_counts,
+                        indegrees,
+                        seventh_center,
+                        seventh_row,
+                    )
+                    seventh_status, _edge_count = _partial_vertex_circle_status(
+                        assigned
+                    )
+                    _remove_row(
+                        assigned,
+                        pair_counts,
+                        indegrees,
+                        seventh_center,
+                        seventh_row,
+                    )
+
+                    pair_status[seventh_status] += 1
+                    overall_status[seventh_status] += 1
+                    center_counter[seventh_status] += 1
+                    if seventh_status == "ok":
+                        local_clean_seventh += 1
+                        seventh_record = (seventh_center, tuple(seventh_row))
+                        unique_clean_seven_states.add(
+                            tuple(sorted((*state, seventh_record)))
+                        )
+                        if first_clean_seventh_example is None:
+                            first_clean_seventh_example = {
+                                "six_state": [
+                                    _record_payload(record) for record in state
+                                ],
+                                "seventh": _record_payload(seventh_record),
+                            }
+            if local_clean_seventh:
+                pair_clean_six_with_clean += 1
+                clean_six_with_clean_seventh += 1
+
+            for center, row in reversed(state):
+                _remove_row(assigned, pair_counts, indegrees, center, row)
+
+        by_center_pair[_center_pair_key(center_pair)] = {
+            "clean_six_states": len(matching_states),
+            "clean_six_states_with_clean_seventh": pair_clean_six_with_clean,
+            "seventh_status_counts": _status_counts(pair_status),
+            "by_seventh_center": {
+                center: _status_counts(counter)
+                for center, counter in sorted(
+                    by_seventh_center.items(),
+                    key=lambda item: int(item[0]),
+                )
+            },
+            "first_clean_seventh_example": first_clean_seventh_example,
+        }
+
+    return {
+        "clean_six_states": sum(
+            item["clean_six_states"] for item in by_center_pair.values()
+        ),
+        "clean_six_states_with_clean_seventh": clean_six_with_clean_seventh,
+        "ordered_legal_seventh_rows": sum(overall_status.values()),
+        "ordered_clean_seventh_rows": int(overall_status["ok"]),
+        "ordered_self_edge_seventh_rows": int(overall_status["self_edge"]),
+        "ordered_strict_cycle_seventh_rows": int(overall_status["strict_cycle"]),
+        "unique_clean_seven_states": len(unique_clean_seven_states),
+        "by_center_pair": by_center_pair,
+    }
+
+
 def _orbit_count(states: set[RowRecord] | set[SixState]) -> tuple[int, Counter[int]]:
     seen: set[Any] = set()
     sizes: Counter[int] = Counter()
@@ -465,8 +642,9 @@ def survivor_payload() -> dict[str, Any]:
         "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
         "claim_scope": (
             "Legal sixth rows after clean one-row extensions of the two-block "
-            "block-6 fragile rows in the natural cyclic order; not a proof of "
-            "Erdos Problem #97 and not a counterexample."
+            "block-6 fragile rows, plus legal seventh rows after the two "
+            "minimum-support six-row center pairs, in the natural cyclic "
+            "order; not a proof of Erdos Problem #97 and not a counterexample."
         ),
         "fixed_centers": sorted(assigned),
         "totals": totals,
@@ -487,6 +665,9 @@ def survivor_payload() -> dict[str, Any]:
         },
         "low_support_row_content_forms": _low_support_row_content_forms(
             clean_six_states
+        ),
+        "low_support_seventh_extension_audit": (
+            _low_support_seventh_extension_audit(clean_six_states)
         ),
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
@@ -527,6 +708,14 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(
             "unexpected low-support row-content normal forms: "
             f"{payload['low_support_row_content_forms']!r}"
+        )
+    if (
+        payload["low_support_seventh_extension_audit"]
+        != EXPECTED_LOW_SUPPORT_SEVENTH_AUDIT
+    ):
+        raise AssertionError(
+            "unexpected low-support seventh-extension audit: "
+            f"{payload['low_support_seventh_extension_audit']!r}"
         )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -37,6 +37,24 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "0,3|0,1": 14,
         "0,3|0,4": 14,
     }
+    seventh_audit = payload["low_support_seventh_extension_audit"]
+    assert seventh_audit["clean_six_states"] == 56
+    assert seventh_audit["clean_six_states_with_clean_seventh"] == 56
+    assert seventh_audit["ordered_legal_seventh_rows"] == 5590
+    assert seventh_audit["ordered_clean_seventh_rows"] == 2252
+    assert seventh_audit["ordered_self_edge_seventh_rows"] == 1560
+    assert seventh_audit["ordered_strict_cycle_seventh_rows"] == 1778
+    assert seventh_audit["unique_clean_seven_states"] == 2252
+    assert seventh_audit["by_center_pair"]["4,5"]["seventh_status_counts"] == {
+        "ok": 1126,
+        "self_edge": 780,
+        "strict_cycle": 889,
+    }
+    assert seventh_audit["by_center_pair"]["10,11"]["by_seventh_center"]["2"] == {
+        "ok": 362,
+        "self_edge": 120,
+        "strict_cycle": 229,
+    }
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 645 audits whether the Cycle 644 low-support disjoint-pair normal forms for the two minimum-support block-6 six-row center-pair families close after one more row.

## Result

They do not close at the seventh row. Every one of the 56 low-support clean six-row states has at least one legal seventh-row continuation that remains vertex-circle-clean.

The exact audit enumerates 5,590 legal seventh rows after those states:

- 2,252 vertex-circle-clean
- 1,560 self-edge obstruction
- 1,778 strict-cycle obstruction

Named result: Block-6 Low-support Seventh-row Survivor Audit.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`
- `tests/test_block6_fragile_sixth_row_survivors.py`
- `docs/block6-fragile-sixth-row-survivor-catalog.md`
- `docs/index.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `python3 scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`

Full pytest passed locally with `540 passed, 276 deselected`.

## Remaining limitations

This is a bounded natural-order two-block block-6 audit only. It is not a proof of Erdos Problem #97, not a counterexample, and the clean seven-row states are abstract selected-row states, not Euclidean realizability claims.

Supersedes draft PR #360, which was closed after the connector failed while marking it ready for review.