### PR TITLE
[codex] Harden artifact provenance metadata checks

### DIFF
--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -7,6 +7,10 @@ path_convention: >
   New generated checked artifacts live under data/certificates/. The top-level
   certificates/ directory is legacy/path-stable space for early n=8 artifacts
   and manual templates retained at their historical paths.
+optional_integrity_fields: >
+  Artifact entries may include sha256 and size_bytes fields. When present,
+  scripts/check_artifact_provenance.py verifies them against the current file
+  bytes without rerunning the generator.
 
 artifacts:
   - id: n8_reconstructed_survivors

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Sequence
@@ -14,6 +16,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MANIFEST = REPO_ROOT / "metadata" / "generated_artifacts.yaml"
 SCHEMA = "erdos97.generated_artifacts.v1"
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 KNOWN_TRUST = {
     "EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
@@ -55,6 +58,14 @@ def load_manifest(path: Path) -> dict[str, Any]:
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def dotted_get(payload: Any, dotted_key: str) -> Any:
@@ -119,6 +130,7 @@ def validate_artifact(
             errors.append(f"{label}.path does not exist: {raw_path}")
             payload = None
         else:
+            errors.extend(validate_file_metadata(artifact, path, label))
             try:
                 payload = load_json(path)
             except json.JSONDecodeError as exc:
@@ -171,6 +183,31 @@ def validate_artifact(
 
     if payload is not None:
         errors.extend(validate_json_payload(artifact, payload, label))
+    return errors
+
+
+def validate_file_metadata(artifact: dict[str, Any], path: Path, label: str) -> list[str]:
+    """Validate optional byte-for-byte artifact metadata."""
+    errors: list[str] = []
+
+    expected_sha = artifact.get("sha256")
+    if expected_sha is not None:
+        if not isinstance(expected_sha, str) or not SHA256_RE.fullmatch(expected_sha):
+            errors.append(f"{label}.sha256 must be a 64-character hex string when present")
+        else:
+            actual_sha = sha256_file(path)
+            if actual_sha != expected_sha.lower():
+                errors.append(f"{label}.sha256 is {actual_sha!r}, expected {expected_sha!r}")
+
+    expected_size = artifact.get("size_bytes")
+    if expected_size is not None:
+        if not isinstance(expected_size, int) or isinstance(expected_size, bool) or expected_size < 0:
+            errors.append(f"{label}.size_bytes must be a nonnegative integer when present")
+        else:
+            actual_size = path.stat().st_size
+            if actual_size != expected_size:
+                errors.append(f"{label}.size_bytes is {actual_size!r}, expected {expected_size!r}")
+
     return errors
 
 

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from scripts.check_artifact_provenance import load_manifest, validate_manifest
+from scripts.check_artifact_provenance import load_manifest, sha256_file, validate_manifest
 
 
 def test_generated_artifact_manifest_is_valid() -> None:
@@ -137,3 +137,70 @@ def test_manifest_accepts_exact_certificate_diagnostic_trust(tmp_path: Path) -> 
     errors = validate_manifest(manifest)
 
     assert errors == []
+
+
+def test_manifest_accepts_matching_file_metadata(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    artifact.write_text(json.dumps({"status": "GOOD"}) + "\n", encoding="utf-8")
+    generator.write_text("print('ok')\n", encoding="utf-8")
+    manifest = {
+        "schema": "erdos97.generated_artifacts.v1",
+        "claim_scope": "test manifest only",
+        "artifacts": [
+            {
+                "id": "sample",
+                "path": str(artifact),
+                "kind": "test",
+                "generator": str(generator),
+                "command": f"python {generator}",
+                "direct_edit_allowed": False,
+                "provenance_mode": "manifest_only_legacy",
+                "trust": "EXACT_OBSTRUCTION",
+                "claim_scope": "test artifact only",
+                "json_top_level_type": "object",
+                "sha256": sha256_file(artifact),
+                "size_bytes": artifact.stat().st_size,
+                "expected_json": {"status": "GOOD"},
+                "forbidden_claims": ["general proof"],
+            }
+        ],
+    }
+
+    errors = validate_manifest(manifest)
+
+    assert errors == []
+
+
+def test_manifest_rejects_mismatched_file_metadata(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    artifact.write_text(json.dumps({"status": "GOOD"}) + "\n", encoding="utf-8")
+    generator.write_text("print('ok')\n", encoding="utf-8")
+    manifest = {
+        "schema": "erdos97.generated_artifacts.v1",
+        "claim_scope": "test manifest only",
+        "artifacts": [
+            {
+                "id": "sample",
+                "path": str(artifact),
+                "kind": "test",
+                "generator": str(generator),
+                "command": f"python {generator}",
+                "direct_edit_allowed": False,
+                "provenance_mode": "manifest_only_legacy",
+                "trust": "EXACT_OBSTRUCTION",
+                "claim_scope": "test artifact only",
+                "json_top_level_type": "object",
+                "sha256": "0" * 64,
+                "size_bytes": artifact.stat().st_size + 1,
+                "expected_json": {"status": "GOOD"},
+                "forbidden_claims": ["general proof"],
+            }
+        ],
+    }
+
+    errors = validate_manifest(manifest)
+
+    assert any(".sha256 is" in error for error in errors)
+    assert any(".size_bytes is" in error for error in errors)


### PR DESCRIPTION
## Summary

- Teach `scripts/check_artifact_provenance.py` to validate optional `sha256` and `size_bytes` fields on existing generated-artifact manifest entries.
- Document those optional integrity fields in `metadata/generated_artifacts.yaml` without adding a second manifest.
- Add tests for matching and mismatching byte-for-byte metadata.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check .`
- `python -m pytest -q` (`542 passed, 276 deselected`)
- GitHub Actions `tests` on PR #372: success for Python 3.10, 3.11, 3.12

## Notes

This does not rerun generators, regenerate certificates, or change mathematical claims. Existing manifest entries remain valid without the new optional fields; future entries can opt into byte-for-byte checks incrementally.