### PR TITLE
[codex] Audit block6 triple-profile terminality

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -353,6 +353,29 @@ The remaining orbit representatives are recorded by the checker output under
 `low_support_terminal_eighth_center_audit`. The split is equivariant under the
 block-swap map `i -> i+6 mod 12`.
 
+## Triple-plus-profile Terminality Audit
+
+Adding the seven-center triple to the row-content profile is still not enough
+to force terminality. Among the `2060` two-and-two clean seven-row states,
+there are `26` combined `(seven-center triple, row-content profile)` classes.
+The `12` terminal states occupy `6` of those classes, and every one of those
+`6` classes also contains extendable states:
+
+```text
+seven centers  terminal  extendable
+2,4,5          2         118
+2,10,11        1         293
+4,5,8          1         293
+4,5,11         3         152
+5,10,11        3         152
+8,10,11        2         118
+```
+
+Thus terminality is not determined by the seven-center triple together with
+the same/opposite-block row-content profile. The checker records one terminal
+and one extendable example in each terminal-containing combined class under
+`low_support_triple_profile_terminality_audit`.
+
 ## Center Counts
 
 ```text
@@ -395,7 +418,8 @@ orbits for the clean fifth-row and clean six-row states. Finally, it audits
 every legal seventh row after the `56` low-support clean six-row states in the
 `4,5` and `10,11` minimum-support center-pair families, and every legal
 eighth row after the resulting `2252` clean seven-row states, including the
-center-level split for the `12` terminal seven-row pockets.
+center-level split for the `12` terminal seven-row pockets and the
+triple-plus-profile terminality audit.
 
 ## Effect
 
@@ -415,4 +439,6 @@ row-content normal-form family, or to classify the `12` terminal seven-row
 states by a boundary-pair invariant that distinguishes them from the `2240`
 seven-row states that still extend cleanly. The eighth-center split rules out
 the coarsest possible terminal explanation: terminality is not concentrated at
-one eighth center or one obstruction type.
+one eighth center or one obstruction type. The triple-plus-profile audit also
+shows that terminality is not determined by adding the seven-center triple to
+the row-content profile.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,152 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 650 - Block-6 Triple-plus-profile Terminality Failure
+
+### Mathematical Subquestion
+
+Cycle 649 showed that terminal pockets have varied eighth-center obstruction
+splits. The next precise question was:
+
+```text
+Does the seven-center triple together with the same/opposite-block
+row-content profile determine eighth-row terminality?
+```
+
+### Definitions and Assumptions
+
+Use the low-support clean seven-row states from Cycles 646-649. A state is in
+the two-and-two profile domain when each of its three added rows has exactly
+two witnesses in the same six-label block as its center and two witnesses in
+the opposite block.
+
+The combined invariant is the pair:
+
+```text
+(sorted seven-center triple, same/opposite-block row-content profile).
+```
+
+Here the row-content profile is the union-size, pairwise-intersection, and
+degree-multiset profile from Cycle 648.
+
+### Result Status
+
+Failed lemma:
+**Triple-plus-profile Terminality Failure**.
+
+### Argument Or Obstruction
+
+The checker now groups all `2060` two-and-two clean seven-row states by the
+combined invariant above. These states form `26` combined classes. The `12`
+terminal states occupy `6` combined classes, and every one of those `6`
+classes also contains extendable clean seven-row states:
+
+```text
+seven centers  terminal  extendable
+2,4,5          2         118
+2,10,11        1         293
+4,5,8          1         293
+4,5,11         3         152
+5,10,11        3         152
+8,10,11        2         118
+```
+
+For example, the combined class with seven-center triple `2,4,5` and profile
+
+```text
+same_u=4,same_i=0,1,1,same_d=1,1,2,2|
+opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2
+```
+
+contains the terminal state:
+
+```text
+2 -> {1,5,6,7}
+4 -> {0,3,6,10}
+5 -> {0,1,8,11}
+```
+
+and the extendable state:
+
+```text
+2 -> {1,3,6,7}
+4 -> {0,3,6,9}
+5 -> {0,4,8,11}
+```
+
+Thus adding the seven-center triple to the row-content profile still does not
+produce a terminality criterion.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers all `2252` clean
+seven-row states in that branch and all `2060` states in the two-and-two
+profile domain. It is not a Euclidean realizability result, is not a proof of
+Erdos Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This blocks another plausible proof-mining route. Terminality is not captured
+by the center triple plus coarse row-content statistics; the distinguishing
+data must include exact witness labels or boundary-pair placement. The
+positive value is that terminal pockets remain localized: only `6` combined
+classes contain terminal states, so comparing terminal and extendable examples
+inside those classes is now the next exact target.
+
+### Next Lead
+
+Within each of the `6` terminal-containing combined classes, compute a minimal
+row-label edit distance from each terminal state to an extendable state in the
+same class, then inspect whether the changed witnesses align with the
+eighth-center obstruction split from Cycle 649.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-650`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-650`.
+- The branch was based on `origin/main` at commit
+  `01dd15fc0b88959c5d30bb4126e815ed17666c42`, after PR #368 merged Cycle
+  649.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `26` two-and-two triple/profile classes, `6`
+  terminal triple/profile classes, and `6` terminal triple/profile classes
+  with extendable states.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 649 - Block-6 Terminal Eighth-center Split Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -625,6 +625,68 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EIGHTH_CENTER_AUDIT = {
         "self_only_centers=3;strict_only_centers=1;mixed_centers=0": 4,
     },
 }
+EXPECTED_LOW_SUPPORT_TRIPLE_PROFILE_TERMINALITY_AUDIT = {
+    "clean_seven_states": 2252,
+    "terminal_clean_seven_states": 12,
+    "non_two_two_clean_seven_states": 192,
+    "non_two_two_terminal_clean_seven_states": 0,
+    "two_two_clean_seven_states": 2060,
+    "two_two_terminal_clean_seven_states": 12,
+    "two_two_triple_profile_classes": 26,
+    "terminal_triple_profile_classes": 6,
+    "terminal_triple_profiles_with_extendable_states": 6,
+    "triple_profile_only_terminality_holds": False,
+    "terminal_triple_profile_counts": {
+        (
+            "2,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "clean_two_two_seven_states": 294,
+            "terminal": 1,
+            "extendable": 293,
+        },
+        (
+            "2,4,5|same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "clean_two_two_seven_states": 120,
+            "terminal": 2,
+            "extendable": 118,
+        },
+        (
+            "4,5,8|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "clean_two_two_seven_states": 294,
+            "terminal": 1,
+            "extendable": 293,
+        },
+        (
+            "4,5,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "clean_two_two_seven_states": 155,
+            "terminal": 3,
+            "extendable": 152,
+        },
+        (
+            "5,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "clean_two_two_seven_states": 155,
+            "terminal": 3,
+            "extendable": 152,
+        },
+        (
+            "8,10,11|same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "clean_two_two_seven_states": 120,
+            "terminal": 2,
+            "extendable": 118,
+        },
+    },
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -1406,6 +1468,83 @@ def _low_support_profile_terminality_audit(
     }
 
 
+def _triple_profile_key(state: SevenState, profile: str) -> str:
+    return f"{_center_tuple_key(tuple(record[0] for record in state))}|{profile}"
+
+
+def _low_support_triple_profile_terminality_audit(
+    clean_seven_states: set[SevenState],
+    terminal_audits: list[TerminalSevenAudit],
+) -> dict[str, Any]:
+    terminal_states = {state for state, _status in terminal_audits}
+    triple_profile_counts: Counter[str] = Counter()
+    triple_profile_terminal: Counter[str] = Counter()
+    triple_profile_extendable: Counter[str] = Counter()
+    non_two_two_by_triple: Counter[str] = Counter()
+    non_two_two_terminal = 0
+    first_terminal_examples: dict[str, SevenState] = {}
+    first_extendable_examples: dict[str, SevenState] = {}
+
+    for state in sorted(clean_seven_states):
+        is_terminal = state in terminal_states
+        profile = _optional_row_content_profile_key(state)
+        if profile is None:
+            non_two_two_by_triple[
+                _center_tuple_key(tuple(record[0] for record in state))
+            ] += 1
+            non_two_two_terminal += int(is_terminal)
+            continue
+
+        key = _triple_profile_key(state, profile)
+        triple_profile_counts[key] += 1
+        if is_terminal:
+            triple_profile_terminal[key] += 1
+            first_terminal_examples.setdefault(key, state)
+        else:
+            triple_profile_extendable[key] += 1
+            first_extendable_examples.setdefault(key, state)
+
+    terminal_keys = sorted(triple_profile_terminal)
+    terminal_keys_with_extendable = [
+        key for key in terminal_keys if triple_profile_extendable[key] > 0
+    ]
+    non_two_two_total = sum(non_two_two_by_triple.values())
+
+    return {
+        "clean_seven_states": len(clean_seven_states),
+        "terminal_clean_seven_states": len(terminal_audits),
+        "non_two_two_clean_seven_states": non_two_two_total,
+        "non_two_two_terminal_clean_seven_states": non_two_two_terminal,
+        "two_two_clean_seven_states": len(clean_seven_states) - non_two_two_total,
+        "two_two_terminal_clean_seven_states": len(terminal_audits),
+        "two_two_triple_profile_classes": len(triple_profile_counts),
+        "terminal_triple_profile_classes": len(terminal_keys),
+        "terminal_triple_profiles_with_extendable_states": len(
+            terminal_keys_with_extendable
+        ),
+        "triple_profile_only_terminality_holds": not terminal_keys_with_extendable,
+        "terminal_triple_profile_counts": {
+            key: {
+                "clean_two_two_seven_states": int(triple_profile_counts[key]),
+                "terminal": int(triple_profile_terminal[key]),
+                "extendable": int(triple_profile_extendable[key]),
+            }
+            for key in terminal_keys
+        },
+        "terminal_triple_profile_extendable_examples": {
+            key: {
+                "terminal": [
+                    _record_payload(record) for record in first_terminal_examples[key]
+                ],
+                "extendable": [
+                    _record_payload(record) for record in first_extendable_examples[key]
+                ],
+            }
+            for key in terminal_keys_with_extendable
+        },
+    }
+
+
 def _orbit_count(states: set[RowRecord] | set[SixState]) -> tuple[int, Counter[int]]:
     seen: set[Any] = set()
     sizes: Counter[int] = Counter()
@@ -1583,6 +1722,12 @@ def survivor_payload() -> dict[str, Any]:
                 low_support_terminal_audits,
             )
         ),
+        "low_support_triple_profile_terminality_audit": (
+            _low_support_triple_profile_terminality_audit(
+                low_support_clean_seven_states,
+                low_support_terminal_audits,
+            )
+        ),
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
             for center, counter in sorted(by_fifth_center.items(), key=lambda item: int(item[0]))
@@ -1661,6 +1806,14 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
             raise AssertionError(
                 f"unexpected low-support terminal eighth-center {key}: "
                 f"{terminal_center_audit[key]!r}"
+            )
+    triple_profile_audit = payload["low_support_triple_profile_terminality_audit"]
+    expected_triple_profile = EXPECTED_LOW_SUPPORT_TRIPLE_PROFILE_TERMINALITY_AUDIT
+    for key, expected in expected_triple_profile.items():
+        if triple_profile_audit[key] != expected:
+            raise AssertionError(
+                f"unexpected low-support triple/profile {key}: "
+                f"{triple_profile_audit[key]!r}"
             )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -180,6 +180,31 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "7": {"ok": 0, "self_edge": 0, "strict_cycle": 2},
         "8": {"ok": 0, "self_edge": 3, "strict_cycle": 0},
     }
+    triple_profile_audit = payload["low_support_triple_profile_terminality_audit"]
+    assert triple_profile_audit["triple_profile_only_terminality_holds"] is False
+    assert triple_profile_audit["two_two_triple_profile_classes"] == 26
+    assert triple_profile_audit["terminal_triple_profile_classes"] == 6
+    assert triple_profile_audit[
+        "terminal_triple_profiles_with_extendable_states"
+    ] == 6
+    terminal_triple_key = (
+        "2,4,5|same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+        "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+    )
+    assert triple_profile_audit["terminal_triple_profile_counts"][
+        terminal_triple_key
+    ] == {
+        "clean_two_two_seven_states": 120,
+        "terminal": 2,
+        "extendable": 118,
+    }
+    assert triple_profile_audit["terminal_triple_profile_extendable_examples"][
+        terminal_triple_key
+    ]["extendable"] == [
+        {"center": 2, "row": [1, 3, 6, 7]},
+        {"center": 4, "row": [0, 3, 6, 9]},
+        {"center": 5, "row": [0, 4, 8, 11]},
+    ]
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Mathematical scope

Cycle 650 tests the next coarse terminality invariant after the profile-only and eighth-center audits: whether the seven-center triple together with the same/opposite-block row-content profile determines eighth-row terminality.

## What changed

- Added `low_support_triple_profile_terminality_audit` to `scripts/check_block6_fragile_sixth_row_survivors.py`.
- Recorded that the 2060 two-and-two clean seven-row states form 26 combined `(seven-center triple, row-content profile)` classes.
- Recorded that the 12 terminal states occupy 6 combined classes, and all 6 also contain extendable states.
- Updated the block-6 catalog doc and Cycle 650 research log.
- Extended focused regression tests for the new audit payload.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`540 passed, 276 deselected`)

## Review notes

This PR is opened non-draft because the connector ready-for-review mutation currently fails on a GraphQL response-shape bug, and local `gh` auth is invalid. The branch has already passed the full local gate; I will still self-review and require hosted CI before merging.

## Remaining limitations

This is an exact finite audit inside the bounded block-6 low-support natural-order branch. It is not a Euclidean realizability result, not a proof of Erdos Problem #97, and not a counterexample. The global proof/counterexample objective remains open.