### PR TITLE
[codex] Audit block6 opened centers

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -445,6 +445,36 @@ clean eighth centers after nearest transition  nearest transitions
 3                                              4
 ```
 
+Across those `56` transitions, the opened clean eighth-center choices give
+`88` transition-center incidences. Their block-swap orbit distribution is:
+
+```text
+opened eighth center orbit  incidences
+1,7                         8
+2,8                         46
+4,10                        30
+5,11                        4
+```
+
+Relative to the terminal state's legal eighth rows, the opened centers had
+these prior status types:
+
+```text
+prior status  incidences
+self only     30
+mixed         30
+strict only   22
+not legal     6
+```
+
+Here `self only` means all legal eighth rows at that center failed by quotient
+self-edge, `strict only` means all failed by strict cycle, and `mixed` means
+both failure types appeared. The `not legal` cases were not legal eighth
+centers at all before the one-row replacement. Only `4` transitions open the
+added witness label and only `4` open the removed witness label; the other
+`48` transitions open neither replacement label. Thus the one-row escape is
+usually indirect rather than a replacement simply opening its own label.
+
 For example, the terminal state
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,163 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 653 - Block-6 Opened-center Transition Audit
+
+### Mathematical Subquestion
+
+Cycle 652 classified the nearest one-replacement terminal-to-extendable
+transitions in the low-support block-6 branch. The next precise question was:
+
+```text
+For each nearest transition, which previously obstructed or not-legal eighth
+centers become clean, and is the opened clean center simply the added or
+removed replacement label?
+```
+
+### Definitions and Assumptions
+
+Use the same finite branch, terminal clean seven-row states, same-class
+extendable states, and nearest transitions as Cycles 651 and 652. An
+**opened clean eighth center** for a nearest transition `(T,E)` is an eighth
+center with at least one clean eighth-row extension after `E`.
+
+For the corresponding terminal state `T`, the center's prior status is:
+
+- `self_only`: legal eighth rows existed at that center, and all failed by
+  quotient self-edge.
+- `strict_only`: legal eighth rows existed at that center, and all failed by
+  strict cycle.
+- `mixed`: legal eighth rows existed at that center, with both failure types.
+- `not_legal`: no legal eighth row at that center was present for `T`.
+
+The replacement-label relation records whether an opened center is the added
+label, the removed label, or neither.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 Opened-center Transition Audit**.
+
+### Argument Or Obstruction
+
+Across the `56` nearest one-replacement transitions, the extendable states
+open `88` clean eighth-center incidences. The number of opened centers per
+transition is the same split as Cycle 652:
+
+```text
+opened clean eighth centers  nearest transitions
+1                            28
+2                            24
+3                            4
+```
+
+The opened-center block-swap orbit distribution is:
+
+```text
+opened center orbit  incidences
+1,7                  8
+2,8                  46
+4,10                 30
+5,11                 4
+```
+
+Relative to the terminal state before replacement, the opened centers had
+these prior statuses:
+
+```text
+prior status  incidences
+self_only     30
+mixed         30
+strict_only   22
+not_legal     6
+```
+
+The replacement-label relation is:
+
+```text
+relation        nearest transitions
+added_opened    4
+removed_opened  4
+neither_opened  48
+```
+
+Thus the most direct candidate explanation fails: in `48` of the `56`
+nearest transitions, no opened clean eighth center is the added or removed
+witness label. Also, `6` opened centers were not legal eighth centers before
+the replacement, so the transition can change the legal-center set itself and
+not merely remove a prior self-edge or strict-cycle obstruction at an already
+legal center.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers the `56` nearest
+same-class terminal-to-extendable transitions from the `12` terminal clean
+seven-row states and the `88` opened clean eighth-center incidences after
+those transitions. It is not a Euclidean realizability result, is not a proof
+of Erdos Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+The audit rules out a simple "the replacement opens its own label" lemma and
+also rules out a proof route that only tracks the previous obstruction kind at
+already legal eighth centers. The next invariant must see how the row
+replacement changes boundary-pair placement, center legality, and quotient
+self-edge or strict-cycle formation together.
+
+### Next Lead
+
+Inspect exact quotient paths for the `6` transitions that open `not_legal`
+centers, then compare them with the `self_only`, `mixed`, and `strict_only`
+openings. A useful next lemma would isolate a boundary-pair or cyclic-order
+sign condition that predicts when a one-row replacement changes center
+legality rather than only changing obstruction type.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-653`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-653`.
+- The branch was started from `origin/main` at commit
+  `d480d8c19dbf23dcebdff070b729658794839bb9`, after PR #375 merged Cycle
+  652.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `56` nearest transitions and `88` opened
+  clean eighth-center incidences.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `542 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 652 - Block-6 Nearest-transition Signatures
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -766,6 +766,69 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
         "10": 2,
         "13": 2,
     },
+    "opened_center_instance_count": 88,
+    "opened_center_distribution": {
+        "1": 4,
+        "2": 23,
+        "4": 15,
+        "5": 2,
+        "7": 4,
+        "8": 23,
+        "10": 15,
+        "11": 2,
+    },
+    "opened_center_orbit_distribution": {
+        "1,7": 8,
+        "2,8": 46,
+        "4,10": 30,
+        "5,11": 4,
+    },
+    "opened_center_prior_status_distribution": {
+        "mixed": 30,
+        "not_legal": 6,
+        "self_only": 30,
+        "strict_only": 22,
+    },
+    "opened_center_prior_status_by_transition": {
+        "mixed:1": 6,
+        "mixed:1;not_legal:1": 4,
+        "mixed:1;self_only:1": 4,
+        "mixed:1;strict_only:1": 10,
+        "mixed:1;strict_only:2": 2,
+        "mixed:2": 2,
+        "not_legal:1;self_only:1;strict_only:1": 2,
+        "self_only:1": 18,
+        "self_only:1;strict_only:1": 2,
+        "self_only:2": 2,
+        "strict_only:1": 4,
+    },
+    "opened_contains_replacement_label_distribution": {
+        "added_opened": 4,
+        "neither_opened": 48,
+        "removed_opened": 4,
+    },
+    "changed_to_opened_center_orbit_distribution": {
+        "2,8->1,7": 2,
+        "2,8->2,8": 6,
+        "2,8->4,10": 12,
+        "2,8->5,11": 2,
+        "4,10->2,8": 6,
+        "4,10->4,10": 4,
+        "4,10->5,11": 2,
+        "5,11->1,7": 6,
+        "5,11->2,8": 34,
+        "5,11->4,10": 14,
+    },
+    "replacement_side_to_opened_prior_status_distribution": {
+        "opposite_block->mixed": 18,
+        "opposite_block->not_legal": 4,
+        "opposite_block->self_only": 26,
+        "opposite_block->strict_only": 12,
+        "same_block->mixed": 12,
+        "same_block->not_legal": 2,
+        "same_block->self_only": 4,
+        "same_block->strict_only": 10,
+    },
     "class_summary": {
         (
             "2,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
@@ -1696,6 +1759,20 @@ def _replacement_side(center: int, removed: int, added: int) -> str:
     return removed_side
 
 
+def _eighth_center_status_kind(status_counts: Mapping[str, int]) -> str:
+    if status_counts["ok"] > 0:
+        return "ok"
+    has_self_edge = status_counts["self_edge"] > 0
+    has_strict_cycle = status_counts["strict_cycle"] > 0
+    if has_self_edge and has_strict_cycle:
+        return "mixed"
+    if has_self_edge:
+        return "self_only"
+    if has_strict_cycle:
+        return "strict_only"
+    return "none"
+
+
 def _state_replacement_distance(left: SevenState, right: SevenState) -> int:
     right_by_center = {center: row for center, row in right}
     return sum(
@@ -1752,7 +1829,15 @@ def _low_support_terminal_edit_distance_audit(
     replacement_side_counts: Counter[str] = Counter()
     extendable_ok_center_counts: Counter[int] = Counter()
     extendable_ok_row_counts: Counter[int] = Counter()
+    opened_center_counts: Counter[int] = Counter()
+    opened_center_orbit_counts: Counter[str] = Counter()
+    opened_center_prior_status_counts: Counter[str] = Counter()
+    opened_center_prior_status_by_transition: Counter[str] = Counter()
+    opened_contains_replacement_label_counts: Counter[str] = Counter()
+    changed_to_opened_center_orbit_counts: Counter[str] = Counter()
+    replacement_side_to_opened_prior_status_counts: Counter[str] = Counter()
     nearest_transition_count = 0
+    opened_center_instance_count = 0
     class_summary: dict[str, dict[str, Any]] = {}
     by_terminal: list[dict[str, Any]] = []
     options = _options()
@@ -1764,6 +1849,11 @@ def _low_support_terminal_edit_distance_audit(
             raise AssertionError(f"terminal class has no extendable state: {key}")
         class_distances = []
         for terminal in entry["terminal"]:
+            terminal_eighth_counts = _state_eighth_center_counts(terminal, options)
+            terminal_prior_status_by_center = {
+                int(center): _eighth_center_status_kind(status_counts)
+                for center, status_counts in terminal_eighth_counts.items()
+            }
             distances = [
                 (_state_replacement_distance(terminal, extendable), extendable)
                 for extendable in entry["extendable"]
@@ -1820,6 +1910,52 @@ def _low_support_terminal_edit_distance_audit(
                 )
                 extendable_ok_center_counts[ok_center_count] += 1
                 extendable_ok_row_counts[ok_row_count] += 1
+                opened_centers = [
+                    int(center)
+                    for center, status_counts in sorted(
+                        extendable_eighth_counts.items(),
+                        key=lambda item: int(item[0]),
+                    )
+                    if status_counts["ok"] > 0
+                ]
+                opened_center_instance_count += len(opened_centers)
+                relation_parts = []
+                if added_label in opened_centers:
+                    relation_parts.append("added_opened")
+                if removed_label in opened_centers:
+                    relation_parts.append("removed_opened")
+                if not relation_parts:
+                    relation_parts.append("neither_opened")
+                opened_contains_replacement_label_counts[
+                    "+".join(relation_parts)
+                ] += 1
+
+                transition_prior_statuses: Counter[str] = Counter()
+                changed_center_orbit = _center_orbit_key(center)
+                for opened_center in opened_centers:
+                    prior_status = terminal_prior_status_by_center.get(
+                        opened_center,
+                        "not_legal",
+                    )
+                    opened_center_counts[opened_center] += 1
+                    opened_center_orbit_counts[
+                        _center_orbit_key(opened_center)
+                    ] += 1
+                    opened_center_prior_status_counts[prior_status] += 1
+                    transition_prior_statuses[prior_status] += 1
+                    changed_to_opened_center_orbit_counts[
+                        f"{changed_center_orbit}->{_center_orbit_key(opened_center)}"
+                    ] += 1
+                    replacement_side_to_opened_prior_status_counts[
+                        f"{_replacement_side(center, removed_label, added_label)}"
+                        f"->{prior_status}"
+                    ] += 1
+                opened_center_prior_status_by_transition[
+                    ";".join(
+                        f"{status}:{transition_prior_statuses[status]}"
+                        for status in sorted(transition_prior_statuses)
+                    )
+                ] += 1
 
             by_terminal.append(
                 {
@@ -1869,6 +2005,32 @@ def _low_support_terminal_edit_distance_audit(
         "extendable_ok_row_count_distribution": _json_counter(
             extendable_ok_row_counts
         ),
+        "opened_center_instance_count": opened_center_instance_count,
+        "opened_center_distribution": _json_counter(opened_center_counts),
+        "opened_center_orbit_distribution": {
+            key: int(opened_center_orbit_counts[key])
+            for key in sorted(opened_center_orbit_counts)
+        },
+        "opened_center_prior_status_distribution": {
+            key: int(opened_center_prior_status_counts[key])
+            for key in sorted(opened_center_prior_status_counts)
+        },
+        "opened_center_prior_status_by_transition": {
+            key: int(opened_center_prior_status_by_transition[key])
+            for key in sorted(opened_center_prior_status_by_transition)
+        },
+        "opened_contains_replacement_label_distribution": {
+            key: int(opened_contains_replacement_label_counts[key])
+            for key in sorted(opened_contains_replacement_label_counts)
+        },
+        "changed_to_opened_center_orbit_distribution": {
+            key: int(changed_to_opened_center_orbit_counts[key])
+            for key in sorted(changed_to_opened_center_orbit_counts)
+        },
+        "replacement_side_to_opened_prior_status_distribution": {
+            key: int(replacement_side_to_opened_prior_status_counts[key])
+            for key in sorted(replacement_side_to_opened_prior_status_counts)
+        },
         "class_summary": class_summary,
         "by_terminal": by_terminal,
     }

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -258,6 +258,30 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "10": 2,
         "13": 2,
     }
+    assert edit_distance_audit["opened_center_instance_count"] == 88
+    assert edit_distance_audit["opened_center_orbit_distribution"] == {
+        "1,7": 8,
+        "2,8": 46,
+        "4,10": 30,
+        "5,11": 4,
+    }
+    assert edit_distance_audit["opened_center_prior_status_distribution"] == {
+        "mixed": 30,
+        "not_legal": 6,
+        "self_only": 30,
+        "strict_only": 22,
+    }
+    assert edit_distance_audit["opened_contains_replacement_label_distribution"] == {
+        "added_opened": 4,
+        "neither_opened": 48,
+        "removed_opened": 4,
+    }
+    assert edit_distance_audit["changed_to_opened_center_orbit_distribution"][
+        "5,11->2,8"
+    ] == 34
+    assert edit_distance_audit[
+        "replacement_side_to_opened_prior_status_distribution"
+    ]["opposite_block->self_only"] == 26
     assert edit_distance_audit["changed_row_count_distribution_for_first_nearest"] == {
         "1": 12
     }


### PR DESCRIPTION
## Mathematical scope

Cycle 653 adds an exact finite audit for the low-support block-6 nearest terminal-to-extendable transitions. It records which clean eighth-center choices appear after the nearest one-row replacement and compares those centers with their prior terminal-state status.

Main audited facts:

- 56 nearest one-replacement transitions.
- 88 opened clean eighth-center incidences.
- Opened center orbit counts: `1,7: 8`, `2,8: 46`, `4,10: 30`, `5,11: 4`.
- Prior terminal-state status counts: `self_only: 30`, `mixed: 30`, `strict_only: 22`, `not_legal: 6`.
- Replacement-label relation: `added_opened: 4`, `removed_opened: 4`, `neither_opened: 48`.

This rules out the simple explanation that a nearest one-row escape usually opens the added or removed witness label itself.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds opened-center counters to the exact block-6 edit-distance audit and expected payload.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts representative opened-center distributions.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the opened-center audit result.
- `reports/codex_goal_erdos97_log.md`: adds Cycle 653 with scope, limitations, validation, and next lead.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q` -> `2 passed`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `542 passed, 278 deselected`

## Remaining limitations

This is an exact finite audit within the repo-local low-support two-block block-6 selected-row extension tree. It is not a Euclidean realizability result, not a proof of Erdos Problem #97, and not a counterexample. The overarching proof/counterexample goal remains open.