### PR TITLE
[codex] improve reviewability provenance and fast test tier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: tests
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 1'
 
 jobs:
   pytest:
@@ -20,9 +23,19 @@ jobs:
           cache-dependency-path: pyproject.toml
       - run: python -m pip install --upgrade pip
       - run: pip install -e .[dev]
-      - run: python scripts/check_text_clean.py
-      - run: python scripts/check_status_consistency.py
-      - run: python scripts/check_artifact_provenance.py
-      - run: git diff --check
-      - run: python -m ruff check .
-      - run: python -m pytest -q
+      - run: make verify-fast
+
+  artifact-review:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e .[dev]
+      - run: make verify-pytest-artifacts
+      - run: make verify-artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Claim and artifact changelog
+
+Status: reviewability aid only; not mathematical evidence.
+
+This changelog records claim-scope changes, demotions, audit additions, and
+reviewability fixes that affect how an external reader should interpret the
+repository. It is intentionally not a full git history. No general proof and no
+counterexample are claimed.
+
+## 2026-05-10
+
+- Added `docs/public-provenance.md` as the public replacement map for old
+  private-archive footnotes. The cited mathematical and computational content
+  now points to checked-in docs, scripts, data, or verification routes.
+- Clarified the `n=8` exact-survivor status split: each reconstructed survivor
+  class has an exact obstruction, while the aggregate `n=8` exclusion remains a
+  repo-local `MACHINE_CHECKED_FINITE_CASE_ARTIFACT` pending independent review.
+- Recorded this changelog so claim promotions and demotions are visible even
+  when the public git history is not the most convenient audit surface.
+- The default pytest tier was sped up in the public branch history; full
+  artifact and exhaustive checks remain separate from `pytest -q`.
+
+## 2026-05-08
+
+- Added several review-pending `n=9` vertex-circle lemma packets and selected
+  baseline D=3 bookkeeping artifacts. These are proof-mining and audit aids
+  only; they do not promote the `n=9` finite-case status or alter the
+  official/global problem status.
+
+## 2026-05-06
+
+- Added replayable real-root and non-degeneracy decoders for the remaining
+  `n=9` Groebner families F07, F08, F09, and F13. These are recorded as
+  review-pending algebraic corroboration only.
+
+## 2026-05-05
+
+- Added a second-source Groebner audit for the 15 `n=8` incidence-completeness
+  survivors. It is strong corroborating evidence for the local `n <= 8`
+  pipeline, but the public theorem-style status still requires independent
+  review.
+- Added partial `n=9` Groebner pruning results for selected families. These are
+  review-pending and do not promote the `n=9` source-of-truth status.
+- Recorded sparse-frontier diagnostics for C25/C29-style Sidon patterns. The
+  C29 survivor order was later killed by a fixed-order Kalmanson/Farkas
+  certificate; no all-order C29 claim is made.
+
+## Prior Public Ledger Entries
+
+- `B12_3x4_danzer_lift` was demoted from numerical near-miss to historical
+  degeneration diagnostic once the fixed selected-witness pattern was exactly
+  killed by mutual-rhombus midpoint equations.
+- `C19_skew` was first killed for one fixed cyclic order by a compact
+  Kalmanson/Farkas certificate, then later killed across all cyclic orders for
+  that fixed abstract selected-witness pattern by the stored Z3 all-order
+  certificate. This remains fixed-pattern work only, not a proof of Erdos #97.
+- `C13_sidon_1_2_4_10` was first killed for one fixed cyclic order by a compact
+  Kalmanson/Farkas certificate, then later killed across all cyclic orders for
+  that fixed abstract selected-witness pattern by the exact order search. This
+  remains fixed-pattern work only.
+- The repo-local source-of-truth finite-case claim remains `n <= 8`. The
+  `n=9` and `n=10` artifacts are audit targets until independent review
+  justifies promotion.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: verify-lint verify-fast verify-n8 verify-kalmanson verify-n9-review verify-n10-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-n10-review verify-artifacts audit-artifacts verify-all
 
 verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
@@ -11,6 +11,12 @@ verify-lint:
 
 verify-fast: verify-lint
 	$(PYTHON) -m pytest -q
+
+verify-pytest-artifacts:
+	$(PYTHON) -m pytest -q -m "artifact"
+
+verify-pytest-all:
+	$(PYTHON) -m pytest -q -o addopts=
 
 verify-n8:
 	$(PYTHON) scripts/independent_check_n8_artifacts.py --check --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -75,7 +75,9 @@ all `n=7` selected-witness equality patterns. See
 ### Machine-checked finite-case artifact: selected-witness incidence rules out n = 8
 
 Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT` in repo-local sense. External
-review is still recommended before paper-style or public theorem claims.
+review is still recommended before paper-style or public theorem claims. The
+individual survivor-class kills are `EXACT_OBSTRUCTION_PER_SURVIVOR_CLASS`;
+the aggregate `n=8` exclusion is the machine-checked finite-case artifact.
 
 The incidence-completeness checker derives `n=8` indegree regularity from the
 column-pair cap, exhaustively enumerates all selected-witness systems satisfying

--- a/STATE.md
+++ b/STATE.md
@@ -264,13 +264,13 @@ archived-ID provenance mapping when the archive JSON is available.
 - Search related work on repeated distances, order-k Voronoi degeneracies, and
   metric oriented-matroid realizability before paper-style claims.[^repo]
 
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
-[^small]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/02_SMALL_CASES_N5_N6_N7.md`.
-[^comp]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/04_COMPUTATIONAL_FINDINGS.md`.
-[^forest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/11_forest_lemma_counterexample_review.md`.
-[^n39]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/12_n39_circulant_degeneracy.md`.
-[^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.
-[^alg]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/04_algebraic_and_semicircle_corrections.md`.
-[^digest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
-[^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
+[^repo]: Public consolidation: `docs/public-provenance.md#repository-handoff-and-claim-taxonomy`.
+[^small]: Public consolidation: `docs/public-provenance.md#small-cases-n5-through-n8`.
+[^comp]: Public consolidation: `docs/public-provenance.md#computational-finding-digest`.
+[^forest]: Public consolidation: `docs/public-provenance.md#forest-lemma-failure`.
+[^n39]: Public consolidation: `docs/public-provenance.md#n39-circulant-degeneracy`.
+[^rank]: Public consolidation: `docs/public-provenance.md#rank-and-bridge-status`.
+[^alg]: Public consolidation: `docs/public-provenance.md#algebraic-and-semicircle-corrections`.
+[^digest]: Public consolidation: `docs/public-provenance.md#literature-digest`.
+[^syn]: Public consolidation: `docs/public-provenance.md#canonical-synthesis`.
 [^canon]: Source file: `docs/canonical-synthesis.md`.

--- a/contradictions.md
+++ b/contradictions.md
@@ -1,33 +1,36 @@
 # Contradictions surfaced from the archive
 
-These are not resolved away; the docs route the validated or informative side and keep the abandoned side as failed-route evidence.
+These are not resolved away; the docs route the validated or informative side
+and keep the abandoned side as failed-route evidence. Historical archive paths
+have been replaced below by public consolidation references in
+`docs/public-provenance.md`.
 
 ## C-001: n=8 status
 - Cube-pattern obstruction is valid but does not prove all n=8 cases.
 - Some source files claimed n=8 was proved by uniqueness of the cube pattern.
-- Kernel: `INCIDENCE_PATTERN` / `abandoned` / erd archive/outputs/erdos97_synthesis.md
-- Kernel: `FAILED_APPROACH` / `abandoned` / erd archive/outputs/erdos97_synthesis.md
+- Kernel: `INCIDENCE_PATTERN` / `abandoned` / `docs/public-provenance.md#canonical-synthesis`
+- Kernel: `FAILED_APPROACH` / `abandoned` / `docs/public-provenance.md#canonical-synthesis`
 
 ## C-002: Counting threshold
 - Validated incidence count gives only n>=7.
 - Some source files claimed a direct count gives n>=13 / rules out n<=12.
-- Kernel: `LEMMA` / `validated` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md
-- Kernel: `FAILED_APPROACH` / `abandoned` / erd archive/outputs/erdos97_synthesis.md
+- Kernel: `LEMMA` / `validated` / `docs/public-provenance.md#repository-handoff-and-claim-taxonomy`
+- Kernel: `FAILED_APPROACH` / `abandoned` / `docs/public-provenance.md#canonical-synthesis`
 
 ## C-003: Jacobian rank at solutions
 - Validated scaling identity gives rank <= 2n-4 at exact solutions.
 - Some rank-route drafts treated rank 2n-3 as an obstruction at solutions or sampled only non-solutions.
-- Kernel: `LEMMA` / `validated` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md
-- Kernel: `FAILED_APPROACH` / `abandoned` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/05_rank_scaling_and_verifier_review.md
+- Kernel: `LEMMA` / `validated` / `docs/public-provenance.md#rank-and-bridge-status`
+- Kernel: `FAILED_APPROACH` / `abandoned` / `docs/public-provenance.md#paper-style-verifier-review`
 
 ## C-004: Circumcenter location
 - Validated semicircle criterion allows the center outside the witness hull.
 - Some proof drafts claimed every cyclic witness quadrilateral contains its center.
-- Kernel: `LEMMA` / `validated` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/04_algebraic_and_semicircle_corrections.md
-- Kernel: `FAILED_APPROACH` / `abandoned` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/04_algebraic_and_semicircle_corrections.md
+- Kernel: `LEMMA` / `validated` / `docs/public-provenance.md#algebraic-and-semicircle-corrections`
+- Kernel: `FAILED_APPROACH` / `abandoned` / `docs/public-provenance.md#algebraic-and-semicircle-corrections`
 
 ## C-005: n=39 circulant branch
 - The fixed n=39 pattern has an exact three-overlap and is impossible.
 - Earlier numerical notes treated the same branch as a promising near-miss.
-- Kernel: `INCIDENCE_PATTERN` / `abandoned` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/12_n39_circulant_degeneracy.md
-- Kernel: `FAILED_APPROACH` / `abandoned` / erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/12_n39_circulant_degeneracy.md
+- Kernel: `INCIDENCE_PATTERN` / `abandoned` / `docs/public-provenance.md#n39-circulant-degeneracy`
+- Kernel: `FAILED_APPROACH` / `abandoned` / `docs/public-provenance.md#n39-circulant-degeneracy`

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -69,7 +69,7 @@ row-overlap failure that killed the n=39 branch.[^n39]
 | A8 | `C13_pm_3_5` | 13 | offsets `{-5,-3,3,5}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; all labels collapse |
 | A9 | `C9_pm_2_4` | 9 | offsets `{-4,-2,2,4}` | palindromic circulant | exactly killed by mutual-rhombus midpoint equations; all labels collapse |
 
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
-[^comp]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/04_COMPUTATIONAL_FINDINGS.md`.
-[^n39]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/12_n39_circulant_degeneracy.md`.
-[^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
+[^repo]: Public consolidation: `public-provenance.md#repository-handoff-and-claim-taxonomy`.
+[^comp]: Public consolidation: `public-provenance.md#computational-finding-digest`.
+[^n39]: Public consolidation: `public-provenance.md#n39-circulant-degeneracy`.
+[^syn]: Public consolidation: `public-provenance.md#canonical-synthesis`.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -492,10 +492,10 @@ The two-point smallest-enclosing-circle case is controlled by known cap
 arguments. The three-support case remains open and would need a bridge lemma
 forcing enough witnesses into opposite caps.[^syn]
 
-[^small]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/02_SMALL_CASES_N5_N6_N7.md`.
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
-[^digest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
-[^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
-[^alg]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/04_algebraic_and_semicircle_corrections.md`.
-[^paper]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/05_rank_scaling_and_verifier_review.md`.
-[^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.
+[^small]: Public consolidation: `public-provenance.md#small-cases-n5-through-n8`.
+[^repo]: Public consolidation: `public-provenance.md#repository-handoff-and-claim-taxonomy`.
+[^digest]: Public consolidation: `public-provenance.md#literature-digest`.
+[^syn]: Public consolidation: `public-provenance.md#canonical-synthesis`.
+[^alg]: Public consolidation: `public-provenance.md#algebraic-and-semicircle-corrections`.
+[^paper]: Public consolidation: `public-provenance.md#paper-style-verifier-review`.
+[^rank]: Public consolidation: `public-provenance.md#rank-and-bridge-status`.

--- a/docs/exactification-plan.md
+++ b/docs/exactification-plan.md
@@ -99,7 +99,7 @@ A certificate should contain:
 
 See `certificates/best_B12_certificate_template.json` for a placeholder format.
 
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
-[^alg]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/04_algebraic_and_semicircle_corrections.md`.
-[^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
-[^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.
+[^repo]: Public consolidation: `public-provenance.md#repository-handoff-and-claim-taxonomy`.
+[^alg]: Public consolidation: `public-provenance.md#algebraic-and-semicircle-corrections`.
+[^syn]: Public consolidation: `public-provenance.md#canonical-synthesis`.
+[^rank]: Public consolidation: `public-provenance.md#rank-and-bridge-status`.

--- a/docs/failed-ideas.md
+++ b/docs/failed-ideas.md
@@ -137,13 +137,13 @@ fixed selected-witness pattern of the exact concave alternating decagon has no
 cyclic order satisfying the two-overlap crossing filter. See
 `docs/two-orbit-radius-propagation.md`.
 
-[^lit]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
-[^forest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/11_forest_lemma_counterexample_review.md`.
-[^rank]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/03_RANK_AND_BRIDGE_STATUS.md`.
-[^alg]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/04_algebraic_and_semicircle_corrections.md`.
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
-[^n39]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/12_n39_circulant_degeneracy.md`.
-[^paper]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/05_rank_scaling_and_verifier_review.md`.
-[^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
+[^lit]: Public consolidation: `public-provenance.md#literature-digest`.
+[^forest]: Public consolidation: `public-provenance.md#forest-lemma-failure`.
+[^rank]: Public consolidation: `public-provenance.md#rank-and-bridge-status`.
+[^alg]: Public consolidation: `public-provenance.md#algebraic-and-semicircle-corrections`.
+[^repo]: Public consolidation: `public-provenance.md#repository-handoff-and-claim-taxonomy`.
+[^n39]: Public consolidation: `public-provenance.md#n39-circulant-degeneracy`.
+[^paper]: Public consolidation: `public-provenance.md#paper-style-verifier-review`.
+[^syn]: Public consolidation: `public-provenance.md#canonical-synthesis`.
 [^canon]: Source file: `docs/canonical-synthesis.md`.
-[^p24]: Source files: `erd archive/outputs/data/1/linear_case_geometry_handoff.md` and `erd archive/outputs/data/1/verify_24_point_near_counterexample.py`.
+[^p24]: Public consolidation: `public-provenance.md#p24-metric-linear-negative-control`.

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -59,9 +59,9 @@ are claimed here.
 - Treat any numerical near-equality as only numerical evidence unless it has an
   exact or certified verification artifact.[^repo]
 
-[^digest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
-[^syn]: Source file: `erd archive/outputs/erdos97_synthesis.md`.
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
+[^digest]: Public consolidation: `public-provenance.md#literature-digest`.
+[^syn]: Public consolidation: `public-provenance.md#canonical-synthesis`.
+[^repo]: Public consolidation: `public-provenance.md#repository-handoff-and-claim-taxonomy`.
 [^canon]: Source file: `docs/canonical-synthesis.md`.
 [^erdos97]: T. F. Bloom, "Erdos Problem #97," Erdos Problems, accessed 2026-04-30. <https://www.erdosproblems.com/97>
 [^erdos1987]: P. Erdos, "Some combinatorial and metric problems in geometry," Intuitive Geometry, Colloquia Mathematica Societatis Janos Bolyai 48, 167--177, 1987. <https://www.renyi.hu/~p_erdos/1987-27.pdf>

--- a/docs/n10-vertex-circle-singleton-slices.md
+++ b/docs/n10-vertex-circle-singleton-slices.md
@@ -113,11 +113,11 @@ python scripts/check_n10_secondary_singleton_replay.py \
   --json
 ```
 
-Regenerate the checked-in artifact from the archived JSONL:
+Regenerate the checked-in artifact from the historical JSONL, if available:
 
 ```bash
 python scripts/check_n10_vertex_circle_singletons.py \
-  --import-jsonl "C:\Users\User\Desktop\code\erd archive\outputs\data\1\3\10\n10_rows.jsonl" \
+  --import-jsonl path/to/n10_rows.jsonl \
   --write \
   --assert-expected
 ```

--- a/docs/n8-exact-survivors.md
+++ b/docs/n8-exact-survivors.md
@@ -1,6 +1,13 @@
 # n=8 Exact Survivor Obstruction Artifact
 
-Status: `EXACT_OBSTRUCTION`.
+Status: `EXACT_OBSTRUCTION_PER_SURVIVOR_CLASS` and
+`MACHINE_CHECKED_FINITE_CASE_ARTIFACT_FOR_AGGREGATE_N8`.
+
+Each of the 15 reconstructed `n=8` selected-witness incidence survivor classes
+has an exact obstruction in this artifact. The aggregate statement that the
+selected-witness method rules out `n=8` remains repo-local and
+machine-checked pending independent review; it is not a paper-style public
+theorem claim by itself.
 
 This note records an exact obstruction pass over a reconstructed canonical list of
 15 `n=8` selected-witness incidence classes. The list was reconstructed from the
@@ -15,12 +22,12 @@ known incidence filters:
 - no same-color forced-parallel chords sharing an endpoint.
 
 The reconstruction produced exactly 15 simultaneous-relabeling classes. In this
-workspace, these classes were compared against the archived
-`erd archive/outputs/data/n8_exact_geometry_filter_results.json` artifact and
-matched exactly up to simultaneous relabeling. The independent incidence
-enumerator in `docs/n8-incidence-enumeration.md` now reproduces the same 15
-classes from the strong selected-witness convention and necessary incidence
-filters.
+workspace, these classes were also compared against the historical
+`n8_exact_geometry_filter_results.json` archive artifact and matched exactly up
+to simultaneous relabeling. That archive artifact is provenance only, not a
+public reproduction dependency. The independent incidence enumerator in
+`docs/n8-incidence-enumeration.md` now reproduces the same 15 classes from the
+strong selected-witness convention and necessary incidence filters.
 
 The archived IDs map to reconstructed IDs as follows:
 

--- a/docs/public-provenance.md
+++ b/docs/public-provenance.md
@@ -1,0 +1,154 @@
+# Public provenance map
+
+Status: reviewability aid only; not mathematical evidence.
+
+This file replaces old private-archive footnotes with public, checked-in
+references. It does not promote any claim. No general proof and no
+counterexample are claimed.
+
+The historical notes that seeded this repository were consolidated into public
+docs, data files, scripts, and verification commands. When a nearby document
+cites one of the source labels below, use the public references listed here as
+the referee-facing source of truth.
+
+## Repository handoff and claim taxonomy
+
+Public references:
+
+- `README.md`
+- `STATE.md`
+- `RESULTS.md`
+- `metadata/erdos97.yaml`
+- `docs/claims.md`
+- `docs/reviewer-guide.md`
+- `docs/verification-contract.md`
+- `docs/canonical-synthesis.md`
+
+These files record the non-overclaiming rules, trust labels, official/global
+status discipline, and the split between repo-local artifacts and public
+theorem-style claims.
+
+## Small cases n5 through n8
+
+Public references:
+
+- `docs/claims.md`
+- `docs/n7-fano-enumeration.md`
+- `docs/n8-incidence-enumeration.md`
+- `docs/n8-exact-survivors.md`
+- `docs/n8-geometric-proof.md`
+- `scripts/enumerate_n7_fano.py`
+- `scripts/enumerate_n8_incidence.py`
+- `scripts/analyze_n8_exact_survivors.py`
+
+These are the public sources for the two-circle cap, sharpened incidence count,
+Fano equality-case audit, `n=8` incidence-completeness enumeration, and exact
+survivor obstruction pipeline.
+
+## Computational finding digest
+
+Public references:
+
+- `docs/canonical-synthesis.md`
+- `docs/failed-ideas.md`
+- `docs/candidate-patterns.md`
+- `docs/reproduction-log.md`
+- `data/runs/`
+- `data/certificates/`
+
+These files retain the public version of numerical near-misses, retired
+patterns, finite artifacts, and reproduction guidance. Numerical artifacts are
+evidence and regression inputs only, not proof certificates.
+
+## Literature digest
+
+Public references:
+
+- `docs/literature-risk.md`
+- `docs/canonical-synthesis.md`
+- `metadata/erdos97.yaml`
+
+These files record the checked external anchors, nearby `k=3` constructions,
+unit-distance caveats, and instructions to recheck the official Erdos Problems
+page before any status update.
+
+## Forest-lemma failure
+
+Public references:
+
+- `docs/failed-ideas.md`
+- `docs/stuck-set-miner.md`
+- `docs/stuck-frontier-snapshot.md`
+
+These files record why middle-neighbor, endpoint, and forest-style arguments
+need extra hypotheses before they can be used in a proof.
+
+## n39 circulant degeneracy
+
+Public references:
+
+- `docs/candidate-patterns.md`
+- `docs/failed-ideas.md`
+- `docs/sat-smt-plan.md`
+
+These files record the exact row-overlap failure for the `C39_pm_18_19`
+circulant branch and its role as a finite-filter sanity check.
+
+## Algebraic and semicircle corrections
+
+Public references:
+
+- `docs/claims.md`
+- `docs/exactification-plan.md`
+- `docs/failed-ideas.md`
+- `docs/verification-contract.md`
+
+These files record the public versions of the affine-linear distance equations,
+circumcenter caveats, semicircle correction, and exact certificate standards.
+
+## Rank and bridge status
+
+Public references:
+
+- `docs/claims.md`
+- `docs/exactification-plan.md`
+- `docs/minimal-fragile-cover-bridge.md`
+- `docs/stuck-set-miner.md`
+
+These files record the public versions of the Jacobian-kernel caveat, rank-drop
+frontier, ear-orderable bridge status, and fragile-cover bridge.
+
+## Paper-style verifier review
+
+Public references:
+
+- `docs/verification-contract.md`
+- `docs/reviewer-guide.md`
+- `docs/exactification-plan.md`
+
+These files record proof-certificate requirements and independent review
+expectations for paper-style use.
+
+## Canonical synthesis
+
+Public references:
+
+- `docs/canonical-synthesis.md`
+- `contradictions.md`
+- `dropped_kernels.md`
+- `inventory.json`
+- `kernels.json`
+
+These files are the public reconciliation layer for superseded archive claims,
+failed routes, dropped kernels, and source inventory.
+
+## P24 metric-linear negative control
+
+Public references:
+
+- `docs/failed-ideas.md`
+- `scripts/verify_p24_metric_linear_nonconvex.py`
+
+These files record the public negative control showing that metric equations,
+lifted affine circuits, row-linearity, and rank alone do not force strict
+convexity.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -220,12 +220,19 @@ Review checklist:
 - the Z3 constraints encode exactly "not both ordered quadrilaterals occur";
 - replaying the stored clauses gives UNSAT without relying on the refinement
   search history;
+- the all-order UNSAT step is replayed by at least one Z3-independent route,
+  such as a DIMACS/DRAT/LRAT proof, another SMT solver with a checkable proof,
+  or a pure finite-order proof checker for the stored clauses;
+- an UNSAT core alone is not treated as a proof object unless a separate
+  checker verifies it;
 - the claim remains scoped to the fixed abstract `C19_skew` selected-witness
   pattern.
 
 Acceptance standard: a reviewer should either accept the certificate as an
-exact all-order obstruction for fixed abstract `C19_skew`, or identify a
-specific encoding or verifier gap.
+exact all-order obstruction for fixed abstract `C19_skew` with an independent
+UNSAT replay path, or identify a specific encoding, solver-trust, or verifier
+gap. Until then, the stored artifact remains a checked Z3 certificate rather
+than a solver-independent proof object.
 
 ## Priority 7b - audit the C19 sampled-prefix catalog prefilter
 

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -127,6 +127,9 @@ For `python scripts/analyze_n8_exact_survivors.py --check --json`, expected
 invariants:
 
 - status is `exact_obstruction_artifact_pending_independent_review`;
+- the per-class obstruction status is exact, while the aggregate `n=8`
+  exclusion remains a repo-local machine-checked finite-case artifact pending
+  independent review;
 - `survivor_classes` is `15`;
 - `cyclic_order_remaining_count` is `14`, with class `12` killed by cyclic
   order noncrossing;
@@ -221,6 +224,9 @@ Check:
 - A minimal standalone class `14` checker would be especially valuable because
   that obstruction combines Groebner reasoning with a strict-interior
   conclusion.
+- A Z3-independent replay path for the C19 all-order Kalmanson order UNSAT
+  certificate would reduce single-solver trust. A checkable SAT/SMT proof or a
+  pure finite-order checker is preferred over an UNSAT core alone.
 - Independent reproduction of `certificates/n8_exact_analysis.json`.
 - A Lean, SMT, interval, or algebraic certificate checker would be high value.
 

--- a/docs/sat-smt-plan.md
+++ b/docs/sat-smt-plan.md
@@ -65,7 +65,7 @@ search-convenience constraints only rules out that restricted class.[^repo]
 - Use SAT patterns as inputs to exactification, not as candidates by
   themselves.[^repo]
 
-[^repo]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/source_notes/16_repo_handoff_and_claim_taxonomy.md`.
-[^comp]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/04_COMPUTATIONAL_FINDINGS.md`.
-[^digest]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/01_USEFUL_FINDINGS_DIGEST.md`.
-[^small]: Source file: `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/02_SMALL_CASES_N5_N6_N7.md`.
+[^repo]: Public consolidation: `public-provenance.md#repository-handoff-and-claim-taxonomy`.
+[^comp]: Public consolidation: `public-provenance.md#computational-finding-digest`.
+[^digest]: Public consolidation: `public-provenance.md#literature-digest`.
+[^small]: Public consolidation: `public-provenance.md#small-cases-n5-through-n8`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -95,7 +95,7 @@ local_repo:
       status: "MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING"
       artifact: "data/certificates/n10_vertex_circle_singleton_slices.json"
       verifier: "scripts/check_n10_vertex_circle_singletons.py"
-      archive_provenance: "erd archive/outputs/data/1/3/10/"
+      archive_provenance: "historical n10_rows.jsonl import, not checked in"
       claim_scope: "draft selected-witness n=10 singleton-slice finite-case obstruction only; does not alter official/global status or the source-of-truth strongest local result"
       review_note: "Promote only after independent code review or a compact replayable certificate validates the generic checker and all 126 row0 singleton slices."
   notable_fixed_order_obstructions:

--- a/scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py
+++ b/scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py
@@ -60,10 +60,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    payload = d3_incidence_capacity_packet_report()
-    if args.assert_expected:
-        assert_expected_packet_counts(payload)
-
+    checked = None
+    artifact = None
     if args.check_artifact is not None:
         artifact = (
             args.check_artifact
@@ -86,6 +84,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
+
+    payload = d3_incidence_capacity_packet_report()
+    if args.assert_expected:
+        assert_expected_packet_counts(payload)
+
+    if checked is not None:
         if checked != payload:
             print(
                 f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",

--- a/scripts/analyze_n9_base_apex_d3_p19_incidence_capacity_pilot.py
+++ b/scripts/analyze_n9_base_apex_d3_p19_incidence_capacity_pilot.py
@@ -60,17 +60,36 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    payload = p19_incidence_capacity_pilot_report()
-    if args.assert_expected:
-        assert_expected_pilot_counts(payload)
-
+    checked = None
+    artifact = None
     if args.check_artifact is not None:
         artifact = (
             args.check_artifact
             if args.check_artifact.is_absolute()
             else ROOT / args.check_artifact
         )
-        checked = load_json(artifact)
+        try:
+            checked = load_json(artifact)
+        except OSError as exc:
+            print(
+                "FAILED: could not load "
+                f"{display_path(artifact, ROOT)}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        except json.JSONDecodeError as exc:
+            print(
+                "FAILED: could not parse "
+                f"{display_path(artifact, ROOT)} as JSON: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+    payload = p19_incidence_capacity_pilot_report()
+    if args.assert_expected:
+        assert_expected_pilot_counts(payload)
+
+    if checked is not None:
         if checked != payload:
             print(
                 f"FAILED: generated payload differs from {display_path(artifact, ROOT)}",

--- a/tests/test_c13_kalmanson_partial_branches.py
+++ b/tests/test_c13_kalmanson_partial_branches.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "certify_c13_kalmanson_partial_branches.py"
 ARTIFACT = ROOT / "data" / "certificates" / "c13_kalmanson_partial_branch_closures.json"
@@ -23,6 +25,8 @@ def run_script(*args: str) -> dict[str, object]:
     return json.loads(result.stdout)
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c13_partial_branch_closures_match_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c13_kalmanson_third_pair_refinement.py
+++ b/tests/test_c13_kalmanson_third_pair_refinement.py
@@ -52,6 +52,8 @@ def test_c13_third_pair_refinement_artifact_summary() -> None:
     assert unclosed[-1]["parent_label"] == "partial_branch_5284"
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c13_third_pair_refinement_small_replay() -> None:
     payload = run_script(
         "--max-parents",

--- a/tests/test_c19_fifth_pair_two_row_prefilter.py
+++ b/tests/test_c19_fifth_pair_two_row_prefilter.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from c19_replay_helpers import assert_c19_replay_matches_artifact
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -82,6 +84,8 @@ def test_c19_fifth_pair_two_row_prefilter_artifact() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_fifth_pair_two_row_prefilter_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_prefix_window.py
+++ b/tests/test_c19_kalmanson_prefix_window.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from c19_replay_helpers import assert_c19_replay_matches_artifact
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -82,6 +84,8 @@ def test_c19_prefix_window_artifact_summary() -> None:
     assert first_fifth["certificate_summary"]["forced_inequalities_available"] == 3300
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefix_window_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
@@ -147,6 +151,8 @@ def test_c19_prefix_window_160_191_artifact_summary() -> None:
     assert payload["unclosed_fifth_pair_child_branches"] == []
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefix_window_160_191_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",

--- a/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
@@ -74,6 +74,7 @@ def test_c19_catalog_prefilter_window_sweep_artifact_summary() -> None:
     }
 
 
+@pytest.mark.artifact
 def test_c19_catalog_prefilter_window_sweep_small_replay() -> None:
     payload = run_script("--window-count", "1", "--json")
 

--- a/tests/test_c19_kalmanson_prefix_window_prefilter.py
+++ b/tests/test_c19_kalmanson_prefix_window_prefilter.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from c19_replay_helpers import assert_c19_replay_matches_artifact
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -68,6 +70,8 @@ def test_c19_prefilter_window_288_319_artifact_summary() -> None:
     }
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_288_319_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -122,6 +126,8 @@ def test_c19_prefilter_window_320_351_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_320_351_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -171,6 +177,8 @@ def test_c19_prefilter_window_352_383_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_352_383_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -223,6 +231,8 @@ def test_c19_prefilter_window_384_415_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_384_415_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -279,6 +289,8 @@ def test_c19_prefilter_window_416_447_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_416_447_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",
@@ -323,6 +335,8 @@ def test_c19_prefilter_window_448_479_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_window_448_479_replay_matches_artifact() -> None:
     payload = run_script(
         "--start-index",

--- a/tests/test_c19_kalmanson_prefix_window_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_prefilter_sweep.py
@@ -76,6 +76,7 @@ def test_c19_prefilter_window_sweep_artifact_summary() -> None:
     ]
 
 
+@pytest.mark.artifact
 def test_c19_prefilter_window_sweep_small_replay() -> None:
     payload = run_script("--window-count", "1", "--json")
 

--- a/tests/test_c19_kalmanson_prefix_window_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_sweep.py
@@ -72,6 +72,8 @@ def test_c19_prefix_window_sweep_artifact_summary() -> None:
     assert [len(row["fifth_pair_survivor_labels"]) for row in windows] == [0, 0, 0, 0, 0]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefix_window_sweep_small_replay() -> None:
     payload = run_script("--window-count", "1", "--json")
 

--- a/tests/test_c19_kalmanson_sampled_fifth_pair_refinement.py
+++ b/tests/test_c19_kalmanson_sampled_fifth_pair_refinement.py
@@ -77,6 +77,7 @@ def test_c19_sampled_fifth_pair_refinement_artifact_summary() -> None:
     assert first["certificate_summary"]["forced_inequalities_available"] == 3300
 
 
+@pytest.mark.artifact
 def test_c19_sampled_fifth_pair_refinement_small_replay() -> None:
     payload = run_script(
         "--max-parents",

--- a/tests/test_c19_kalmanson_sampled_fourth_pair_refinement.py
+++ b/tests/test_c19_kalmanson_sampled_fourth_pair_refinement.py
@@ -78,6 +78,7 @@ def test_c19_sampled_fourth_pair_refinement_artifact_summary() -> None:
     assert first["certificate_summary"]["forced_inequalities_available"] == 1932
 
 
+@pytest.mark.artifact
 def test_c19_sampled_fourth_pair_refinement_small_replay() -> None:
     payload = run_script(
         "--max-parents",

--- a/tests/test_c19_prefilter_small_unit_supports.py
+++ b/tests/test_c19_prefilter_small_unit_supports.py
@@ -7,6 +7,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "analyze_c19_prefilter_small_unit_supports.py"
 ARTIFACT = ROOT / "reports" / "c19_prefilter_small_unit_support_search.json"
@@ -53,6 +55,8 @@ def test_c19_prefilter_small_unit_support_artifact_summary() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c19_prefilter_small_unit_support_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c25_c29_sparse_frontier_probe.py
+++ b/tests/test_c25_c29_sparse_frontier_probe.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "scripts") not in sys.path:
     sys.path.insert(0, str(ROOT / "scripts"))
@@ -71,6 +73,8 @@ def test_c25_c29_sparse_frontier_probe_matches_exact_filter_sweep() -> None:
         ]["survives_pre_kalmanson_filters"]
 
 
+@pytest.mark.artifact
+@pytest.mark.slow
 def test_c25_c29_orders_have_no_two_inequality_kalmanson_inverse_pair() -> None:
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
     by_pattern = {row["pattern"]: row for row in artifact["cases"]}

--- a/tests/test_kalmanson_z3_clause_diagnostics.py
+++ b/tests/test_kalmanson_z3_clause_diagnostics.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.analyze_kalmanson_z3_clauses import (
     DEFAULT_ARTIFACT,
     assert_expected,
@@ -14,6 +16,7 @@ from scripts.analyze_kalmanson_z3_clauses import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_c19_z3_clause_diagnostic_matches_artifact() -> None:

--- a/tests/test_n9_base_apex.py
+++ b/tests/test_n9_base_apex.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from erdos97.n9_base_apex import (
     base_apex_slack,
     canonical_deficit_placement,
@@ -275,6 +277,7 @@ def test_low_excess_ledger_report_records_unresolved_counts() -> None:
     assert "No proof of the n=9 case is claimed." in report["notes"]
 
 
+@pytest.mark.artifact
 def test_escape_budget_report_records_budget_compatible_escape_counts() -> None:
     report = escape_budget_report()
 
@@ -328,6 +331,7 @@ def test_escape_budget_report_records_budget_compatible_escape_counts() -> None:
     assert "No proof of the n=9 case is claimed." in report["interpretation"]
 
 
+@pytest.mark.artifact
 def test_checked_low_excess_ledger_artifact_matches_generator() -> None:
     repo = Path(__file__).resolve().parents[1]
     artifact = repo / "data" / "certificates" / "n9_base_apex_low_excess_ledgers.json"
@@ -337,6 +341,7 @@ def test_checked_low_excess_ledger_artifact_matches_generator() -> None:
     assert payload == low_excess_ledger_report()
 
 
+@pytest.mark.artifact
 def test_checked_escape_budget_artifact_matches_generator() -> None:
     repo = Path(__file__).resolve().parents[1]
     artifact = repo / "data" / "certificates" / "n9_base_apex_escape_budget_report.json"

--- a/tests/test_n9_base_apex_d3_artifact_join.py
+++ b/tests/test_n9_base_apex_d3_artifact_join.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from erdos97.n9_base_apex_d3_artifact_join import (
     EXPECTED_CLAIM_SCOPE,
     cloned_artifacts,
@@ -16,6 +18,7 @@ from erdos97.n9_base_apex_d3_artifact_join import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def load_default_stack() -> tuple[dict[str, Path], dict[str, Any]]:

--- a/tests/test_n9_base_apex_d3_escape_frontier_packet.py
+++ b/tests/test_n9_base_apex_d3_escape_frontier_packet.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_d3_escape_frontier_packet import (
     EXPECTED_CLAIM_SCOPE,
     EXPECTED_INTERPRETATION,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_d3_escape_frontier_packet import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_expected_d3_escape_frontier_packet_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_d3_incidence_capacity_packet.py
+++ b/tests/test_n9_base_apex_d3_incidence_capacity_packet.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 import scripts.check_n9_base_apex_d3_incidence_capacity_packet as checker
 from scripts.check_n9_base_apex_d3_incidence_capacity_packet import (
     EXPECTED_CLAIM_SCOPE,
@@ -16,6 +18,7 @@ from scripts.check_n9_base_apex_d3_incidence_capacity_packet import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_full_packet_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_d3_p19_incidence_capacity_pilot.py
+++ b/tests/test_n9_base_apex_d3_p19_incidence_capacity_pilot.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 import scripts.check_n9_base_apex_d3_p19_incidence_capacity_pilot as checker
 from scripts.check_n9_base_apex_d3_p19_incidence_capacity_pilot import (
     EXPECTED_CLAIM_SCOPE,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_d3_p19_incidence_capacity_pilot import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_p19_pilot_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_escape_budget.py
+++ b/tests/test_n9_base_apex_escape_budget.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_escape_budget import (
     DEFAULT_ARTIFACT,
     load_artifact,
@@ -14,6 +16,7 @@ from scripts.check_n9_base_apex_escape_budget import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_escape_budget_artifact_passes_independent_checker() -> None:

--- a/tests/test_n9_base_apex_low_excess_escape_crosswalk.py
+++ b/tests/test_n9_base_apex_low_excess_escape_crosswalk.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_low_excess_escape_crosswalk import (
     EXPECTED_CLAIM_SCOPE,
     EXPECTED_INTERPRETATION,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_low_excess_escape_crosswalk import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_expected_low_excess_escape_crosswalk_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_low_excess_escape_ladder.py
+++ b/tests/test_n9_base_apex_low_excess_escape_ladder.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_low_excess_escape_ladder import (
     EXPECTED_CLAIM_SCOPE,
     EXPECTED_INTERPRETATION,
@@ -15,6 +17,7 @@ from scripts.check_n9_base_apex_low_excess_escape_ladder import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_expected_low_excess_escape_ladder_counts_are_pinned() -> None:

--- a/tests/test_n9_base_apex_low_excess_ledgers.py
+++ b/tests/test_n9_base_apex_low_excess_ledgers.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_base_apex_low_excess_ledgers import (
     DEFAULT_ARTIFACT,
     load_artifact,
@@ -14,6 +16,7 @@ from scripts.check_n9_base_apex_low_excess_ledgers import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_low_excess_ledger_artifact_passes_independent_checker() -> None:

--- a/tests/test_n9_row_ptolemy_family_signatures.py
+++ b/tests/test_n9_row_ptolemy_family_signatures.py
@@ -21,6 +21,7 @@ from scripts.check_n9_row_ptolemy_family_signatures import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_row_ptolemy_family_signature_artifact_counts_and_scope() -> None:

--- a/tests/test_n9_row_ptolemy_order_sensitivity.py
+++ b/tests/test_n9_row_ptolemy_order_sensitivity.py
@@ -21,6 +21,7 @@ from scripts.check_n9_row_ptolemy_order_sensitivity import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_row_ptolemy_order_sensitivity_artifact_scope() -> None:

--- a/tests/test_n9_selected_baseline_d3_escape_class_crosswalk.py
+++ b/tests/test_n9_selected_baseline_d3_escape_class_crosswalk.py
@@ -22,6 +22,7 @@ from scripts.check_n9_selected_baseline_d3_escape_class_crosswalk import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_selected_baseline_d3_crosswalk_artifact_is_nonclaiming() -> None:

--- a/tests/test_n9_selected_baseline_escape_budget_overlay.py
+++ b/tests/test_n9_selected_baseline_escape_budget_overlay.py
@@ -19,6 +19,7 @@ from scripts.check_n9_selected_baseline_escape_budget_overlay import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_selected_baseline_overlay_artifact_summary_is_nonclaiming() -> None:

--- a/tests/test_n9_vertex_circle_local_core_packet.py
+++ b/tests/test_n9_vertex_circle_local_core_packet.py
@@ -18,6 +18,7 @@ from scripts.check_n9_vertex_circle_local_core_packet import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
 
 
 def test_local_core_packet_artifact_counts_and_scope() -> None:

--- a/unclassified.md
+++ b/unclassified.md
@@ -2,15 +2,27 @@
 
 11 of 138 inventoried files are SCRATCH (8.0%).
 
-These files resisted trust-label routing or were archive/prompt/provenance containers.
-- `erd archive/best_of_n_for_erdos_problem.md`: This file is `Best-of-N Workflow for Attacking an Erdos Problem` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/erdos97_gpt52_pro_prompt_notes.md`: This file is `Erdos Problem #97 - Useful Prompt & Notes` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/erdos97_prompt_notes (1).md`: This file is `Erdos Problem #97 Prompt Notes` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/erdos97_prompt_notes.md`: This file is `Erdos Problem #97 Prompt Notes` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/lemma12_review_notes.zip`: This file is `lemma12_review_notes.zip` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/lemma12_review_notes.zip::best_of_n_for_erdos_problem.md`: This file is `Best-of-N Workflow for Attacking an Erdos Problem` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/lemma12_review_notes.zip::erdos97_gpt52_pro_prompt_notes.md`: This file is `Erdos Problem #97 - Useful Prompt & Notes` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/lemma12_review_notes.zip::erdos97_prompt_notes (1).md`: This file is `Erdos Problem #97 Prompt Notes` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/lemma12_review_notes.zip::erdos97_prompt_notes.md`: This file is `Erdos Problem #97 Prompt Notes` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/outputs/useful_research_findings.zip`: This file is `useful_research_findings.zip` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
-- `erd archive/outputs/useful_research_findings.zip::useful_research_findings/generated_summaries/05_SELECTION_MANIFEST.md`: This file is `Selection manifest` and was classified as SCRATCH because it is an archive, manifest, prompt, or workflow-only file. No trust-labelled research kernel was promoted from the file itself.
+These files resisted trust-label routing or were archive/prompt/provenance
+containers.
+
+- Historical best-of-N workflow prompt note: classified as SCRATCH because it
+  is archive, manifest, prompt, or workflow-only material. No trust-labelled
+  research kernel was promoted from the file itself.
+- Historical GPT-5.2 Pro prompt notes: classified as SCRATCH because they are
+  archive, manifest, prompt, or workflow-only material. No trust-labelled
+  research kernel was promoted from the file itself.
+- Historical Erdos #97 prompt notes variants: classified as SCRATCH because
+  they are archive, manifest, prompt, or workflow-only material. No
+  trust-labelled research kernel was promoted from the files themselves.
+- Historical Lemma 12 review-note bundle and prompt-note contents: classified
+  as SCRATCH because they are archive, manifest, prompt, or workflow-only
+  material. No trust-labelled research kernel was promoted from the bundle
+  itself.
+- Historical `useful_research_findings.zip` bundle: classified as SCRATCH
+  because it is an archive, manifest, prompt, or workflow-only container. No
+  trust-labelled research kernel was promoted from the bundle itself. Public
+  replacement references are mapped in `docs/public-provenance.md`.
+- Historical selection manifest inside `useful_research_findings.zip`:
+  classified as SCRATCH because it is an archive manifest. No trust-labelled
+  research kernel was promoted from the manifest itself. Public replacement
+  references are mapped in `docs/public-provenance.md`.


### PR DESCRIPTION
## Summary

- Keeps the default pytest tier fast by excluding exhaustive test classes from the default run.
- Adds a public provenance map and claim/artifact changelog so old private-archive references resolve to checked-in review surfaces.
- Clarifies that n=8 exact obstructions are per survivor class while the aggregate n=8 exclusion remains a repo-local machine-checked artifact pending independent review.
- Adds reviewer guidance for a Z3-independent replay path for the C19 all-order order-UNSAT step.

## Scope notes

This PR does not claim a general proof or counterexample for Erdos Problem #97. It only improves verification ergonomics and external reviewability.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`542 passed, 290 deselected`)