### PR TITLE
[codex] Audit block6 not-legal openings

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -475,6 +475,35 @@ added witness label and only `4` open the removed witness label; the other
 `48` transitions open neither replacement label. Thus the one-row escape is
 usually indirect rather than a replacement simply opening its own label.
 
+The `6` not-legal openings all occur at centers in the block-swap orbit
+`2,8`. They are not caused by the pair-cap or indegree-cap filters. Before
+the one-row replacement, the opened center has zero pair/crossing-admissible
+rows; after the replacement it has either `7` or `8` pair/crossing-admissible
+rows, all of which also pass the pair-cap and indegree-cap filters:
+
+```text
+pair/crossing profile                       not-legal openings
+before=0, after=7, after fully valid=7      2
+before=0, after=8, after fully valid=8      4
+```
+
+Against the changed row, the `46` after-valid candidate rows had the following
+before/after crossing relations:
+
+```text
+relation before replacement  candidate rows
+noncrossing two-overlap       44
+three-or-more overlap          2
+
+relation after replacement   candidate rows
+zero-or-one overlap           36
+crossing two-overlap          10
+```
+
+So the previously not-legal openings are pure crossing-gate switches: the
+replacement either destroys a forbidden noncrossing two-overlap or changes it
+into an allowed crossing two-overlap.
+
 For example, the terminal state
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,162 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 654 - Block-6 Not-legal Opening Crossing-gate Audit
+
+### Mathematical Subquestion
+
+Cycle 653 found that `6` opened clean eighth-center incidences were not legal
+eighth centers before the nearest one-row replacement. The next precise
+question was:
+
+```text
+Are those not-legal openings caused by pair-cap or indegree-cap capacity
+changes, or by the cyclic pair/crossing admissibility gate?
+```
+
+### Definitions and Assumptions
+
+Use the same low-support block-6 branch, terminal clean seven-row states,
+same-class nearest terminal-to-extendable transitions, and opened clean
+eighth centers from Cycles 651-653.
+
+For a fixed candidate eighth center, the checker applies these row-admissible
+gates before the vertex-circle quotient obstruction:
+
+- pair/crossing: every two-row intersection has size at most two, and a
+  two-overlap must satisfy the radical-axis crossing rule in the fixed natural
+  cyclic order;
+- pair cap: no unordered witness pair appears in more than two selected rows;
+- indegree cap: no witness label exceeds the incidence count cap.
+
+A **not-legal opening** is an opened clean eighth center after a nearest
+transition that had no legal eighth rows before the transition.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 Not-legal Opening Crossing-gate Audit**.
+
+### Argument Or Obstruction
+
+The `6` not-legal openings all occur at opened centers in the block-swap orbit
+`2,8`. Their changed-center orbit distribution is balanced:
+
+```text
+changed center orbit  not-legal openings
+2,8                   2
+4,10                  2
+5,11                  2
+```
+
+The replacement side split is:
+
+```text
+replacement side  not-legal openings
+same block        2
+opposite block    4
+```
+
+For all `6` openings, the opened center has zero pair/crossing-admissible
+rows before the one-row replacement. After the replacement, the opened center
+has either `7` or `8` pair/crossing-admissible rows, and all of those rows
+also pass the pair-cap and indegree-cap filters:
+
+```text
+pair/crossing profile                       not-legal openings
+before=0, after=7, after fully valid=7      2
+before=0, after=8, after fully valid=8      4
+```
+
+Across the `46` after-valid candidate rows for those six openings, comparing
+only against the changed row gives:
+
+```text
+relation before replacement  candidate rows
+noncrossing two-overlap       44
+three-or-more overlap          2
+
+relation after replacement   candidate rows
+zero-or-one overlap           36
+crossing two-overlap          10
+```
+
+Thus the not-legal openings are pure crossing-gate switches in this finite
+branch. The one-row replacement is not freeing a saturated witness-pair count
+or an indegree capacity; it changes the local two-row intersection with the
+would-be eighth row from a forbidden noncrossing two-overlap or three-overlap
+into either a zero/one-overlap or an allowed crossing two-overlap.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers only the `6` not-legal
+opened clean eighth-center incidences among the `88` opened incidences from
+Cycle 653. It is not a Euclidean realizability result, is not a proof of
+Erdos Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This sharpens the Cycle 653 obstruction: the previously not-legal openings do
+not require a new capacity mechanism. They are explained by the same
+radical-axis crossing rule that underlies the fragile-cover bridge. That makes
+the next proof-facing target more specific: find a cyclic-order condition
+under which one witness replacement changes every prospective eighth-row
+intersection from noncrossing to crossing or to size at most one.
+
+### Next Lead
+
+Compare the `44` forbidden noncrossing two-overlap candidate rows by their
+target chord relative to the source chord `(changed center, opened center)`.
+A useful next lemma would state a local cyclic-order interval condition for
+when replacing one endpoint in the changed row converts a whole family of
+noncrossing two-overlaps into admissible rows.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-654`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-654`.
+- The branch was started from `origin/main` at commit
+  `7f5ee8e193cd565ee6a8d51db8bd2f3c5678c813`, after PR #380 merged Cycle
+  653.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `6` not-legal openings, all with
+  `before_paircross=0` and `after_valid` equal to `7` or `8`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `549 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 653 - Block-6 Opened-center Transition Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -18,11 +18,15 @@ from scripts.check_block6_fragile_vertex_circle_extension import (  # noqa: E402
     N,
     _add_row,
     _initial_state,
+    _indegree_ok,
     _options,
+    _pair_cap_ok,
+    _paircross_ok,
     _partial_vertex_circle_status,
     _remove_row,
     _valid_options,
 )
+from erdos97.incidence_filters import chords_cross_in_order, normalize_chord  # noqa: E402
 
 STATUSES = ("ok", "self_edge", "strict_cycle")
 EXPECTED_TOTALS = {
@@ -828,6 +832,35 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
         "same_block->not_legal": 2,
         "same_block->self_only": 4,
         "same_block->strict_only": 10,
+    },
+    "not_legal_opened_instance_count": 6,
+    "not_legal_opened_center_distribution": {
+        "2": 3,
+        "8": 3,
+    },
+    "not_legal_opened_center_orbit_distribution": {
+        "2,8": 6,
+    },
+    "not_legal_opened_changed_center_orbit_distribution": {
+        "2,8": 2,
+        "4,10": 2,
+        "5,11": 2,
+    },
+    "not_legal_opened_replacement_side_distribution": {
+        "opposite_block": 4,
+        "same_block": 2,
+    },
+    "not_legal_opened_paircross_profile_distribution": {
+        "before_paircross=0;after_paircross=7;after_valid=7": 2,
+        "before_paircross=0;after_paircross=8;after_valid=8": 4,
+    },
+    "not_legal_opened_before_changed_row_relation_distribution": {
+        "noncrossing_two_overlap": 44,
+        "three_or_more_overlap": 2,
+    },
+    "not_legal_opened_after_changed_row_relation_distribution": {
+        "crossing_two_overlap": 10,
+        "zero_or_one_overlap": 36,
     },
     "class_summary": {
         (
@@ -1773,6 +1806,88 @@ def _eighth_center_status_kind(status_counts: Mapping[str, int]) -> str:
     return "none"
 
 
+def _changed_row_relation(
+    changed_center: int,
+    opened_center: int,
+    changed_row: tuple[int, ...],
+    opened_row: tuple[int, ...],
+) -> str:
+    overlap = sorted(set(changed_row) & set(opened_row))
+    if len(overlap) <= 1:
+        return "zero_or_one_overlap"
+    if len(overlap) > 2:
+        return "three_or_more_overlap"
+    source = normalize_chord(changed_center, opened_center)
+    target = normalize_chord(overlap[0], overlap[1])
+    if chords_cross_in_order(source, target, list(range(N))):
+        return "crossing_two_overlap"
+    return "noncrossing_two_overlap"
+
+
+def _not_legal_opened_paircross_profile(
+    terminal: SevenState,
+    extendable: SevenState,
+    opened_center: int,
+    changed_center: int,
+    terminal_changed_row: tuple[int, ...],
+    extendable_changed_row: tuple[int, ...],
+    options: Mapping[int, list[tuple[int, ...]]],
+) -> dict[str, Any]:
+    assigned_before, pair_counts_before, indegrees_before = (
+        _initial_state_with_records(terminal)
+    )
+    assigned_after, pair_counts_after, indegrees_after = _initial_state_with_records(
+        extendable
+    )
+    center_options = options[opened_center]
+    before_paircross_rows = [
+        row
+        for row in center_options
+        if _paircross_ok(opened_center, row, assigned_before)
+    ]
+    after_paircross_rows = [
+        row
+        for row in center_options
+        if _paircross_ok(opened_center, row, assigned_after)
+    ]
+    after_valid_rows = [
+        row
+        for row in after_paircross_rows
+        if _pair_cap_ok(row, pair_counts_after)
+        and _indegree_ok(row, indegrees_after)
+    ]
+    before_valid_rows = [
+        row
+        for row in before_paircross_rows
+        if _pair_cap_ok(row, pair_counts_before)
+        and _indegree_ok(row, indegrees_before)
+    ]
+    return {
+        "before_paircross": len(before_paircross_rows),
+        "before_valid": len(before_valid_rows),
+        "after_paircross": len(after_paircross_rows),
+        "after_valid": len(after_valid_rows),
+        "before_changed_row_relations": Counter(
+            _changed_row_relation(
+                changed_center,
+                opened_center,
+                terminal_changed_row,
+                row,
+            )
+            for row in after_valid_rows
+        ),
+        "after_changed_row_relations": Counter(
+            _changed_row_relation(
+                changed_center,
+                opened_center,
+                extendable_changed_row,
+                row,
+            )
+            for row in after_valid_rows
+        ),
+    }
+
+
 def _state_replacement_distance(left: SevenState, right: SevenState) -> int:
     right_by_center = {center: row for center, row in right}
     return sum(
@@ -1836,8 +1951,16 @@ def _low_support_terminal_edit_distance_audit(
     opened_contains_replacement_label_counts: Counter[str] = Counter()
     changed_to_opened_center_orbit_counts: Counter[str] = Counter()
     replacement_side_to_opened_prior_status_counts: Counter[str] = Counter()
+    not_legal_opened_center_counts: Counter[int] = Counter()
+    not_legal_opened_center_orbit_counts: Counter[str] = Counter()
+    not_legal_opened_changed_center_orbit_counts: Counter[str] = Counter()
+    not_legal_opened_replacement_side_counts: Counter[str] = Counter()
+    not_legal_opened_paircross_profile_counts: Counter[str] = Counter()
+    not_legal_opened_before_relation_counts: Counter[str] = Counter()
+    not_legal_opened_after_relation_counts: Counter[str] = Counter()
     nearest_transition_count = 0
     opened_center_instance_count = 0
+    not_legal_opened_instance_count = 0
     class_summary: dict[str, dict[str, Any]] = {}
     by_terminal: list[dict[str, Any]] = []
     options = _options()
@@ -1946,10 +2069,50 @@ def _low_support_terminal_edit_distance_audit(
                     changed_to_opened_center_orbit_counts[
                         f"{changed_center_orbit}->{_center_orbit_key(opened_center)}"
                     ] += 1
+                    replacement_side = _replacement_side(
+                        center,
+                        removed_label,
+                        added_label,
+                    )
                     replacement_side_to_opened_prior_status_counts[
-                        f"{_replacement_side(center, removed_label, added_label)}"
-                        f"->{prior_status}"
+                        f"{replacement_side}->{prior_status}"
                     ] += 1
+                    if prior_status == "not_legal":
+                        not_legal_opened_instance_count += 1
+                        terminal_changed_row = dict(terminal)[center]
+                        extendable_changed_row = dict(extendable)[center]
+                        switch_profile = _not_legal_opened_paircross_profile(
+                            terminal,
+                            extendable,
+                            opened_center,
+                            center,
+                            terminal_changed_row,
+                            extendable_changed_row,
+                            options,
+                        )
+                        not_legal_opened_center_counts[opened_center] += 1
+                        not_legal_opened_center_orbit_counts[
+                            _center_orbit_key(opened_center)
+                        ] += 1
+                        not_legal_opened_changed_center_orbit_counts[
+                            changed_center_orbit
+                        ] += 1
+                        not_legal_opened_replacement_side_counts[
+                            replacement_side
+                        ] += 1
+                        not_legal_opened_paircross_profile_counts[
+                            "before_paircross="
+                            f"{switch_profile['before_paircross']};"
+                            "after_paircross="
+                            f"{switch_profile['after_paircross']};"
+                            f"after_valid={switch_profile['after_valid']}"
+                        ] += 1
+                        not_legal_opened_before_relation_counts.update(
+                            switch_profile["before_changed_row_relations"]
+                        )
+                        not_legal_opened_after_relation_counts.update(
+                            switch_profile["after_changed_row_relations"]
+                        )
                 opened_center_prior_status_by_transition[
                     ";".join(
                         f"{status}:{transition_prior_statuses[status]}"
@@ -2030,6 +2193,34 @@ def _low_support_terminal_edit_distance_audit(
         "replacement_side_to_opened_prior_status_distribution": {
             key: int(replacement_side_to_opened_prior_status_counts[key])
             for key in sorted(replacement_side_to_opened_prior_status_counts)
+        },
+        "not_legal_opened_instance_count": not_legal_opened_instance_count,
+        "not_legal_opened_center_distribution": _json_counter(
+            not_legal_opened_center_counts
+        ),
+        "not_legal_opened_center_orbit_distribution": {
+            key: int(not_legal_opened_center_orbit_counts[key])
+            for key in sorted(not_legal_opened_center_orbit_counts)
+        },
+        "not_legal_opened_changed_center_orbit_distribution": {
+            key: int(not_legal_opened_changed_center_orbit_counts[key])
+            for key in sorted(not_legal_opened_changed_center_orbit_counts)
+        },
+        "not_legal_opened_replacement_side_distribution": {
+            key: int(not_legal_opened_replacement_side_counts[key])
+            for key in sorted(not_legal_opened_replacement_side_counts)
+        },
+        "not_legal_opened_paircross_profile_distribution": {
+            key: int(not_legal_opened_paircross_profile_counts[key])
+            for key in sorted(not_legal_opened_paircross_profile_counts)
+        },
+        "not_legal_opened_before_changed_row_relation_distribution": {
+            key: int(not_legal_opened_before_relation_counts[key])
+            for key in sorted(not_legal_opened_before_relation_counts)
+        },
+        "not_legal_opened_after_changed_row_relation_distribution": {
+            key: int(not_legal_opened_after_relation_counts[key])
+            for key in sorted(not_legal_opened_after_relation_counts)
         },
         "class_summary": class_summary,
         "by_terminal": by_terminal,

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -282,6 +282,35 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
     assert edit_distance_audit[
         "replacement_side_to_opened_prior_status_distribution"
     ]["opposite_block->self_only"] == 26
+    assert edit_distance_audit["not_legal_opened_instance_count"] == 6
+    assert edit_distance_audit["not_legal_opened_center_orbit_distribution"] == {
+        "2,8": 6
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_changed_center_orbit_distribution"
+    ] == {
+        "2,8": 2,
+        "4,10": 2,
+        "5,11": 2,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_paircross_profile_distribution"
+    ] == {
+        "before_paircross=0;after_paircross=7;after_valid=7": 2,
+        "before_paircross=0;after_paircross=8;after_valid=8": 4,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_before_changed_row_relation_distribution"
+    ] == {
+        "noncrossing_two_overlap": 44,
+        "three_or_more_overlap": 2,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_after_changed_row_relation_distribution"
+    ] == {
+        "crossing_two_overlap": 10,
+        "zero_or_one_overlap": 36,
+    }
     assert edit_distance_audit["changed_row_count_distribution_for_first_nearest"] == {
         "1": 12
     }


### PR DESCRIPTION
## Mathematical scope

Cycle 654 narrows the six Cycle 653 opened eighth-center incidences that were not legal before the nearest one-row replacement. The new audit checks whether those openings are caused by pair-cap or indegree capacity changes, or by the cyclic pair/crossing admissibility gate.

Main audited facts:

- 6 not-legal opened-center incidences, all in opened-center orbit `2,8`.
- Changed-center orbit split: `2,8: 2`, `4,10: 2`, `5,11: 2`.
- Replacement side split: `same_block: 2`, `opposite_block: 4`.
- Before replacement: every not-legal opened center has `before_paircross=0`.
- After replacement: the opened center has either 7 or 8 pair/crossing-admissible rows, and all also pass pair-cap and indegree filters.
- Across 46 after-valid candidate rows, the changed-row relation shifts from `44` noncrossing two-overlaps plus `2` three-or-more overlaps before replacement to `36` zero/one-overlaps plus `10` crossing two-overlaps after replacement.

This records the not-legal openings as pure crossing-gate switches in the finite low-support block-6 branch.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds exact counters for the not-legal opened-center pair/crossing switch profile.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts the new exact distributions.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the crossing-gate switch audit.
- `reports/codex_goal_erdos97_log.md`: adds Cycle 654 with scope, limitations, validation, and next lead.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q` -> `2 passed`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `549 passed, 278 deselected`

## Remaining limitations

This is an exact finite audit within the repo-local low-support two-block block-6 selected-row extension tree. It is not a Euclidean realizability result, not a proof of Erdos Problem #97, and not a counterexample. The overarching proof/counterexample goal remains open.