### PR TITLE
[codex] Classify block6 terminal seven-row pockets

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -215,6 +215,50 @@ self-edge and `2` force a strict cycle. Thus the eighth-row audit supplies
 small terminal pockets but still does not produce a full low-support closure
 theorem.
 
+## Terminal Seven-row Classification
+
+The `12` terminal clean seven-row states form exactly `6` orbits under the
+block-swap symmetry `i -> i+6 mod 12`; every orbit has size `2`.
+
+For each terminal state, split each added row into the two witnesses in the
+same block as its center and the two witnesses in the opposite block. The
+terminal row-content profiles are exactly:
+
+```text
+profile                                      terminal states  block-swap orbits
+same union 5, intersections 0,0,1;
+  opposite union 6, intersections 0,0,0      8                4
+same union 4, intersections 0,1,1;
+  opposite union 5, intersections 0,0,1      4                2
+```
+
+The terminal eighth-row obstruction splits are:
+
+```text
+legal eighth rows  self-edge  strict-cycle  terminal states
+9                  7          2             4
+19                 10         9             2
+9                  4          5             2
+9                  5          4             2
+11                 2          9             2
+```
+
+One representative from each block-swap orbit is:
+
+```text
+2  -> {0,1,6,11}; 10 -> {0,4,6,9}; 11 -> {3,5,6,7}  | legal 9, self 7, cycle 2
+2  -> {1,5,6,7};  4  -> {0,3,6,10}; 5  -> {0,1,8,11} | legal 19, self 10, cycle 9
+2  -> {1,5,6,7};  4  -> {0,3,6,10}; 5  -> {0,1,9,11} | legal 9, self 4, cycle 5
+4  -> {0,3,6,10}; 5  -> {0,1,9,11}; 11 -> {0,5,6,7}  | legal 9, self 7, cycle 2
+4  -> {0,3,8,11}; 5  -> {0,1,6,9};  11 -> {3,5,6,7}  | legal 9, self 5, cycle 4
+4  -> {0,3,9,11}; 5  -> {0,1,6,10}; 11 -> {3,5,6,7}  | legal 11, self 2, cycle 9
+```
+
+Applying the block-swap map to these six representatives gives the other six
+terminal states. This classification is useful as a proof-mining target: a
+terminality lemma must use more than the seven-center triple, but may only need
+the two row-content profiles above plus one short list of boundary variants.
+
 ## Center Counts
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,153 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 647 - Block-6 Terminal Seven-row Classification
+
+### Mathematical Subquestion
+
+Cycle 646 found `12` terminal clean seven-row states in the low-support
+block-6 branch. The next precise question was:
+
+```text
+Do those 12 terminal states collapse to a small exact classification under
+block-swap symmetry and same/opposite-block row-content profiles?
+```
+
+### Definitions and Assumptions
+
+The four fixed two-block block-6 fragile rows are:
+
+```text
+0 -> {1,2,3,4}
+3 -> {0,2,4,5}
+6 -> {7,8,9,10}
+9 -> {6,8,10,11}
+```
+
+The block-swap symmetry is the involution `sigma(i) = i+6 mod 12`. For an
+added row `c -> S`, the row-content split means the two labels of `S` in the
+same six-label block as `c` and the two labels of `S` in the opposite block.
+For the three added rows of a clean seven-row state, the profile records the
+same-block pair intersection multiset, same-block union size and degree
+multiset, and the analogous opposite-block data.
+
+### Result Status
+
+Exact classification:
+**Block-6 Terminal-pocket Six-orbit Classification**.
+
+The `12` terminal clean seven-row states form exactly `6` block-swap orbits,
+all of size `2`, and fall into exactly two row-content profile classes.
+
+### Argument Or Obstruction
+
+The checker now carries forward the terminal clean seven-row states found
+during the eighth-row audit and classifies them directly. No floating-point
+geometry or heuristic search is used.
+
+The row-content profile counts are:
+
+```text
+profile                                      terminal states  block-swap orbits
+same union 5, intersections 0,0,1;
+  opposite union 6, intersections 0,0,0      8                4
+same union 4, intersections 0,1,1;
+  opposite union 5, intersections 0,0,1      4                2
+```
+
+The terminal eighth-row obstruction splits are:
+
+```text
+legal eighth rows  self-edge  strict-cycle  terminal states
+9                  7          2             4
+19                 10         9             2
+9                  4          5             2
+9                  5          4             2
+11                 2          9             2
+```
+
+One representative from each block-swap orbit is:
+
+```text
+2  -> {0,1,6,11}; 10 -> {0,4,6,9}; 11 -> {3,5,6,7}  | legal 9, self 7, cycle 2
+2  -> {1,5,6,7};  4  -> {0,3,6,10}; 5  -> {0,1,8,11} | legal 19, self 10, cycle 9
+2  -> {1,5,6,7};  4  -> {0,3,6,10}; 5  -> {0,1,9,11} | legal 9, self 4, cycle 5
+4  -> {0,3,6,10}; 5  -> {0,1,9,11}; 11 -> {0,5,6,7}  | legal 9, self 7, cycle 2
+4  -> {0,3,8,11}; 5  -> {0,1,6,9};  11 -> {3,5,6,7}  | legal 9, self 5, cycle 4
+4  -> {0,3,9,11}; 5  -> {0,1,6,10}; 11 -> {3,5,6,7}  | legal 11, self 2, cycle 9
+```
+
+Applying `sigma` to these six representatives gives the other six terminal
+states.
+
+### Exact Scope
+
+This is an exact finite classification inside the two-block block-6
+natural-order selected-row extension tree. It covers only the `12` terminal
+clean seven-row states produced by the low-support `4,5` and `10,11` six-row
+families. It is not a Euclidean realizability result, is not a proof of Erdos
+Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+The exact terminal pockets are now small enough to be a plausible
+human-readable lemma target. A terminality lemma cannot use only the
+seven-center triple, because terminal states occur in triples that also have
+many extendable states. The two row-content profiles above are the next
+candidate hypotheses to test.
+
+### Next Lead
+
+For one of the two terminal profiles, try to prove directly that every legal
+eighth row creates either a quotient self-edge or a directed strict cycle,
+using only the fixed block-6 rows, block order, and the displayed
+same/opposite-block pair profile.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-647`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-647`.
+- The branch was based on `origin/main` at commit
+  `68e9741f30beee2de615ff9bab35d147d66c657a`, after PR #363 merged Cycle
+  646.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `python3 scripts/check_block6_fragile_sixth_row_survivors.py
+  --assert-expected --json`: passed; reported `12` terminal clean seven-row
+  states, `6` block-swap orbits, and two row-content profile classes of sizes
+  `8` and `4`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 646 - Block-6 Low-support Eighth-row Terminal Pockets
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Catalog block-6 sixth-row survivors and low-support seventh-row extensions."""
+"""Catalog block-6 low-support survivor and terminal-pocket structure."""
 
 from __future__ import annotations
 
@@ -357,6 +357,162 @@ EXPECTED_LOW_SUPPORT_EIGHTH_AUDIT = {
         },
     },
 }
+EXPECTED_LOW_SUPPORT_TERMINAL_CLASSIFICATION = {
+    "terminal_clean_seven_states": 12,
+    "block_swap_orbits": 6,
+    "block_swap_orbit_sizes": {"2": 6},
+    "row_content_profile_counts": {
+        (
+            "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): 4,
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): 8,
+    },
+    "eighth_status_split_counts": {
+        "legal=9;self_edge=4;strict_cycle=5": 2,
+        "legal=9;self_edge=5;strict_cycle=4": 2,
+        "legal=9;self_edge=7;strict_cycle=2": 4,
+        "legal=11;self_edge=2;strict_cycle=9": 2,
+        "legal=19;self_edge=10;strict_cycle=9": 2,
+    },
+    "block_swap_orbit_representatives": [
+        {
+            "representative": [
+                {"center": 2, "row": [0, 1, 6, 11]},
+                {"center": 10, "row": [0, 4, 6, 9]},
+                {"center": 11, "row": [3, 5, 6, 7]},
+            ],
+            "block_swap_member": [
+                {"center": 4, "row": [0, 3, 6, 10]},
+                {"center": 5, "row": [0, 1, 9, 11]},
+                {"center": 8, "row": [0, 5, 6, 7]},
+            ],
+            "legal_eighth_rows": 9,
+            "eighth_status_counts": {
+                "ok": 0,
+                "self_edge": 7,
+                "strict_cycle": 2,
+            },
+            "row_content_profile": (
+                "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+                "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+            ),
+        },
+        {
+            "representative": [
+                {"center": 2, "row": [1, 5, 6, 7]},
+                {"center": 4, "row": [0, 3, 6, 10]},
+                {"center": 5, "row": [0, 1, 8, 11]},
+            ],
+            "block_swap_member": [
+                {"center": 8, "row": [0, 1, 7, 11]},
+                {"center": 10, "row": [0, 4, 6, 9]},
+                {"center": 11, "row": [2, 5, 6, 7]},
+            ],
+            "legal_eighth_rows": 19,
+            "eighth_status_counts": {
+                "ok": 0,
+                "self_edge": 10,
+                "strict_cycle": 9,
+            },
+            "row_content_profile": (
+                "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+                "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+            ),
+        },
+        {
+            "representative": [
+                {"center": 2, "row": [1, 5, 6, 7]},
+                {"center": 4, "row": [0, 3, 6, 10]},
+                {"center": 5, "row": [0, 1, 9, 11]},
+            ],
+            "block_swap_member": [
+                {"center": 8, "row": [0, 1, 7, 11]},
+                {"center": 10, "row": [0, 4, 6, 9]},
+                {"center": 11, "row": [3, 5, 6, 7]},
+            ],
+            "legal_eighth_rows": 9,
+            "eighth_status_counts": {
+                "ok": 0,
+                "self_edge": 4,
+                "strict_cycle": 5,
+            },
+            "row_content_profile": (
+                "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+                "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+            ),
+        },
+        {
+            "representative": [
+                {"center": 4, "row": [0, 3, 6, 10]},
+                {"center": 5, "row": [0, 1, 9, 11]},
+                {"center": 11, "row": [0, 5, 6, 7]},
+            ],
+            "block_swap_member": [
+                {"center": 5, "row": [0, 1, 6, 11]},
+                {"center": 10, "row": [0, 4, 6, 9]},
+                {"center": 11, "row": [3, 5, 6, 7]},
+            ],
+            "legal_eighth_rows": 9,
+            "eighth_status_counts": {
+                "ok": 0,
+                "self_edge": 7,
+                "strict_cycle": 2,
+            },
+            "row_content_profile": (
+                "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+                "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+            ),
+        },
+        {
+            "representative": [
+                {"center": 4, "row": [0, 3, 8, 11]},
+                {"center": 5, "row": [0, 1, 6, 9]},
+                {"center": 11, "row": [3, 5, 6, 7]},
+            ],
+            "block_swap_member": [
+                {"center": 5, "row": [0, 1, 9, 11]},
+                {"center": 10, "row": [2, 5, 6, 9]},
+                {"center": 11, "row": [0, 3, 6, 7]},
+            ],
+            "legal_eighth_rows": 9,
+            "eighth_status_counts": {
+                "ok": 0,
+                "self_edge": 5,
+                "strict_cycle": 4,
+            },
+            "row_content_profile": (
+                "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+                "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+            ),
+        },
+        {
+            "representative": [
+                {"center": 4, "row": [0, 3, 9, 11]},
+                {"center": 5, "row": [0, 1, 6, 10]},
+                {"center": 11, "row": [3, 5, 6, 7]},
+            ],
+            "block_swap_member": [
+                {"center": 5, "row": [0, 1, 9, 11]},
+                {"center": 10, "row": [3, 5, 6, 9]},
+                {"center": 11, "row": [0, 4, 6, 7]},
+            ],
+            "legal_eighth_rows": 11,
+            "eighth_status_counts": {
+                "ok": 0,
+                "self_edge": 2,
+                "strict_cycle": 9,
+            },
+            "row_content_profile": (
+                "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+                "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+            ),
+        },
+    ],
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -421,6 +577,7 @@ SixState = tuple[RowRecord, RowRecord]
 SevenState = tuple[RowRecord, RowRecord, RowRecord]
 CenterPair = tuple[int, int]
 LabelPair = tuple[int, int]
+TerminalSevenAudit = tuple[SevenState, Counter[str]]
 
 
 def _json_counter(counter: Counter[Any]) -> dict[str, int]:
@@ -466,6 +623,10 @@ def _center_pair_orbit_key(pair: CenterPair) -> str:
 
 
 def _block_swap_six_state(state: SixState) -> SixState:
+    return tuple(sorted(_block_swap_row(record) for record in state))  # type: ignore[return-value]
+
+
+def _block_swap_seven_state(state: SevenState) -> SevenState:
     return tuple(sorted(_block_swap_row(record) for record in state))  # type: ignore[return-value]
 
 
@@ -538,6 +699,53 @@ def _low_support_row_content_forms(
 
 def _status_counts(counter: Counter[str]) -> dict[str, int]:
     return {status: int(counter[status]) for status in STATUSES}
+
+
+def _intersection_profile(pairs: list[LabelPair]) -> tuple[int, ...]:
+    return tuple(
+        sorted(
+            len(set(pairs[left]) & set(pairs[right]))
+            for left in range(len(pairs))
+            for right in range(left + 1, len(pairs))
+        )
+    )
+
+
+def _degree_multiset(pairs: list[LabelPair]) -> tuple[int, ...]:
+    return tuple(sorted(Counter(label for pair in pairs for label in pair).values()))
+
+
+def _row_content_profile_key(state: SevenState) -> str:
+    same_pairs: list[LabelPair] = []
+    opposite_pairs: list[LabelPair] = []
+    for center, row in state:
+        same, opposite = _split_row_by_center_block(center, row)
+        same_pairs.append(same)
+        opposite_pairs.append(opposite)
+
+    same_labels = set().union(*(set(pair) for pair in same_pairs))
+    opposite_labels = set().union(*(set(pair) for pair in opposite_pairs))
+    same_intersections = ",".join(str(value) for value in _intersection_profile(same_pairs))
+    opposite_intersections = ",".join(
+        str(value) for value in _intersection_profile(opposite_pairs)
+    )
+    same_degrees = ",".join(str(value) for value in _degree_multiset(same_pairs))
+    opposite_degrees = ",".join(
+        str(value) for value in _degree_multiset(opposite_pairs)
+    )
+    return (
+        f"same_u={len(same_labels)},same_i={same_intersections},"
+        f"same_d={same_degrees}|opposite_u={len(opposite_labels)},"
+        f"opposite_i={opposite_intersections},opposite_d={opposite_degrees}"
+    )
+
+
+def _status_split_key(counter: Counter[str]) -> str:
+    return (
+        f"legal={sum(counter.values())};"
+        f"self_edge={int(counter['self_edge'])};"
+        f"strict_cycle={int(counter['strict_cycle'])}"
+    )
 
 
 def _record_payload(record: RowRecord) -> dict[str, Any]:
@@ -665,12 +873,13 @@ def _low_support_seventh_extension_scan(
 
 def _low_support_eighth_extension_audit(
     clean_seven_states: set[SevenState],
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[TerminalSevenAudit]]:
     options = _options()
     overall_status: Counter[str] = Counter()
     clean_seven_with_clean_eighth = 0
     unique_clean_eight_states: set[tuple[RowRecord, ...]] = set()
     by_seven_center_triple: dict[str, dict[str, Any]] = {}
+    terminal_seven_state_audits: list[TerminalSevenAudit] = []
     first_clean_eighth_example: dict[str, Any] | None = None
     first_terminal_seven_state: dict[str, Any] | None = None
 
@@ -735,12 +944,14 @@ def _low_support_eighth_extension_audit(
         if local_clean_eighth:
             clean_seven_with_clean_eighth += 1
             triple_entry["clean_seven_states_with_clean_eighth"] += 1
-        elif first_terminal_seven_state is None:
-            first_terminal_seven_state = {
-                "seven_state": [_record_payload(record) for record in state],
-                "legal_eighth_rows": sum(local_status.values()),
-                "eighth_status_counts": _status_counts(local_status),
-            }
+        else:
+            terminal_seven_state_audits.append((state, Counter(local_status)))
+            if first_terminal_seven_state is None:
+                first_terminal_seven_state = {
+                    "seven_state": [_record_payload(record) for record in state],
+                    "legal_eighth_rows": sum(local_status.values()),
+                    "eighth_status_counts": _status_counts(local_status),
+                }
 
     return {
         "clean_seven_states": len(clean_seven_states),
@@ -767,6 +978,69 @@ def _low_support_eighth_extension_audit(
         },
         "first_clean_eighth_example": first_clean_eighth_example,
         "first_terminal_seven_state": first_terminal_seven_state,
+    }, terminal_seven_state_audits
+
+
+def _terminal_state_orbit_payload(
+    representative: SevenState,
+    block_swap_member: SevenState,
+    status: Counter[str],
+) -> dict[str, Any]:
+    return {
+        "representative": [_record_payload(record) for record in representative],
+        "block_swap_member": [_record_payload(record) for record in block_swap_member],
+        "legal_eighth_rows": sum(status.values()),
+        "eighth_status_counts": _status_counts(status),
+        "row_content_profile": _row_content_profile_key(representative),
+    }
+
+
+def _low_support_terminal_classification(
+    terminal_audits: list[TerminalSevenAudit],
+) -> dict[str, Any]:
+    status_by_state = {state: status for state, status in terminal_audits}
+    seen: set[SevenState] = set()
+    orbit_sizes: Counter[int] = Counter()
+    row_content_profiles: Counter[str] = Counter()
+    status_splits: Counter[str] = Counter()
+    orbit_representatives: list[dict[str, Any]] = []
+
+    for state, status in sorted(terminal_audits):
+        row_content_profiles[_row_content_profile_key(state)] += 1
+        status_splits[_status_split_key(status)] += 1
+        if state in seen:
+            continue
+
+        orbit = sorted({state, _block_swap_seven_state(state)})
+        seen.update(orbit)
+        orbit_sizes[len(orbit)] += 1
+        if len(orbit) != 2:
+            raise AssertionError(f"unexpected terminal block-swap orbit: {orbit!r}")
+        representative = orbit[0]
+        block_swap_member = orbit[1]
+        if representative not in status_by_state or block_swap_member not in status_by_state:
+            raise AssertionError("terminal block-swap orbit left terminal catalog")
+        if status_by_state[representative] != status_by_state[block_swap_member]:
+            raise AssertionError("terminal block-swap orbit changed status split")
+        orbit_representatives.append(
+            _terminal_state_orbit_payload(
+                representative,
+                block_swap_member,
+                status_by_state[representative],
+            )
+        )
+
+    return {
+        "terminal_clean_seven_states": len(terminal_audits),
+        "block_swap_orbits": sum(orbit_sizes.values()),
+        "block_swap_orbit_sizes": _json_counter(orbit_sizes),
+        "row_content_profile_counts": {
+            key: int(row_content_profiles[key]) for key in sorted(row_content_profiles)
+        },
+        "eighth_status_split_counts": {
+            key: int(status_splits[key]) for key in sorted(status_splits)
+        },
+        "block_swap_orbit_representatives": orbit_representatives,
     }
 
 
@@ -882,6 +1156,9 @@ def survivor_payload() -> dict[str, Any]:
     low_support_seventh_audit, low_support_clean_seven_states = (
         _low_support_seventh_extension_scan(clean_six_states)
     )
+    low_support_eighth_audit, low_support_terminal_audits = (
+        _low_support_eighth_extension_audit(low_support_clean_seven_states)
+    )
     totals = {
         "clean_fifth_rows": len(clean_fifth_rows),
         "clean_fifth_block_swap_orbits": clean_fifth_orbits,
@@ -929,8 +1206,9 @@ def survivor_payload() -> dict[str, Any]:
             clean_six_states
         ),
         "low_support_seventh_extension_audit": low_support_seventh_audit,
-        "low_support_eighth_extension_audit": (
-            _low_support_eighth_extension_audit(low_support_clean_seven_states)
+        "low_support_eighth_extension_audit": low_support_eighth_audit,
+        "low_support_terminal_seven_state_classification": (
+            _low_support_terminal_classification(low_support_terminal_audits)
         ),
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
@@ -987,6 +1265,14 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(
             "unexpected low-support eighth-extension audit: "
             f"{payload['low_support_eighth_extension_audit']!r}"
+        )
+    if (
+        payload["low_support_terminal_seven_state_classification"]
+        != EXPECTED_LOW_SUPPORT_TERMINAL_CLASSIFICATION
+    ):
+        raise AssertionError(
+            "unexpected low-support terminal classification: "
+            f"{payload['low_support_terminal_seven_state_classification']!r}"
         )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -73,6 +73,51 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
             "strict_cycle": 1947,
         },
     }
+    terminal_classification = payload[
+        "low_support_terminal_seven_state_classification"
+    ]
+    assert terminal_classification["terminal_clean_seven_states"] == 12
+    assert terminal_classification["block_swap_orbits"] == 6
+    assert terminal_classification["block_swap_orbit_sizes"] == {"2": 6}
+    assert terminal_classification["row_content_profile_counts"] == {
+        (
+            "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): 4,
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): 8,
+    }
+    assert terminal_classification["eighth_status_split_counts"] == {
+        "legal=9;self_edge=4;strict_cycle=5": 2,
+        "legal=9;self_edge=5;strict_cycle=4": 2,
+        "legal=9;self_edge=7;strict_cycle=2": 4,
+        "legal=11;self_edge=2;strict_cycle=9": 2,
+        "legal=19;self_edge=10;strict_cycle=9": 2,
+    }
+    assert terminal_classification["block_swap_orbit_representatives"][0] == {
+        "representative": [
+            {"center": 2, "row": [0, 1, 6, 11]},
+            {"center": 10, "row": [0, 4, 6, 9]},
+            {"center": 11, "row": [3, 5, 6, 7]},
+        ],
+        "block_swap_member": [
+            {"center": 4, "row": [0, 3, 6, 10]},
+            {"center": 5, "row": [0, 1, 9, 11]},
+            {"center": 8, "row": [0, 5, 6, 7]},
+        ],
+        "legal_eighth_rows": 9,
+        "eighth_status_counts": {
+            "ok": 0,
+            "self_edge": 7,
+            "strict_cycle": 2,
+        },
+        "row_content_profile": (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ),
+    }
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 647 classifies the 12 terminal clean seven-row states from the low-support block-6 branch. The result is diagnostic only: no general proof and no counterexample are claimed.

The classification records:
- 6 block-swap orbits, each of size 2;
- 2 same/opposite-block row-content profile classes, with state counts 8 and 4;
- exact eighth-row obstruction split counts for the terminal states;
- one representative from each block-swap orbit.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`
- `tests/test_block6_fragile_sixth_row_survivors.py`
- `docs/block6-fragile-sixth-row-survivor-catalog.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `python3 scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`540 passed, 276 deselected`)

## Self-review

The first draft review found one robustness issue: the classifier should assert that terminal block-swap partners remain terminal and preserve the eighth-row status split. The final head includes that assertion and was revalidated locally.

## Remaining limitations

This is an exact finite classification inside the two-block block-6 natural-order selected-row extension tree. It does not establish Euclidean realizability, does not close the whole low-support branch, and does not prove or refute Erdos Problem #97.