### PR TITLE
[codex] Classify block6 terminal transitions

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -415,6 +415,36 @@ nearest extendable states  terminal states
 7                          2
 ```
 
+Across all nearest terminal-to-extendable transitions, there are `56`
+one-replacement transitions. The changed center distribution is block-swap
+equivariant:
+
+```text
+changed center orbit  nearest transitions
+2,8                   14
+4,10                  8
+5,11                  34
+```
+
+The replacement preserves whether the changed witness lies in the center's
+same six-label block or in the opposite six-label block. The side split is:
+
+```text
+replacement side  nearest transitions
+same block        14
+opposite block    42
+```
+
+The nearest extendable states have only a small number of clean eighth-center
+choices:
+
+```text
+clean eighth centers after nearest transition  nearest transitions
+1                                              28
+2                                              24
+3                                              4
+```
+
 For example, the terminal state
 
 ```text
@@ -434,8 +464,8 @@ in the row centered at `2`:
 
 Thus no terminality lemma can be stable under even one witness replacement
 inside the same combined triple/profile class. The next useful invariant must
-see the exact boundary-pair placement that distinguishes those adjacent
-states.
+see the exact boundary-pair placement and changed-center orbit that
+distinguishes those adjacent states.
 
 ## Center Counts
 
@@ -505,4 +535,6 @@ one eighth center or one obstruction type. The triple-plus-profile audit also
 shows that terminality is not determined by adding the seven-center triple to
 the row-content profile. The edit-distance audit sharpens this failure:
 terminality can disappear after changing a single witness in one row while
-staying inside the same combined class.
+staying inside the same combined class. The nearest-transition classification
+also shows that the escapes are not explained by one exceptional changed
+center: all three nonfixed block-swap center orbits occur.

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,159 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 652 - Block-6 Nearest-transition Signatures
+
+### Mathematical Subquestion
+
+Cycle 651 showed that every terminal clean seven-row state in the low-support
+block-6 branch is one witness replacement from a same-class extendable state.
+The next precise question was:
+
+```text
+Across all nearest terminal-to-extendable transitions, which centers and
+witness replacements occur, and how many clean eighth-center choices appear
+after the transition?
+```
+
+### Definitions and Assumptions
+
+Use the same terminal-containing combined triple/profile classes and row
+replacement distance from Cycle 651. A **nearest transition** is an ordered
+pair `(T,E)` where `T` is a terminal clean seven-row state, `E` is an
+extendable clean seven-row state in the same combined class, and the state
+replacement distance from `T` to `E` is minimal. Cycle 651 proved this minimum
+is `1` for all `12` terminal states.
+
+For a nearest transition, the checker records the changed row center, the
+removed and added witness labels, whether that replacement stayed in the
+center's same six-label block or opposite six-label block, and the number of
+eighth centers that have at least one clean eighth-row extension after `E`.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 Nearest-transition Signature Audit**.
+
+### Argument Or Obstruction
+
+There are `56` nearest one-replacement transitions across the `12` terminal
+states. The changed-center distribution is:
+
+```text
+changed center  nearest transitions
+2               7
+4               4
+5               17
+8               7
+10              4
+11              17
+```
+
+Equivalently, by block-swap center orbit:
+
+```text
+changed center orbit  nearest transitions
+2,8                   14
+4,10                  8
+5,11                  34
+```
+
+The replacement never changes the same/opposite-block side of the modified
+witness. The side split is:
+
+```text
+replacement side  nearest transitions
+same block        14
+opposite block    42
+```
+
+The nearest extendable states expose only `1`, `2`, or `3` clean eighth
+centers:
+
+```text
+clean eighth centers after transition  nearest transitions
+1                                      28
+2                                      24
+3                                      4
+```
+
+The checker also records the full changed-center/removed/added distribution.
+The two highest-multiplicity signatures are `5:1->4` and `11:7->10`, with
+`5` transitions each.
+
+### Exact Scope
+
+This is an exact finite audit inside the same low-support two-block block-6
+natural-order selected-row extension tree as Cycles 646-651. It classifies
+the nearest same-class terminal-to-extendable transitions from the `12`
+terminal clean seven-row states. It is not a Euclidean realizability result,
+is not a proof of Erdos Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This rules out another overly simple local explanation: the one-step escapes
+are not caused by a single exceptional changed center. All three relevant
+block-swap center orbits occur, and most nearest transitions change an
+opposite-block witness. The audit points toward a boundary-pair or local
+order-sign invariant rather than a center-only invariant.
+
+### Next Lead
+
+For each nearest transition, compare the removed/added witness pair with the
+terminal state's self-only, strict-only, and mixed eighth-center obstruction
+sets. A useful next lemma would say which boundary-pair replacement opens a
+clean eighth center and why that replacement avoids the prior quotient
+self-edge or strict cycle.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-652`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-652`.
+- The branch was started from `origin/main` at commit
+  `dd8e63b2c0befd478bdda7be94528b62a52ab7df`, after PR #371 merged Cycle
+  651, then rebased onto `origin/main` at commit
+  `3e9b2b9f9b20cc6d7b88d2fceefddbc72efc29e7` after PR #372 merged, and
+  finally onto `origin/main` at commit
+  `723b4645d77d71edb6f0f73fc9f3c11c87e9a2fc` after subsequent research-loop
+  report updates landed.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `56` nearest transitions, changed-center orbit
+  counts `14,8,34`, and clean eighth-center counts `28,24,4`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `542 passed, 276 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 651 - Block-6 One-replacement Terminal Fragility
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -692,6 +692,7 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
     "terminal_triple_profile_classes": 6,
     "terminal_states_with_nearest_extendable": 12,
     "min_replacement_distribution": {"1": 12},
+    "nearest_transition_count": 56,
     "nearest_extendable_count_distribution": {
         "1": 2,
         "3": 2,
@@ -700,6 +701,71 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
         "7": 2,
     },
     "changed_row_count_distribution_for_first_nearest": {"1": 12},
+    "changed_center_distribution": {
+        "2": 7,
+        "4": 4,
+        "5": 17,
+        "8": 7,
+        "10": 4,
+        "11": 17,
+    },
+    "changed_center_orbit_distribution": {
+        "2,8": 14,
+        "4,10": 8,
+        "5,11": 34,
+    },
+    "changed_center_removed_added_distribution": {
+        "2:11->10": 1,
+        "2:5->4": 2,
+        "2:6->7": 1,
+        "2:6->8": 1,
+        "2:6->9": 1,
+        "2:7->9": 1,
+        "4:10->9": 1,
+        "4:8->7": 1,
+        "4:9->7": 1,
+        "4:9->8": 1,
+        "5:1->4": 5,
+        "5:11->10": 1,
+        "5:6->8": 1,
+        "5:6->9": 1,
+        "5:9->10": 1,
+        "5:9->6": 2,
+        "5:9->7": 3,
+        "5:9->8": 3,
+        "8:0->1": 1,
+        "8:0->2": 1,
+        "8:0->3": 1,
+        "8:1->3": 1,
+        "8:11->10": 2,
+        "8:5->4": 1,
+        "10:2->1": 1,
+        "10:3->1": 1,
+        "10:3->2": 1,
+        "10:4->3": 1,
+        "11:0->2": 1,
+        "11:0->3": 1,
+        "11:3->0": 2,
+        "11:3->1": 3,
+        "11:3->2": 3,
+        "11:3->4": 1,
+        "11:5->4": 1,
+        "11:7->10": 5,
+    },
+    "replacement_side_distribution": {"opposite_block": 42, "same_block": 14},
+    "extendable_ok_center_count_distribution": {"1": 28, "2": 24, "3": 4},
+    "extendable_ok_row_count_distribution": {
+        "1": 18,
+        "2": 16,
+        "3": 4,
+        "4": 4,
+        "5": 4,
+        "6": 2,
+        "7": 2,
+        "9": 2,
+        "10": 2,
+        "13": 2,
+    },
     "class_summary": {
         (
             "2,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
@@ -1289,7 +1355,7 @@ def _low_support_terminal_classification(
     }
 
 
-def _terminal_state_eighth_center_counts(
+def _state_eighth_center_counts(
     state: SevenState,
     options: Mapping[int, list[tuple[int, ...]]],
 ) -> dict[str, dict[str, int]]:
@@ -1366,7 +1432,7 @@ def _low_support_terminal_eighth_center_audit(
 ) -> dict[str, Any]:
     options = _options()
     center_counts_by_state = {
-        state: _terminal_state_eighth_center_counts(state, options)
+        state: _state_eighth_center_counts(state, options)
         for state, _status in terminal_audits
     }
     status_by_state = {state: status for state, status in terminal_audits}
@@ -1613,6 +1679,23 @@ def _row_replacement_distance(left: tuple[int, ...], right: tuple[int, ...]) -> 
     return len(set(left) ^ set(right)) // 2
 
 
+def _center_orbit_key(center: int) -> str:
+    return ",".join(str(item) for item in sorted({center, _swap_label(center)}))
+
+
+def _replacement_side(center: int, removed: int, added: int) -> str:
+    center_block_start = 0 if center < N // 2 else N // 2
+    center_block = set(range(center_block_start, center_block_start + N // 2))
+    removed_side = "same_block" if removed in center_block else "opposite_block"
+    added_side = "same_block" if added in center_block else "opposite_block"
+    if removed_side != added_side:
+        raise AssertionError(
+            "nearest replacement changed same/opposite side: "
+            f"center={center}, removed={removed}, added={added}"
+        )
+    return removed_side
+
+
 def _state_replacement_distance(left: SevenState, right: SevenState) -> int:
     right_by_center = {center: row for center, row in right}
     return sum(
@@ -1663,8 +1746,16 @@ def _low_support_terminal_edit_distance_audit(
     min_replacements: Counter[int] = Counter()
     nearest_counts: Counter[int] = Counter()
     changed_row_counts: Counter[int] = Counter()
+    changed_center_counts: Counter[int] = Counter()
+    changed_center_orbit_counts: Counter[str] = Counter()
+    changed_center_removed_added_counts: Counter[str] = Counter()
+    replacement_side_counts: Counter[str] = Counter()
+    extendable_ok_center_counts: Counter[int] = Counter()
+    extendable_ok_row_counts: Counter[int] = Counter()
+    nearest_transition_count = 0
     class_summary: dict[str, dict[str, Any]] = {}
     by_terminal: list[dict[str, Any]] = []
+    options = _options()
 
     for key, entry in sorted(by_triple_profile.items()):
         if not entry["terminal"]:
@@ -1687,6 +1778,49 @@ def _low_support_terminal_edit_distance_audit(
             nearest_counts[len(nearest)] += 1
             changed_row_counts[len(changed_rows)] += 1
             class_distances.append(best_distance)
+            nearest_transition_count += len(nearest)
+
+            for extendable in nearest:
+                nearest_changed_rows = _changed_row_payload(terminal, extendable)
+                if len(nearest_changed_rows) != 1:
+                    raise AssertionError(
+                        "nearest transition changed more than one row: "
+                        f"{nearest_changed_rows!r}"
+                    )
+                changed_row = nearest_changed_rows[0]
+                removed = changed_row["removed"]
+                added = changed_row["added"]
+                if len(removed) != 1 or len(added) != 1:
+                    raise AssertionError(
+                        "nearest transition is not one-for-one: "
+                        f"{changed_row!r}"
+                    )
+                center = changed_row["center"]
+                removed_label = removed[0]
+                added_label = added[0]
+                changed_center_counts[center] += 1
+                changed_center_orbit_counts[_center_orbit_key(center)] += 1
+                changed_center_removed_added_counts[
+                    f"{center}:{removed_label}->{added_label}"
+                ] += 1
+                replacement_side_counts[
+                    _replacement_side(center, removed_label, added_label)
+                ] += 1
+                extendable_eighth_counts = _state_eighth_center_counts(
+                    extendable,
+                    options,
+                )
+                ok_center_count = sum(
+                    status_counts["ok"] > 0
+                    for status_counts in extendable_eighth_counts.values()
+                )
+                ok_row_count = sum(
+                    status_counts["ok"]
+                    for status_counts in extendable_eighth_counts.values()
+                )
+                extendable_ok_center_counts[ok_center_count] += 1
+                extendable_ok_row_counts[ok_row_count] += 1
+
             by_terminal.append(
                 {
                     "triple_profile": key,
@@ -1711,9 +1845,29 @@ def _low_support_terminal_edit_distance_audit(
         "terminal_triple_profile_classes": len(class_summary),
         "terminal_states_with_nearest_extendable": len(by_terminal),
         "min_replacement_distribution": _json_counter(min_replacements),
+        "nearest_transition_count": nearest_transition_count,
         "nearest_extendable_count_distribution": _json_counter(nearest_counts),
         "changed_row_count_distribution_for_first_nearest": _json_counter(
             changed_row_counts
+        ),
+        "changed_center_distribution": _json_counter(changed_center_counts),
+        "changed_center_orbit_distribution": {
+            key: int(changed_center_orbit_counts[key])
+            for key in sorted(changed_center_orbit_counts)
+        },
+        "changed_center_removed_added_distribution": {
+            key: int(changed_center_removed_added_counts[key])
+            for key in sorted(changed_center_removed_added_counts)
+        },
+        "replacement_side_distribution": {
+            key: int(replacement_side_counts[key])
+            for key in sorted(replacement_side_counts)
+        },
+        "extendable_ok_center_count_distribution": _json_counter(
+            extendable_ok_center_counts
+        ),
+        "extendable_ok_row_count_distribution": _json_counter(
+            extendable_ok_row_counts
         ),
         "class_summary": class_summary,
         "by_terminal": by_terminal,

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -217,6 +217,47 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "6": 4,
         "7": 2,
     }
+    assert edit_distance_audit["nearest_transition_count"] == 56
+    assert edit_distance_audit["changed_center_distribution"] == {
+        "2": 7,
+        "4": 4,
+        "5": 17,
+        "8": 7,
+        "10": 4,
+        "11": 17,
+    }
+    assert edit_distance_audit["changed_center_orbit_distribution"] == {
+        "2,8": 14,
+        "4,10": 8,
+        "5,11": 34,
+    }
+    assert edit_distance_audit["replacement_side_distribution"] == {
+        "opposite_block": 42,
+        "same_block": 14,
+    }
+    assert edit_distance_audit["changed_center_removed_added_distribution"][
+        "5:1->4"
+    ] == 5
+    assert edit_distance_audit["changed_center_removed_added_distribution"][
+        "11:7->10"
+    ] == 5
+    assert edit_distance_audit["extendable_ok_center_count_distribution"] == {
+        "1": 28,
+        "2": 24,
+        "3": 4,
+    }
+    assert edit_distance_audit["extendable_ok_row_count_distribution"] == {
+        "1": 18,
+        "2": 16,
+        "3": 4,
+        "4": 4,
+        "5": 4,
+        "6": 2,
+        "7": 2,
+        "9": 2,
+        "10": 2,
+        "13": 2,
+    }
     assert edit_distance_audit["changed_row_count_distribution_for_first_nearest"] == {
         "1": 12
     }


### PR DESCRIPTION
## Scope

Adds Cycle 652 exact finite audit data for the low-support block-6 terminal pockets. This extends the Cycle 651 one-replacement fragility audit by classifying all nearest terminal-to-extendable transitions.

Named result: **Block-6 Nearest-transition Signature Audit**.

## Mathematical result

- Covers the 56 nearest one-replacement transitions from the 12 terminal clean seven-row states to same-class extendable states.
- Changed-center distribution: `2:7`, `4:4`, `5:17`, `8:7`, `10:4`, `11:17`.
- Changed-center orbit distribution: `2,8:14`, `4,10:8`, `5,11:34`.
- Replacement side distribution: `same_block:14`, `opposite_block:42`.
- Clean eighth-center count after nearest transition: `1:28`, `2:24`, `3:4`.
- Stores the full changed-center/removed/added distribution in the checker payload and expected constants.

This is a local finite audit only. It is not a proof of Erdos Problem #97 and not a counterexample.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`
- `tests/test_block6_fragile_sixth_row_survivors.py`
- `docs/block6-fragile-sixth-row-survivor-catalog.md`
- `reports/codex_goal_erdos97_log.md`

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `542 passed, 276 deselected`

## Limitations

The audit rules out a center-only explanation for one-step terminal escape behavior in this branch. It points toward exact boundary-pair or local order-sign data, but does not establish a Euclidean obstruction or a general bridge lemma.