### PR TITLE
[codex] Add Bridge Lemma frontier diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: verify-lint verify-fast verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-n10-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review verify-artifacts audit-artifacts verify-all
 
 verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
@@ -64,11 +64,14 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
 	$(PYTHON) scripts/check_n9_base_apex_d3_artifact_join.py --check --json
 
+verify-bridge-frontier:
+	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+
 verify-n10-review:
 	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 	$(PYTHON) scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json
 
-verify-artifacts: verify-n8 verify-kalmanson verify-n9-review verify-n10-review
+verify-artifacts: verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review
 
 audit-artifacts:
 	$(PYTHON) scripts/check_status_consistency.py --max-official-status-age-days 90

--- a/data/certificates/bridge_lemma_frontier.json
+++ b/data/certificates/bridge_lemma_frontier.json
@@ -1,0 +1,2136 @@
+{
+  "bridge_lemma_a_prime_status": "OPEN_NOT_PROVED_OR_REFUTED",
+  "claim_scope": "Finite n=8/n=9 ear-orderability and obstruction cross-tab for Bridge Lemma A' proof mining; not a proof of the bridge, not a proof of Erdos Problem #97, not a counterexample, and not an official/global status update.",
+  "geometry": {
+    "interpretation": "Run scripts/check_bridge_lemma_frontier.py --run-geometry for optional numerical smoke probes. Numerical output is evidence only.",
+    "status": "NOT_RUN"
+  },
+  "interpretation_warnings": [
+    "All results are finite-frontier diagnostics, not a proof of Bridge Lemma A'.",
+    "The n=9 vertex-circle obstruction remains review-pending.",
+    "Numerical geometry probes, when enabled, are evidence only.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "n8": {
+    "records": [
+      {
+        "ear_order": {
+          "exists": false,
+          "largest_closure_size": 5,
+          "order": null,
+          "seed": null
+        },
+        "ear_orderable": false,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 0,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": false,
+          "largest_closure_size": 5,
+          "order": null,
+          "seed": null
+        },
+        "ear_orderable": false,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 1,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": false,
+          "largest_closure_size": 5,
+          "order": null,
+          "seed": null
+        },
+        "ear_orderable": false,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 2,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": false,
+          "largest_closure_size": 5,
+          "order": null,
+          "seed": null
+        },
+        "ear_orderable": false,
+        "exact_obstructions": [
+          {
+            "detail": "Groebner substitution chain forces duplicate vertices",
+            "method": "class3_duplicate_vertex",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 3,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            6,
+            2,
+            4,
+            7,
+            3,
+            5
+          ],
+          "seed": [
+            0,
+            1,
+            6
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "Groebner substitution chain forces collinearity",
+            "method": "class4_collinearity",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 4,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            6,
+            2,
+            7,
+            3,
+            4,
+            5
+          ],
+          "seed": [
+            0,
+            1,
+            6
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "Groebner basis contains 1",
+            "method": "class5_groebner_contradiction",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 5,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            2,
+            5,
+            1,
+            3,
+            7,
+            4,
+            6
+          ],
+          "seed": [
+            0,
+            2,
+            5
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 6,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            4,
+            6,
+            7,
+            2,
+            3,
+            5
+          ],
+          "seed": [
+            0,
+            1,
+            4
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 7,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            7,
+            5,
+            4,
+            6,
+            2,
+            3
+          ],
+          "seed": [
+            0,
+            1,
+            7
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 8,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            5,
+            7,
+            6,
+            3,
+            4,
+            2
+          ],
+          "seed": [
+            0,
+            1,
+            5
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 9,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            3,
+            7,
+            6,
+            4,
+            5,
+            2
+          ],
+          "seed": [
+            0,
+            1,
+            3
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 10,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            2,
+            6,
+            7,
+            4,
+            5,
+            3
+          ],
+          "seed": [
+            0,
+            1,
+            2
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 11,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            2,
+            7,
+            6,
+            4,
+            5,
+            3
+          ],
+          "seed": [
+            0,
+            1,
+            2
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "0 compatible cyclic orders",
+            "method": "cyclic_order_noncrossing",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 12,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            6,
+            4,
+            5,
+            7,
+            2,
+            3
+          ],
+          "seed": [
+            0,
+            1,
+            6
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "y_2 lies in the rational PB-polynomial span",
+            "method": "pb_y2_span",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 13,
+        "n": 8
+      },
+      {
+        "ear_order": {
+          "exists": true,
+          "largest_closure_size": 8,
+          "order": [
+            0,
+            1,
+            3,
+            7,
+            4,
+            5,
+            6,
+            2
+          ],
+          "seed": [
+            0,
+            1,
+            3
+          ]
+        },
+        "ear_orderable": true,
+        "exact_obstructions": [
+          {
+            "detail": "PB+ED Groebner branches exist only in configurations failing strict convexity",
+            "method": "class14_pb_ed_groebner_strict_interior",
+            "scope": "n=8 selected-witness survivor class",
+            "status": "EXACT_OBSTRUCTION"
+          }
+        ],
+        "id": 14,
+        "n": 8
+      }
+    ],
+    "source": "data/incidence/n8_reconstructed_15_survivors.json"
+  },
+  "n9": {
+    "records": [
+      {
+        "assignment_index": 0,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 1,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 2,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 3,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 4,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 5,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 6,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 7,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 8,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 9,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 10,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 11,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 12,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 13,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 14,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 15,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 16,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 17,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 18,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 19,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 20,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 21,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 22,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 23,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 24,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 25,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 26,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 27,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 28,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 29,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 30,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 31,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 32,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 33,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 34,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 35,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 36,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 37,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 38,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 39,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 40,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 41,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 42,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 43,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 44,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 45,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 46,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 47,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 48,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 49,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 50,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 51,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 52,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 53,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 54,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 55,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 56,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 57,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 58,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 59,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 60,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 61,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 62,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 63,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 64,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 65,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 66,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 67,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 68,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 69,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 70,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 71,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 72,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 73,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 74,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 75,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 76,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 77,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 78,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 79,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 80,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 81,
+        "circulant_offsets": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "ear_orderable": false,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 82,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 83,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 84,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 85,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 86,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 87,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 88,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 89,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 90,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 91,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 92,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 93,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 94,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 95,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 96,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 97,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 98,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 99,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 100,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 101,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 102,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 103,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 104,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 105,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 106,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 107,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 108,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 109,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 110,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 111,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 112,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 113,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 114,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 115,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 116,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 117,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 118,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 119,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 120,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 121,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 122,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 123,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 124,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 125,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 126,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 127,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 128,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 129,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 130,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 131,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 132,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 133,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 134,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 135,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 136,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 137,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 138,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 139,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 140,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 141,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 142,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 143,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 144,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 145,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 146,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 147,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 148,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 149,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 150,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 151,
+        "circulant_offsets": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "ear_orderable": false,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 152,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 153,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 154,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 155,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 156,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 157,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 158,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 159,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 160,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 161,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 162,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 163,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 164,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 165,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 166,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 167,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 168,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 169,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 170,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 171,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 172,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 173,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 174,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 175,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 176,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 177,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 178,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 179,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "strict_cycle"
+      },
+      {
+        "assignment_index": 180,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 181,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 182,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      },
+      {
+        "assignment_index": 183,
+        "ear_orderable": true,
+        "n": 9,
+        "vertex_circle_status": "self_edge"
+      }
+    ],
+    "source": "src/erdos97/n9_vertex_circle_exhaustive.py"
+  },
+  "proof_mining_targets": [
+    {
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          2,
+          3,
+          6
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "exact_obstructions": [
+        {
+          "detail": "y_2 lies in the rational PB-polynomial span",
+          "method": "pb_y2_span",
+          "scope": "n=8 selected-witness survivor class",
+          "status": "EXACT_OBSTRUCTION"
+        }
+      ],
+      "n": 8,
+      "selected_rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          7
+        ],
+        [
+          0,
+          5,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          4,
+          5,
+          6
+        ]
+      ],
+      "source": "data/incidence/n8_reconstructed_15_survivors.json",
+      "source_record_id": 0,
+      "target_id": "n8-class-0",
+      "why": "Non-ear-orderable n=8 selected-witness survivor; small fixed-selection stuck target for Bridge Lemma A' proof mining."
+    },
+    {
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          2,
+          3,
+          6
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "exact_obstructions": [
+        {
+          "detail": "y_2 lies in the rational PB-polynomial span",
+          "method": "pb_y2_span",
+          "scope": "n=8 selected-witness survivor class",
+          "status": "EXACT_OBSTRUCTION"
+        }
+      ],
+      "n": 8,
+      "selected_rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ]
+      ],
+      "source": "data/incidence/n8_reconstructed_15_survivors.json",
+      "source_record_id": 1,
+      "target_id": "n8-class-1",
+      "why": "Non-ear-orderable n=8 selected-witness survivor; small fixed-selection stuck target for Bridge Lemma A' proof mining."
+    },
+    {
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          2,
+          3,
+          6
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "exact_obstructions": [
+        {
+          "detail": "y_2 lies in the rational PB-polynomial span",
+          "method": "pb_y2_span",
+          "scope": "n=8 selected-witness survivor class",
+          "status": "EXACT_OBSTRUCTION"
+        }
+      ],
+      "n": 8,
+      "selected_rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          6
+        ]
+      ],
+      "source": "data/incidence/n8_reconstructed_15_survivors.json",
+      "source_record_id": 2,
+      "target_id": "n8-class-2",
+      "why": "Non-ear-orderable n=8 selected-witness survivor; small fixed-selection stuck target for Bridge Lemma A' proof mining."
+    },
+    {
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          2,
+          4,
+          6
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "exact_obstructions": [
+        {
+          "detail": "Groebner substitution chain forces duplicate vertices",
+          "method": "class3_duplicate_vertex",
+          "scope": "n=8 selected-witness survivor class",
+          "status": "EXACT_OBSTRUCTION"
+        }
+      ],
+      "n": 8,
+      "selected_rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          4,
+          5,
+          6
+        ]
+      ],
+      "source": "data/incidence/n8_reconstructed_15_survivors.json",
+      "source_record_id": 3,
+      "target_id": "n8-class-3",
+      "why": "Non-ear-orderable n=8 selected-witness survivor; small fixed-selection stuck target for Bridge Lemma A' proof mining."
+    },
+    {
+      "circulant_offsets": [
+        1,
+        3,
+        6,
+        7
+      ],
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          3,
+          4,
+          6
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          4
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "exact_obstructions": [
+        {
+          "method": "vertex_circle_strict_cycle",
+          "scope": "n=9 selected-witness assignment in the review-pending checker",
+          "status": "EXACT_OBSTRUCTION_REVIEW_PENDING"
+        }
+      ],
+      "n": 9,
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "source": "src/erdos97/n9_vertex_circle_exhaustive.py",
+      "source_record_id": 81,
+      "target_id": "n9-assignment-81",
+      "vertex_circle_status": "strict_cycle",
+      "why": "Non-ear-orderable n=9 selected-witness frontier assignment; killed by the review-pending exact vertex-circle obstruction and useful as an edge-case target for Bridge Lemma A' proof mining."
+    },
+    {
+      "circulant_offsets": [
+        2,
+        3,
+        6,
+        8
+      ],
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          4,
+          6,
+          7
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "exact_obstructions": [
+        {
+          "method": "vertex_circle_strict_cycle",
+          "scope": "n=9 selected-witness assignment in the review-pending checker",
+          "status": "EXACT_OBSTRUCTION_REVIEW_PENDING"
+        }
+      ],
+      "n": 9,
+      "selected_rows": [
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source": "src/erdos97/n9_vertex_circle_exhaustive.py",
+      "source_record_id": 151,
+      "target_id": "n9-assignment-151",
+      "vertex_circle_status": "strict_cycle",
+      "why": "Non-ear-orderable n=9 selected-witness frontier assignment; killed by the review-pending exact vertex-circle obstruction and useful as an edge-case target for Bridge Lemma A' proof mining."
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_bridge_lemma_frontier.py --write --assert-expected",
+    "generator": "scripts/check_bridge_lemma_frontier.py",
+    "sources": [
+      "data/incidence/n8_reconstructed_15_survivors.json",
+      "scripts/analyze_n8_exact_survivors.py",
+      "src/erdos97/n9_vertex_circle_exhaustive.py",
+      "src/erdos97/stuck_sets.py"
+    ]
+  },
+  "schema": "erdos97.bridge_lemma_frontier.v1",
+  "status": "BRIDGE_LEMMA_FRONTIER_DIAGNOSTIC_ONLY",
+  "summary": {
+    "n8_ear_orderable": 11,
+    "n8_non_ear_ids": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "n8_non_ear_orderable": 4,
+    "n8_total": 15,
+    "n9_cross_tabulation": {
+      "ear|ok": 0,
+      "ear|self_edge": 158,
+      "ear|strict_cycle": 24,
+      "non_ear|ok": 0,
+      "non_ear|self_edge": 0,
+      "non_ear|strict_cycle": 2
+    },
+    "n9_ear_orderable": 182,
+    "n9_non_ear_indices": [
+      81,
+      151
+    ],
+    "n9_non_ear_orderable": 2,
+    "n9_total": 184,
+    "n9_vertex_circle_status_counts": {
+      "self_edge": 158,
+      "strict_cycle": 26
+    },
+    "proof_mining_target_count": 6
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bridge-lemma-frontier.md
+++ b/docs/bridge-lemma-frontier.md
@@ -1,0 +1,75 @@
+# Bridge Lemma Frontier Diagnostic
+
+Status: proof-mining diagnostic only. No general proof, no Bridge Lemma A'
+proof, and no counterexample are claimed.
+
+Bridge Lemma A' says that every realizable strictly convex `k=4`
+counterexample admits an ear-orderable selected-witness pattern. The lemma is
+open. This diagnostic makes the current finite frontier around that question
+replayable:
+
+- `n=8`: all 15 incidence-completeness survivor classes are rechecked for
+  ear-orderability and cross-referenced with exact obstruction certificates.
+- `n=9`: all 184 pre-vertex-circle frontier assignments are regenerated from
+  the review-pending exhaustive checker, rechecked for ear-orderability, and
+  cross-tabulated against the exact vertex-circle obstruction type.
+- The four non-ear `n=8` classes and two non-ear `n=9` assignments are emitted
+  as explicit proof-mining targets.
+
+The checked artifact is:
+
+```bash
+data/certificates/bridge_lemma_frontier.json
+```
+
+## Reproduction
+
+Regenerate and compare the checked artifact:
+
+```bash
+python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+```
+
+Rewrite the artifact after an intentional generator change:
+
+```bash
+python scripts/check_bridge_lemma_frontier.py --write --assert-expected
+```
+
+Run optional numerical smoke probes on the six non-ear targets:
+
+```bash
+python scripts/check_bridge_lemma_frontier.py \
+  --run-geometry \
+  --geometry-restarts 3 \
+  --geometry-max-nfev 1000
+```
+
+Numerical output is evidence only. A low residual would still require exact
+coordinates, interval certificates, SMT certificates, or a formal proof before
+supporting any counterexample-style claim.
+
+## Current Counts
+
+| Frontier | total | ear-orderable | non-ear | non-ear ids |
+|---|---:|---:|---:|---|
+| `n=8` survivor classes | 15 | 11 | 4 | `0, 1, 2, 3` |
+| `n=9` frontier assignments | 184 | 182 | 2 | `81, 151` |
+
+For `n=9`, the two non-ear assignments are both killed by strict-cycle
+vertex-circle obstructions in the review-pending checker. The full cross-tab is
+stored in the artifact summary.
+
+## Usefulness
+
+This is useful because it separates three questions that were easy to blur:
+
+1. Which finite frontier objects are ear-orderable?
+2. Which non-ear fixed selections are already killed by exact finite-case
+   obstructions?
+3. Which small non-ear objects should be studied next when trying to prove or
+   refute Bridge Lemma A'?
+
+The diagnostic does not prove the bridge. Its value is that it gives future
+work six concrete, reproducible edge cases instead of a vague instruction to
+"look at stuck sets."

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,9 @@ put detailed reconciliation in the canonical synthesis.
   for the bridge/peeling program.
 - [`stuck-frontier-snapshot.md`](stuck-frontier-snapshot.md): first stuck-set,
   radius-propagation, and fragile-cover pass over sparse frontier benchmarks.
+- [`bridge-lemma-frontier.md`](bridge-lemma-frontier.md): replayable
+  n=8/n=9 ear-orderability and obstruction cross-tab for Bridge Lemma A'
+  proof-mining targets.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1679,6 +1679,52 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: bridge_lemma_frontier
+    path: data/certificates/bridge_lemma_frontier.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bridge_lemma_frontier.py
+    command: python scripts/check_bridge_lemma_frontier.py --write --assert-expected
+    checker: scripts/check_bridge_lemma_frontier.py
+    check_command: python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Finite n=8/n=9 ear-orderability and obstruction cross-tab for Bridge Lemma A' proof mining; not a proof of the bridge, not a proof of Erdos Problem #97, not a counterexample, and not an official/global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bridge_lemma_frontier.v1
+      status: BRIDGE_LEMMA_FRONTIER_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      bridge_lemma_a_prime_status: OPEN_NOT_PROVED_OR_REFUTED
+      geometry.status: NOT_RUN
+      summary.n8_total: 15
+      summary.n8_ear_orderable: 11
+      summary.n8_non_ear_orderable: 4
+      summary.n8_non_ear_ids:
+        - 0
+        - 1
+        - 2
+        - 3
+      summary.n9_total: 184
+      summary.n9_ear_orderable: 182
+      summary.n9_non_ear_orderable: 2
+      summary.n9_non_ear_indices:
+        - 81
+        - 151
+      summary.n9_vertex_circle_status_counts.self_edge: 158
+      summary.n9_vertex_circle_status_counts.strict_cycle: 26
+      summary.proof_mining_target_count: 6
+      provenance.command: python scripts/check_bridge_lemma_frontier.py --write --assert-expected
+    forbidden_claims:
+      - Bridge Lemma A' is proved
+      - Bridge Lemma A' is refuted
+      - n=9 is proved
+      - n=8/n=9 finite diagnostics prove the general theorem
+      - independent review of the n=9 checker is complete
+      - numerical geometry output is a counterexample
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
   - id: speculative_circulant_frontier_obstructions
     path: data/certificates/speculative_circulant_frontier_obstructions.json
     kind: certificate_artifact

--- a/scripts/check_bridge_lemma_frontier.py
+++ b/scripts/check_bridge_lemma_frontier.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Check the finite Bridge Lemma A' frontier diagnostic artifact.
+
+This script regenerates the n=8/n=9 ear-orderability frontier and the exact
+obstruction crosswalk for the non-ear proof-mining targets.  It is diagnostic
+only: no general proof, bridge proof, or counterexample is claimed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import analyze_n8_exact_survivors as n8_exact  # noqa: E402
+from erdos97.bridge_lemma_frontier import (  # noqa: E402
+    CLAIM_SCOPE,
+    GeometryConfig,
+    assert_expected_payload,
+    build_payload,
+)
+
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "bridge_lemma_frontier.json"
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def n8_exact_obstruction_map(root: Path) -> dict[int, list[dict[str, object]]]:
+    """Return exact obstruction labels for the reconstructed n=8 classes."""
+
+    survivors = n8_exact.load_survivors(root)
+    compatible_counts = n8_exact.check_cyclic_counts(survivors)
+    y2_span = n8_exact.check_y2_span(survivors)
+    class3_duplicate = n8_exact.check_class3_duplicate_certificate(survivors)
+    class4_collinearity = n8_exact.check_class4_collinearity_certificate(survivors)
+    class5_groebner = n8_exact.check_class5_groebner(survivors)
+    class14 = n8_exact.check_class14_certificate(survivors)
+
+    out: dict[int, list[dict[str, object]]] = {}
+    for record in survivors:
+        class_id = int(record["id"])
+        obstructions: list[dict[str, object]] = []
+        count = int(compatible_counts[class_id])
+        if count == 0:
+            obstructions.append(
+                {
+                    "method": "cyclic_order_noncrossing",
+                    "status": "EXACT_OBSTRUCTION",
+                    "scope": "n=8 selected-witness survivor class",
+                    "detail": "0 compatible cyclic orders",
+                }
+            )
+        if y2_span.get(class_id):
+            obstructions.append(
+                {
+                    "method": "pb_y2_span",
+                    "status": "EXACT_OBSTRUCTION",
+                    "scope": "n=8 selected-witness survivor class",
+                    "detail": "y_2 lies in the rational PB-polynomial span",
+                }
+            )
+        if class_id == 3 and class3_duplicate:
+            obstructions.append(
+                {
+                    "method": "class3_duplicate_vertex",
+                    "status": "EXACT_OBSTRUCTION",
+                    "scope": "n=8 selected-witness survivor class",
+                    "detail": "Groebner substitution chain forces duplicate vertices",
+                }
+            )
+        if class_id == 4 and class4_collinearity:
+            obstructions.append(
+                {
+                    "method": "class4_collinearity",
+                    "status": "EXACT_OBSTRUCTION",
+                    "scope": "n=8 selected-witness survivor class",
+                    "detail": "Groebner substitution chain forces collinearity",
+                }
+            )
+        if class_id == 5 and class5_groebner:
+            obstructions.append(
+                {
+                    "method": "class5_groebner_contradiction",
+                    "status": "EXACT_OBSTRUCTION",
+                    "scope": "n=8 selected-witness survivor class",
+                    "detail": "Groebner basis contains 1",
+                }
+            )
+        if class_id == 14 and all(bool(value) for value in class14.values()):
+            obstructions.append(
+                {
+                    "method": "class14_pb_ed_groebner_strict_interior",
+                    "status": "EXACT_OBSTRUCTION",
+                    "scope": "n=8 selected-witness survivor class",
+                    "detail": (
+                        "PB+ED Groebner branches exist only in configurations "
+                        "failing strict convexity"
+                    ),
+                }
+            )
+        out[class_id] = obstructions
+    return out
+
+
+def build_payload_from_repo(
+    root: Path = ROOT,
+    geometry_config: GeometryConfig | None = None,
+) -> dict[str, object]:
+    survivors_path = root / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+    survivors = load_json(survivors_path)
+    if not isinstance(survivors, list):
+        raise ValueError("n8 survivor artifact should be a JSON list")
+    return build_payload(
+        survivors,
+        n8_exact_obstruction_map(root),
+        geometry_config=geometry_config,
+    )
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = load_json(path)
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_human_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("Bridge Lemma A' frontier diagnostic")
+    print(f"claim scope: {CLAIM_SCOPE}")
+    print(
+        "n=8: "
+        f"{summary['n8_ear_orderable']} ear-orderable, "
+        f"{summary['n8_non_ear_orderable']} non-ear "
+        f"{summary['n8_non_ear_ids']}"
+    )
+    print(
+        "n=9: "
+        f"{summary['n9_ear_orderable']} ear-orderable, "
+        f"{summary['n9_non_ear_orderable']} non-ear "
+        f"{summary['n9_non_ear_indices']}"
+    )
+    print(f"n=9 vertex-circle statuses: {summary['n9_vertex_circle_status_counts']}")
+    print(f"proof-mining targets: {summary['proof_mining_target_count']}")
+    geometry = payload.get("geometry")
+    if isinstance(geometry, Mapping) and geometry.get("status") == "RAN":
+        print("geometry smoke probes:")
+        records = geometry.get("records")
+        if isinstance(records, list):
+            for record in records:
+                if not isinstance(record, Mapping):
+                    continue
+                if record.get("status") != "RAN":
+                    print(f"  {record.get('target_id')}: {record.get('status')}")
+                    continue
+                print(
+                    f"  {record.get('target_id')}: "
+                    f"eq_rms={record.get('eq_rms')} "
+                    f"max_spread={record.get('max_spread')} "
+                    f"success={record.get('success')}"
+                )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the checked artifact")
+    parser.add_argument("--check", action="store_true", help="compare against the checked artifact")
+    parser.add_argument("--assert-expected", action="store_true", help="assert stable frontier counts")
+    parser.add_argument("--json", action="store_true", help="print the full JSON payload")
+    parser.add_argument("--run-geometry", action="store_true", help="run optional numerical smoke probes")
+    parser.add_argument("--geometry-mode", choices=["polar", "direct", "support"], default="polar")
+    parser.add_argument("--geometry-optimizer", choices=["trf", "slsqp"], default="slsqp")
+    parser.add_argument("--geometry-restarts", type=int, default=3)
+    parser.add_argument("--geometry-seed", type=int, default=0)
+    parser.add_argument("--geometry-max-nfev", type=int, default=1000)
+    parser.add_argument("--geometry-margin", type=float, default=1e-3)
+    args = parser.parse_args(argv)
+    if args.check and args.run_geometry:
+        parser.error("--check cannot be combined with --run-geometry")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    geometry = GeometryConfig(
+        run=args.run_geometry,
+        mode=args.geometry_mode,
+        optimizer=args.geometry_optimizer,
+        restarts=args.geometry_restarts,
+        seed=args.geometry_seed,
+        max_nfev=args.geometry_max_nfev,
+        margin=args.geometry_margin,
+    )
+    payload = build_payload_from_repo(ROOT, geometry)
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_human_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bridge_lemma_frontier.py
+++ b/src/erdos97/bridge_lemma_frontier.py
@@ -1,0 +1,465 @@
+"""Bridge Lemma A' frontier diagnostics.
+
+This module regenerates small finite ear-orderability diagnostics used for the
+Bridge Lemma A' / key-peeling program.  It is a research diagnostic only: it
+does not prove the bridge, does not prove Erdos Problem #97, and does not claim
+a counterexample.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.fragile_hypergraph import rows_from_zero_one_matrix
+from erdos97.search import PatternInfo, result_to_json, search_pattern
+from erdos97.stuck_sets import ForwardEarOrderResult, forward_ear_order
+
+
+SCHEMA = "erdos97.bridge_lemma_frontier.v1"
+STATUS = "BRIDGE_LEMMA_FRONTIER_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Finite n=8/n=9 ear-orderability and obstruction cross-tab for Bridge "
+    "Lemma A' proof mining; not a proof of the bridge, not a proof of Erdos "
+    "Problem #97, not a counterexample, and not an official/global status "
+    "update."
+)
+DEFAULT_SOURCE_N8 = "data/incidence/n8_reconstructed_15_survivors.json"
+DEFAULT_SOURCE_N9 = "src/erdos97/n9_vertex_circle_exhaustive.py"
+
+EXPECTED_N8_TOTAL = 15
+EXPECTED_N8_EAR = 11
+EXPECTED_N8_NON_EAR_IDS = [0, 1, 2, 3]
+EXPECTED_N9_TOTAL = 184
+EXPECTED_N9_EAR = 182
+EXPECTED_N9_NON_EAR_INDICES = [81, 151]
+EXPECTED_N9_STATUS_COUNTS = {"self_edge": 158, "strict_cycle": 26}
+EXPECTED_CROSS_TAB = {
+    "ear|ok": 0,
+    "ear|self_edge": 158,
+    "ear|strict_cycle": 24,
+    "non_ear|ok": 0,
+    "non_ear|self_edge": 0,
+    "non_ear|strict_cycle": 2,
+}
+
+
+Pattern = list[list[int]]
+
+
+@dataclass(frozen=True)
+class GeometryConfig:
+    """Configuration for optional numerical smoke probes."""
+
+    run: bool = False
+    mode: str = "polar"
+    optimizer: str = "slsqp"
+    restarts: int = 3
+    seed: int = 0
+    max_nfev: int = 1000
+    margin: float = 1e-3
+
+
+def _ear_json(result: ForwardEarOrderResult) -> dict[str, object]:
+    return {
+        "exists": result.exists,
+        "seed": result.seed,
+        "order": result.order,
+        "largest_closure_size": result.largest_closure_size,
+        "largest_closure_seed": result.largest_closure_seed,
+        "largest_closure": result.largest_closure,
+    }
+
+
+def _short_ear_json(result: ForwardEarOrderResult) -> dict[str, object]:
+    return {
+        "exists": result.exists,
+        "seed": result.seed,
+        "order": result.order,
+        "largest_closure_size": result.largest_closure_size,
+    }
+
+
+def _n8_selected_rows(record: Mapping[str, object]) -> Pattern:
+    rows = record.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("n=8 survivor record is missing rows")
+    matrix = [[int(value) for value in row] for row in rows]
+    converted = rows_from_zero_one_matrix(matrix)
+    return [converted[center] for center in range(len(converted))]
+
+
+def _n9_assignment_rows(assign: n9.Assignment) -> Pattern:
+    return [list(n9.MASK_BITS[assign[center]]) for center in range(n9.N)]
+
+
+def collect_n9_frontier_assignments() -> list[tuple[int, Pattern, str]]:
+    """Return full n=9 assignments before vertex-circle pruning.
+
+    The traversal mirrors ``exhaustive_search(use_vertex_circle=False)`` so the
+    assignment indices are stable against the checked n=9 review artifact.
+    """
+
+    assignments: list[tuple[int, Pattern, str]] = []
+
+    def search(
+        assign: n9.Assignment,
+        column_counts: list[int],
+        witness_pair_counts: list[int],
+    ) -> None:
+        if len(assign) == n9.N:
+            rows = _n9_assignment_rows(assign)
+            status = n9.vertex_circle_status(assign)
+            assignments.append((len(assignments), rows, status))
+            return
+
+        best_center = None
+        best_options = None
+        for center in range(n9.N):
+            if center in assign:
+                continue
+            opts = n9.valid_options_for_center(
+                center,
+                assign,
+                column_counts,
+                witness_pair_counts,
+            )
+            if best_options is None or len(opts) < len(best_options):
+                best_center = center
+                best_options = opts
+                if not opts:
+                    break
+        if not best_options:
+            return
+
+        center = best_center
+        assert center is not None
+        for row_mask in best_options:
+            assign[center] = row_mask
+            for target in n9.MASK_BITS[row_mask]:
+                column_counts[target] += 1
+            for pair_index in n9.ROW_PAIR_INDICES[row_mask]:
+                witness_pair_counts[pair_index] += 1
+
+            search(assign, column_counts, witness_pair_counts)
+
+            for pair_index in n9.ROW_PAIR_INDICES[row_mask]:
+                witness_pair_counts[pair_index] -= 1
+            for target in n9.MASK_BITS[row_mask]:
+                column_counts[target] -= 1
+            del assign[center]
+
+    for row0 in n9.OPTIONS[0]:
+        assign: n9.Assignment = {0: row0}
+        column_counts = [0] * n9.N
+        witness_pair_counts = [0] * len(n9.PAIRS)
+        for target in n9.MASK_BITS[row0]:
+            column_counts[target] += 1
+        for pair_index in n9.ROW_PAIR_INDICES[row0]:
+            witness_pair_counts[pair_index] += 1
+        if n9.vertex_circle_status(assign) == "ok":
+            search(assign, column_counts, witness_pair_counts)
+
+    return assignments
+
+
+def circulant_offsets(rows: Pattern) -> list[int] | None:
+    """Return common row offsets when a selected pattern is circulant."""
+
+    n = len(rows)
+    offsets = sorted((target - 0) % n for target in rows[0])
+    for center, row in enumerate(rows):
+        if sorted((target - center) % n for target in row) != offsets:
+            return None
+    return offsets
+
+
+def _geometry_payload_for_target(
+    target: Mapping[str, object],
+    config: GeometryConfig,
+) -> dict[str, object]:
+    rows = target.get("selected_rows")
+    if not isinstance(rows, list):
+        return {"status": "SKIPPED_NO_SELECTED_ROWS", "success": False}
+    pattern = PatternInfo(
+        name=str(target["target_id"]),
+        n=int(target["n"]),
+        S=[[int(label) for label in row] for row in rows],
+        family="bridge-frontier",
+        formula="non-ear proof-mining target",
+        notes="numerical smoke probe only",
+    )
+    try:
+        result = search_pattern(
+            pattern,
+            mode=config.mode,
+            restarts=config.restarts,
+            seed=config.seed,
+            max_nfev=config.max_nfev,
+            optimizer=config.optimizer,
+            margin=config.margin,
+        )
+    except RuntimeError as exc:
+        return {
+            "target_id": target["target_id"],
+            "status": "OPTIMIZER_FAILED",
+            "success": False,
+            "message": str(exc),
+            "interpretation": (
+                "Numerical optimizer failure is not an exact obstruction or a "
+                "counterexample."
+            ),
+        }
+
+    data = result_to_json(result)
+    keys = [
+        "pattern_name",
+        "n",
+        "mode",
+        "loss",
+        "eq_rms",
+        "max_spread",
+        "max_rel_spread",
+        "convexity_margin",
+        "min_edge_length",
+        "min_pair_distance",
+        "success",
+        "elapsed_sec",
+    ]
+    return {
+        "target_id": target["target_id"],
+        "status": "RAN",
+        **{key: data[key] for key in keys},
+        "interpretation": (
+            "NUMERICAL_EVIDENCE only. A low residual is not a counterexample "
+            "without exact or interval certificates."
+        ),
+    }
+
+
+def _geometry_section(
+    targets: Sequence[Mapping[str, object]],
+    config: GeometryConfig,
+) -> dict[str, object]:
+    if not config.run:
+        return {
+            "status": "NOT_RUN",
+            "interpretation": (
+                "Run scripts/check_bridge_lemma_frontier.py --run-geometry "
+                "for optional numerical smoke probes. Numerical output is "
+                "evidence only."
+            ),
+        }
+    return {
+        "status": "RAN",
+        "config": {
+            "mode": config.mode,
+            "optimizer": config.optimizer,
+            "restarts": config.restarts,
+            "seed": config.seed,
+            "max_nfev": config.max_nfev,
+            "margin": config.margin,
+        },
+        "records": [_geometry_payload_for_target(target, config) for target in targets],
+        "interpretation": "NUMERICAL_EVIDENCE only.",
+    }
+
+
+def build_payload(
+    n8_survivors: Sequence[Mapping[str, object]],
+    n8_exact_obstructions: Mapping[int, Sequence[Mapping[str, object]]],
+    geometry_config: GeometryConfig | None = None,
+) -> dict[str, object]:
+    """Build a deterministic Bridge Lemma A' frontier payload."""
+
+    geometry_config = geometry_config or GeometryConfig()
+
+    n8_records: list[dict[str, object]] = []
+    proof_targets: list[dict[str, object]] = []
+    for raw_record in n8_survivors:
+        class_id = int(raw_record["id"])
+        rows = _n8_selected_rows(raw_record)
+        ear = forward_ear_order(rows)
+        obstructions = list(n8_exact_obstructions.get(class_id, []))
+        record = {
+            "id": class_id,
+            "n": 8,
+            "ear_orderable": ear.exists,
+            "ear_order": _short_ear_json(ear),
+            "exact_obstructions": obstructions,
+        }
+        n8_records.append(record)
+        if not ear.exists:
+            proof_targets.append(
+                {
+                    "target_id": f"n8-class-{class_id}",
+                    "n": 8,
+                    "source": DEFAULT_SOURCE_N8,
+                    "source_record_id": class_id,
+                    "selected_rows": rows,
+                    "ear_order": _ear_json(ear),
+                    "exact_obstructions": obstructions,
+                    "why": (
+                        "Non-ear-orderable n=8 selected-witness survivor; "
+                        "small fixed-selection stuck target for Bridge Lemma "
+                        "A' proof mining."
+                    ),
+                }
+            )
+
+    n8_ear_count = sum(1 for record in n8_records if record["ear_orderable"])
+    n8_non_ear_ids = [
+        int(record["id"]) for record in n8_records if not record["ear_orderable"]
+    ]
+
+    n9_assignments = collect_n9_frontier_assignments()
+    n9_records: list[dict[str, object]] = []
+    n9_status_counts: Counter[str] = Counter()
+    cross_tab: Counter[str] = Counter()
+    for index, rows, status in n9_assignments:
+        ear = forward_ear_order(rows)
+        label = "ear" if ear.exists else "non_ear"
+        n9_status_counts[status] += 1
+        cross_tab[f"{label}|{status}"] += 1
+        offsets = circulant_offsets(rows)
+        record: dict[str, object] = {
+            "assignment_index": index,
+            "n": 9,
+            "ear_orderable": ear.exists,
+            "vertex_circle_status": status,
+        }
+        if not ear.exists and offsets is not None:
+            record["circulant_offsets"] = offsets
+        n9_records.append(record)
+        if not ear.exists:
+            proof_targets.append(
+                {
+                    "target_id": f"n9-assignment-{index}",
+                    "n": 9,
+                    "source": DEFAULT_SOURCE_N9,
+                    "source_record_id": index,
+                    "selected_rows": rows,
+                    "ear_order": _ear_json(ear),
+                    "vertex_circle_status": status,
+                    "circulant_offsets": offsets,
+                    "exact_obstructions": [
+                        {
+                            "method": f"vertex_circle_{status}",
+                            "status": "EXACT_OBSTRUCTION_REVIEW_PENDING",
+                            "scope": "n=9 selected-witness assignment in the review-pending checker",
+                        }
+                    ],
+                    "why": (
+                        "Non-ear-orderable n=9 selected-witness frontier "
+                        "assignment; killed by the review-pending exact "
+                        "vertex-circle obstruction and useful as an edge-case "
+                        "target for Bridge Lemma A' proof mining."
+                    ),
+                }
+            )
+
+    n9_ear_count = sum(1 for record in n9_records if record["ear_orderable"])
+    n9_non_ear_indices = [
+        int(record["assignment_index"])
+        for record in n9_records
+        if not record["ear_orderable"]
+    ]
+    cross_tab_payload = {
+        key: cross_tab.get(key, 0)
+        for key in [
+            "ear|self_edge",
+            "ear|strict_cycle",
+            "ear|ok",
+            "non_ear|self_edge",
+            "non_ear|strict_cycle",
+            "non_ear|ok",
+        ]
+    }
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "bridge_lemma_a_prime_status": "OPEN_NOT_PROVED_OR_REFUTED",
+        "interpretation_warnings": [
+            "All results are finite-frontier diagnostics, not a proof of Bridge Lemma A'.",
+            "The n=9 vertex-circle obstruction remains review-pending.",
+            "Numerical geometry probes, when enabled, are evidence only.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "summary": {
+            "n8_total": len(n8_records),
+            "n8_ear_orderable": n8_ear_count,
+            "n8_non_ear_orderable": len(n8_records) - n8_ear_count,
+            "n8_non_ear_ids": n8_non_ear_ids,
+            "n9_total": len(n9_records),
+            "n9_ear_orderable": n9_ear_count,
+            "n9_non_ear_orderable": len(n9_records) - n9_ear_count,
+            "n9_non_ear_indices": n9_non_ear_indices,
+            "n9_vertex_circle_status_counts": dict(sorted(n9_status_counts.items())),
+            "n9_cross_tabulation": cross_tab_payload,
+            "proof_mining_target_count": len(proof_targets),
+        },
+        "n8": {
+            "source": DEFAULT_SOURCE_N8,
+            "records": n8_records,
+        },
+        "n9": {
+            "source": DEFAULT_SOURCE_N9,
+            "records": n9_records,
+        },
+        "proof_mining_targets": proof_targets,
+        "geometry": _geometry_section(proof_targets, geometry_config),
+        "provenance": {
+            "generator": "scripts/check_bridge_lemma_frontier.py",
+            "command": "python scripts/check_bridge_lemma_frontier.py --write --assert-expected",
+            "sources": [
+                DEFAULT_SOURCE_N8,
+                "scripts/analyze_n8_exact_survivors.py",
+                DEFAULT_SOURCE_N9,
+                "src/erdos97/stuck_sets.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert stable frontier counts used by the checked artifact."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("payload summary is missing or malformed")
+
+    expected = {
+        "n8_total": EXPECTED_N8_TOTAL,
+        "n8_ear_orderable": EXPECTED_N8_EAR,
+        "n8_non_ear_orderable": EXPECTED_N8_TOTAL - EXPECTED_N8_EAR,
+        "n8_non_ear_ids": EXPECTED_N8_NON_EAR_IDS,
+        "n9_total": EXPECTED_N9_TOTAL,
+        "n9_ear_orderable": EXPECTED_N9_EAR,
+        "n9_non_ear_orderable": EXPECTED_N9_TOTAL - EXPECTED_N9_EAR,
+        "n9_non_ear_indices": EXPECTED_N9_NON_EAR_INDICES,
+        "n9_vertex_circle_status_counts": EXPECTED_N9_STATUS_COUNTS,
+        "n9_cross_tabulation": EXPECTED_CROSS_TAB,
+        "proof_mining_target_count": 6,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(f"summary {key!r} is {summary.get(key)!r}, expected {value!r}")
+
+    targets = payload.get("proof_mining_targets")
+    if not isinstance(targets, list) or len(targets) != 6:
+        raise AssertionError("expected exactly six proof-mining targets")
+    for target in targets:
+        if not isinstance(target, Mapping):
+            raise AssertionError("proof-mining target is malformed")
+        if target.get("exact_obstructions") in (None, []):
+            raise AssertionError(f"target lacks obstruction status: {target.get('target_id')!r}")

--- a/tests/test_bridge_lemma_frontier.py
+++ b/tests/test_bridge_lemma_frontier.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bridge_lemma_frontier import assert_expected_payload
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_bridge_lemma_frontier import DEFAULT_OUT, build_payload_from_repo  # noqa: E402
+
+
+pytestmark = [pytest.mark.artifact, pytest.mark.exhaustive]
+
+
+@pytest.fixture(scope="module")
+def bridge_payload() -> dict[str, object]:
+    return build_payload_from_repo(ROOT)
+
+
+def test_bridge_lemma_frontier_counts_match_expected(
+    bridge_payload: dict[str, object],
+) -> None:
+    assert_expected_payload(bridge_payload)
+
+
+def test_bridge_lemma_frontier_artifact_is_current(
+    bridge_payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))
+
+    assert checked_in == bridge_payload


### PR DESCRIPTION
## Summary

- add a replayable Bridge Lemma A' frontier checker for the n=8/n=9 finite frontier
- record the checked diagnostic artifact with the current ear-orderability cross-tab and six proof-mining targets
- document the workflow and wire the checker into artifact verification

## Validation

- `python scripts/check_bridge_lemma_frontier.py --check --assert-expected`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check src/erdos97/bridge_lemma_frontier.py scripts/check_bridge_lemma_frontier.py tests/test_bridge_lemma_frontier.py`
- `python -m pytest tests/test_bridge_lemma_frontier.py -q -o addopts=`
- `python -m pytest -q`

## Scope

This is a proof-mining diagnostic only. It does not prove Bridge Lemma A', does not prove Erdős Problem #97, and does not claim a counterexample.