### PR TITLE
[codex] Audit block6 terminal eighth-center splits

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -305,6 +305,54 @@ One clean extendable state outside the two-and-two profile domain is:
 5 -> {0,4,8,11}
 ```
 
+## Terminal Eighth-center Split Audit
+
+A finer terminal-pocket audit splits the legal eighth-row candidates by their
+eighth center before applying the vertex-circle status test. Across the `12`
+terminal clean seven-row states there are `132` legal eighth rows, all
+obstructed:
+
+```text
+eighth center  self-edge  strict-cycle
+1              7          20
+2              14         8
+4              12         3
+5              2          0
+7              7          20
+8              14         8
+10             12         3
+11             2          0
+```
+
+Thus no terminal pocket has a hidden clean eighth continuation after center
+splitting. The center-level obstruction profiles across the `12` terminal
+states are:
+
+```text
+self-only centers  strict-only centers  mixed centers  terminal states
+3                  1                    0              4
+1                  0                    4              2
+1                  1                    2              2
+1                  3                    1              2
+0                  3                    1              2
+```
+
+The first block-swap orbit representative has the split:
+
+```text
+2  -> {0,1,6,11}; 10 -> {0,4,6,9}; 11 -> {3,5,6,7}
+
+eighth center  self-edge  strict-cycle
+1              2          0
+4              2          0
+7              0          2
+8              3          0
+```
+
+The remaining orbit representatives are recorded by the checker output under
+`low_support_terminal_eighth_center_audit`. The split is equivariant under the
+block-swap map `i -> i+6 mod 12`.
+
 ## Center Counts
 
 ```text
@@ -346,7 +394,8 @@ every legal sixth row after each of them. It also computes the block-swap
 orbits for the clean fifth-row and clean six-row states. Finally, it audits
 every legal seventh row after the `56` low-support clean six-row states in the
 `4,5` and `10,11` minimum-support center-pair families, and every legal
-eighth row after the resulting `2252` clean seven-row states.
+eighth row after the resulting `2252` clean seven-row states, including the
+center-level split for the `12` terminal seven-row pockets.
 
 ## Effect
 
@@ -363,5 +412,7 @@ continue.
 
 The next useful step is to mine the `6047` clean six-row states for a smaller
 row-content normal-form family, or to classify the `12` terminal seven-row
-states and compare their row-content signatures with the `2240` seven-row
-states that still extend cleanly.
+states by a boundary-pair invariant that distinguishes them from the `2240`
+seven-row states that still extend cleanly. The eighth-center split rules out
+the coarsest possible terminal explanation: terminality is not concentrated at
+one eighth center or one obstruction type.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,165 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 649 - Block-6 Terminal Eighth-center Split Audit
+
+### Mathematical Subquestion
+
+Cycle 648 showed that the two terminal row-content profiles do not force
+eighth-row terminality. The next precise question was:
+
+```text
+For each terminal clean seven-row pocket, how do the remaining legal eighth
+rows split by eighth center and by vertex-circle obstruction type?
+```
+
+### Definitions and Assumptions
+
+The fixed block-6 fragile rows and the low-support clean seven-row terminal
+pockets are as in Cycles 646-648. A legal eighth row is any row returned by
+the existing incidence/order `_valid_options` filter for an unassigned center
+after a terminal clean seven-row state has been fixed.
+
+The vertex-circle status labels are the checker statuses:
+
+```text
+ok           no partial vertex-circle quotient obstruction found
+self_edge    selected-distance quotient plus order constraints force x < x
+strict_cycle selected-distance quotient plus order constraints force a strict
+             directed cycle
+```
+
+For a terminal state, an eighth center is **self-only** if all its legal rows
+are killed by self-edge, **strict-only** if all are killed by strict-cycle, and
+**mixed** if both obstruction types occur among legal rows for that center.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 Terminal Eighth-center Split Audit**.
+
+### Argument Or Obstruction
+
+The checker now recomputes the legal eighth-row candidates for the `12`
+terminal clean seven-row states, splits them by eighth center, and verifies
+that the center split sums back to the terminal status counts from Cycle 647.
+It also verifies block-swap equivariance under `i -> i+6 mod 12`.
+
+Across all `12` terminal states there are `132` legal eighth-row candidates;
+none has status `ok`. The aggregate eighth-center split is:
+
+```text
+eighth center  self-edge  strict-cycle
+1              7          20
+2              14         8
+4              12         3
+5              2          0
+7              7          20
+8              14         8
+10             12         3
+11             2          0
+```
+
+Thus the aggregate terminal split is `70` self-edge obstructions and `62`
+strict-cycle obstructions. The terminal states fall into five exact
+center-obstruction profiles:
+
+```text
+self-only centers  strict-only centers  mixed centers  terminal states
+3                  1                    0              4
+1                  0                    4              2
+1                  1                    2              2
+1                  3                    1              2
+0                  3                    1              2
+```
+
+One representative terminal pocket has:
+
+```text
+2  -> {0,1,6,11}
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+
+eighth center  self-edge  strict-cycle
+1              2          0
+4              2          0
+7              0          2
+8              3          0
+```
+
+The other five block-swap orbit representatives are recorded in the checker
+payload under `low_support_terminal_eighth_center_audit`.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers only the `12` terminal
+clean seven-row states found in Cycle 646. It is not a Euclidean
+realizability result, is not a proof of Erdos Problem #97, and is not a
+counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+The audit rules out another coarse explanation of terminality. Terminality is
+not concentrated at one eighth center, nor at one obstruction type: both
+self-edge and strict-cycle mechanisms are essential, and the mix varies across
+terminal pockets. A proof-mining lemma probably needs the exact boundary-pair
+placement inside a terminal pocket, not just the row-content profile or the
+remaining center set.
+
+### Next Lead
+
+Compare each terminal pocket against nearby extendable states with the same
+row-content profile and the same candidate eighth centers, then isolate the
+smallest boundary-pair move that changes one center from obstructed to
+extendable.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-649`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-649`.
+- The branch was based on `origin/main` at commit
+  `f0820afd8f8fb0c734fc7fed869766fe9c228eab`, after PR #366 merged Cycle
+  648.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `12` terminal clean seven-row states, `6`
+  block-swap orbits, and aggregate eighth-center obstruction totals `70`
+  self-edge plus `62` strict-cycle.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 648 - Block-6 Profile-only Terminality Failure
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -604,6 +604,27 @@ EXPECTED_LOW_SUPPORT_PROFILE_TERMINALITY_AUDIT = {
         ],
     },
 }
+EXPECTED_LOW_SUPPORT_TERMINAL_EIGHTH_CENTER_AUDIT = {
+    "terminal_clean_seven_states": 12,
+    "block_swap_orbits": 6,
+    "aggregate_by_eighth_center": {
+        "1": {"ok": 0, "self_edge": 7, "strict_cycle": 20},
+        "2": {"ok": 0, "self_edge": 14, "strict_cycle": 8},
+        "4": {"ok": 0, "self_edge": 12, "strict_cycle": 3},
+        "5": {"ok": 0, "self_edge": 2, "strict_cycle": 0},
+        "7": {"ok": 0, "self_edge": 7, "strict_cycle": 20},
+        "8": {"ok": 0, "self_edge": 14, "strict_cycle": 8},
+        "10": {"ok": 0, "self_edge": 12, "strict_cycle": 3},
+        "11": {"ok": 0, "self_edge": 2, "strict_cycle": 0},
+    },
+    "center_obstruction_profile_counts": {
+        "self_only_centers=0;strict_only_centers=3;mixed_centers=1": 2,
+        "self_only_centers=1;strict_only_centers=0;mixed_centers=4": 2,
+        "self_only_centers=1;strict_only_centers=1;mixed_centers=2": 2,
+        "self_only_centers=1;strict_only_centers=3;mixed_centers=1": 2,
+        "self_only_centers=3;strict_only_centers=1;mixed_centers=0": 4,
+    },
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -1142,6 +1163,170 @@ def _low_support_terminal_classification(
     }
 
 
+def _terminal_state_eighth_center_counts(
+    state: SevenState,
+    options: Mapping[int, list[tuple[int, ...]]],
+) -> dict[str, dict[str, int]]:
+    assigned, pair_counts, indegrees = _initial_state_with_records(state)
+    by_eighth_center: dict[str, dict[str, int]] = {}
+    for eighth_center in range(N):
+        if eighth_center in assigned:
+            continue
+        center_status: Counter[str] = Counter()
+        for eighth_row in _valid_options(
+            eighth_center,
+            options,
+            assigned,
+            pair_counts,
+            indegrees,
+        ):
+            _add_row(
+                assigned,
+                pair_counts,
+                indegrees,
+                eighth_center,
+                eighth_row,
+            )
+            eighth_status, _edge_count = _partial_vertex_circle_status(assigned)
+            _remove_row(
+                assigned,
+                pair_counts,
+                indegrees,
+                eighth_center,
+                eighth_row,
+            )
+            center_status[eighth_status] += 1
+        if center_status:
+            by_eighth_center[str(eighth_center)] = _status_counts(center_status)
+    return by_eighth_center
+
+
+def _center_obstruction_profile_key(
+    by_eighth_center: Mapping[str, Mapping[str, int]],
+) -> str:
+    self_only = 0
+    strict_only = 0
+    mixed = 0
+    for status_counts in by_eighth_center.values():
+        has_self_edge = status_counts["self_edge"] > 0
+        has_strict_cycle = status_counts["strict_cycle"] > 0
+        if has_self_edge and has_strict_cycle:
+            mixed += 1
+        elif has_self_edge:
+            self_only += 1
+        elif has_strict_cycle:
+            strict_only += 1
+        else:
+            raise AssertionError(
+                f"terminal eighth center has no obstruction: {status_counts!r}"
+            )
+    return (
+        f"self_only_centers={self_only};"
+        f"strict_only_centers={strict_only};mixed_centers={mixed}"
+    )
+
+
+def _block_swap_eighth_center_counts(
+    by_eighth_center: Mapping[str, Mapping[str, int]],
+) -> dict[str, dict[str, int]]:
+    return {
+        str(_swap_label(int(center))): dict(status_counts)
+        for center, status_counts in by_eighth_center.items()
+    }
+
+
+def _low_support_terminal_eighth_center_audit(
+    terminal_audits: list[TerminalSevenAudit],
+) -> dict[str, Any]:
+    options = _options()
+    center_counts_by_state = {
+        state: _terminal_state_eighth_center_counts(state, options)
+        for state, _status in terminal_audits
+    }
+    status_by_state = {state: status for state, status in terminal_audits}
+    aggregate_by_center: dict[str, Counter[str]] = {}
+    center_profiles: Counter[str] = Counter()
+    seen: set[SevenState] = set()
+    orbit_representatives: list[dict[str, Any]] = []
+
+    for state, status in sorted(terminal_audits):
+        by_eighth_center = center_counts_by_state[state]
+        status_total = Counter()
+        for center, center_status in by_eighth_center.items():
+            aggregate = aggregate_by_center.setdefault(center, Counter())
+            for status_name in STATUSES:
+                count = center_status[status_name]
+                aggregate[status_name] += count
+                status_total[status_name] += count
+        if status_total != status:
+            raise AssertionError(
+                "terminal center split does not match terminal status: "
+                f"{state!r}"
+            )
+        if status_total["ok"] != 0:
+            raise AssertionError(f"terminal state has a clean eighth row: {state!r}")
+        center_profiles[_center_obstruction_profile_key(by_eighth_center)] += 1
+
+        if state in seen:
+            continue
+        orbit = sorted({state, _block_swap_seven_state(state)})
+        seen.update(orbit)
+        representative = orbit[0]
+        block_swap_member = orbit[1]
+        representative_counts = center_counts_by_state[representative]
+        block_swap_counts = center_counts_by_state[block_swap_member]
+        if (
+            _block_swap_eighth_center_counts(representative_counts)
+            != block_swap_counts
+        ):
+            raise AssertionError("terminal center split is not block-swap equivariant")
+        if status_by_state[representative] != status_by_state[block_swap_member]:
+            raise AssertionError("terminal block-swap orbit changed status split")
+        orbit_representatives.append(
+            {
+                "representative": [
+                    _record_payload(record) for record in representative
+                ],
+                "block_swap_member": [
+                    _record_payload(record) for record in block_swap_member
+                ],
+                "representative_by_eighth_center": {
+                    center: representative_counts[center]
+                    for center in sorted(
+                        representative_counts,
+                        key=lambda value: int(value),
+                    )
+                },
+                "block_swap_by_eighth_center": {
+                    center: block_swap_counts[center]
+                    for center in sorted(
+                        block_swap_counts,
+                        key=lambda value: int(value),
+                    )
+                },
+                "center_obstruction_profile": _center_obstruction_profile_key(
+                    representative_counts
+                ),
+            }
+        )
+
+    return {
+        "terminal_clean_seven_states": len(terminal_audits),
+        "block_swap_orbits": len(orbit_representatives),
+        "aggregate_by_eighth_center": {
+            center: _status_counts(counter)
+            for center, counter in sorted(
+                aggregate_by_center.items(),
+                key=lambda item: int(item[0]),
+            )
+        },
+        "center_obstruction_profile_counts": {
+            key: int(center_profiles[key]) for key in sorted(center_profiles)
+        },
+        "block_swap_orbit_representatives": orbit_representatives,
+    }
+
+
 def _low_support_profile_terminality_audit(
     clean_seven_states: set[SevenState],
     terminal_audits: list[TerminalSevenAudit],
@@ -1387,6 +1572,11 @@ def survivor_payload() -> dict[str, Any]:
         "low_support_terminal_seven_state_classification": (
             _low_support_terminal_classification(low_support_terminal_audits)
         ),
+        "low_support_terminal_eighth_center_audit": (
+            _low_support_terminal_eighth_center_audit(
+                low_support_terminal_audits
+            )
+        ),
         "low_support_profile_terminality_audit": (
             _low_support_profile_terminality_audit(
                 low_support_clean_seven_states,
@@ -1465,6 +1655,13 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
             "unexpected low-support profile terminality audit: "
             f"{payload['low_support_profile_terminality_audit']!r}"
         )
+    terminal_center_audit = payload["low_support_terminal_eighth_center_audit"]
+    for key, expected in EXPECTED_LOW_SUPPORT_TERMINAL_EIGHTH_CENTER_AUDIT.items():
+        if terminal_center_audit[key] != expected:
+            raise AssertionError(
+                f"unexpected low-support terminal eighth-center {key}: "
+                f"{terminal_center_audit[key]!r}"
+            )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(
             f"unexpected by-fifth-center counts: {payload['by_fifth_center']!r}"

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -152,6 +152,34 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         {"center": 4, "row": [0, 3, 6, 9]},
         {"center": 5, "row": [0, 4, 8, 11]},
     ]
+    terminal_center_audit = payload["low_support_terminal_eighth_center_audit"]
+    assert terminal_center_audit["terminal_clean_seven_states"] == 12
+    assert terminal_center_audit["block_swap_orbits"] == 6
+    assert terminal_center_audit["aggregate_by_eighth_center"] == {
+        "1": {"ok": 0, "self_edge": 7, "strict_cycle": 20},
+        "2": {"ok": 0, "self_edge": 14, "strict_cycle": 8},
+        "4": {"ok": 0, "self_edge": 12, "strict_cycle": 3},
+        "5": {"ok": 0, "self_edge": 2, "strict_cycle": 0},
+        "7": {"ok": 0, "self_edge": 7, "strict_cycle": 20},
+        "8": {"ok": 0, "self_edge": 14, "strict_cycle": 8},
+        "10": {"ok": 0, "self_edge": 12, "strict_cycle": 3},
+        "11": {"ok": 0, "self_edge": 2, "strict_cycle": 0},
+    }
+    assert terminal_center_audit["center_obstruction_profile_counts"] == {
+        "self_only_centers=0;strict_only_centers=3;mixed_centers=1": 2,
+        "self_only_centers=1;strict_only_centers=0;mixed_centers=4": 2,
+        "self_only_centers=1;strict_only_centers=1;mixed_centers=2": 2,
+        "self_only_centers=1;strict_only_centers=3;mixed_centers=1": 2,
+        "self_only_centers=3;strict_only_centers=1;mixed_centers=0": 4,
+    }
+    assert terminal_center_audit["block_swap_orbit_representatives"][0][
+        "representative_by_eighth_center"
+    ] == {
+        "1": {"ok": 0, "self_edge": 2, "strict_cycle": 0},
+        "4": {"ok": 0, "self_edge": 2, "strict_cycle": 0},
+        "7": {"ok": 0, "self_edge": 0, "strict_cycle": 2},
+        "8": {"ok": 0, "self_edge": 3, "strict_cycle": 0},
+    }
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 649 adds a checker-backed terminal eighth-center split audit for the low-support block-6 terminal pockets. It recomputes, for the 12 terminal clean seven-row states, each remaining legal eighth-row candidate by eighth center and vertex-circle obstruction type.

## What changed

- Added `low_support_terminal_eighth_center_audit` to `scripts/check_block6_fragile_sixth_row_survivors.py`.
- Recorded aggregate center counts: 132 legal eighth-row candidates, 0 clean, 70 self-edge, and 62 strict-cycle.
- Added block-swap orbit representative center splits and center-obstruction profile counts.
- Updated the block-6 catalog doc and Cycle 649 research log.
- Extended focused regression tests for the new audit payload.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`540 passed, 276 deselected`)

## Review notes

Self-review found no blocking issues. The new audit asserts that the per-center totals match the prior terminal status counters and that the center split is block-swap equivariant.

## Remaining limitations

This is an exact finite audit inside the bounded block-6 low-support natural-order branch. It is not a Euclidean realizability result, not a proof of Erdos Problem #97, and not a counterexample. The global proof/counterexample objective remains open.