### PR TITLE
[codex] Add bridge triage negative controls

### DIFF
--- a/docs/adaptive-radius-blocker-bridge.md
+++ b/docs/adaptive-radius-blocker-bridge.md
@@ -1,0 +1,120 @@
+# Adaptive radius-blocker bridge
+
+Status: `LEMMA` / bridge fork. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note records the useful proof-facing extraction from the 2026-05-10
+bridge-output triage. It replaces a fixed-row peeling question by an adaptive
+alternative over all rich distance classes.
+
+## Definitions
+
+Let `P` be a strictly convex 4-bad polygon with vertex set `V`. For a vertex
+`y`, let `R(y)` be the family of rich distance classes at `y`:
+
+```text
+R(y) = { C subset V \ {y} : C is one exact distance class at y and |C| >= 4 }.
+```
+
+A selected row at `y` is any 4-subset of a class in `R(y)`.
+
+For `U subset V`, with `|U| >= 4`, call `U` a radius-blocker if
+
+```text
+for every y in U and every C in R(y), |C cap U| <= 2.
+```
+
+Thus no vertex inside `U` has any rich class with three witnesses still inside
+`U`.
+
+## Lemma
+
+For any strictly convex 4-bad polygon, adaptive reverse peeling has the
+following alternative.
+
+Either:
+
+1. it reaches a three-vertex seed and constructs an ear-orderable selected
+   witness system; or
+2. it stops at a radius-blocker.
+
+Consequently, if a hypothetical counterexample admits no ear-orderable
+selected-witness system, then it contains a radius-blocker.
+
+If `P` is a minimal counterexample and `U` is such a blocker, with
+`O = V \ U`, then every rich class at every center in `U` contains at least
+two vertices of `O`, and
+
+```text
+|U| <= |O| (|O| - 1).
+```
+
+Moreover, any fragile critical 4-tie centered at a vertex of `U` contains at
+most two vertices of `U` and at least two vertices of `O`.
+
+## Proof
+
+Start with `X = V`. If `|X| > 3` and `X` is not a radius-blocker, then some
+`y in X` and some rich class `C in R(y)` have `|C cap X| >= 3`. Choose a
+selected row at `y` containing three vertices of `C cap X`, and remove `y`
+from `X`.
+
+If this process reaches a three-set, put that three-set first in the forward
+order and append the removed vertices in reverse removal order. When a vertex
+`y` is added back, the three witnesses chosen at its removal time are already
+present, because they remained in the set after `y` was removed. Choosing
+arbitrary rich rows for the three seed vertices completes a full selected
+witness system. This is an ear-orderable selection.
+
+If the process stops with `|X| >= 4`, then by construction no `y in X` has a
+rich class meeting `X` in three or more vertices. Hence `X` is a
+radius-blocker.
+
+Now suppose an ear-orderable selected-witness system is impossible. A maximal
+adaptive peeling cannot reach a three-set, so it stops at a blocker `U`.
+For every `y in U` and every `C in R(y)`, the blocker condition gives
+`|C cap U| <= 2`. Since `|C| >= 4`, each such class contains at least two
+vertices outside `U`.
+
+Choose one outside pair from one rich class for each `y in U`. A fixed
+unordered outside pair `{a,b}` can be chosen for at most two centers, because
+all such centers lie on the perpendicular bisector of `ab`, and a line meets a
+strictly convex polygon boundary in at most two vertices. There are
+`binom(|O|, 2)` outside pairs, so
+
+```text
+|U| <= 2 binom(|O|, 2) = |O| (|O| - 1).
+```
+
+Finally, if a fragile critical 4-tie is centered at some `y in U`, it is one
+of the rich classes in `R(y)`. The blocker condition therefore permits at most
+two of its four witnesses inside `U`, so at least two are in `O`.
+
+## Research use
+
+This fork is useful because it handles the noncanonical selection issue: a real
+bad polygon may have several rich distance classes at a center, and fixed-row
+stuck sets do not see that disjunction.
+
+The next bridge target is therefore precise:
+
+```text
+minimal fragile cover + full badness + strict convex geometry
+    => no radius-blocker.
+```
+
+or else:
+
+```text
+construct an exact radius-blocker escape mechanism that survives the current
+vertex-circle, Kalmanson/Farkas, row-circle, and fragile-cover filters.
+```
+
+The helper module `src/erdos97/adaptive_blockers.py` implements the finite
+bookkeeping behind this alternative. It does not certify geometry by itself.
+
+Check the smoke tests with:
+
+```bash
+python -m pytest tests/test_adaptive_blockers.py -q
+```

--- a/docs/bridge-negative-controls.md
+++ b/docs/bridge-negative-controls.md
@@ -1,0 +1,118 @@
+# Bridge negative controls
+
+Status: `EXACT_NEGATIVE_CONTROL` / `PROVENANCE`. No general proof of Erdos
+Problem #97 is claimed. No counterexample is claimed.
+
+This note records small exact guardrails extracted from the 2026-05-10
+bridge-output triage. Their purpose is to prevent overstrong bridge claims.
+They are not evidence for a real counterexample.
+
+Run the replay checker with:
+
+```bash
+python scripts/check_bridge_negative_controls.py --assert-expected
+```
+
+## C13 linear selected system
+
+Let `V = Z/13Z` and
+
+```text
+S_i = i + {1,2,4,10}.
+```
+
+The set `{1,2,4,10}` is a Sidon difference set modulo `13`, so every two rows
+meet in exactly one witness. Consequently:
+
+- the row-pair cap holds in the sparse form `|S_i cap S_j| <= 1`;
+- the witness-pair cap holds;
+- the `phi` map has no edges;
+- two-overlap filters, odd perpendicularity cycles, mutual-rhombus equations,
+  and phi-4 rectangle traps have no input;
+- the fixed selected system has no forward ear order from a three-vertex seed.
+
+All rows may also be declared fragile at the abstract incidence level: the map
+`x -> x - 1` assigns each vertex to a row that covers it.
+
+This is an abstract incidence negative control only. The fixed C13 Sidon
+selected pattern is already killed across all cyclic orders by the repo's
+exact Kalmanson/Farkas search.
+
+More generally, any full selected-witness system with `n > 4`, `|S_i| = 4`,
+`i notin S_i`, and
+
+```text
+|S_i cap S_j| <= 1 for all i != j
+```
+
+is not forward-ear-orderable. From a three-vertex seed, either no row contains
+the seed, or a unique row contains it and only that row's center can be added.
+After that addition, linearity prevents every remaining row from seeing three
+vertices in the closure. Thus every three-seed closure has size at most four.
+This is an abstract selected-row lemma, not a geometric realization claim.
+
+## Exact block-6 fragile atom
+
+The following six points, in cyclic order `0,1,2,3,4,5`, realize the block-6
+fragile rows exactly over `Q(sqrt(3))`:
+
+```text
+p0 = (0, 0)
+p1 = (-5/13, 12/13)
+p2 = (1/2, sqrt(3)/2)
+p3 = (1, 0)
+p4 = (1/2, -sqrt(3)/2)
+p5 = (2/5, -4/5)
+```
+
+The fragile rows are:
+
+```text
+F_0 = {1,2,3,4}
+F_3 = {0,2,4,5}
+```
+
+The checker verifies:
+
+- strict convexity in the displayed order by exact edge-side determinants;
+- the equalities `|p0 pj|^2 = 1` for `j in F_0`;
+- the equalities `|p3 pj|^2 = 1` for `j in F_3`;
+- uniqueness of these size-4 distance classes at centers `0` and `3`;
+- the fragile-cover axioms for the two retained rows;
+- crossing of source chord `{0,3}` and witness chord `{2,4}`;
+- the exact midpoint and perpendicular-bisector relation for those chords.
+
+This realizes only the fragile critical rows. Centers `1,2,4,5` are not shown
+to be bad, so the atom is not a counterexample and not a full selected-witness
+realization. Its value is sharper: fragile-cover geometry alone is not enough
+to prove the theorem.
+
+## Two-block no-forward-ear incidence control
+
+One abstract 12-row full selected extension from the triage bundle passes the
+row-pair cap, witness-pair cap, and crossing checks in its supplied cyclic
+order, but has no forward ear order. It is retained as an incidence-only
+negative control.
+
+The checker also records the correction to the similar 12-row table from
+Outputs 8 and 10: that table is in fact forward-ear-orderable, with seed
+`[0,7,10]`. It must not be used as a no-ear obstruction.
+
+## What these controls rule out
+
+They rule out proof schemas that try to derive ear-orderability or an immediate
+two-overlap obstruction from only:
+
+```text
+self-exclusion
+four-uniformity
+row-pair cap
+witness-pair cap
+fragile cover
+row-use matching
+full selected-row extension
+two-overlap crossing checks
+```
+
+They do not rule out Erdos Problem #97, and they do not rule out the existence
+of a stronger bridge using metric/order information.

--- a/docs/bridge-output-triage-2026-05-10.md
+++ b/docs/bridge-output-triage-2026-05-10.md
@@ -1,0 +1,54 @@
+# GPT-5.5 bridge-output triage, 2026-05-10
+
+Status: `PROVENANCE` / triage note. No general proof and no counterexample are
+claimed.
+
+This note records the triage of ten GPT-5.5 Pro outputs aimed at the missing
+bridge from minimal fragile-cover structure to selected-witness machinery.
+The raw outputs should be treated as AI-generated provenance only. The only
+material extracted into proof-facing form is the adaptive radius-blocker fork
+and a small set of exact negative controls.
+
+## Triage table
+
+| Output | Verdict | Action |
+|---|---|---|
+| 1 | Mostly correct abstract C13 Sidon negative control. | Subsumed by `docs/bridge-negative-controls.md`. |
+| 2 | Correct projective-plane incidence idea, but the no-ear proof uses a stuck set where a forward-ear argument is needed. | Quarantine as redundant with Output 3. |
+| 3 | Best abstract obstruction: linear selected systems are phi-silent and not forward-ear-orderable. | Extract as the C13 linear negative control. |
+| 4 | Valid finite C9 symbolic certificate: no forward ear and vertex-circle killed. | Keep as optional future regression fixture, not central. |
+| 5 | Exact six-label fragile block geometry checks out. | Extract as the block-6 geometric atom. |
+| 6 | Best route worth pursuing: adaptive peeling versus radius-blocker alternative. | Extract as `docs/adaptive-radius-blocker-bridge.md`. |
+| 7 | Abstract two-block full extension has no forward ear and passes pair/crossing checks. | Keep as an incidence negative control. |
+| 8 | Six-block part is fine, but the 12-row no-ear claim is false. | Record correction only. |
+| 9 | Six-block geometry and forced dependency cycle are good. | Subsumed by the block-6 geometric atom. |
+| 10 | Six-block coordinates are good, but it repeats the false 12-row no-ear claim from Output 8. | Use the six-block atom; reject the full-extension conclusion. |
+
+## Extracted work
+
+The useful extracted artifacts are:
+
+- `docs/adaptive-radius-blocker-bridge.md`: a proof-facing fork lemma. Either
+  adaptive selected-witness peeling gives an ear-orderable selection, or a
+  radius-blocker remains.
+- `docs/bridge-negative-controls.md`: exact guardrails for bridge work:
+  the C13 linear/Sidon fixed pattern, the exact geometric block-6 fragile atom,
+  and the two-block incidence no-forward-ear control.
+- `scripts/check_bridge_negative_controls.py`: replayable checks for the
+  extracted finite claims.
+
+## Non-overclaiming guardrails
+
+The extracted material does not prove Erdos Problem #97. It does not produce a
+counterexample. It does not promote `n=9`, `n=10`, or any fixed sparse pattern.
+
+The C13 Sidon pattern is already retired as a fixed selected-witness pattern
+across all cyclic orders by the exact Kalmanson/Farkas order search. Its role
+here is only to show that incidence-only bridge claims can fail.
+
+The block-6 geometric atom realizes only fragile rows. Its non-fragile centers
+are not bad, so it is not a selected-witness counterexample.
+
+The adaptive radius-blocker fork is a bridge target, not a finished proof:
+future work must rule out radius-blockers using genuinely geometric input, or
+construct an exact blocker escape mechanism that survives all current filters.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -367,6 +367,28 @@ family checked by `scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok`
 shows that fragile-cover hypergraph constraints alone are too weak to prove
 the problem. See `docs/minimal-fragile-cover-bridge.md`.
 
+### Adaptive peeling / radius-blocker alternative
+
+Status: `LEMMA` / bridge fork.
+
+Given the full family of rich distance classes at each bad vertex, adaptive
+reverse peeling has an exact alternative: either it reaches a three-vertex seed
+and constructs an ear-orderable selected-witness system, or it stops at a
+radius-blocker `U` in which every rich class at every center of `U` has at most
+two witnesses inside `U`.
+
+If a minimal counterexample avoids all ear-orderable selected-witness
+reductions, then it must contain such a radius-blocker. Writing
+`O = V \ U`, every rich class centered in `U` has at least two witnesses in
+`O`, and the perpendicular-bisector pair-sharing lemma gives
+`|U| <= |O|(|O|-1)`. Any fragile critical row centered inside `U` therefore
+has at most two witnesses in `U` and at least two outside.
+
+This is not a proof of Erdos Problem #97. It isolates the next bridge target:
+rule out radius-blockers using strict convexity, fragile-cover geometry, and
+the current exact obstruction stack, or construct an exact blocker escape
+mechanism. See `docs/adaptive-radius-blocker-bridge.md`.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`bridge-lemma-frontier.md`](bridge-lemma-frontier.md): replayable
   n=8/n=9 ear-orderability and obstruction cross-tab for Bridge Lemma A'
   proof-mining targets.
+- [`adaptive-radius-blocker-bridge.md`](adaptive-radius-blocker-bridge.md):
+  adaptive selected-witness peeling versus radius-blocker bridge fork.
+- [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
+  guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`
   selected-witness obstruction.
 - [`n8-incidence-enumeration.md`](n8-incidence-enumeration.md): reproducible
@@ -235,6 +239,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`prompt-roadmap.md`](prompt-roadmap.md): prompt-derived planning roadmap and
   next recommended workstreams; heuristic guidance only, not mathematical
   evidence.
+- [`bridge-output-triage-2026-05-10.md`](bridge-output-triage-2026-05-10.md):
+  triage of ten AI-generated bridge-output candidates; provenance only.
 - [`n9-base-apex-frontier.md`](n9-base-apex-frontier.md): corrected exploratory
   slack ledger for the first `n=9` base-apex workstream; not a proof.
 - [`repo-roadmap.md`](repo-roadmap.md): staged repository plan.

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -114,6 +114,14 @@ However, two disjoint blocks still pass the full-extension diagnostic. Thus
 full-row extendability is a real strengthening, but it is still far from a
 proof.
 
+There is also an exact geometric sharpness example for one six-vertex fragile
+block. The coordinates recorded in `docs/bridge-negative-controls.md` realize
+the two fragile rows as unique exact 4-ties in a strictly convex hexagon and
+satisfy the crossing/bisection geometry for their two-overlap. This does not
+make the block a counterexample: the other four centers are not bad. Its role
+is only to show that even exact local fragile-row geometry is not enough by
+itself.
+
 ## Research Use
 
 This bridge is still useful because it gives a necessary finite object for any

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -295,6 +295,9 @@ condition that the surviving multi-block family does not automatically satisfy:
 - exact row-circle constraints on the fragile rows;
 - interaction between fragile-cover rows and stuck-set/ear-orderability
   failures.
+- adaptive radius-blocker analysis, as recorded in
+  `docs/adaptive-radius-blocker-bridge.md`, which keeps all rich distance
+  classes visible instead of fixing one selected row per center.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/scripts/check_bridge_negative_controls.py
+++ b/scripts/check_bridge_negative_controls.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Check bridge negative-control certificates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bridge_negative_controls import (  # noqa: E402
+    block6_geometric_atom_certificate,
+    c13_sidon_negative_control,
+    false_output8_correction_certificate,
+    output7_two_block_negative_control,
+)
+
+
+def all_certificates() -> dict[str, object]:
+    return {
+        "type": "bridge_negative_controls_v1",
+        "status": "NEGATIVE_CONTROLS_AND_TRIAGE",
+        "certificates": {
+            "c13_sidon_linear": c13_sidon_negative_control(),
+            "block6_geometric_atom": block6_geometric_atom_certificate(),
+            "two_block_no_forward_ear": output7_two_block_negative_control(),
+            "false_output8_correction": false_output8_correction_certificate(),
+        },
+        "interpretation": (
+            "These are bridge guardrails and triage checks only. They do not "
+            "claim a general proof, a counterexample, or a new finite-case "
+            "status."
+        ),
+    }
+
+
+def assert_expected(payload: dict[str, object]) -> None:
+    certificates = payload["certificates"]
+    if not isinstance(certificates, dict):
+        raise AssertionError("certificates must be a dict")
+
+    c13 = certificates["c13_sidon_linear"]
+    if not isinstance(c13, dict):
+        raise AssertionError("C13 certificate must be a dict")
+    if c13["max_row_intersection"] != 1:
+        raise AssertionError("C13 should be linear")
+    if c13["phi_edges"] != 0:
+        raise AssertionError("C13 should have no phi edges")
+    if c13["forward_ear_order"]["exists"]:
+        raise AssertionError("C13 should have no forward ear order")
+    if not c13["fragile_cover_all_rows"]["ok"]:
+        raise AssertionError("C13 all-row fragile cover should pass")
+
+    block6 = certificates["block6_geometric_atom"]
+    if not isinstance(block6, dict):
+        raise AssertionError("block6 certificate must be a dict")
+    if not block6["strict_convex_clockwise"]:
+        raise AssertionError("block6 should be strictly convex")
+    if not block6["row_equalities_ok"]:
+        raise AssertionError("block6 fragile row equalities should hold")
+    if not block6["unique_size4_rows_at_fragile_centers"]:
+        raise AssertionError("block6 fragile rows should be unique at centers")
+    if not block6["source_witness_chords_cross"]:
+        raise AssertionError("block6 source/witness chords should cross")
+    if not block6["source_witness_bisection_ok"]:
+        raise AssertionError("block6 source/witness chords should bisect perpendicularly")
+
+    two_block = certificates["two_block_no_forward_ear"]
+    if not isinstance(two_block, dict):
+        raise AssertionError("two-block certificate must be a dict")
+    if two_block["forward_ear_order"]["exists"]:
+        raise AssertionError("output7 two-block control should have no forward ear")
+    if two_block["crossing_bisector_violations"]:
+        raise AssertionError("output7 two-block control should pass crossing checks")
+
+    correction = certificates["false_output8_correction"]
+    if not isinstance(correction, dict):
+        raise AssertionError("correction certificate must be a dict")
+    if not correction["forward_ear_order"]["exists"]:
+        raise AssertionError("outputs 8/10 correction should exhibit an ear order")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--write-certificate", help="write JSON to this path")
+    args = parser.parse_args()
+
+    payload = all_certificates()
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        certificates = payload["certificates"]
+        assert isinstance(certificates, dict)
+        print("certificate  n  key status")
+        for name, certificate in certificates.items():
+            assert isinstance(certificate, dict)
+            if name == "block6_geometric_atom":
+                status = "strict-convex fragile atom"
+            elif name == "false_output8_correction":
+                status = (
+                    "ear order found"
+                    if certificate["forward_ear_order"]["exists"]
+                    else "unexpected no ear"
+                )
+            else:
+                status = (
+                    "no forward ear"
+                    if not certificate["forward_ear_order"]["exists"]
+                    else "ear order found"
+                )
+            print(f"{name}  {certificate['n']}  {status}")
+        if args.assert_expected:
+            print("OK: bridge negative-control expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/adaptive_blockers.py
+++ b/src/erdos97/adaptive_blockers.py
@@ -1,0 +1,225 @@
+"""Adaptive selected-witness peeling and radius-blocker helpers.
+
+The routines here are combinatorial bookkeeping for the bridge program.  They
+do not certify Euclidean realizability, a counterexample, or a general proof of
+Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable, Sequence
+
+
+RichClasses = Sequence[Sequence[Sequence[int]]]
+
+
+@dataclass(frozen=True)
+class AdaptivePeelingStep:
+    removed_center: int
+    rich_class_index: int
+    rich_class: list[int]
+    internal_witnesses: list[int]
+    chosen_selected_row: list[int]
+    remaining_before: list[int]
+
+
+@dataclass(frozen=True)
+class AdaptivePeelingResult:
+    success: bool
+    seed: list[int] | None
+    forward_order: list[int] | None
+    selected_rows: dict[int, list[int]]
+    removal_steps: list[AdaptivePeelingStep]
+    blocker: list[int] | None
+
+
+def _mask(vertices: Iterable[int]) -> int:
+    out = 0
+    for vertex in vertices:
+        out |= 1 << int(vertex)
+    return out
+
+
+def _vertices(mask: int, n: int) -> list[int]:
+    return [vertex for vertex in range(n) if mask & (1 << vertex)]
+
+
+def _subset_vertices(vertices: Iterable[int], n: int, name: str) -> list[int]:
+    out: list[int] = []
+    seen: set[int] = set()
+    for raw_vertex in vertices:
+        vertex = int(raw_vertex)
+        if vertex < 0 or vertex >= n:
+            raise ValueError(f"{name} contains out-of-range label {vertex}")
+        if vertex not in seen:
+            out.append(vertex)
+            seen.add(vertex)
+    return out
+
+
+def validate_rich_classes(rich_classes: RichClasses) -> None:
+    """Validate a family of per-center rich distance classes.
+
+    Each rich class represents one exact distance class of size at least four
+    at its center.  This function checks only the finite incidence contract.
+    """
+
+    n = len(rich_classes)
+    if n < 4:
+        raise ValueError(f"expected at least four centers, got {n}")
+    for center, classes in enumerate(rich_classes):
+        if not classes:
+            raise ValueError(f"center {center} has no rich classes")
+        for class_index, row in enumerate(classes):
+            row_set = set(int(label) for label in row)
+            if len(row_set) != len(row):
+                raise ValueError(
+                    f"center {center} rich class {class_index} has repeated labels"
+                )
+            if len(row_set) < 4:
+                raise ValueError(
+                    f"center {center} rich class {class_index} has size {len(row_set)}"
+                )
+            if center in row_set:
+                raise ValueError(
+                    f"center {center} rich class {class_index} contains its center"
+                )
+            for label in row_set:
+                if label < 0 or label >= n:
+                    raise ValueError(
+                        f"center {center} rich class {class_index} has "
+                        f"out-of-range label {label}"
+                    )
+
+
+def singleton_rich_classes_from_pattern(
+    selected_rows: Sequence[Sequence[int]],
+) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    """Treat one fixed selected row per center as the only rich class."""
+
+    return tuple((tuple(int(label) for label in row),) for row in selected_rows)
+
+
+def is_radius_blocker(
+    rich_classes: RichClasses,
+    subset: Iterable[int],
+    threshold: int = 3,
+) -> bool:
+    """Return whether ``subset`` is a radius-blocker for the rich classes."""
+
+    validate_rich_classes(rich_classes)
+    n = len(rich_classes)
+    subset_vertices = _subset_vertices(subset, n, "subset")
+    subset_mask = _mask(subset_vertices)
+    subset_vertices = _vertices(subset_mask, n)
+    if len(subset_vertices) < threshold + 1:
+        return False
+    for center in subset_vertices:
+        for row in rich_classes[center]:
+            if (_mask(row) & subset_mask).bit_count() >= threshold:
+                return False
+    return True
+
+
+def first_blocker(
+    rich_classes: RichClasses,
+    min_size: int = 4,
+    max_size: int | None = None,
+) -> list[int] | None:
+    """Return the first radius-blocker by cardinality and lexicographic order."""
+
+    validate_rich_classes(rich_classes)
+    n = len(rich_classes)
+    if max_size is None:
+        max_size = n
+    for size in range(max(min_size, 4), min(max_size, n) + 1):
+        for subset in combinations(range(n), size):
+            if is_radius_blocker(rich_classes, subset):
+                return list(subset)
+    return None
+
+
+def adaptive_reverse_peeling(
+    rich_classes: RichClasses,
+    threshold: int = 3,
+) -> AdaptivePeelingResult:
+    """Run the adaptive reverse-peeling/blocker alternative.
+
+    If the process reaches a three-vertex seed, the returned ``selected_rows``
+    and ``forward_order`` give an adaptive ear-order certificate.  If it stops
+    earlier, the terminal set is a radius-blocker.
+    """
+
+    validate_rich_classes(rich_classes)
+    if threshold != 3:
+        raise ValueError("only the three-witness bridge threshold is supported")
+
+    n = len(rich_classes)
+    remaining_mask = (1 << n) - 1
+    steps: list[AdaptivePeelingStep] = []
+    selected_rows: dict[int, list[int]] = {}
+
+    while remaining_mask.bit_count() > threshold:
+        removed: AdaptivePeelingStep | None = None
+        for center in _vertices(remaining_mask, n):
+            for class_index, row in enumerate(rich_classes[center]):
+                row_list = [int(label) for label in row]
+                internal = [
+                    label for label in row_list if remaining_mask & (1 << label)
+                ]
+                if len(internal) < threshold:
+                    continue
+                chosen = internal[:threshold]
+                for label in row_list:
+                    if label not in chosen:
+                        chosen.append(label)
+                    if len(chosen) == 4:
+                        break
+                removed = AdaptivePeelingStep(
+                    removed_center=center,
+                    rich_class_index=class_index,
+                    rich_class=row_list,
+                    internal_witnesses=internal[:threshold],
+                    chosen_selected_row=chosen,
+                    remaining_before=_vertices(remaining_mask, n),
+                )
+                break
+            if removed is not None:
+                break
+
+        if removed is None:
+            return AdaptivePeelingResult(
+                success=False,
+                seed=None,
+                forward_order=None,
+                selected_rows=selected_rows,
+                removal_steps=steps,
+                blocker=_vertices(remaining_mask, n),
+            )
+
+        steps.append(removed)
+        selected_rows[removed.removed_center] = removed.chosen_selected_row
+        remaining_mask &= ~(1 << removed.removed_center)
+
+    seed = _vertices(remaining_mask, n)
+    for center in seed:
+        selected_rows[center] = [int(label) for label in rich_classes[center][0][:4]]
+    forward_order = seed + [step.removed_center for step in reversed(steps)]
+    return AdaptivePeelingResult(
+        success=True,
+        seed=seed,
+        forward_order=forward_order,
+        selected_rows=dict(sorted(selected_rows.items())),
+        removal_steps=steps,
+        blocker=None,
+    )
+
+
+def outside_pair_expansion_bound(outside_size: int) -> int:
+    """Return the blocker-size upper bound from the outside-pair argument."""
+
+    if outside_size < 0:
+        raise ValueError("outside_size must be nonnegative")
+    return outside_size * (outside_size - 1)

--- a/src/erdos97/bridge_negative_controls.py
+++ b/src/erdos97/bridge_negative_controls.py
@@ -1,0 +1,317 @@
+"""Replayable negative controls for bridge-lemma work.
+
+These certificates are intentionally scoped.  They are not counterexamples to
+Erdos Problem #97 and do not move the repository's global or finite-case
+status.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Sequence
+
+from erdos97.fragile_hypergraph import check_fragile_hypergraph, check_to_json
+from erdos97.incidence_filters import chords_cross_in_order, filter_summary
+from erdos97.stuck_sets import find_minimal_stuck_sets, forward_ear_order
+from erdos97.vertex_circle_order_filter import (
+    order_result_to_json,
+    vertex_circle_order_obstruction,
+)
+
+
+Pattern = list[list[int]]
+
+
+def c13_sidon_rows() -> Pattern:
+    """Return the retired fixed C13 Sidon selected-witness pattern."""
+
+    offsets = (1, 2, 4, 10)
+    return [[(center + offset) % 13 for offset in offsets] for center in range(13)]
+
+
+def output7_two_block_rows() -> Pattern:
+    """Return the abstract two-block full extension from the triage bundle.
+
+    This pattern is kept only as an incidence negative control: it passes the
+    pair/crossing entry filters and has no forward ear order, but it is not
+    claimed to be geometrically realizable.
+    """
+
+    rows = {
+        0: [1, 2, 3, 4],
+        1: [3, 6, 7, 11],
+        2: [1, 5, 9, 11],
+        3: [0, 2, 4, 5],
+        4: [0, 3, 6, 9],
+        5: [0, 2, 10, 11],
+        6: [7, 8, 9, 10],
+        7: [0, 1, 8, 9],
+        8: [4, 5, 7, 11],
+        9: [6, 8, 10, 11],
+        10: [1, 5, 6, 7],
+        11: [0, 3, 5, 8],
+    }
+    return [rows[center] for center in range(12)]
+
+
+def false_output8_two_block_rows() -> Pattern:
+    """Return the triaged 12-row table whose no-ear claim is false."""
+
+    rows = {
+        0: [1, 2, 3, 4],
+        1: [3, 6, 9, 11],
+        2: [1, 3, 5, 8],
+        3: [0, 2, 4, 5],
+        4: [0, 3, 8, 11],
+        5: [0, 1, 6, 7],
+        6: [7, 8, 9, 10],
+        7: [0, 4, 6, 9],
+        8: [0, 5, 7, 10],
+        9: [6, 8, 10, 11],
+        10: [2, 5, 9, 11],
+        11: [1, 5, 6, 10],
+    }
+    return [rows[center] for center in range(12)]
+
+
+def _row_pair_stats(rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    max_intersection = 0
+    violations: list[dict[str, object]] = []
+    for left, right in combinations(range(len(rows)), 2):
+        inter = sorted(set(rows[left]) & set(rows[right]))
+        max_intersection = max(max_intersection, len(inter))
+        if len(inter) > 2:
+            violations.append(
+                {
+                    "centers": [left, right],
+                    "intersection": inter,
+                    "intersection_size": len(inter),
+                }
+            )
+    return {
+        "max_row_intersection": max_intersection,
+        "row_pair_cap_ok": not violations,
+        "row_pair_cap_violations": violations,
+    }
+
+
+def _column_pair_violations(rows: Sequence[Sequence[int]]) -> list[dict[str, object]]:
+    violations: list[dict[str, object]] = []
+    for left, right in combinations(range(len(rows)), 2):
+        centers = [
+            center for center, row in enumerate(rows) if left in row and right in row
+        ]
+        if len(centers) > 2:
+            violations.append(
+                {"pair": [left, right], "centers": centers, "count": len(centers)}
+            )
+    return violations
+
+
+def fixed_pattern_summary(
+    name: str,
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+) -> dict[str, object]:
+    """Return exact fixed-pattern diagnostics for a negative control."""
+
+    if order is None:
+        order = list(range(len(rows)))
+    filters = filter_summary(rows, order)
+    ear = forward_ear_order(rows)
+    stuck = find_minimal_stuck_sets(rows, max_examples=2)
+    vertex_circle = vertex_circle_order_obstruction(rows, order, name)
+    column_violations = _column_pair_violations(rows)
+    return {
+        "type": "bridge_negative_control_fixed_pattern",
+        "name": name,
+        "n": len(rows),
+        "selected_rows": rows,
+        **_row_pair_stats(rows),
+        "column_pair_cap_ok": not column_violations,
+        "column_pair_cap_violations": column_violations,
+        "phi_edges": filters["phi_edges"],
+        "crossing_bisector_violations": filters["crossing_bisector_violations"],
+        "odd_forced_perpendicular_cycle_length": filters["odd_cycle_length"],
+        "rectangle_trap_4_cycles": filters["rectangle_trap_4_cycles"],
+        "forward_ear_order": {
+            "exists": ear.exists,
+            "seed": ear.seed,
+            "order": ear.order,
+            "largest_closure_size": ear.largest_closure_size,
+            "largest_closure_seed": ear.largest_closure_seed,
+        },
+        "minimal_stuck_set": {
+            "size": stuck.minimal_size,
+            "count_at_size": stuck.total_at_minimal_size,
+            "examples": [
+                {
+                    "vertices": example.vertices,
+                    "internal_counts": [
+                        row.internal_count for row in example.rows
+                    ],
+                }
+                for example in stuck.examples
+            ],
+        },
+        "vertex_circle_in_supplied_order": order_result_to_json(vertex_circle),
+        "interpretation": (
+            "Fixed selected-witness pattern diagnostics only; passing any "
+            "incidence filter here is not a Euclidean realization certificate."
+        ),
+    }
+
+
+def c13_sidon_negative_control() -> dict[str, object]:
+    """Return the exact C13 linear/Sidon negative-control certificate."""
+
+    rows = c13_sidon_rows()
+    witness_map = {vertex: (vertex - 1) % 13 for vertex in range(13)}
+    fragile = check_fragile_hypergraph(
+        13,
+        {center: row for center, row in enumerate(rows)},
+        witness_map=witness_map,
+    )
+    payload = fixed_pattern_summary("C13_sidon_1_2_4_10", rows)
+    payload["fragile_cover_all_rows"] = {
+        **check_to_json(fragile),
+        "witness_map": {str(vertex): center for vertex, center in witness_map.items()},
+    }
+    payload["interpretation"] = (
+        "Abstract linear selected-witness negative control. The fixed C13 "
+        "Sidon pattern is already killed across all cyclic orders by the "
+        "repo's exact Kalmanson/Farkas search; this certificate is only a "
+        "guardrail against incidence-only bridge claims."
+    )
+    return payload
+
+
+def output7_two_block_negative_control() -> dict[str, object]:
+    """Return the abstract no-forward-ear two-block control."""
+
+    return fixed_pattern_summary(
+        "two_block_full_extension_no_forward_ear",
+        output7_two_block_rows(),
+        order=[0, 4, 3, 1, 2, 5, 6, 10, 9, 7, 8, 11],
+    )
+
+
+def false_output8_correction_certificate() -> dict[str, object]:
+    """Return the correction for the false no-ear claim in outputs 8/10."""
+
+    rows = false_output8_two_block_rows()
+    return fixed_pattern_summary(
+        "false_no_ear_two_block_table_from_outputs_8_10",
+        rows,
+    )
+
+
+def _sympy():
+    try:
+        import sympy as sp  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depends on dev dependency
+        raise RuntimeError("SymPy is required for this exact certificate") from exc
+    return sp
+
+
+def block6_geometric_atom_certificate() -> dict[str, object]:
+    """Verify the exact six-label fragile atom over ``Q(sqrt(3))``."""
+
+    sp = _sympy()
+    sqrt3 = sp.sqrt(3)
+    points = {
+        0: (sp.Rational(0), sp.Rational(0)),
+        1: (sp.Rational(-5, 13), sp.Rational(12, 13)),
+        2: (sp.Rational(1, 2), sqrt3 / 2),
+        3: (sp.Rational(1), sp.Rational(0)),
+        4: (sp.Rational(1, 2), -sqrt3 / 2),
+        5: (sp.Rational(2, 5), sp.Rational(-4, 5)),
+    }
+    order = [0, 1, 2, 3, 4, 5]
+    rows = {0: [1, 2, 3, 4], 3: [0, 2, 4, 5]}
+
+    def det(a: int, b: int, c: int):
+        ax, ay = points[a]
+        bx, by = points[b]
+        cx, cy = points[c]
+        return sp.simplify((bx - ax) * (cy - ay) - (by - ay) * (cx - ax))
+
+    def dist2(a: int, b: int):
+        ax, ay = points[a]
+        bx, by = points[b]
+        return sp.simplify((ax - bx) ** 2 + (ay - by) ** 2)
+
+    def midpoint(a: int, b: int):
+        ax, ay = points[a]
+        bx, by = points[b]
+        return (sp.simplify((ax + bx) / 2), sp.simplify((ay + by) / 2))
+
+    def dot(a: int, b: int, c: int, d: int):
+        ax, ay = points[a]
+        bx, by = points[b]
+        cx, cy = points[c]
+        dx, dy = points[d]
+        return sp.simplify((bx - ax) * (dx - cx) + (by - ay) * (dy - cy))
+
+    side_values = []
+    strict_convex = True
+    for idx, left in enumerate(order):
+        right = order[(idx + 1) % len(order)]
+        edge_values = [
+            det(left, right, label)
+            for label in order
+            if label not in {left, right}
+        ]
+        side_values.append([str(sp.simplify(value)) for value in edge_values])
+        strict_convex = strict_convex and all(value.is_negative for value in edge_values)
+
+    distance_rows = {
+        center: {label: str(dist2(center, label)) for label in range(6) if label != center}
+        for center in (0, 3)
+    }
+    row_equalities_ok = all(dist2(0, label) == 1 for label in rows[0]) and all(
+        dist2(3, label) == 1 for label in rows[3]
+    )
+    uniqueness_ok = dist2(0, 5) != 1 and dist2(3, 1) != 1
+    source_midpoint = midpoint(0, 3)
+    witness_midpoint = midpoint(2, 4)
+    same_midpoint = source_midpoint == witness_midpoint
+    perpendicular = dot(0, 3, 2, 4) == 0
+    fragile = check_fragile_hypergraph(
+        6,
+        rows,
+        witness_map={0: 3, 1: 0, 2: 0, 3: 0, 4: 0, 5: 3},
+    )
+
+    return {
+        "type": "block6_geometric_atom_certificate",
+        "status": "EXACT_GEOMETRIC_NEGATIVE_CONTROL",
+        "field": "Q(sqrt(3))",
+        "n": 6,
+        "order": order,
+        "points": {
+            str(label): [str(coord) for coord in coords]
+            for label, coords in points.items()
+        },
+        "fragile_rows": {str(center): row for center, row in rows.items()},
+        "strict_convex_clockwise": strict_convex,
+        "edge_side_determinants": side_values,
+        "distance_rows": distance_rows,
+        "row_equalities_ok": row_equalities_ok,
+        "unique_size4_rows_at_fragile_centers": uniqueness_ok,
+        "fragile_hypergraph": check_to_json(fragile),
+        "source_witness_chords_cross": chords_cross_in_order((0, 3), (2, 4), order),
+        "source_witness_midpoints": {
+            "source": [str(coord) for coord in source_midpoint],
+            "witness": [str(coord) for coord in witness_midpoint],
+            "same_midpoint": same_midpoint,
+        },
+        "source_witness_perpendicular": perpendicular,
+        "source_witness_bisection_ok": same_midpoint and perpendicular,
+        "forced_dependency_cycle": [[0, 3], [3, 0]],
+        "interpretation": (
+            "Exact strict-convex realization of the fragile rows only. The "
+            "non-fragile centers are not bad, so this is not a counterexample "
+            "and not a full selected-witness realization."
+        ),
+    }

--- a/tests/test_adaptive_blockers.py
+++ b/tests/test_adaptive_blockers.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.adaptive_blockers import (
+    adaptive_reverse_peeling,
+    first_blocker,
+    is_radius_blocker,
+    outside_pair_expansion_bound,
+    singleton_rich_classes_from_pattern,
+)
+from erdos97.bridge_negative_controls import c13_sidon_rows
+
+
+def test_adaptive_reverse_peeling_builds_ear_order_without_blocker() -> None:
+    rich_classes = tuple(
+        (tuple(label for label in range(5) if label != center),)
+        for center in range(5)
+    )
+
+    result = adaptive_reverse_peeling(rich_classes)
+
+    assert result.success
+    assert result.seed is not None
+    assert len(result.seed) == 3
+    assert result.forward_order is not None
+    assert sorted(result.forward_order) == list(range(5))
+    assert result.blocker is None
+    assert sorted(result.selected_rows) == list(range(5))
+
+
+def test_radius_blocker_detects_fixed_linear_sidon_seed() -> None:
+    rich_classes = singleton_rich_classes_from_pattern(c13_sidon_rows())
+    blocker = [0, 1, 2, 3]
+
+    assert is_radius_blocker(rich_classes, blocker)
+    assert first_blocker(rich_classes, max_size=4) is not None
+
+
+def test_radius_blocker_rejects_out_of_range_subset_label() -> None:
+    rich_classes = singleton_rich_classes_from_pattern(c13_sidon_rows())
+
+    with pytest.raises(ValueError, match="out-of-range"):
+        is_radius_blocker(rich_classes, [0, 1, 2, 99])
+
+
+def test_outside_pair_expansion_bound() -> None:
+    assert outside_pair_expansion_bound(0) == 0
+    assert outside_pair_expansion_bound(1) == 0
+    assert outside_pair_expansion_bound(5) == 20

--- a/tests/test_bridge_negative_controls.py
+++ b/tests/test_bridge_negative_controls.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from scripts.check_bridge_negative_controls import all_certificates, assert_expected
+
+
+def test_bridge_negative_controls_replay_expected_statuses() -> None:
+    payload = all_certificates()
+
+    assert_expected(payload)
+
+
+def test_false_output8_table_has_forward_ear_order() -> None:
+    payload = all_certificates()
+    certificates = payload["certificates"]
+    assert isinstance(certificates, dict)
+    correction = certificates["false_output8_correction"]
+    assert isinstance(correction, dict)
+
+    ear = correction["forward_ear_order"]
+    assert ear["exists"]
+    assert ear["seed"] == [0, 7, 10]
+
+
+def test_block6_certificate_checks_exact_bisection() -> None:
+    payload = all_certificates()
+    certificates = payload["certificates"]
+    assert isinstance(certificates, dict)
+    block6 = certificates["block6_geometric_atom"]
+    assert isinstance(block6, dict)
+
+    assert block6["source_witness_bisection_ok"]
+    assert block6["source_witness_midpoints"]["source"] == ["1/2", "0"]
+    assert block6["source_witness_midpoints"]["witness"] == ["1/2", "0"]


### PR DESCRIPTION
## Summary

- Adds a scoped triage note for the ten GPT-5.5 bridge-output candidates.
- Adds the adaptive peeling vs radius-blocker bridge fork, with small helper routines and tests.
- Adds replayable bridge negative controls for the C13 linear/Sidon pattern, the exact block-6 fragile atom, a two-block no-forward-ear incidence control, and the false Output 8/10 no-ear correction.
- Updates claims, fragile-cover bridge notes, review priorities, and the documentation index without changing global or finite-case status.

## Scope

This is a bridge/provenance and negative-control PR only. It does not claim a general proof, a counterexample, or a new finite-case result.

## Validation

- `python scripts/check_bridge_negative_controls.py --assert-expected`
- `python -m pytest tests/test_adaptive_blockers.py tests/test_bridge_negative_controls.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check origin/main..HEAD`
- `python -m ruff check .`
- `python -m pytest -q`