### PR TITLE
[codex] Audit block6 profile-only terminality

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -259,6 +259,52 @@ terminal states. This classification is useful as a proof-mining target: a
 terminality lemma must use more than the seven-center triple, but may only need
 the two row-content profiles above plus one short list of boundary variants.
 
+## Profile-only Terminality Audit
+
+The two terminal row-content profiles are not sufficient by themselves. Among
+the `2252` clean seven-row states, `192` do not split every added row into
+two same-block and two opposite-block witnesses; all `192` are extendable at
+the eighth-row level.
+
+The remaining `2060` two-and-two clean seven-row states have exactly `6`
+row-content profiles. The two profiles that contain terminal states also
+contain many extendable states:
+
+```text
+profile summary                              clean states  terminal  extendable
+same u4, i011;  opposite u5, i001          320           4         316
+same u5, i001;  opposite u6, i000          1230          8         1222
+```
+
+Here `u` is the union size of the three same-block or opposite-block pairs,
+and `i` is the sorted pairwise-intersection multiset. Thus any terminality
+lemma for these pockets needs finer boundary data than this coarse
+same/opposite-block profile.
+
+A clean extendable state with the first terminal profile is:
+
+```text
+1 -> {3,5,6,7}
+4 -> {0,3,6,9}
+5 -> {0,4,8,11}
+```
+
+A clean extendable state with the second terminal profile is:
+
+```text
+1  -> {0,2,7,11}
+10 -> {0,1,6,9}
+11 -> {2,5,6,10}
+```
+
+One clean extendable state outside the two-and-two profile domain is:
+
+```text
+2 -> {0,1,3,7}
+4 -> {0,3,6,9}
+5 -> {0,4,8,11}
+```
+
 ## Center Counts
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,156 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 648 - Block-6 Profile-only Terminality Failure
+
+### Mathematical Subquestion
+
+Cycle 647 found two row-content profile classes containing all `12` terminal
+clean seven-row states. The next precise question was:
+
+```text
+Does either terminal row-content profile by itself force eighth-row
+terminality in the low-support block-6 branch?
+```
+
+### Definitions and Assumptions
+
+The fixed block-6 fragile rows, the low-support clean seven-row states, and
+the block-swap symmetry are as in Cycle 647. A two-and-two row-content profile
+is defined only for clean seven-row states whose three added rows each split
+into exactly two witnesses in the same six-label block as the row center and
+two witnesses in the opposite block.
+
+For such a state, the profile records the same-block pair union size,
+same-block pairwise-intersection multiset and degree multiset, together with
+the analogous opposite-block data.
+
+### Result Status
+
+Failed lemma:
+**Profile-only Terminality Failure**.
+
+The two terminal row-content profiles do not force eighth-row terminality.
+Each also occurs among many clean seven-row states that have a clean eighth-row
+continuation.
+
+### Argument Or Obstruction
+
+The checker now audits all `2252` low-support clean seven-row states against
+the terminal profile data. Of these, `192` do not have the two-and-two split
+needed by the terminal profile classification; all `192` are extendable at the
+eighth-row level. The remaining `2060` split-compatible states fall into `6`
+row-content profiles.
+
+The two profiles containing terminal states have the following exact counts:
+
+```text
+profile summary                              clean states  terminal  extendable
+same union 4, intersections 0,1,1;
+  opposite union 5, intersections 0,0,1      320           4         316
+same union 5, intersections 0,0,1;
+  opposite union 6, intersections 0,0,0      1230          8         1222
+```
+
+A clean extendable state with the first terminal profile is:
+
+```text
+1 -> {3,5,6,7}
+4 -> {0,3,6,9}
+5 -> {0,4,8,11}
+```
+
+A clean extendable state with the second terminal profile is:
+
+```text
+1  -> {0,2,7,11}
+10 -> {0,1,6,9}
+11 -> {2,5,6,10}
+```
+
+One clean extendable state outside the two-and-two profile domain is:
+
+```text
+2 -> {0,1,3,7}
+4 -> {0,3,6,9}
+5 -> {0,4,8,11}
+```
+
+Thus a profile-only local lemma is false. Any terminality lemma for these
+pockets must use finer boundary data than the coarse same/opposite-block
+profile.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers all `2252` clean
+seven-row states generated from the `4,5` and `10,11` low-support six-row
+families. It is not a Euclidean realizability result, is not a proof of Erdos
+Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This rules out the simplest proof-mining route suggested by Cycle 647. The
+terminal pockets are not explained by the two coarse row-content profiles
+alone. The next lemma candidate must incorporate either the exact boundary
+pairs from the six block-swap orbits, the seventh center position, or the
+legal eighth-row candidate set.
+
+### Next Lead
+
+Classify the six terminal block-swap orbits by a finer invariant: for each
+remaining center, count which legal eighth rows are killed by self-edge versus
+strict-cycle obstructions, then look for a common local forcing pattern.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-648`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-648`.
+- The branch was based on `origin/main` at commit
+  `3a21411a2888cd956623199a04f10f3ebed9bd25`, after PR #365 merged Cycle
+  647.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- One-off profile terminality audit over all `2252` clean seven-row states:
+  found `192` non-two-and-two extendable states, `2060` two-and-two states,
+  `6` two-and-two profile classes, and terminal-profile extendable counts
+  `316` and `1222`.
+- `python3 scripts/check_block6_fragile_sixth_row_survivors.py
+  --assert-expected --json`: passed; reported `192` non-two-and-two
+  extendable states, `2060` two-and-two states, `6` two-and-two profile
+  classes, and `profile_only_terminality_holds: false`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 647 - Block-6 Terminal Seven-row Classification
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -513,6 +513,97 @@ EXPECTED_LOW_SUPPORT_TERMINAL_CLASSIFICATION = {
         },
     ],
 }
+EXPECTED_LOW_SUPPORT_PROFILE_TERMINALITY_AUDIT = {
+    "clean_seven_states": 2252,
+    "terminal_clean_seven_states": 12,
+    "non_two_two_clean_seven_states": 192,
+    "non_two_two_terminal_clean_seven_states": 0,
+    "two_two_clean_seven_states": 2060,
+    "two_two_terminal_clean_seven_states": 12,
+    "two_two_profile_classes": 6,
+    "terminal_profile_classes": 2,
+    "terminal_profiles_with_extendable_states": 2,
+    "profile_only_terminality_holds": False,
+    "non_two_two_by_center_triple": {
+        "2,10,11": 68,
+        "2,4,5": 28,
+        "4,5,8": 68,
+        "8,10,11": 28,
+    },
+    "profile_counts": {
+        (
+            "same_u=3,same_i=1,1,1,same_d=2,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "clean_two_two_seven_states": 40,
+            "terminal": 0,
+            "extendable": 40,
+        },
+        (
+            "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=4,opposite_i=0,1,1,opposite_d=1,1,2,2"
+        ): {
+            "clean_two_two_seven_states": 150,
+            "terminal": 0,
+            "extendable": 150,
+        },
+        (
+            "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "clean_two_two_seven_states": 320,
+            "terminal": 4,
+            "extendable": 316,
+        },
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=4,opposite_i=0,1,1,opposite_d=1,1,2,2"
+        ): {
+            "clean_two_two_seven_states": 120,
+            "terminal": 0,
+            "extendable": 120,
+        },
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "clean_two_two_seven_states": 200,
+            "terminal": 0,
+            "extendable": 200,
+        },
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "clean_two_two_seven_states": 1230,
+            "terminal": 8,
+            "extendable": 1222,
+        },
+    },
+    "first_non_two_two_example": [
+        {"center": 2, "row": [0, 1, 3, 7]},
+        {"center": 4, "row": [0, 3, 6, 9]},
+        {"center": 5, "row": [0, 4, 8, 11]},
+    ],
+    "terminal_profile_extendable_examples": {
+        (
+            "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): [
+            {"center": 1, "row": [3, 5, 6, 7]},
+            {"center": 4, "row": [0, 3, 6, 9]},
+            {"center": 5, "row": [0, 4, 8, 11]},
+        ],
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): [
+            {"center": 1, "row": [0, 2, 7, 11]},
+            {"center": 10, "row": [0, 1, 6, 9]},
+            {"center": 11, "row": [2, 5, 6, 10]},
+        ],
+    },
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -738,6 +829,13 @@ def _row_content_profile_key(state: SevenState) -> str:
         f"same_d={same_degrees}|opposite_u={len(opposite_labels)},"
         f"opposite_i={opposite_intersections},opposite_d={opposite_degrees}"
     )
+
+
+def _optional_row_content_profile_key(state: SevenState) -> str | None:
+    try:
+        return _row_content_profile_key(state)
+    except AssertionError:
+        return None
 
 
 def _status_split_key(counter: Counter[str]) -> str:
@@ -1044,6 +1142,85 @@ def _low_support_terminal_classification(
     }
 
 
+def _low_support_profile_terminality_audit(
+    clean_seven_states: set[SevenState],
+    terminal_audits: list[TerminalSevenAudit],
+) -> dict[str, Any]:
+    terminal_states = {state for state, _status in terminal_audits}
+    profile_counts: Counter[str] = Counter()
+    profile_terminal: Counter[str] = Counter()
+    profile_extendable: Counter[str] = Counter()
+    non_two_two_by_triple: Counter[str] = Counter()
+    non_two_two_terminal = 0
+    first_non_two_two_example: SevenState | None = None
+    extendable_examples: dict[str, SevenState] = {}
+
+    for state in sorted(clean_seven_states):
+        is_terminal = state in terminal_states
+        profile = _optional_row_content_profile_key(state)
+        if profile is None:
+            non_two_two_by_triple[
+                _center_tuple_key(tuple(record[0] for record in state))
+            ] += 1
+            non_two_two_terminal += int(is_terminal)
+            if first_non_two_two_example is None:
+                first_non_two_two_example = state
+            continue
+
+        profile_counts[profile] += 1
+        if is_terminal:
+            profile_terminal[profile] += 1
+        else:
+            profile_extendable[profile] += 1
+            extendable_examples.setdefault(profile, state)
+
+    terminal_profile_keys = {
+        _row_content_profile_key(state) for state, _status in terminal_audits
+    }
+    terminal_profiles_with_extendable = sorted(
+        profile
+        for profile in terminal_profile_keys
+        if profile_extendable[profile] > 0
+    )
+    non_two_two_total = sum(non_two_two_by_triple.values())
+
+    return {
+        "clean_seven_states": len(clean_seven_states),
+        "terminal_clean_seven_states": len(terminal_audits),
+        "non_two_two_clean_seven_states": non_two_two_total,
+        "non_two_two_terminal_clean_seven_states": non_two_two_terminal,
+        "two_two_clean_seven_states": len(clean_seven_states) - non_two_two_total,
+        "two_two_terminal_clean_seven_states": len(terminal_audits),
+        "two_two_profile_classes": len(profile_counts),
+        "terminal_profile_classes": len(terminal_profile_keys),
+        "terminal_profiles_with_extendable_states": len(
+            terminal_profiles_with_extendable
+        ),
+        "profile_only_terminality_holds": not terminal_profiles_with_extendable,
+        "non_two_two_by_center_triple": {
+            key: int(non_two_two_by_triple[key])
+            for key in sorted(non_two_two_by_triple)
+        },
+        "profile_counts": {
+            profile: {
+                "clean_two_two_seven_states": int(profile_counts[profile]),
+                "terminal": int(profile_terminal[profile]),
+                "extendable": int(profile_extendable[profile]),
+            }
+            for profile in sorted(profile_counts)
+        },
+        "first_non_two_two_example": (
+            [_record_payload(record) for record in first_non_two_two_example]
+            if first_non_two_two_example is not None
+            else None
+        ),
+        "terminal_profile_extendable_examples": {
+            profile: [_record_payload(record) for record in extendable_examples[profile]]
+            for profile in terminal_profiles_with_extendable
+        },
+    }
+
+
 def _orbit_count(states: set[RowRecord] | set[SixState]) -> tuple[int, Counter[int]]:
     seen: set[Any] = set()
     sizes: Counter[int] = Counter()
@@ -1210,6 +1387,12 @@ def survivor_payload() -> dict[str, Any]:
         "low_support_terminal_seven_state_classification": (
             _low_support_terminal_classification(low_support_terminal_audits)
         ),
+        "low_support_profile_terminality_audit": (
+            _low_support_profile_terminality_audit(
+                low_support_clean_seven_states,
+                low_support_terminal_audits,
+            )
+        ),
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
             for center, counter in sorted(by_fifth_center.items(), key=lambda item: int(item[0]))
@@ -1273,6 +1456,14 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(
             "unexpected low-support terminal classification: "
             f"{payload['low_support_terminal_seven_state_classification']!r}"
+        )
+    if (
+        payload["low_support_profile_terminality_audit"]
+        != EXPECTED_LOW_SUPPORT_PROFILE_TERMINALITY_AUDIT
+    ):
+        raise AssertionError(
+            "unexpected low-support profile terminality audit: "
+            f"{payload['low_support_profile_terminality_audit']!r}"
         )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -118,6 +118,40 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
             "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
         ),
     }
+    profile_audit = payload["low_support_profile_terminality_audit"]
+    assert profile_audit["profile_only_terminality_holds"] is False
+    assert profile_audit["clean_seven_states"] == 2252
+    assert profile_audit["non_two_two_clean_seven_states"] == 192
+    assert profile_audit["non_two_two_terminal_clean_seven_states"] == 0
+    assert profile_audit["two_two_clean_seven_states"] == 2060
+    assert profile_audit["two_two_profile_classes"] == 6
+    assert profile_audit["terminal_profile_classes"] == 2
+    assert profile_audit["terminal_profiles_with_extendable_states"] == 2
+    assert profile_audit["profile_counts"][
+        (
+            "same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        )
+    ] == {
+        "clean_two_two_seven_states": 320,
+        "terminal": 4,
+        "extendable": 316,
+    }
+    assert profile_audit["profile_counts"][
+        (
+            "same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        )
+    ] == {
+        "clean_two_two_seven_states": 1230,
+        "terminal": 8,
+        "extendable": 1222,
+    }
+    assert profile_audit["first_non_two_two_example"] == [
+        {"center": 2, "row": [0, 1, 3, 7]},
+        {"center": 4, "row": [0, 3, 6, 9]},
+        {"center": 5, "row": [0, 4, 8, 11]},
+    ]
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 648 tests the simplest lemma candidate suggested by the terminal-pocket classification: whether either terminal row-content profile alone forces eighth-row terminality in the low-support block-6 branch.

Result: the profile-only terminality lemma is false. Both terminal profiles also occur among extendable clean seven-row states.

The audit records:
- all 2,252 low-support clean seven-row states;
- 192 non-two-and-two states, all extendable;
- 2,060 two-and-two states across 6 profile classes;
- terminal-profile counts of 4/320 and 8/1230, with 316 and 1,222 extendable states respectively;
- explicit extendable examples for both terminal profiles.

No proof or counterexample is claimed.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`
- `tests/test_block6_fragile_sixth_row_survivors.py`
- `docs/block6-fragile-sixth-row-survivor-catalog.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `python3 scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`540 passed, 276 deselected`)

## Remaining limitations

This is an exact finite audit inside the low-support two-block block-6 natural-order selected-row extension tree. It does not establish Euclidean realizability, does not close the low-support branch, and does not prove or refute Erdos Problem #97.