### PR TITLE
[codex] add research loop reports

### DIFF
--- a/reports/research_loops/affine_circuit_loop.md
+++ b/reports/research_loops/affine_circuit_loop.md
@@ -1,0 +1,203 @@
+# Affine-Circuit Rank-Rigidity Loop
+
+Status: `EXACT_CHECKER_DIAGNOSTIC` / bounded research-loop note.
+
+No general proof of Erdos Problem #97 is claimed. No counterexample is
+claimed. The checks below are exact diagnostics for fixed coordinates and fixed
+selected four-cohorts only. They do not prove rank rigidity, do not rule out
+all exotic syzygies, and do not alter the repo source-of-truth status.
+
+## Scope
+
+Task bridge: continue the affine-circuit/rank-rigidity program by turning
+possible quotient-kernel defects into small checker experiments for exotic
+syzygies and cofactor certificates.
+
+Exact object studied:
+
+- points `p_j = (x_j,y_j)` with lifted rows
+  `(1, x_j, y_j, x_j^2 + y_j^2)`;
+- signed affine-circuit matrix `L` from fixed selected four-cohorts;
+- quotient matrix `L_N` after choosing a nonsingular lifted base `B`;
+- singleton-peeled weighted two-core;
+- minimal-support cofactor certificates and pure pair-gain components.
+
+Inputs read first:
+
+- `AGENTS.md`
+- `README.md`, `STATE.md`, `RESULTS.md`, `metadata/erdos97.yaml`
+- `docs/claims.md`, `docs/review-priorities.md`, `docs/codex-backlog.md`
+- `docs/codex-strategy-instructions.md`
+- `docs/exactification-plan.md`
+- `docs/prompt-roadmap.md`
+- `docs/failed-ideas.md`
+- `incoming/prompt2-runs/audit.md`
+- `incoming/prompt2-runs/run-02.md`
+- `src/erdos97/affine_circuit_certificates.py`
+- `scripts/check_affine_circuit_certificates.py`
+- `tests/test_affine_circuit_certificates.py`
+
+Verifier commands run during this loop:
+
+```bash
+python scripts/check_affine_circuit_certificates.py --example single-circle-row --assert-expected --json
+python scripts/check_affine_circuit_certificates.py --example golden-decagon --assert-expected --json
+python -m pytest tests/test_affine_circuit_certificates.py -q
+```
+
+Focused results:
+
+- `single-circle-row`: `rank_z = 4`, `LZ = 0`, `kernel_dim_l = 5`,
+  `kernel_dim_quotient = 1`, singleton peeling removes quotient column `3`,
+  and the remaining isolated quotient column `5` yields the cofactor
+  certificate `support = [5]`, `cofactors = [1]`.
+- `golden-decagon`: `rank_z = 4`, `LZ = 0`, `kernel_dim_l = 6`,
+  `kernel_dim_quotient = 2`, no singleton peeling for the default base
+  `[0,1,2,3]`, three reported cofactor certificates, and one balanced
+  pair-gain component. This is a nonconvex negative-control example, not a
+  counterexample candidate.
+- Focused tests: `5 passed`.
+
+One exploratory base-sweep command was attempted and timed out:
+
+```bash
+@' ... golden_decagon valid-base sweep ... '@ | python -
+```
+
+It timed out after about 21 minutes. Before timeout it printed a useful
+diagnostic summary, but this is not a completed artifact:
+
+```text
+valid_bases 180
+kernel_dims {2: 180}
+core_size_counts {6: 60, 4: 120}
+peeled_counts {0: 60, 2: 120}
+cert_count_counts {3: 60, 2: 120}
+pair_component_counts {1: 60, 2: 120}
+```
+
+The working tree already contained unrelated edits before this report was
+written. They were not reverted or modified.
+
+## Cycle 1 - Existing Checker Baseline
+
+Propose:
+
+Use the existing fixed-coordinate checker as the first bounded continuation.
+The goal is not to prove rank rigidity, but to confirm that the implemented
+Prompt 2 reductions expose the three expected quotient-defect mechanisms:
+isolated quotient columns, pair-gain components, and cofactor circuits.
+
+Audit:
+
+The baseline examples do expose those mechanisms. The single-circle example is
+the clean isolated-column case. The golden-decagon negative control has an
+exotic quotient kernel of dimension `2` and reports nontrivial cofactor and
+pair-gain data. The checker also records `status:
+exact_checker_not_a_proof`, which is the right scope.
+
+The baseline is still too narrow for any proof-facing claim. Both examples are
+fixed coordinate systems, and the golden-decagon example is explicitly
+nonconvex. The output says that defects can be represented exactly in this
+framework; it does not say such defects exist or fail for strictly convex
+counterexample candidates.
+
+Refine:
+
+Treat the golden-decagon example as a regression benchmark for exotic syzygy
+classification, not as evidence about Erdos #97. The next useful checker
+experiment should focus on base dependence: quotient columns and individual
+minimal supports can vary with the lifted base even though
+`dim ker L_N = dim ker L - 4` is base-independent.
+
+## Cycle 2 - Base-Dependence Probe
+
+Propose:
+
+Run a small exact sweep over valid lifted bases for the golden-decagon negative
+control, recording only quotient dimension, two-core size, peel count,
+certificate count, and pair-component count. This tests whether the defect
+mechanism is stable enough to summarize in a future report or checker mode.
+
+Audit:
+
+The attempted sweep timed out, so it should not be cited as a verified
+artifact. The partial printed summary is still suggestive:
+
+- all printed valid bases had quotient kernel dimension `2`;
+- two-core sizes split between `6` and `4`;
+- bases with core size `4` appeared to peel two columns;
+- printed certificate counts split between `3` and `2`;
+- printed pair-component counts split between `1` and `2`.
+
+This matches the audit warning from `incoming/prompt2-runs/audit.md`: quotient
+dimension is base-independent for nonsingular lifted bases, while immediate
+certificates and isolated-column visibility can be base-dependent.
+
+Refine:
+
+Do not add a heavy all-base symbolic sweep as a default test. The next
+experiment should be bounded, cheap, and explicitly a diagnostic.
+
+## Cycle 3 - Concrete Next Experiment
+
+Recommended next checker experiment:
+
+Add a bounded "base-certificate profile" diagnostic for the existing
+`golden-decagon` negative control. The checker should enumerate valid lifted
+bases only under an explicit cap, for example `--max-bases`, and for each base
+record:
+
+- `base`;
+- `kernel_dim_quotient`;
+- `core_columns`;
+- `peeled_columns`;
+- number of minimal cofactor certificates found with
+  `max_support_size <= 2` or another documented small bound;
+- pure pair-gain component summaries.
+
+Acceptance standard for that experiment:
+
+- it verifies `kernel_dim_quotient = 2` for every visited valid base;
+- it records, but does not overinterpret, which bases expose pair-support
+  cofactor certificates or balanced pair-gain components;
+- it exits quickly under the cap and reports if the cap prevents full coverage;
+- it labels the result as a negative-control exact checker diagnostic.
+
+Why this is the right next experiment:
+
+The existing code already verifies the quotient reduction and minimal
+cofactor machinery on hand examples. The unresolved risk is explanatory:
+certificate visibility depends on base choice, and a future rank-rigidity
+workflow needs to distinguish invariant data from base-local witnesses. A
+bounded base-certificate profile directly tests that interface without
+claiming a general obstruction and without touching finite-case source-of-truth
+artifacts.
+
+What it would not prove:
+
+- It would not prove `ker L = U` for any general family.
+- It would not rule out exotic syzygies in strictly convex polygons.
+- It would not promote `n = 9`, `n = 10`, or any fixed sparse pattern.
+- It would not produce a counterexample.
+
+Trust label for this loop: `EXACT_CHECKER_DIAGNOSTIC`.
+
+## Commands Not Run
+
+The full fast tier was not run after writing this report because the checkpoint
+request asked to stop heavy/full-test work and finalize with the bounded-loop
+report. In particular, these were not run in this loop:
+
+```bash
+python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
+python scripts/check_artifact_provenance.py
+git diff --check
+python -m ruff check .
+python -m pytest -q
+make verify-fast
+make verify-artifacts
+```
+
+No code change or finite-case/certificate artifact change was made.

--- a/reports/research_loops/fragile_geo_loop.md
+++ b/reports/research_loops/fragile_geo_loop.md
@@ -1,0 +1,250 @@
+# Fragile-cover geometric loop
+
+Status: `FAILED_ROUTE` / `NEXT_EXPERIMENT`. This is a bounded research-loop
+report, not a proof, not a counterexample, and not a source-of-truth status
+change. The official/global status remains falsifiable/open. The local
+`n <= 8` result remains repo-local and machine-checked with independent review
+recommended for public theorem-style claims.
+
+## Bridge target
+
+Target bridge: strengthen the minimal fragile-cover bridge with a genuinely
+geometric necessary condition. The current fragile hypergraph axioms and
+two-overlap crossing rule are necessary but too weak; the block-6 family is the
+standing negative control.
+
+I used the existing block-6 controls and diagnostics rather than adding code.
+No checker is implemented here because the refined condition below is necessary
+for geometry but does not yet reject all audited full extensions of the
+two-block control.
+
+## Control baseline
+
+Commands run:
+
+```bash
+python scripts/check_fragile_hypergraph.py --blocks 1 --json
+python scripts/check_fragile_hypergraph.py --blocks 1 --check-full-extension --json
+python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json
+python scripts/check_fragile_hypergraph.py --blocks 2 --check-full-extension --assert-full-extension --json
+```
+
+Observed baseline:
+
+- One block passes the fragile-cover hypergraph check.
+- One block fails the optional full selected-row extension check with
+  `failure_reason = no extension exists`.
+- Two blocks pass the fragile-cover hypergraph check.
+- Two blocks also pass the optional full selected-row extension check. The
+  first extension found has full rows
+
+```text
+0  -> {1,2,3,4}
+1  -> {3,6,9,11}
+2  -> {1,3,5,8}
+3  -> {0,2,4,5}
+4  -> {0,3,8,11}
+5  -> {0,1,6,7}
+6  -> {7,8,9,10}
+7  -> {0,4,6,9}
+8  -> {0,5,7,10}
+9  -> {6,8,10,11}
+10 -> {2,5,9,11}
+11 -> {1,5,6,10}
+```
+
+## Cycle 1: dependency-cycle condition
+
+Propose: forbid directed cycles in the fragile witness map `pi`, or at least
+forbid reciprocal fragile-center dependencies.
+
+Audit: the canonical block-6 witness map already has reciprocal dependencies
+inside each block:
+
+```text
+0 -> 3, 3 -> 0
+6 -> 9, 9 -> 6
+```
+
+Mental geometric check: a reciprocal pair only says each center belongs to the
+other center's critical 4-tie. This forces the two critical radii to share the
+same inter-center distance, but equality of two critical radii is not a
+contradiction. With a two-overlap, the source chord and common-witness chord can
+be mutual perpendicular bisectors, producing a rhombus-type local picture
+rather than an immediate impossibility.
+
+Refine: pure acyclicity of `pi` is not established as necessary. Do not
+implement it.
+
+## Cycle 2: critical-radius propagation
+
+Propose: apply the minimum-radius short-chord argument to the fragile rows.
+For a fragile center `i`, one consecutive pair among its four critical witnesses
+is shorter than the critical radius. If an endpoint of that pair is also a
+fragile center selecting the other endpoint, this gives a strict radius
+inequality between fragile critical radii.
+
+Audit against the two-block full extension used above:
+
+```text
+row/column pair caps: pass
+minimum-radius fixed-order filter: pass
+radius propagation: PASS_ACYCLIC_CHOICE
+certified minimum radius-propagation edge count: 5
+```
+
+The same run also found many fixed-selection stuck sets in this arbitrary full
+extension:
+
+```text
+minimal stuck size: 4
+total stuck sets at size 4: 449
+forward ear order exists: yes, seed {0,7,10}
+greedy reverse peeling terminal set: {3,5,7,8,9,11}
+```
+
+Interpretation: the radius signal is geometric and necessary in the usual fixed
+selected-row setting, but it still has acyclic short-gap choices on this
+control. The stuck-set data is useful stress information, not a necessary
+geometric obstruction, because the fixed-row ear-orderable bridge remains open.
+
+Refine: radius propagation alone does not reject the two-block control.
+
+## Cycle 3: row-circle Ptolemy quotient
+
+Propose: every full selected-row extension of a geometric fragile-cover system
+must satisfy row-circle constraints. For each selected row `i`, its four
+witnesses lie on a circle centered at `i`; in their cyclic/angular order they
+satisfy Ptolemy equality. Therefore the strict Ptolemy-log inequalities used in
+the existing fixed-pattern tooling are valid row-wise necessary inequalities.
+If a positive combination of these strict inequalities sums to zero after
+quotienting by selected-distance equalities, that full extension is exactly
+obstructed.
+
+This is genuinely geometric: it uses concyclicity of each selected witness
+quadruple, not just incidence.
+
+Audit 1, first two-block extension: using the existing Ptolemy-log row builder,
+the first extension found above has an exact zero Ptolemy-log row:
+
+```text
+row: 6
+witness order: 7,8,9,10
+positive pairs: {7,9}, {8,10}
+negative pairs: {7,8}, {9,10}
+```
+
+After selected-distance quotienting for that full extension, the row vector is
+identically zero. If the full extension were geometric in the supplied cyclic
+order, the strict inequality would read `0 > 0`, so that specific full
+extension is exactly killed.
+
+Audit 2, bounded extension enumeration: a quick bounded enumeration of full
+extensions found a survivor after three extensions examined. That survivor has
+no single zero Ptolemy-log row, and a nonnegative zero-sum LP over the
+Ptolemy-log rows was infeasible.
+
+The escaping full extension was:
+
+```text
+0  -> {1,2,3,4}
+1  -> {3,6,9,11}
+2  -> {1,3,5,10}
+3  -> {0,2,4,5}
+4  -> {0,3,8,11}
+5  -> {0,1,6,7}
+6  -> {7,8,9,10}
+7  -> {1,5,6,8}
+8  -> {0,5,7,9}
+9  -> {6,8,10,11}
+10 -> {2,5,9,11}
+11 -> {0,4,6,10}
+```
+
+I also ran the row-circle Ptolemy NLP diagnostic on the first full extension.
+It returned `ROW_CIRCLE_PTOLEMY_NLP_FAILED`, not an obstruction:
+
+```text
+distance classes: 31
+row Ptolemy equalities: 12
+max margin: -0.028147134441496933
+row Ptolemy max residual: 0.0006520414228680285
+optimizer message: Positive directional derivative for linesearch
+```
+
+This numerical failure is not proof of obstruction.
+
+Refine: the row-circle Ptolemy quotient condition is the best candidate from
+this loop, but a simple zero-row or positive-cone Ptolemy-log checker is not
+yet sufficient to reject the two-block fragile family. A checker should not be
+promoted until it searches all relevant full extensions, or until a stronger
+exact row-circle certificate is available for the extension family rather than
+one extension.
+
+## Blocker
+
+The key quantifier is the blocker:
+
+```text
+fragile rows from a minimal counterexample must admit at least one full
+selected-row extension satisfying all geometric row-circle constraints.
+```
+
+Killing one arbitrary extension is not enough. The current full-extension
+diagnostic is existential and returns the first abstract extension it finds.
+The row-circle Ptolemy zero-row obstruction kills that first extension, but the
+bounded enumeration already found another extension escaping the same simple
+certificate.
+
+## Next experiment
+
+The next productive experiment is an all-extension audit for the two-block
+control:
+
+1. Enumerate full selected-row extensions of the fixed two-block fragile rows
+   under the existing pair/crossing constraints, with explicit node and output
+   limits.
+2. For each extension, run exact row-circle Ptolemy-log tests:
+   single zero rows first, then nonnegative zero-sum cone feasibility after
+   selected-distance quotienting.
+3. Report one of three outcomes:
+   `ALL_EXTENSIONS_KILLED_BY_EXACT_ROW_CIRCLE_CERTIFICATE`,
+   `SURVIVOR_EXTENSION_FOUND`, or `UNKNOWN_LIMIT_REACHED`.
+4. Only if all extensions are killed with replayable exact certificates should
+   this become a tiny checker.
+
+Trust label for the present report: `FAILED_ROUTE` for dependency-cycle and
+fragile-only radius acyclicity as immediate filters; `NEXT_EXPERIMENT` for the
+row-circle all-extension audit.
+
+## Commands run beyond the baseline
+
+The following were run as inline Python diagnostics without writing artifacts:
+
+```bash
+python - <<'PY'
+# Imported block6_family/full_selected_extension, stuck-set diagnostics,
+# radius-choice optimization, and row_circle_ptolemy_nlp_diagnostic.
+# Summarized the first two-block full extension, stuck-set state,
+# radius propagation state, and row-circle NLP state.
+PY
+
+python - <<'PY'
+# Imported scripts/check_ptolemy_log_filter.py helpers.
+# Built Ptolemy-log rows for the first two-block full extension and found
+# one exact zero row.
+PY
+
+python - <<'PY'
+# Bounded full-extension enumeration for the two-block fragile rows.
+# Examined 3 full extensions, killed 2 by a zero Ptolemy-log row,
+# and found 1 survivor without a zero row.
+PY
+
+python - <<'PY'
+# Ran nonnegative zero-sum LP over the survivor extension's Ptolemy-log rows.
+# Result: infeasible for that simple Ptolemy-log cone test.
+PY
+```
+
+These diagnostics do not alter any repository theorem claim.

--- a/reports/research_loops/independent_audit_loop.md
+++ b/reports/research_loops/independent_audit_loop.md
@@ -266,4 +266,3 @@ replay row0 coverage and the 184 pre-vertex-circle obstruction classification,
 and review the geometric necessity of the vertex-circle self-edge/strict-cycle
 filter. It must keep the artifact review-pending unless a broader review
 decision explicitly promotes it.
-

--- a/reports/research_loops/independent_audit_loop.md
+++ b/reports/research_loops/independent_audit_loop.md
@@ -1,0 +1,269 @@
+# Independent audit target loop
+
+Date: 2026-05-10
+
+Status: planning guidance only; not mathematical evidence. This report does
+not change any repository claim. No general proof and no counterexample are
+claimed. The official/global status remains falsifiable/open. The `n <= 8`
+selected-witness result remains repo-local and machine-checked pending
+independent review. The `n=9` and `n=10` vertex-circle artifacts remain
+review-pending/draft as already recorded.
+
+## Inputs read
+
+- `AGENTS.md`
+- `README.md`
+- `STATE.md`
+- `RESULTS.md`
+- `docs/claims.md`
+- `docs/review-priorities.md`
+- `docs/reviewer-guide.md`
+- `docs/n8-exact-survivors.md`
+- `docs/n9-vertex-circle-exhaustive.md`
+- `docs/n10-vertex-circle-singleton-slices.md`
+- `docs/codex-backlog.md`
+- `metadata/erdos97.yaml`
+
+## Small live check
+
+Command run:
+
+```bash
+python scripts/independent_check_n8_artifacts.py --check --json
+```
+
+Result: passed in this workspace.
+
+Key reproduced fields:
+
+- `verified: true`
+- `overall_status: n8_artifacts_verified_repo_local_pending_external_review`
+- `survivor_json.record_count: 15`
+- `exact_obstruction_artifacts.certificates.class14_pb_ed_groebner_basis: true`
+- `exact_obstruction_artifacts.certificates.class14_solution_branches: true`
+- `exact_obstruction_artifacts.certificates.class14_strict_interior: true`
+
+This command is useful as a baseline, but it imports the current n=8 analyzer.
+It should not be mistaken for the independent standalone class-14 audit
+recommended below.
+
+## Cycle 1: propose, audit, refine
+
+Proposal: choose the review-pending `n=9` vertex-circle checker because it has
+the largest possible trust payoff: a successful independent audit could move a
+candidate finite-case extension closer to the repo-local `n <= 8` trust level.
+
+Audit of proposal: the `n=9` target has a broad audit surface. A reviewer must
+check the geometric necessity of each pruning rule, the row0 coverage, the
+minimum-remaining-options branch order, partial vertex-circle pruning, and the
+archive convention reconciliation. That is valuable, but it is too large for
+the next bounded input-data replay if the goal is to remove the most delicate
+current trust dependency first.
+
+Refinement: demote `n=9` to runner-up and first audit the narrowest high-risk
+dependency in the current source-of-truth local result: `n=8` class `14`.
+
+## Cycle 2: propose, audit, refine
+
+Proposal: choose `n=8` class `14` and verify the PB+ED Groebner basis plus the
+strict-interior branch conclusion as a standalone certificate replay.
+
+Audit of proposal: merely rerunning `scripts/analyze_n8_exact_survivors.py`
+would reuse the same code path that produced the current acceptance. The
+valuable audit must treat checked-in JSON as input data, reconstruct the
+polynomial system independently from the class-14 incidence rows, and fail
+closed when certificate fields are missing or unsupported.
+
+Refinement: the target is not "rerun n=8"; it is "standalone class-14 input
+replay." The audit should avoid current canonicalization helpers and should not
+import `scripts/analyze_n8_exact_survivors.py`. It may use a standard exact
+algebra engine, but the certificate logic and strict-interior sign check should
+be written as a small separate verifier or as external review notes.
+
+## Cycle 3: propose, audit, refine
+
+Proposal: define a concrete class-14 audit with explicit pass/fail/unknown
+criteria, negative controls, and no source-of-truth metadata updates.
+
+Audit of proposal: the plan must not promote any result. It must also not
+silently convert the checked-in artifact into proof by prose. The checked JSON
+is input data to be validated, not generated truth.
+
+Refinement: select `n=8` class `14` as the best next independent trust audit
+target. Record `n=9` vertex-circle as the next target after class `14`; defer
+`n=10` singleton slices until the shared generic vertex-circle machinery has
+more independent review or a replayable terminal-conflict certificate format.
+
+## Selection
+
+Best next independent audit target: `n=8` class `14`.
+
+Why this target:
+
+- It is explicitly called out as the most delicate current `n=8` survivor
+  obstruction: PB+ED Groebner reasoning plus a strict-interior conclusion.
+- It supports the repository's current strongest local finite-case artifact,
+  while still staying inside the repo-local pending-review scope.
+- It is small enough for a reviewer to audit without reading the full search
+  pipeline.
+- It has concrete checked-in inputs and a crisp expected outcome: every
+  recorded real branch fails strict convexity by having only four hull vertices.
+- A successful audit improves trust in the existing `n <= 8` artifact without
+  changing the official/global status or promoting the review-pending `n=9` or
+  draft `n=10` artifacts.
+
+Runner-up: `n=9` vertex-circle checker.
+
+Why not first: it has high payoff but broader risk. Its audit should follow
+after the class-14 standalone replay, using the same discipline: checked-in
+JSON as input data, no status promotion, and explicit uncertainty on
+unsupported cases.
+
+Deferred: `n=10` singleton slices.
+
+Why deferred: it is still a draft continuation with all 126 singleton slices
+recorded, but it depends on the same generic vertex-circle machinery and needs
+either broader second-implementation agreement or replayable terminal-conflict
+certificates before it is the best next trust target.
+
+## Concrete audit plan for `n=8` class `14`
+
+### Scope
+
+Audit only the class-14 exact obstruction certificate. Do not regenerate the
+full `n=8` incidence enumeration. Do not update `README.md`, `STATE.md`,
+`RESULTS.md`, `metadata/erdos97.yaml`, or any generated artifact.
+
+### Input data
+
+Treat these checked-in files as read-only input data:
+
+- `data/incidence/n8_reconstructed_15_survivors.json`
+- `certificates/n8_exact_analysis.json`
+- optionally `certificates/n8_polynomial_systems.txt` as a human-readable
+  cross-check, not as authority
+
+The verifier or written audit should identify class `14` by its stored class
+id and rows. It should not rely on canonicalization code to discover the class.
+
+### Independent reconstruction
+
+1. Parse the class-14 `8 x 8` binary selected-witness matrix.
+2. Check only local schema facts needed by the certificate: zero diagonal,
+   row size `4`, and binary entries.
+3. Use the gauge
+
+   ```text
+   p0 = (0,0), p1 = (1,0), y2 != 0
+   ```
+
+4. Reconstruct perpendicular-bisector equations from each two-overlap
+   row-pair `{i,j}` with common witnesses `{a,b}`:
+
+   ```text
+   (p_i - p_j) dot (p_a - p_b) = 0
+   det(p_j - p_i, p_a + p_b - 2 p_i) = 0
+   ```
+
+5. Reconstruct equal-distance equations for every selected row by choosing a
+   deterministic base witness from the row and equating squared distances from
+   the center to the other selected witnesses.
+
+### Algebra replay
+
+1. Recompute the lexicographic Groebner basis over `QQ` from the reconstructed
+   PB+ED equations, using the class-14 variable order recorded by the current
+   artifact:
+
+   ```text
+   x6, y6, y7, x2, y2, x3, y3, x4, y4, x5, y5, x7
+   ```
+
+2. Normalize the basis to monic polynomial representatives and compare against
+   the certificate's expected basis, or independently reduce the expected
+   basis and generated equations both ways.
+3. Report `UNKNOWN` rather than pass if the stored basis cannot be parsed, if
+   the variable order is absent or ambiguous, or if the generated equations do
+   not reduce exactly.
+
+### Branch replay
+
+1. Parse the four recorded real algebraic branches.
+2. Represent `a = sqrt(3)/2` exactly by `4*a^2 - 3 = 0` with `a > 0`.
+3. Evaluate every reconstructed PB+ED equation on each branch.
+4. Check that the four branches exhaust the real solutions exposed by the
+   basis: the independent factors force `y5 = +/- 1` and
+   `x3 = +/- sqrt(3)/2`, with the remaining coordinates determined by the
+   linear basis elements.
+5. Reject or report `UNKNOWN` if any branch is missing, duplicate, malformed,
+   or not forced by the basis.
+
+### Strict-interior replay
+
+For each branch:
+
+1. Use the hull labels recorded in the certificate as input.
+2. Compute exact orientation signs for each hull edge and its next hull vertex.
+3. Compute exact orientation signs from each hull edge to every non-hull label.
+4. Verify all hull turns have one strict sign and all non-hull points lie
+   strictly on the same interior side of every hull edge.
+5. Use exact sign reasoning only. Acceptable sign facts include
+   `0 < 1 - a < 1/2 < a < 1` for `a = sqrt(3)/2`.
+
+The expected conclusion is only that the recorded class-14 PB+ED branches are
+not strictly convex realizations. It is not a general proof and not a
+counterexample claim.
+
+### Negative controls
+
+Run at least these failure checks before trusting the verifier:
+
+- remove one equal-distance equation and require the verifier to stop short of
+  the same conclusion;
+- flip one class-14 row entry and require schema/equation/basis mismatch;
+- perturb one branch coordinate and require branch evaluation failure;
+- replace one hull label list with a non-hull label and require the
+  strict-interior check to fail or return `UNKNOWN`;
+- delete the stored branch list and require `UNKNOWN`, not success.
+
+### Deliverable
+
+Preferred deliverable: a short standalone audit report plus, if warranted, a
+small checker with a command shaped like:
+
+```bash
+python scripts/independent_check_n8_class14.py \
+  --survivors data/incidence/n8_reconstructed_15_survivors.json \
+  --certificate certificates/n8_exact_analysis.json \
+  --check --json
+```
+
+The checker should be disjoint from the current analyzer except for unavoidable
+standard-library or exact-algebra dependencies. If no checker is added, the
+written audit should still include the exact equations, basis comparison,
+branch evaluation, strict-interior sign table, environment, command transcript,
+and failure modes.
+
+### Acceptance standard
+
+Accept the audit as useful only if it answers all of these:
+
+- Did the auditor reconstruct the class-14 PB+ED system from checked-in JSON?
+- Did the auditor verify the exact algebra without importing the current n=8
+  analyzer?
+- Did the auditor verify every real branch and the strict-interior conclusion
+  by exact signs?
+- Did negative controls fail closed?
+- Did the report preserve the current claim scope and avoid promoting `n=8`,
+  `n=9`, `n=10`, or the global Erdos #97 status?
+
+## Follow-on target after class `14`
+
+After the class-14 audit, the next best independent trust target is the `n=9`
+vertex-circle checker. A future n=9 audit should treat
+`data/certificates/n9_vertex_circle_exhaustive.json` as input, independently
+replay row0 coverage and the 184 pre-vertex-circle obstruction classification,
+and review the geometric necessity of the vertex-circle self-edge/strict-cycle
+filter. It must keep the artifact review-pending unless a broader review
+decision explicitly promotes it.
+

--- a/reports/research_loops/kalmanson_templates_loop.md
+++ b/reports/research_loops/kalmanson_templates_loop.md
@@ -1,0 +1,195 @@
+# Kalmanson/Farkas Template Loop
+
+Status: `EXACT_CERTIFICATE_DIAGNOSTIC` / template-extraction research note.
+
+No general proof of Erdos Problem #97 is claimed. No counterexample is
+claimed. The C13 and C19 entries discussed below are fixed abstract
+selected-witness pattern obstructions. The C29 entry is one fixed-order
+obstruction only.
+
+## Scope
+
+Task bridge: extract reusable Kalmanson/Farkas order-search templates from the
+retired sparse leads, then test whether the same viewpoint explains the larger
+C29 full-cone certificate.
+
+Inputs read first:
+
+- `AGENTS.md`
+- `README.md`, `STATE.md`, `RESULTS.md`, `metadata/erdos97.yaml`
+- `docs/claims.md`, `docs/review-priorities.md`, `docs/codex-backlog.md`
+- `docs/codex-strategy-instructions.md`
+- `docs/kalmanson-two-order-search.md`
+- `docs/kalmanson-certificate-diagnostics.md`
+- `docs/round2/kalmanson_distance_filter.md`
+- `data/certificates/c13_sidon_all_orders_kalmanson_two_search.json`
+- `data/certificates/c19_skew_all_orders_kalmanson_z3.json`
+- `data/certificates/c29_sidon_fixed_order_kalmanson_165_unsat.json`
+- existing diagnostics under `reports/c19_kalmanson_z3_clause_diagnostics.json`
+
+Verifier commands run during this loop:
+
+```bash
+python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
+python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
+python scripts/check_kalmanson_certificate.py data/certificates/c29_sidon_fixed_order_kalmanson_165_unsat.json --summary-json
+python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
+python scripts/analyze_kalmanson_certificates.py data/certificates/c29_sidon_fixed_order_kalmanson_165_unsat.json --top 20 --json
+python scripts/analyze_kalmanson_certificates.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --top 8 --json
+python scripts/find_kalmanson_two_certificate.py --name C29_sidon_1_3_7_15 --n 29 --offsets 1,3,7,15 --order 0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16 --summary-json
+```
+
+The C13 all-order checker replayed `1496677` nodes, pruned `6192576`
+branches, and found no survivor order. The C19 Z3 checker replayed UNSAT with
+`7981` clauses. The C29 fixed-order checker verified `165` positive
+inequalities, `319` quotient distance classes, and zero weighted sum.
+
+## Cycle 1 - Inverse-Pair Proposal
+
+Propose:
+
+A reusable template family is the support-two quotient-edge inverse pair. Let
+`[xy]` denote the selected-distance quotient class of ordinary pair-distance
+variable `d(x,y)`. For a quadrilateral `a,b,c,d` in cyclic order, a Kalmanson
+row is a signed vector in these quotient classes. If quotienting cancels one
+positive and one negative term inside the same row, the row reduces to a
+directed edge
+
+```text
+[A] - [B].
+```
+
+Two strict Kalmanson rows whose reduced quotient edges are opposite,
+
+```text
+[A] - [B]  and  +[B] - [A],
+```
+
+sum to `0 > 0`. This is a reusable fixed-order obstruction template. It is
+not tied to C13 or C19 labels; those patterns are only benchmarks showing the
+template in action.
+
+Audit:
+
+The compact C13 fixed-order certificate has two `K2_diag_gt_other` rows:
+
+```text
+K2 [5,0,9,3]    -> class 17 - class 6
+K2 [5,10,8,9]   -> class 6 - class 17
+```
+
+The compact C19 fixed-order certificate has the same quotient-edge shape:
+
+```text
+K2 [18,10,7,2]  -> class 54 - class 33
+K2 [7,5,2,16]   -> class 33 - class 54
+```
+
+The class IDs are checker-local identifiers, but the cancellation statement is
+not: each class is a selected-distance quotient class. The stored C19
+all-order clause diagnostic confirms that this small support family dominates
+the Z3 certificate: `7780` of `7981` stored clauses use inverse vector pairs
+with support size `2`; the remaining `201` use support size `4`.
+
+Refine:
+
+Template record `QE2`:
+
+- Object: two strict Kalmanson rows available in one fixed cyclic order.
+- Hypotheses: after selected-distance quotienting, row 1 reduces to
+  `+[A]-[B]` and row 2 reduces to `+[B]-[A]`.
+- Conclusion: the fixed selected-witness pattern and fixed cyclic order are
+  impossible.
+- Verifier pattern: reuse `all_kalmanson_rows`, quotient row vectors, and
+  `inverse_pairs` from `scripts/find_kalmanson_two_certificate.py`.
+- Scope limit: this does not say every cyclic order contains such a pair
+  unless an all-order order search or SMT replay proves that separately.
+
+## Cycle 2 - C29 Audit
+
+Propose:
+
+Try to transfer `QE2` directly to the recorded C29 Sidon fixed order. If the
+larger sparse order only needed the same support-two inverse edge, the
+two-certificate finder should produce a weight-`1,1` certificate.
+
+Audit:
+
+The direct transfer fails cleanly. The fixed C29 order returns:
+
+```text
+NO_TWO_INEQUALITY_KALMANSON_CERTIFICATE_FOUND
+```
+
+The full C29 certificate still contains some small rows, but they do not pair
+off as inverse rows:
+
+```text
+quotient row support sizes: 17 rows of size 2, 148 rows of size 4
+support weights by size:    56,593,811 on size 2, 447,706,983 on size 4
+kind/support split:         K1 size 2: 10; K1 size 4: 55; K2 size 2: 7; K2 size 4: 93
+```
+
+The checked full certificate is a one-dimensional positive dependency over
+the listed support rows: rank `164` for `165` rows over each checked prime,
+with nullity `1`. Its top repeated cyclic gap patterns are weakly repeated:
+the largest observed normalized row-gap count is only `3`.
+
+Refine:
+
+The C29 blocker is precise: support-two quotient edges exist, but no opposite
+edge pair occurs in the fixed order. The obstruction needs a full positive
+Farkas circuit mixing support-two and support-four Kalmanson rows. Treating
+C29 as another inverse-pair order-search clause would lose the actual
+certificate structure.
+
+## Cycle 3 - Full-Cone Template Attempt
+
+Propose:
+
+Extract a reusable full-cone family from C29 by grouping the 165 rows by
+normalized cyclic gap signatures and quotient support size.
+
+Audit:
+
+The current C29 certificate does not yet expose a compact reusable family.
+The repeated row-gap signatures are too sparse, the weights have large spread
+(`gcd 1`, max weight `15835921`, total weight `504300794`), and the positive
+dependency is global across many distance classes rather than a visible small
+translation orbit. This is evidence of a real exact obstruction for the fixed
+order, but not yet a reusable all-order clause family.
+
+Refine:
+
+Next tiny script target: `scripts/analyze_kalmanson_template_families.py`.
+It should be diagnostic-only and should not generate new mathematical claims.
+Minimum useful output:
+
+- for each supplied fixed-order certificate, compute every quotient row vector;
+- classify rows by `K1/K2`, quotient support size, internal cancellation type,
+  normalized cyclic gap signature, and simultaneous cyclic label translate;
+- detect `QE2` inverse-pair clauses as a named family;
+- build the directed support-two quotient-edge graph and report missing
+  opposite edges;
+- for full-cone certificates, compute the positive circuit support projected
+  to support-two edges plus support-four hyperedges;
+- emit the smallest exact subcircuits if any are found, otherwise report the
+  current certificate as a full-support blocker.
+
+The immediate acceptance check for that script should be: it rediscovers the
+C13/C19 compact inverse-pair family, reports no C29 two-row inverse pair for
+the recorded order, and reproduces the C29 `165`-row nullity-`1` full-cone
+dependency without claiming an all-order C29 obstruction.
+
+## Outcome
+
+Classified reusable family: `QE2`, the support-two quotient-edge inverse-pair
+template. It is a fixed-order obstruction template and becomes all-order only
+when paired with an exhaustive order search or SMT certificate.
+
+Precise blocker beyond the retired sparse leads: the recorded C29 fixed order
+has support-two rows but no two-inequality inverse pair. The existing
+obstruction is a full-cone positive circuit with one-dimensional support
+dependency, large weights, and weak repeated gap patterns. The next useful
+work is a diagnostic script that separates support-two inverse-pair templates
+from larger full-cone circuit structure.

--- a/reports/research_loops/n9_low_excess_loop.md
+++ b/reports/research_loops/n9_low_excess_loop.md
@@ -1,0 +1,166 @@
+# n=9 Base-Apex Low-Excess Prompt Loop
+
+Status: bounded research-loop note only. This is not a proof of `n=9`, not a
+counterexample, not a geometric realizability test, and not a global status
+update. Trust label: `FINITE_BOOKKEEPING_NOT_A_PROOF`.
+
+## Object Studied
+
+The object is the strict-threshold low-excess part of the `n=9` base-apex
+ledger. Write `E` for total profile excess and `D` for unused base-apex
+capacity. The bookkeeping identity is
+
+```text
+E + D = 9.
+```
+
+The current turn-cover diagnostic closes only ledgers with `D < 3`. The
+unresolved strict-threshold ledgers are therefore exactly the low-excess band
+
+```text
+E <= 6, equivalently D >= 3.
+```
+
+## Diagnostics Replayed
+
+All commands below completed successfully in this working tree.
+
+```bash
+python scripts/explore_n9_base_apex.py --summary
+python scripts/explore_n9_base_apex.py --turn-cover
+python scripts/explore_n9_base_apex.py --motifs
+python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+python scripts/check_n9_base_apex_escape_budget.py --check --json
+python scripts/check_n9_base_apex_low_excess_escape_ladder.py --check --json
+python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json
+python scripts/check_n9_d3_escape_slice.py --check --json
+python scripts/check_n9_base_apex_d3_escape_frontier_packet.py --check --json
+python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json
+python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
+python scripts/check_n9_base_apex_d3_artifact_join.py --check --json
+python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py --check --json
+python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```
+
+Key checked numbers:
+
+- `95` unlabeled profile-excess ledgers with `E <= 9`.
+- strict threshold: `65` ledgers forced by turn-cover, `30` unresolved.
+- strict minimum relevant escape: `3` length-2/length-3 deficit units,
+  `108` labelled placements, `8` dihedral escape classes.
+- low-excess ladder: `30` ledgers, `108` escape placements,
+  `30,184` common-dihedral profile/escape pair classes.
+- sharp `D=3` slice: `3,003` labelled profile sequences, `108` escape
+  placements, `18,088` common-dihedral pair classes.
+- `D=3` representative packet: `11` profile multisets by `8` escape classes,
+  hence `88` representative rows; realizability and incidence states are
+  still `UNKNOWN`.
+- selected-baseline overlay: strict selected-baseline deficits force `44` of
+  `184` pre-vertex-circle assignments; the `D=3` selected-baseline crosswalk
+  has `13,710` forced and `1,746` escaping assignment/slot choices. These are
+  selected-baseline bookkeeping counts, not profile-capacity realizability
+  counts.
+- review-pending vertex-circle checker: `184` pre-vertex-circle assignments
+  are killed by exact self-edge or strict-cycle obstructions. This remains a
+  separate review-pending selected-witness finite-case artifact.
+
+## Cycle 1: Try `E >= 7`
+
+Propose: target a geometric anti-concentration lemma proving every bad
+strictly convex nonagon has total profile excess `E >= 7`. This would make
+`D <= 2`, so the existing strict turn-cover diagnostic would close the ledger.
+
+Audit: the diagnostics do not expose a local reason for such a strong lower
+bound. Even under the restrictive assumption that only excesses `0` and `1`
+occur, there are `10` profile ledgers and `7` remain unresolved by turn-cover.
+The target would need a new geometric lemma that rules out low-excess profile
+distributions directly, not just a refinement of the current bookkeeping.
+
+Refine: keep `E >= 7` as a possible future bridge, but do not make it the next
+exact target. It is too global for the artifacts currently in hand.
+
+## Cycle 2: Block `D >= 3` Escape Placements
+
+Propose: prove that the `D >= 3` capacity deficit cannot be placed so as to
+spoil the length-2/length-3 turn-cover clauses.
+
+Audit: the statement is correct in spirit but too wide as an immediate finite
+target. The strict-threshold escape mechanism needs only `r=3` relevant
+deficits, while ledgers with `D > 3` have spare budget `D - r`. Existing
+artifacts intentionally do not place this spare budget on sides, length-4
+diagonals, or redundant length-2/length-3 failures. A direct all-`D >= 3`
+statement would therefore mix the sharp escape obstruction with extra
+unassigned-capacity choices.
+
+Refine: isolate the boundary case `D=3`. There, the three relevant deficits
+consume the entire capacity deficit budget, so every displayed escape row has
+exact per-base saturation targets: the three displayed length-2/length-3 bases
+are each down by one unit, and every other cyclic base is saturated.
+
+## Cycle 3: Separate Low-Excess Obstruction
+
+Propose: build a separate exact obstruction for the sharp `E=6, D=3, r=3`
+slice using the existing incidence-capacity packet.
+
+Audit: this is the cleanest next target. The checked packet already exposes
+all `88` representative rows, but leaves both states as `UNKNOWN`. It records
+the profile multisets, escape classes, deficient base chords, and target
+capacity totals. The `D=3` artifact join confirms consistency across the slice,
+packet, low-excess crosswalk, P19 pilot, and all-row packet.
+
+Refined next target:
+
+```text
+For each row of
+data/certificates/n9_base_apex_d3_incidence_capacity_packet.json,
+decide finite profile-capacity feasibility.
+
+Input row data:
+- one total-excess-6 profile multiset on the nine centers;
+- one strict r=3 escape class X00..X07;
+- the three displayed deficient length-2/length-3 base chords;
+- exact target base-apex capacities, with total capacity 60.
+
+Required finite assignment:
+- assign each center a full distance-class partition of the other eight
+  labels matching its profile excess;
+- count every unordered base pair whenever its endpoints lie in the same
+  class at an apex;
+- meet the row's exact per-base target: displayed deficient length-2/3 bases
+  are one below full capacity, all other bases are saturated;
+- satisfy the existing pair/crossing/cap necessary filters when a selected
+  4-witness row is extracted from each center.
+
+Desired outcome:
+- either reject all 88 rows by exact finite bookkeeping, closing the sharp
+  D=3 minimal-escape slice only;
+- or emit a compact survivor packet whose rows can be attacked by exact
+  vertex-circle template checks or a geometric capacity lemma.
+```
+
+This target is a separate obstruction for low-excess ledgers, with the first
+deliverable scoped to the sharp `D=3` slice. It does not claim that ledgers
+with `D > 3` are closed. If the `D=3` slice is obstructed, the next ladder step
+should add the spare-capacity placement data for `D=4`, then repeat the same
+profile-capacity feasibility audit.
+
+## What This Would Rule Out
+
+If completed, this target would rule out only the strict-threshold
+`E=6, D=3, r=3` profile/escape bookkeeping slice under the stated finite
+profile-capacity hypotheses. It would not prove the full `n=9` case, would not
+settle `D > 3`, and would not update the official/global Erdos #97 status.
+
+## Suggested Verification Shape
+
+The checker should treat existing JSON artifacts as inputs rather than as
+generated truth, mirroring the style of the current `check_n9_base_apex_*`
+scripts. A successful first checker should be runnable as something like:
+
+```bash
+python scripts/check_n9_base_apex_d3_profile_capacity_feasibility.py --check --json
+```
+
+The report artifact, if any, should keep rows with status `UNKNOWN` explicit
+instead of silently accepting unsupported feasibility.

--- a/reports/research_loops/n9_t01_template_loop.md
+++ b/reports/research_loops/n9_t01_template_loop.md
@@ -1,0 +1,233 @@
+# n=9 T01/F09 Vertex-circle Template Loop
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+Trust label: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This report records a bounded prompt loop for the `T01/F09` self-edge packet in
+the reusable `n=9` vertex-circle lemma path. It is proof-facing scaffolding
+only. It does not claim a proof of the `n=9` selected-witness case, does not
+claim a counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global falsifiable-open status of
+Erdos Problem #97.
+
+## Bridge value
+
+The bridge being strengthened is the reusable vertex-circle local-template
+path:
+
+```text
+Given exact local selected-witness rows and a cyclic witness order,
+selected-distance quotienting plus vertex-circle monotonicity forces
+a strict self-edge.
+```
+
+This helps separate a small local obstruction from the full review-pending
+`n=9` enumeration. It does not show that arbitrary counterexamples reduce to
+this template.
+
+## Inputs read
+
+- `AGENTS.md`
+- `README.md`
+- `STATE.md`
+- `RESULTS.md`
+- `metadata/erdos97.yaml`
+- `docs/claims.md`
+- `docs/review-priorities.md`
+- `docs/codex-backlog.md`
+- `docs/codex-strategy-instructions.md`
+- `docs/n9-vertex-circle-template-lemma-catalog.md`
+- `docs/n9-vertex-circle-t01-self-edge-lemma.md`
+- `data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json`
+- `docs/n9-vertex-circle-exhaustive.md`
+
+## Exact local object
+
+Use labels `0,...,8` in the natural cyclic order. A selected row is written as
+`[center, witness_1, witness_2, witness_3, witness_4]`, meaning that the four
+witnesses are selected at the same distance from the center.
+
+The focused packet studies the three local rows
+
+```text
+[0, 1, 2, 4, 8]
+[1, 0, 3, 5, 8]
+[2, 0, 1, 4, 6]
+```
+
+and the row-`0` selected witness order
+
+```text
+[1, 2, 4, 8].
+```
+
+The packet covers the six labelled frontier assignments
+
+```text
+A014, A024, A031, A140, A166, A175
+```
+
+inside family `F09` and template id `T01`. This coverage statement is a
+review-pending diagnostic crosswalk, not a theorem name.
+
+## Cycle 1: Propose
+
+Candidate local lemma statement:
+
+If a strictly convex labelled nonagon in cyclic order `0,...,8` has the three
+selected rows above, then the selected-distance quotient identifies the
+ordinary pair distances `[1,8]` and `[1,2]`. Row `0` simultaneously gives the
+strict vertex-circle inequality `[1,8] > [1,2]`. Therefore the quotient strict
+graph has a reflexive strict edge.
+
+The equality path is exactly
+
+```text
+[1,8] -- row 1 --> [0,1]
+[0,1] -- row 0 --> [0,2]
+[0,2] -- row 2 --> [1,2].
+```
+
+The strict inequality is exactly
+
+```text
+row 0 witness order [1,2,4,8] forces [1,8] > [1,2].
+```
+
+Reason: on the selected circle centered at `0`, the chord with endpoints
+`1,8` strictly contains the chord with endpoints `1,2` in the row-`0`
+vertex-circle order. The vertex-circle strict monotonicity rule therefore
+orients a strict edge from the quotient class of `[1,8]` to the quotient class
+of `[1,2]`. The equality path makes those classes equal.
+
+## Cycle 2: Audit
+
+The compact packet verifier already exists:
+
+```bash
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+```
+
+It was run in this loop and returned `ok: true`, with:
+
+```text
+artifact: data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
+schema: erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1
+status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+template_id: T01
+family_id: F09
+assignment_count: 6
+core_size: 3
+replay_status: self_edge
+strict_edge_count: 27
+self_edge_conflict_count: 2
+validation_errors: []
+```
+
+The targeted artifact tests for the focused packet were also run:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m "artifact"
+```
+
+They passed with 3 artifact tests selected and 8 non-artifact tests deselected.
+
+The nearby catalog checker was also run:
+
+```bash
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+```
+
+It returned `ok: true`, with 12 template records covering 184 review-pending
+frontier assignments: 158 self-edge assignments and 26 strict-cycle
+assignments.
+
+For context, the review-pending exhaustive checker was run:
+
+```bash
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```
+
+It reproduced the stored counts: the main search leaves 0 full assignments
+under vertex-circle pruning, while the cross-check without vertex-circle
+pruning reaches 184 full assignments and classifies them as 158 self-edge and
+26 strict-cycle obstructions. This contextual command does not promote the
+`n=9` result beyond `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.
+
+Audit result: no packet-consistency issue was found. The existing compact
+verifier is enough for this report; no new checker was needed.
+
+## Cycle 3: Refine
+
+Refined proof-facing statement:
+
+Under the exact local hypotheses consisting of the natural cyclic order
+`0,...,8`, the three selected rows
+
+```text
+S_0 = {1,2,4,8}
+S_1 = {0,3,5,8}
+S_2 = {0,1,4,6}
+```
+
+and the row-`0` selected witness order `[1,2,4,8]`, the rows force
+
+```text
+|p_1-p_8| = |p_0-p_1| = |p_0-p_2| = |p_1-p_2|.
+```
+
+The same row-`0` vertex-circle order forces
+
+```text
+|p_1-p_8| > |p_1-p_2|.
+```
+
+Thus the selected-distance quotient has a strict self-edge. Equivalently, the
+local hypotheses are unrealizable by a strictly convex labelled nonagon if the
+vertex-circle monotonicity rule applies as stated.
+
+## What this rules out
+
+This rules out any realization satisfying this exact local T01/F09 row/order
+configuration. It gives a compact local obstruction that a reviewer can inspect
+without reading the full exhaustive brancher.
+
+## What remains review-pending
+
+- The packet remains `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+- The six-assignment coverage of the T01/F09 packet depends on the
+  review-pending n=9 frontier/template artifacts.
+- The full `n=9` vertex-circle exhaustive checker remains
+  `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.
+- This report does not prove that all possible `n=9` systems reduce to this
+  packet or to the twelve cataloged packets.
+- This report does not prove Erdos Problem #97 and does not claim a
+  counterexample.
+
+## Existing verification commands
+
+Packet-level verifier:
+
+```bash
+python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+```
+
+Targeted packet artifact tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m "artifact"
+```
+
+Catalog cross-check:
+
+```bash
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+```
+
+Exhaustive n=9 context checker:
+
+```bash
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+```

--- a/reports/research_loops/summary_2026_05_10.md
+++ b/reports/research_loops/summary_2026_05_10.md
@@ -1,0 +1,94 @@
+# Research Loop Summary, 2026-05-10
+
+Status: orchestration summary only. This is not mathematical evidence, does
+not claim a proof of Erdos Problem #97, does not claim a counterexample, and
+does not update any source-of-truth status. The official/global status remains
+falsifiable/open. The repo-local strongest result remains the checked
+`n <= 8` selected-witness finite-case artifact, with independent review still
+recommended for public theorem-style claims.
+
+## Parallel Loops
+
+Six bounded prompt loops were run in parallel. Each loop used a
+propose/audit/refine pattern and wrote a scoped report under
+`reports/research_loops/`.
+
+| Loop | Report | Outcome | Trust posture |
+| --- | --- | --- | --- |
+| `n9_t01_template` | `n9_t01_template_loop.md` | Extracted a proof-facing T01/F09 self-edge template from the review-pending `n=9` vertex-circle packet. | `REVIEW_PENDING_DIAGNOSTIC` |
+| `fragile_geo` | `fragile_geo_loop.md` | Tested dependency-cycle, radius-propagation, and row-circle Ptolemy ideas; row-circle is promising but blocked by an escaping two-block full extension. | `FAILED_ROUTE` / `NEXT_EXPERIMENT` |
+| `n9_low_excess` | `n9_low_excess_loop.md` | Sharpened the next target to finite profile-capacity feasibility for the sharp `E=6, D=3, r=3` slice's 88 packet rows. | `FINITE_BOOKKEEPING_NOT_A_PROOF` |
+| `kalmanson_templates` | `kalmanson_templates_loop.md` | Classified the reusable `QE2` support-two quotient-edge inverse-pair template and identified the C29 full-cone blocker. | `EXACT_CERTIFICATE_DIAGNOSTIC` |
+| `independent_audit` | `independent_audit_loop.md` | Selected `n=8` class `14` as the best next independent audit target, ahead of `n=9` and `n=10`. | planning guidance only |
+| `affine_circuit` | `affine_circuit_loop.md` | Identified a bounded golden-decagon base-certificate profile diagnostic as the next rank-rigidity checker experiment. | `EXACT_CHECKER_DIAGNOSTIC` |
+
+## Durable Results
+
+1. The T01/F09 local vertex-circle obstruction is now separated into a small
+   proof-facing statement:
+
+   ```text
+   S_0 = {1,2,4,8}
+   S_1 = {0,3,5,8}
+   S_2 = {0,1,4,6}
+   row-0 witness order = [1,2,4,8]
+   ```
+
+   The equality path identifies `[1,8]` with `[1,2]`, while row-0
+   vertex-circle monotonicity forces `[1,8] > [1,2]`. This is a local
+   review-pending template only, not an `n=9` proof.
+
+2. The Kalmanson/Farkas loop named `QE2`, the support-two quotient-edge
+   inverse-pair template. It explains the compact C13/C19 two-inequality
+   certificates as one reusable fixed-order mechanism. It becomes all-order
+   only when paired with an exhaustive order search or SMT replay.
+
+3. The C29 fixed order is now recorded as the first sharp blocker for naive
+   `QE2` transfer: it has support-two quotient rows, but no two-inequality
+   inverse pair. Its known obstruction currently needs the full 165-row
+   positive Kalmanson/Farkas circuit.
+
+4. The fragile-cover bridge did not produce a promotable new condition. The
+   row-circle Ptolemy quotient idea killed one two-block full extension, but a
+   bounded enumeration found another extension escaping the simple zero-row
+   and nonnegative-cone tests. The next useful work is an all-extension
+   row-circle audit with explicit `UNKNOWN_LIMIT_REACHED` behavior.
+
+5. The low-excess `n=9` path should not next try to prove the broad
+   anti-concentration statement `E >= 7`. The cleaner finite target is the
+   sharp `D=3` boundary slice: decide profile-capacity feasibility for all
+   88 rows in `n9_base_apex_d3_incidence_capacity_packet.json`.
+
+6. The next independent trust audit should isolate `n=8` class `14` and
+   replay its PB+ED Groebner/branch/strict-interior certificate independently
+   from checked-in JSON, rather than rerunning the current analyzer.
+
+7. The affine-circuit path should next make base dependence visible with a
+   bounded base-certificate profile diagnostic. The invariant target is
+   quotient kernel dimension; cofactor and pair-gain witnesses are base-local.
+
+## Suggested Next Loop Queue
+
+1. Implement a standalone `n=8` class `14` audit checker or written exact
+   replay. This is the best trust-improving task because it targets the most
+   delicate current `n <= 8` certificate.
+2. Add a diagnostic-only `analyze_kalmanson_template_families.py` that
+   rediscovers `QE2` on C13/C19 and reports the C29 no-`QE2` blocker without
+   claiming an all-order C29 obstruction.
+3. Add a bounded `n9_base_apex_d3_profile_capacity_feasibility` checker that
+   reports `REJECTED`, `SURVIVOR`, or `UNKNOWN` for each of the 88 sharp
+   `D=3` rows.
+4. Add an all-extension row-circle audit for the two-block fragile-cover
+   negative control before promoting any row-circle fragile condition.
+5. Add a capped affine-circuit base-profile mode for the golden-decagon
+   negative control.
+6. Extract the T10/F12 strict-cycle packet into the same proof-facing shape as
+   T01/F09.
+
+## Verification Notes
+
+The individual agents report successful fast-tier verification for every loop
+except `affine_circuit`, which intentionally stopped after a heavy symbolic
+sweep timed out and did not run the full fast tier. A parent-level verification
+run should therefore at least run the repository text/status/provenance checks
+and `git diff --check` after this summary is added.

--- a/reports/research_loops/summary_2026_05_10.md
+++ b/reports/research_loops/summary_2026_05_10.md
@@ -89,6 +89,16 @@ propose/audit/refine pattern and wrote a scoped report under
 
 The individual agents report successful fast-tier verification for every loop
 except `affine_circuit`, which intentionally stopped after a heavy symbolic
-sweep timed out and did not run the full fast tier. A parent-level verification
-run should therefore at least run the repository text/status/provenance checks
-and `git diff --check` after this summary is added.
+sweep timed out and did not run the full fast tier. After this summary was
+added, the parent workspace ran and passed:
+
+```text
+python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
+python scripts/check_artifact_provenance.py
+git diff --check
+python -m ruff check .
+python -m pytest -q
+```
+
+The parent `pytest` run reported `542 passed, 290 deselected`.


### PR DESCRIPTION
## Summary

- Add bounded research-loop reports for the parallel prompt run across vertex-circle, fragile-cover, low-excess, Kalmanson, audit, and affine-circuit paths.
- Add a controller summary that records durable outcomes, blockers, and the next loop queue.
- Keep all outputs scoped as diagnostics/planning/review-pending scaffolding with no global proof or counterexample claim.

## Validation

Parent workspace:

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`542 passed, 290 deselected`)

## Scope notes

This PR contains only `reports/research_loops/*.md` files. The local checkout had unrelated staged/unstaged changes; they were intentionally left out of this branch.