### PR TITLE
[codex] Record T01 proof-facing lemma candidate

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -409,6 +409,40 @@ For witnesses on a circle centered at that vertex, chord length is
 This supports endpoint and short-base reductions, but those reductions still
 need their global bridge claims.[^digest]
 
+### Vertex-circle T01/F09 self-edge local lemma candidate
+
+Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
+
+In a strictly convex nonagon with cyclic order `0,1,2,3,4,5,6,7,8`, suppose the
+following three selected rows are present:
+
+```text
+center 0: {1,2,4,8}
+center 1: {0,3,5,8}
+center 2: {0,1,4,6}
+```
+
+The selected-distance equalities force
+
+```text
+[1,8] = [0,1] = [0,2] = [1,2].
+```
+
+Meanwhile row `0` has witness order `[1,2,4,8]` around vertex `0`, so the
+vertex-circle chord monotonicity lemma gives the strict inequality
+
+```text
+[1,8] > [1,2].
+```
+
+Thus the selected-distance quotient has a reflexive strict edge, and no
+strictly convex realization can satisfy these exact local hypotheses. The
+packet label `T01/F09` is navigation only; the hypotheses are the displayed
+cyclic order and selected rows. This is not an `n=9` completeness proof, not a
+promotion of the review-pending exhaustive checker, and not a proof of Erdos
+Problem #97. Check the focused packet with
+`python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json`.
+
 ### Low-angle ascent for middle witnesses
 
 Let `alpha_p` be the interior angle at a bad vertex `p`, and let

--- a/docs/n9-vertex-circle-t01-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t01-self-edge-lemma.md
@@ -1,144 +1,118 @@
-# n=9 Vertex-circle T01 Self-edge Local Lemma Packet
+# n=9 Vertex-circle T01 Self-edge Local Lemma Candidate
 
-Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
 
-This note records one focused proof-mining packet for the `T01/F09`
-self-edge motif. It does not claim a proof of `n=9`, does not claim a
-counterexample, does not complete independent review of the exhaustive
-checker, and does not update the official/global status.
+This note extracts one proof-facing local obstruction from the
+review-pending `n=9` vertex-circle diagnostics. It does not claim a proof of
+`n=9`, does not claim a counterexample, does not complete independent review
+of the exhaustive checker, and does not update the official/global status of
+Erdos Problem #97.
 
-## Packet scope
+The labels `T01` and `F09` are retained only as packet/catalog navigation. They
+are not theorem hypotheses.
 
-The checked artifact is
-`data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json`.
-It is derived from:
+## Exact Local Hypotheses
 
-- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
-- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
-
-The packet covers the six T01 assignment ids:
+Let `p_0,...,p_8` be distinct vertices of a strictly convex nonagon in cyclic
+order
 
 ```text
-A014, A024, A031, A140, A166, A175
+0,1,2,3,4,5,6,7,8.
 ```
 
-The local core is the family `F09` three-row certificate:
+Assume the following three selected witness rows are present:
 
 ```text
-[0, 1, 2, 4, 8]
-[1, 0, 3, 5, 8]
-[2, 0, 1, 4, 6]
+center 0: {1,2,4,8}
+center 1: {0,3,5,8}
+center 2: {0,1,4,6}
 ```
 
-Here `[c, a, b, d, e]` means that `a,b,d,e` are the selected witnesses for
-center `c`, hence the four distances from `c` to those witnesses are equal.
-
-## Local lemma
-
-The following local obstruction is independent of the exhaustive `n=9`
-brancher.
-
-Assume a strictly convex polygon has labels appearing in cyclic order
+The selected-row hypothesis means that each listed center is equidistant from
+the four listed witnesses. In pair-distance notation, the rows give these
+selected-distance equalities among ordinary pair distances:
 
 ```text
-0,1,2,3,4,5,6,7,8
+row 1: [1,8] = [0,1]
+row 0: [0,1] = [0,2]
+row 2: [0,2] = [1,2]
 ```
 
-and contains the three selected rows
+Equivalently, the three rows force the selected-distance quotient chain
 
 ```text
-S_0 = {1,2,4,8}
-S_1 = {0,3,5,8}
-S_2 = {0,1,4,6}
+[1,8] = [0,1] = [0,2] = [1,2].
 ```
 
-Then these three rows cannot be realized.
+The checked packet recording this local shape is
+`data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json`. It is
+derived from the self-edge template packet and the template lemma catalog, but
+the local argument above uses only the three displayed selected rows plus the
+displayed cyclic order.
 
-Indeed, the selected-distance equalities give
+## Vertex-circle Strict Inequality
+
+At vertex `0`, the selected witnesses occur in boundary/angular order
 
 ```text
-d(1,8) = d(1,0)      from row 1,
-d(1,0) = d(0,2)      from row 0,
-d(0,2) = d(2,1)      from row 2.
+[1,2,4,8].
 ```
 
-Thus
+Since the nonagon is strictly convex, all other vertices lie in the open
+vertex cone at `0` except the adjacent boundary vertices on the cone rays.
+Thus this boundary order agrees with angular order about `p_0`.
+
+The four witnesses in row `0` lie on one circle centered at `p_0`. On one
+circle, chord length is strictly increasing with the central angle while the
+angle is below `pi`; the vertex cone at a strictly convex vertex has angle
+less than `pi`. The chord `[1,8]` spans the full interval from witness position
+`0` to `3`, while `[1,2]` spans the proper subinterval from position `0` to
+`1`. Therefore row `0` gives the strict vertex-circle inequality
 
 ```text
-d(1,8) = d(1,2).
+[1,8] > [1,2].
 ```
 
-On the other hand, the selected witnesses of row `0` lie on one circle
-centered at vertex `0`, and their radial order is
+## Contradiction
+
+The selected-distance rows identify `[1,8]` and `[1,2]` in the quotient, while
+the vertex-circle monotonicity step gives a strict inequality between the same
+two quotient classes:
 
 ```text
-1,2,4,8.
+[1,8] = [1,2]
+[1,8] > [1,2].
 ```
 
-In a strictly convex polygon, the rays from a vertex to the other vertices
-occur in the polygon's cyclic order inside an angle smaller than `pi`. On a
-fixed circle, chord length is strictly increasing with the enclosed central
-angle in this range. The chord `[1,8]` strictly contains the chord `[1,2]` in
-the row-`0` witness order, so
+Equivalently, the strict quotient graph has a reflexive strict edge. No
+Euclidean strictly convex realization satisfying the stated local hypotheses
+can exist.
 
-```text
-d(1,8) > d(1,2).
-```
+## Packet Replay
 
-This contradicts the equality above. Equivalently, after quotienting ordinary
-pair distances by the selected-distance equalities, row `0` creates a
-reflexive strict edge for the quotient class of `[1,8]` and `[1,2]`.
-
-The lemma is local: it rules out any selected-witness system containing these
-three rows in the stated cyclic order. It does not prove the full `n=9`
-finite case, because the exhaustive checker is still needed to show that every
-frontier assignment contains one of the recorded local obstruction templates.
-
-## Packet data
-
-For row `0`, the witness order `[1, 2, 4, 8]` gives the strict
-vertex-circle inequality
-
-```text
-[1, 8] > [1, 2]
-```
-
-The selected-distance equality path is:
-
-```text
-[1, 8] -- row 1 --> [0, 1]
-[0, 1] -- row 0 --> [0, 2]
-[0, 2] -- row 2 --> [1, 2]
-```
-
-Thus the packet isolates a local self-edge shape: a strict edge from a
-selected-distance quotient class back to itself.
-
-## Commands
-
-Generate and check the packet:
+The compact checker treats the JSON packet and its source packets as input
+data. It checks that the source packets are valid, verifies the three equality
+steps from selected rows, replays the vertex-circle quotient graph from the
+three local rows, and reports validation errors if the packet no longer
+supports the stated local lemma candidate.
 
 ```bash
-python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py \
-  --assert-expected \
-  --write
-
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py \
   --check \
   --assert-expected \
   --json
 ```
 
-Run the targeted artifact tests:
+Targeted artifact test:
 
 ```bash
 python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m "artifact"
 ```
 
-## Review standard
+## What This Does Not Prove
 
-Before treating this as a reusable local lemma, a reviewer should restate the
-incidence and cyclic-order hypotheses without relying on `T01` as a theorem
-name, then prove directly that the three rows force the displayed equality
-path and that row `0` gives the displayed strict inequality. The packet is a
-small replay aid for that review, not an independent proof of the `n=9` case.
+This local lemma candidate rules out only configurations satisfying the exact
+cyclic order and three selected rows displayed above. It does not enumerate all
+`n=9` selected-witness systems, does not promote the review-pending exhaustive
+`n=9` checker, does not rule out other vertex-circle templates, does not prove
+Erdos Problem #97, and does not produce or certify a counterexample.

--- a/scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py
@@ -32,10 +32,14 @@ from erdos97.n9_vertex_circle_t01_self_edge_lemma_packet import (  # noqa: E402
     STATUS,
     TRUST,
     assert_expected_t01_self_edge_lemma_packet,
+    equality_steps,
     source_artifacts,
     t01_self_edge_lemma_packet_payload,
+    validate_strict_inequality_support,
 )
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path  # noqa: E402
 from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import pair  # noqa: E402
 
 DEFAULT_ARTIFACT = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t01_self_edge_lemma_packet.json"
@@ -152,6 +156,18 @@ def _validate_local_lemma(payload: dict[str, Any], errors: list[str]) -> None:
     selected_equalities = lemma.get("selected_distance_equalities")
     if not isinstance(selected_equalities, list) or len(selected_equalities) != 3:
         errors.append("local_lemma selected_distance_equalities must have three steps")
+    elif isinstance(payload.get("distance_equality"), dict):
+        try:
+            expected_steps = equality_steps(payload["distance_equality"])
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(f"local_lemma selected_distance_equalities unsupported: {exc}")
+        else:
+            expect_equal(
+                errors,
+                "local_lemma selected_distance_equalities",
+                selected_equalities,
+                expected_steps,
+            )
     statement = str(lemma.get("strict_inequality_statement", ""))
     if "[1, 8]" not in statement or "[1, 2]" not in statement:
         errors.append("local_lemma strict inequality statement must name [1, 8] and [1, 2]")
@@ -174,6 +190,13 @@ def _validate_replay(payload: dict[str, Any], errors: list[str]) -> None:
         replay.get("self_edge_conflict_count"),
         2,
     )
+    expect_equal(errors, "replay cycle_edge_count", replay.get("cycle_edge_count"), 0)
+    conflicts = replay.get("self_edge_conflicts")
+    if not isinstance(conflicts, list):
+        errors.append("replay self_edge_conflicts must be a list")
+        conflicts = []
+    elif len(conflicts) != replay.get("self_edge_conflict_count"):
+        errors.append("replay self_edge_conflicts length must match self_edge_conflict_count")
     primary = replay.get("primary_self_edge_conflict")
     if not isinstance(primary, dict):
         errors.append("replay primary_self_edge_conflict must be an object")
@@ -182,6 +205,45 @@ def _validate_replay(payload: dict[str, Any], errors: list[str]) -> None:
     expect_equal(errors, "primary witness_order", primary.get("witness_order"), [1, 2, 4, 8])
     expect_equal(errors, "primary outer_pair", primary.get("outer_pair"), [1, 8])
     expect_equal(errors, "primary inner_pair", primary.get("inner_pair"), [1, 2])
+    if primary.get("outer_class") != primary.get("inner_class"):
+        errors.append("primary self-edge conflict must have equal outer_class and inner_class")
+    if not any(
+        all(conflict.get(key) == primary.get(key) for key in conflict)
+        for conflict in conflicts
+        if isinstance(conflict, dict)
+    ):
+        errors.append("primary self-edge conflict must be listed in self_edge_conflicts")
+
+
+def _validate_local_support(payload: dict[str, Any], errors: list[str]) -> None:
+    rows = payload.get("core_selected_rows")
+    equality = payload.get("distance_equality")
+    strict = payload.get("strict_inequality")
+    order = payload.get("cyclic_order", list(range(9)))
+    if not isinstance(rows, list):
+        errors.append("core_selected_rows must be a list")
+        return
+    if not isinstance(equality, dict):
+        errors.append("distance_equality must be an object")
+        return
+    if not isinstance(strict, dict):
+        errors.append("strict_inequality must be an object")
+        return
+    try:
+        validate_equality_path(rows, equality)
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"distance_equality is not supported by selected rows: {exc}")
+    try:
+        validate_strict_inequality_support(rows, strict, order=order)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"strict_inequality is not supported by selected rows: {exc}")
+    try:
+        if pair(*strict["outer_pair"]) != pair(*equality["start_pair"]):
+            errors.append("strict outer pair must start the equality path")
+        if pair(*strict["inner_pair"]) != pair(*equality["end_pair"]):
+            errors.append("strict inner pair must end the equality path")
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"strict/equality endpoint validation failed: {exc}")
 
 
 def validate_payload(
@@ -275,6 +337,7 @@ def validate_payload(
 
     _validate_local_lemma(payload, errors)
     _validate_replay(payload, errors)
+    _validate_local_support(payload, errors)
     _validate_sources(source_payloads, errors)
     expected_payload = None if errors else _expected_payload(source_payloads, errors)
     if expected_payload is not None:

--- a/src/erdos97/n9_vertex_circle_t01_self_edge_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t01_self_edge_lemma_packet.py
@@ -7,7 +7,7 @@ checker.
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 from erdos97 import n9_vertex_circle_exhaustive as n9
 from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path
@@ -141,6 +141,74 @@ def equality_steps(equality: dict[str, Any]) -> list[dict[str, Any]]:
     return steps
 
 
+def _strict_interval_pair(
+    witness_order: Sequence[int],
+    interval: Sequence[int],
+) -> list[int]:
+    if len(interval) != 2:
+        raise AssertionError(f"strict interval must have two endpoints: {interval!r}")
+    start = int(interval[0])
+    end = int(interval[1])
+    if not 0 <= start < end < len(witness_order):
+        raise AssertionError(f"strict interval out of range: {interval!r}")
+    return [int(value) for value in pair(witness_order[start], witness_order[end])]
+
+
+def validate_strict_inequality_support(
+    rows: Sequence[Sequence[int]],
+    strict: Mapping[str, Any],
+    *,
+    order: Sequence[int],
+) -> None:
+    """Validate that a strict inequality is supported by one selected row."""
+
+    parsed_rows = parse_selected_rows(rows)
+    row_map = {row.center: row for row in parsed_rows}
+    strict_row = int(strict["row"])
+    if strict_row not in row_map:
+        raise AssertionError(f"strict row {strict_row} is not selected")
+    order_tuple = tuple(int(label) for label in order)
+    if sorted(order_tuple) != list(range(len(order_tuple))):
+        raise AssertionError("cyclic order must be a permutation of 0..n-1")
+    positions = {label: index for index, label in enumerate(order_tuple)}
+    witnesses = tuple(
+        sorted(
+            row_map[strict_row].witnesses,
+            key=lambda witness: (positions[witness] - positions[strict_row])
+            % len(order_tuple),
+        )
+    )
+    if list(witnesses) != [int(label) for label in strict["witness_order"]]:
+        raise AssertionError("strict witness order is not supported by the selected row")
+
+    outer_interval = [int(value) for value in strict["outer_interval"]]
+    inner_interval = [int(value) for value in strict["inner_interval"]]
+    if not (
+        outer_interval[0] <= inner_interval[0]
+        and inner_interval[1] <= outer_interval[1]
+        and (
+            outer_interval[0] < inner_interval[0]
+            or inner_interval[1] < outer_interval[1]
+        )
+    ):
+        raise AssertionError("strict outer interval must properly contain inner interval")
+
+    outer_pair = _strict_interval_pair(witnesses, outer_interval)
+    inner_pair = _strict_interval_pair(witnesses, inner_interval)
+    if outer_pair != [int(value) for value in pair(*strict["outer_pair"])]:
+        raise AssertionError("strict outer pair is not supported by its interval")
+    if inner_pair != [int(value) for value in pair(*strict["inner_pair"])]:
+        raise AssertionError("strict inner pair is not supported by its interval")
+    outer_span = outer_interval[1] - outer_interval[0]
+    inner_span = inner_interval[1] - inner_interval[0]
+    if outer_span <= inner_span:
+        raise AssertionError("strict outer span must be larger than inner span")
+    if int(strict["outer_span"]) != outer_span:
+        raise AssertionError("strict outer span mismatch")
+    if int(strict["inner_span"]) != inner_span:
+        raise AssertionError("strict inner span mismatch")
+
+
 def source_artifacts(
     self_edge_packet: dict[str, Any],
     template_catalog: dict[str, Any],
@@ -206,6 +274,11 @@ def _assert_source_records(
     equality = family["distance_equality"]
     strict = family["strict_inequality"]
     validate_equality_path(rows, equality)
+    validate_strict_inequality_support(rows, strict, order=list(n9.ORDER))
+    if pair(*strict["outer_pair"]) != pair(*equality["start_pair"]):
+        raise AssertionError("strict outer pair must start the equality path")
+    if pair(*strict["inner_pair"]) != pair(*equality["end_pair"]):
+        raise AssertionError("strict inner pair must end the equality path")
 
     if template["template_id"] != EXPECTED_TEMPLATE_ID:
         raise AssertionError("unexpected template id")

--- a/tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py
@@ -115,6 +115,35 @@ def test_t01_self_edge_lemma_packet_rejects_missing_no_proof_note() -> None:
     assert any("no-proof" in error for error in errors)
 
 
+def test_t01_self_edge_lemma_packet_rejects_tampered_local_lemma_steps() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["local_lemma"]["selected_distance_equalities"][0]["right_pair"] = [2, 3]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("local_lemma selected_distance_equalities mismatch" in error for error in errors)
+
+
+def test_t01_self_edge_lemma_packet_rejects_unsupported_strict_interval() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["strict_inequality"]["inner_interval"] = [1, 3]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("unexpected strict inequality" in error for error in errors)
+    assert any("strict inner pair is not supported" in error for error in errors)
+
+
+def test_t01_self_edge_lemma_packet_rejects_replay_primary_not_listed() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["replay"]["self_edge_conflicts"] = payload["replay"]["self_edge_conflicts"][1:]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("self_edge_conflicts length" in error for error in errors)
+    assert any("primary self-edge conflict must be listed" in error for error in errors)
+
+
 def test_t01_self_edge_lemma_packet_detects_source_packet_mismatch() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     sources = copy.deepcopy(load_source_payloads())


### PR DESCRIPTION
## Summary

- Restates the T01/F09 vertex-circle self-edge packet as a proof-facing local lemma candidate with exact cyclic-order and selected-row hypotheses.
- Adds a conservative claims-ledger entry that keeps the result scoped to a review-pending local lemma candidate.
- Hardens the compact T01 checker to validate local lemma equality steps, strict-inequality row support, and replay self-edge consistency from input packet data.

## Scope

This does not claim a proof of n=9, a counterexample, or a global result for Erdos Problem #97. The T01/F09 labels are retained only as packet/catalog navigation.

## Validation

- `python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t01_self_edge_lemma_packet.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`