### PR TITLE
[codex] Audit block6 terminal edit distance

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -376,6 +376,67 @@ the same/opposite-block row-content profile. The checker records one terminal
 and one extendable example in each terminal-containing combined class under
 `low_support_triple_profile_terminality_audit`.
 
+## Terminal-to-extendable Edit-distance Audit
+
+Within each terminal-containing triple/profile class, terminality is fragile:
+every terminal state is one witness replacement away from an extendable state
+in the same class.
+
+The row replacement distance between two clean seven-row states with the same
+centers is
+
+```text
+sum over added centers c of |row_T(c) triangle row_E(c)| / 2.
+```
+
+The exact minimum replacement distribution for the `12` terminal states is:
+
+```text
+minimum replacements  terminal states
+1                     12
+```
+
+For the nearest extendable states chosen by the checker, the changed-row count
+is also concentrated:
+
+```text
+changed rows in nearest example  terminal states
+1                                12
+```
+
+The number of nearest extendable states varies:
+
+```text
+nearest extendable states  terminal states
+1                          2
+3                          2
+5                          2
+6                          4
+7                          2
+```
+
+For example, the terminal state
+
+```text
+2  -> {0,1,6,11}
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+```
+
+has a nearest extendable state obtained by replacing witness `11` with `10`
+in the row centered at `2`:
+
+```text
+2  -> {0,1,6,10}
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+```
+
+Thus no terminality lemma can be stable under even one witness replacement
+inside the same combined triple/profile class. The next useful invariant must
+see the exact boundary-pair placement that distinguishes those adjacent
+states.
+
 ## Center Counts
 
 ```text
@@ -419,7 +480,8 @@ every legal seventh row after the `56` low-support clean six-row states in the
 `4,5` and `10,11` minimum-support center-pair families, and every legal
 eighth row after the resulting `2252` clean seven-row states, including the
 center-level split for the `12` terminal seven-row pockets and the
-triple-plus-profile terminality audit.
+triple-plus-profile terminality and terminal-to-extendable edit-distance
+audits.
 
 ## Effect
 
@@ -441,4 +503,6 @@ seven-row states that still extend cleanly. The eighth-center split rules out
 the coarsest possible terminal explanation: terminality is not concentrated at
 one eighth center or one obstruction type. The triple-plus-profile audit also
 shows that terminality is not determined by adding the seven-center triple to
-the row-content profile.
+the row-content profile. The edit-distance audit sharpens this failure:
+terminality can disappear after changing a single witness in one row while
+staying inside the same combined class.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,170 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 651 - Block-6 One-replacement Terminal Fragility
+
+### Mathematical Subquestion
+
+Cycle 650 showed that terminality is not determined by the seven-center triple
+plus the same/opposite-block row-content profile. The next precise question
+was:
+
+```text
+Within each terminal-containing triple/profile class, what is the minimum
+number of witness replacements needed to move a terminal state to an
+extendable state in the same class?
+```
+
+### Definitions and Assumptions
+
+Use the low-support clean seven-row states from Cycles 646-650. Two states are
+compared only when they have the same three added centers and lie in the same
+combined triple/profile class from Cycle 650.
+
+For two rows with the same center, define the row replacement distance as
+
+```text
+|row_T triangle row_E| / 2,
+```
+
+where `triangle` is symmetric difference. Since each row has four witnesses,
+this is the number of witnesses removed from the terminal row, equivalently
+the number added to reach the comparison row. The state replacement distance
+is the sum of this row distance over the three added centers.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 One-replacement Terminal Fragility Audit**.
+
+### Argument Or Obstruction
+
+The checker compares each of the `12` terminal clean seven-row states with all
+extendable clean seven-row states in the same combined triple/profile class.
+Every terminal state has minimum state replacement distance `1` from an
+extendable state:
+
+```text
+minimum replacements  terminal states
+1                     12
+```
+
+The number of nearest extendable states varies, but every first nearest
+example chosen by the checker changes exactly one row:
+
+```text
+nearest extendable states  terminal states
+1                          2
+3                          2
+5                          2
+6                          4
+7                          2
+
+changed rows in first nearest example  terminal states
+1                                      12
+```
+
+The class-level minimum distances are:
+
+```text
+seven centers  terminal  extendable  minimum distances
+2,4,5          2         118         1,1
+2,10,11        1         293         1
+4,5,8          1         293         1
+4,5,11         3         152         1,1,1
+5,10,11        3         152         1,1,1
+8,10,11        2         118         1,1
+```
+
+For example, the terminal state
+
+```text
+2  -> {0,1,6,11}
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+```
+
+has a nearest extendable state obtained by changing only the row centered at
+`2`, replacing witness `11` by witness `10`:
+
+```text
+2  -> {0,1,6,10}
+10 -> {0,4,6,9}
+11 -> {3,5,6,7}
+```
+
+Thus terminality is not stable under even one witness replacement inside a
+fixed combined triple/profile class.
+
+### Exact Scope
+
+This is an exact finite audit inside the same low-support two-block block-6
+natural-order selected-row extension tree as Cycles 646-650. It covers all
+`12` terminal clean seven-row states and all extendable states in their
+corresponding combined triple/profile classes. It is not a Euclidean
+realizability result, is not a proof of Erdos Problem #97, and is not a
+counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This rules out a stronger stability form of the Cycle 650 failed lemma:
+terminality can disappear after a single witness replacement while the
+seven-center triple and row-content profile remain fixed. Any proof-facing
+terminality invariant in this branch must see exact witness placement, likely
+the boundary-pair placement that controls the eighth-center obstruction split.
+
+### Next Lead
+
+Classify the single replacements by removed witness, added witness, changed
+center, and resulting eighth-center obstruction profile. The useful target is
+an exact local sign or boundary-pair invariant that separates the fragile
+terminal states from their one-step extendable neighbors.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-651`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-651`.
+- The branch was based on `origin/main` at commit
+  `f829b34766634be2ca41538a71463b1cac80de0b`, after PR #369 merged Cycle
+  650.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `12` terminal states with nearest same-class
+  extendable states, all at minimum replacement distance `1`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `540 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 650 - Block-6 Triple-plus-profile Terminality Failure
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -687,6 +687,70 @@ EXPECTED_LOW_SUPPORT_TRIPLE_PROFILE_TERMINALITY_AUDIT = {
         },
     },
 }
+EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
+    "terminal_clean_seven_states": 12,
+    "terminal_triple_profile_classes": 6,
+    "terminal_states_with_nearest_extendable": 12,
+    "min_replacement_distribution": {"1": 12},
+    "nearest_extendable_count_distribution": {
+        "1": 2,
+        "3": 2,
+        "5": 2,
+        "6": 4,
+        "7": 2,
+    },
+    "changed_row_count_distribution_for_first_nearest": {"1": 12},
+    "class_summary": {
+        (
+            "2,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "terminal_states": 1,
+            "extendable_states": 293,
+            "min_replacements_by_terminal": [1],
+        },
+        (
+            "2,4,5|same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "terminal_states": 2,
+            "extendable_states": 118,
+            "min_replacements_by_terminal": [1, 1],
+        },
+        (
+            "4,5,8|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "terminal_states": 1,
+            "extendable_states": 293,
+            "min_replacements_by_terminal": [1],
+        },
+        (
+            "4,5,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "terminal_states": 3,
+            "extendable_states": 152,
+            "min_replacements_by_terminal": [1, 1, 1],
+        },
+        (
+            "5,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
+            "opposite_u=6,opposite_i=0,0,0,opposite_d=1,1,1,1,1,1"
+        ): {
+            "terminal_states": 3,
+            "extendable_states": 152,
+            "min_replacements_by_terminal": [1, 1, 1],
+        },
+        (
+            "8,10,11|same_u=4,same_i=0,1,1,same_d=1,1,2,2|"
+            "opposite_u=5,opposite_i=0,0,1,opposite_d=1,1,1,1,2"
+        ): {
+            "terminal_states": 2,
+            "extendable_states": 118,
+            "min_replacements_by_terminal": [1, 1],
+        },
+    },
+}
 EXPECTED_BY_FIFTH_CENTER = {
     "1": {
         "clean_fifth": 21,
@@ -1545,6 +1609,117 @@ def _low_support_triple_profile_terminality_audit(
     }
 
 
+def _row_replacement_distance(left: tuple[int, ...], right: tuple[int, ...]) -> int:
+    return len(set(left) ^ set(right)) // 2
+
+
+def _state_replacement_distance(left: SevenState, right: SevenState) -> int:
+    right_by_center = {center: row for center, row in right}
+    return sum(
+        _row_replacement_distance(row, right_by_center[center])
+        for center, row in left
+    )
+
+
+def _changed_row_payload(left: SevenState, right: SevenState) -> list[dict[str, Any]]:
+    right_by_center = {center: row for center, row in right}
+    changed_rows = []
+    for center, row in left:
+        right_row = right_by_center[center]
+        removed = sorted(set(row) - set(right_row))
+        added = sorted(set(right_row) - set(row))
+        if removed or added:
+            changed_rows.append(
+                {
+                    "center": center,
+                    "removed": removed,
+                    "added": added,
+                    "row_replacements": len(removed),
+                }
+            )
+    return changed_rows
+
+
+def _low_support_terminal_edit_distance_audit(
+    clean_seven_states: set[SevenState],
+    terminal_audits: list[TerminalSevenAudit],
+) -> dict[str, Any]:
+    terminal_states = {state for state, _status in terminal_audits}
+    by_triple_profile: dict[str, dict[str, list[SevenState]]] = {}
+    for state in sorted(clean_seven_states):
+        profile = _optional_row_content_profile_key(state)
+        if profile is None:
+            continue
+        key = _triple_profile_key(state, profile)
+        entry = by_triple_profile.setdefault(
+            key,
+            {"terminal": [], "extendable": []},
+        )
+        if state in terminal_states:
+            entry["terminal"].append(state)
+        else:
+            entry["extendable"].append(state)
+
+    min_replacements: Counter[int] = Counter()
+    nearest_counts: Counter[int] = Counter()
+    changed_row_counts: Counter[int] = Counter()
+    class_summary: dict[str, dict[str, Any]] = {}
+    by_terminal: list[dict[str, Any]] = []
+
+    for key, entry in sorted(by_triple_profile.items()):
+        if not entry["terminal"]:
+            continue
+        if not entry["extendable"]:
+            raise AssertionError(f"terminal class has no extendable state: {key}")
+        class_distances = []
+        for terminal in entry["terminal"]:
+            distances = [
+                (_state_replacement_distance(terminal, extendable), extendable)
+                for extendable in entry["extendable"]
+            ]
+            best_distance = min(distance for distance, _state in distances)
+            nearest = [
+                state for distance, state in distances if distance == best_distance
+            ]
+            nearest_example = nearest[0]
+            changed_rows = _changed_row_payload(terminal, nearest_example)
+            min_replacements[best_distance] += 1
+            nearest_counts[len(nearest)] += 1
+            changed_row_counts[len(changed_rows)] += 1
+            class_distances.append(best_distance)
+            by_terminal.append(
+                {
+                    "triple_profile": key,
+                    "terminal": [_record_payload(record) for record in terminal],
+                    "min_replacements": best_distance,
+                    "nearest_extendable_count": len(nearest),
+                    "example_extendable": [
+                        _record_payload(record) for record in nearest_example
+                    ],
+                    "example_changed_rows": changed_rows,
+                }
+            )
+
+        class_summary[key] = {
+            "terminal_states": len(entry["terminal"]),
+            "extendable_states": len(entry["extendable"]),
+            "min_replacements_by_terminal": class_distances,
+        }
+
+    return {
+        "terminal_clean_seven_states": len(terminal_audits),
+        "terminal_triple_profile_classes": len(class_summary),
+        "terminal_states_with_nearest_extendable": len(by_terminal),
+        "min_replacement_distribution": _json_counter(min_replacements),
+        "nearest_extendable_count_distribution": _json_counter(nearest_counts),
+        "changed_row_count_distribution_for_first_nearest": _json_counter(
+            changed_row_counts
+        ),
+        "class_summary": class_summary,
+        "by_terminal": by_terminal,
+    }
+
+
 def _orbit_count(states: set[RowRecord] | set[SixState]) -> tuple[int, Counter[int]]:
     seen: set[Any] = set()
     sizes: Counter[int] = Counter()
@@ -1728,6 +1903,12 @@ def survivor_payload() -> dict[str, Any]:
                 low_support_terminal_audits,
             )
         ),
+        "low_support_terminal_edit_distance_audit": (
+            _low_support_terminal_edit_distance_audit(
+                low_support_clean_seven_states,
+                low_support_terminal_audits,
+            )
+        ),
         "by_fifth_center": {
             center: {key: int(counter[key]) for key in sorted(counter)}
             for center, counter in sorted(by_fifth_center.items(), key=lambda item: int(item[0]))
@@ -1814,6 +1995,13 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
             raise AssertionError(
                 f"unexpected low-support triple/profile {key}: "
                 f"{triple_profile_audit[key]!r}"
+            )
+    edit_distance_audit = payload["low_support_terminal_edit_distance_audit"]
+    for key, expected in EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT.items():
+        if edit_distance_audit[key] != expected:
+            raise AssertionError(
+                f"unexpected low-support terminal edit-distance {key}: "
+                f"{edit_distance_audit[key]!r}"
             )
     if payload["by_fifth_center"] != EXPECTED_BY_FIFTH_CENTER:
         raise AssertionError(

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -205,6 +205,35 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         {"center": 4, "row": [0, 3, 6, 9]},
         {"center": 5, "row": [0, 4, 8, 11]},
     ]
+    edit_distance_audit = payload["low_support_terminal_edit_distance_audit"]
+    assert edit_distance_audit["terminal_clean_seven_states"] == 12
+    assert edit_distance_audit["terminal_triple_profile_classes"] == 6
+    assert edit_distance_audit["terminal_states_with_nearest_extendable"] == 12
+    assert edit_distance_audit["min_replacement_distribution"] == {"1": 12}
+    assert edit_distance_audit["nearest_extendable_count_distribution"] == {
+        "1": 2,
+        "3": 2,
+        "5": 2,
+        "6": 4,
+        "7": 2,
+    }
+    assert edit_distance_audit["changed_row_count_distribution_for_first_nearest"] == {
+        "1": 12
+    }
+    assert edit_distance_audit["class_summary"][terminal_triple_key] == {
+        "terminal_states": 2,
+        "extendable_states": 118,
+        "min_replacements_by_terminal": [1, 1],
+    }
+    assert edit_distance_audit["by_terminal"][0]["min_replacements"] == 1
+    assert edit_distance_audit["by_terminal"][0]["example_changed_rows"] == [
+        {
+            "center": 2,
+            "removed": [11],
+            "added": [10],
+            "row_replacements": 1,
+        }
+    ]
     assert payload["first_clean_sixth_example"] == {
         "fifth": {"center": 1, "row": [0, 2, 6, 7]},
         "sixth": {"center": 2, "row": [0, 1, 3, 8]},


### PR DESCRIPTION
## Scope

Adds an exact finite audit for the low-support block-6 terminal pockets: within each terminal-containing triple/profile class, every terminal clean seven-row state is one witness replacement away from an extendable state in the same class.

Named result: **Block-6 One-replacement Terminal Fragility Audit**.

## Mathematical result

- Covers the 12 terminal clean seven-row states from the low-support block-6 branch.
- Compares each terminal state against extendable states in the same seven-center-triple plus row-content-profile class.
- Finds minimum replacement distribution `{"1": 12}`.
- Records nearest-extendable count distribution `{"1": 2, "3": 2, "5": 2, "6": 4, "7": 2}`.
- Records that the first nearest example for each terminal state changes exactly one row.

This is a local finite audit only. It is not a proof of Erdos Problem #97 and not a counterexample.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`
- `tests/test_block6_fragile_sixth_row_survivors.py`
- `docs/block6-fragile-sixth-row-survivor-catalog.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `540 passed, 276 deselected`

## Limitations

The audit rules out a coarse stability lemma for this branch: terminality can disappear after a single witness replacement while the seven-center triple and row-content profile stay fixed. It does not establish Euclidean realizability or nonrealizability beyond the existing finite selected-row audit scope.