### PR TITLE
[codex] Add bootstrap-core bridge capacity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For a partial bridge theorem from minimality to fragile-cover witness
   systems, read
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
+- For the rich-triple closure / bootstrap-core bridge fork, read
+  [`docs/bootstrap-core-bridge.md`](docs/bootstrap-core-bridge.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -121,6 +121,19 @@ block-6 fragile cover but still permits two disjoint blocks, so this is a
 necessary structural bridge only, not a contradiction and not the open
 ear-orderable bridge. See `docs/minimal-fragile-cover-bridge.md`.
 
+### Bootstrap-core bridge
+
+Status: `LEMMA` / bridge fork.
+
+For the full rich distance-class family, rich-triple closure rank is exactly
+the ear-orderable selected-witness bridge: rank at most 3 is equivalent to an
+ear-orderable selection. If the rank is greater than 3, any inclusion-minimal
+generating core has deletion closures and private halos that make it a
+radius-blocker with a weighted cyclic outside-pair capacity ledger. This is a
+necessary bridge target only; it is not a proof of Erdos Problem #97 and not a
+counterexample. See `docs/bootstrap-core-bridge.md` and
+`scripts/check_bootstrap_core_bridge.py`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -44,6 +44,13 @@ from exact critical 4-ties. This is necessary structure only; the block-6
 abstract family shows that fragile-cover hypergraph constraints alone are too
 weak. See `docs/minimal-fragile-cover-bridge.md`.
 
+A separate rich-triple closure bridge records that ear-orderability is
+equivalent to bootstrap rank at most 3. Failure of that rank condition yields
+inclusion-minimal generating cores with deletion closures, private halos, and a
+weighted cyclic outside-pair capacity ledger. This is still only bridge
+bookkeeping, not a contradiction or counterexample. See
+`docs/bootstrap-core-bridge.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/docs/adaptive-radius-blocker-bridge.md
+++ b/docs/adaptive-radius-blocker-bridge.md
@@ -96,6 +96,12 @@ This fork is useful because it handles the noncanonical selection issue: a real
 bad polygon may have several rich distance classes at a center, and fixed-row
 stuck sets do not see that disjunction.
 
+The stronger follow-up object is the bootstrap-core formulation in
+`docs/bootstrap-core-bridge.md`: it replaces a terminal blocker from one
+maximal peeling run by rich-triple closure rank, inclusion-minimal generating
+cores, deletion closures, private halos, and a weighted cyclic outside-pair
+capacity ledger.
+
 The next bridge target is therefore precise:
 
 ```text

--- a/docs/bootstrap-core-bridge.md
+++ b/docs/bootstrap-core-bridge.md
@@ -1,0 +1,198 @@
+# Bootstrap-core bridge
+
+Status: `LEMMA` / bridge fork. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note records the rich-triple closure formulation of the ear-orderable
+bridge. It refines the adaptive radius-blocker alternative by replacing a
+terminal stuck set with a generating core, deletion closures, private halos,
+and a weighted cyclic outside-pair capacity ledger.
+
+## Full rich classes
+
+Let `P` be a strictly convex 4-bad polygon with vertex set `V` in cyclic order.
+For a vertex `y` and radius `r > 0`, define the full distance class
+
+```text
+D_y(r) = { z in V \ {y} : |p_y p_z| = r }.
+```
+
+The rich row family at `y` is
+
+```text
+R(y) = { D_y(r) : |D_y(r)| >= 4 }.
+```
+
+A selected row at `y` is any 4-subset of a class in `R(y)`. Distinct classes
+in `R(y)` are disjoint, because each witness has one distance from `y`.
+
+## Rich-triple closure
+
+For `A subset V`, define `cl(A)` as the least set containing `A` with this
+closure rule:
+
+```text
+if y in V, C in R(y), and |C cap cl(A)| >= 3, then y is in cl(A).
+```
+
+Define the bootstrap rank
+
+```text
+rho(P) = min { |A| : cl(A) = V }.
+```
+
+## Closure-rank lemma
+
+`P` admits an ear-orderable selected-witness system if and only if
+`rho(P) <= 3`.
+
+Here ear-orderable uses the repo convention: the first three vertices are the
+base, and the three-earlier-witness condition is imposed only from the fourth
+vertex onward.
+
+Proof. If an ear order exists, take its first three vertices as `A`. Each later
+vertex is added by three earlier witnesses in one rich class, so `cl(A)=V`.
+
+Conversely, suppose `cl(A)=V` for `|A| <= 3`. Enlarge `A` to a 3-set if needed.
+Take any finite closure construction sequence. When a vertex `y` first enters
+the closure, some triple `T subset C in R(y)` is already present. Since
+`|C| >= 4`, choose `q in C \ T`, and select the row `T union {q}` at `y`.
+This gives three earlier witnesses for every non-base vertex. The three base
+vertices may receive arbitrary rich rows. Thus the selected system is
+ear-orderable.
+
+## Bootstrap cores and private halos
+
+A generator is a set `U` with `cl(U)=V`.
+
+A minimal generator is inclusion-minimal: no proper subset of `U` generates
+`V`. A minimum generator is cardinality-minimum: `|U|=rho(P)`.
+
+Assume `rho(P)>3`, and let `U` be any minimal generator. Put `O=V\U`. For
+`u in U`, define
+
+```text
+A_u = cl(U \ {u})
+D_u = O \ A_u
+```
+
+where `D_u` is the private halo of `u`.
+
+Then:
+
+1. `|U| >= 4`.
+2. `u notin A_u`.
+3. For every `C in R(u)`, `|C cap A_u| <= 2`.
+4. Therefore `|C cap D_u| >= |C|-2 >= 2`.
+5. In particular, `U` is a radius-blocker: `|C cap U| <= 2` for every
+   `u in U` and `C in R(u)`.
+
+Proof. Since `U` is minimal, `A_u != V`. If `u in A_u`, then `U subset A_u`,
+and closedness gives `V=cl(U) subset A_u`, a contradiction. Hence `u notin
+A_u`. If some rich class at `u` had three points in `A_u`, the closure rule
+would add `u`, again a contradiction. Since `U\{u} subset A_u` and witnesses
+exclude their center, the witnesses outside `A_u` lie in `O\A_u=D_u`.
+
+This theorem needs only inclusion-minimality for the private-halo conclusion.
+To certify a non-ear escape, however, one must also certify `rho(P)>3`, for
+example by checking that every 3-seed has proper closure. A larger
+inclusion-minimal generator can coexist with a smaller generator in a general
+closure system.
+
+## Weighted cyclic private-pair capacity
+
+For `u in U` and `C in R(u)`, write
+
+```text
+H_{u,C} = C cap D_u.
+```
+
+Then `|H_{u,C}| >= |C|-2`. Count all private pairs:
+
+```text
+I_priv = { (u,C,{a,b}) : u in U, C in R(u), {a,b} subset H_{u,C} }.
+```
+
+For an outside pair `{a,b} subset O`, let `kappa_U(a,b)` be the number of the
+two open cyclic arcs from `a` to `b` that contain at least one vertex of `U`.
+Thus `kappa_U(a,b)` is `1` or `2` when `U` is nonempty.
+
+Then every non-ear bootstrap core satisfies
+
+```text
+sum_{u in U} sum_{C in R(u)} binom(|C cap D_u|, 2)
+  <= sum_{{a,b} subset O} kappa_U(a,b).
+```
+
+Consequently,
+
+```text
+sum_{u in U} sum_{C in R(u)} binom(|C|-2, 2)
+  <= sum_{{a,b} subset O} kappa_U(a,b)
+  <= 2 binom(|O|, 2).
+```
+
+Proof. Fix an outside pair `{a,b}`. If it appears in a private pair charged by
+`u`, then `u` is equidistant from `a` and `b`, so `u` lies on the perpendicular
+bisector of segment `ab`. In a strictly convex polygon, at most two vertices
+can lie on this line. Since `a` and `b` lie on opposite sides of their
+perpendicular bisector, each boundary arc from `a` to `b` crosses that line.
+Thus, if two such core vertices occur, they lie in the two different open
+cyclic arcs between `a` and `b`. The pair can therefore be charged to at most
+one core center from each arc containing core vertices. Summing over outside
+pairs gives the first inequality, and `|C cap D_u| >= |C|-2` gives the second.
+
+## Outside-run form
+
+Let `R_1,...,R_t` be the maximal consecutive outside-vertex runs in the cyclic
+order, with lengths `o_i`. Then
+
+```text
+sum_{{a,b} subset O} kappa_U(a,b)
+  = 2 binom(|O|, 2) - sum_i binom(o_i, 2).
+```
+
+If `a,b` lie in different outside runs, both arcs between them contain a core
+vertex, so `kappa=2`. If they lie in the same outside run, one open arc stays
+inside that outside run and contains no core vertex, so `kappa=1`.
+
+This run term is the useful strengthening over the earlier one-pair-per-center
+bound. Clustered halo vertices reduce capacity; highly interleaved halo
+vertices maximize it.
+
+## Fragile-cover overlay
+
+If `P` is a minimal counterexample, every fragile critical row is an exact
+critical 4-tie. If such a row is centered at a core vertex `u in U`, then it is
+one class `C in R(u)` of size 4, and the private-halo theorem gives
+
+```text
+|C cap D_u| >= 2.
+```
+
+Thus each core-centered fragile row contributes at least one private outside
+pair to the weighted capacity ledger. If it has three or four private-halo
+witnesses, it contributes three or six pairs, not just one.
+
+This overlay applies only to exact critical 4-ties, not to arbitrary selected
+rows or abstract fragile candidates.
+
+## Certificate semantics
+
+A non-ear/bootstrap-core escape certificate should contain three layers:
+
+1. `rho(P)>3`, usually by exhaustive failure of all 3-seed closures.
+2. A generating core `U` and a closure order showing `cl(U)=V`.
+3. Deletion closures `A_u`, private halos `D_u`, rich-class private slices, and
+   the weighted cyclic capacity ledger.
+
+The helper module `src/erdos97/bootstrap_cores.py` implements this finite
+bookkeeping. The smoke checker is:
+
+```bash
+python scripts/check_bootstrap_core_bridge.py --assert-expected
+```
+
+The checked `C13_sidon_1_2_4_10` fixed-row benchmark is used only as a
+bookkeeping negative control. That fixed selected-witness pattern is already
+killed across all cyclic orders by the repo's exact Kalmanson/Farkas search.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -389,6 +389,35 @@ rule out radius-blockers using strict convexity, fragile-cover geometry, and
 the current exact obstruction stack, or construct an exact blocker escape
 mechanism. See `docs/adaptive-radius-blocker-bridge.md`.
 
+### Bootstrap-core closure rank and weighted capacity
+
+Status: `LEMMA` / bridge fork.
+
+Given the full family of rich distance classes at each bad vertex, define
+`cl(A)` by adding a center once three current vertices lie in one of its rich
+classes. Let `rho` be the minimum size of a set whose closure is all vertices.
+Then a polygon admits an ear-orderable selected-witness system if and only if
+`rho <= 3`, using the repo convention that the first three vertices form the
+base of the ear order.
+
+If `rho > 3` and `U` is an inclusion-minimal generator, then for every
+`u in U`, with `A_u = cl(U \ {u})` and `O = V \ U`, one has `u notin A_u` and
+`|C cap A_u| <= 2` for every rich class `C` at `u`. Thus the private halo
+`D_u = O \ A_u` contains at least `|C|-2` witnesses from each such class.
+
+Counting all private outside pairs gives the weighted cyclic capacity bound
+
+```text
+sum_{u in U} sum_{C in R(u)} binom(|C cap D_u|, 2)
+  <= sum_{{a,b} subset O} kappa_U(a,b)
+  = 2 binom(|O|, 2) - sum_R binom(|R|, 2),
+```
+
+where the last sum is over maximal consecutive outside-vertex runs in the
+cyclic order. This strengthens the one-pair-per-center radius-blocker bound
+but is still only a bridge target, not a proof of Erdos Problem #97. See
+`docs/bootstrap-core-bridge.md`.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -25,9 +25,11 @@ Use this queue when no more specific issue is selected.
    target.
 3. Strengthen the minimal fragile-cover bridge with one geometric necessary
    condition and test it against the block-6 negative controls.
-4. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
+4. Apply the bootstrap-core/private-halo weighted capacity checker to current
+   stuck/frontier motifs and record which packets survive the sharper ledger.
+5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
-5. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
+6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
    with an independent input-data replay.
 
 ## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
@@ -134,12 +136,15 @@ Read first:
 - `src/erdos97/fragile_hypergraph.py`
 - `scripts/check_fragile_hypergraph.py`
 - `docs/stuck-set-miner.md`
+- `docs/bootstrap-core-bridge.md`
+- `src/erdos97/bootstrap_cores.py`
 
 Commands:
 
 ```bash
 python scripts/check_fragile_hypergraph.py --json
 python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json
+python scripts/check_bootstrap_core_bridge.py --assert-expected
 python -m pytest tests/test_fragile_hypergraph.py -q
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,8 @@ put detailed reconciliation in the canonical synthesis.
   proof-mining targets.
 - [`adaptive-radius-blocker-bridge.md`](adaptive-radius-blocker-bridge.md):
   adaptive selected-witness peeling versus radius-blocker bridge fork.
+- [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
+  rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -298,6 +298,9 @@ condition that the surviving multi-block family does not automatically satisfy:
 - adaptive radius-blocker analysis, as recorded in
   `docs/adaptive-radius-blocker-bridge.md`, which keeps all rich distance
   classes visible instead of fixing one selected row per center.
+- bootstrap-core/private-halo analysis, as recorded in
+  `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
+  deletion closures, and weighted cyclic outside-pair capacity.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -148,6 +148,11 @@ local_repo:
       status: "proved necessary structure for a minimal counterexample"
       document: "docs/minimal-fragile-cover-bridge.md"
       claim_scope: "partial bridge theorem only; not a contradiction, not the open ear-orderable bridge, and not a proof of Erdos #97"
+    - name: "bootstrap_core_bridge"
+      status: "proved rich-triple closure rank and weighted private-halo capacity bridge fork"
+      document: "docs/bootstrap-core-bridge.md"
+      verifier: "scripts/check_bootstrap_core_bridge.py"
+      claim_scope: "bridge bookkeeping only; not a contradiction, not a counterexample, and not a proof of Erdos #97"
   best_numerical_object: "B12_3x4_danzer_lift near-miss; rejected as proof/counterexample."
   main_entry_points:
     - "STATE.md"

--- a/scripts/check_bootstrap_core_bridge.py
+++ b/scripts/check_bootstrap_core_bridge.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Check bootstrap-core bridge bookkeeping packets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_cores import (  # noqa: E402
+    audit_bootstrap_core,
+    cyclic_capacity_from_runs,
+    cyclic_capacity_sum,
+    outside_runs,
+    search_generating_seed,
+)
+from erdos97.bridge_negative_controls import c13_sidon_rows  # noqa: E402
+from erdos97.adaptive_blockers import (  # noqa: E402
+    singleton_rich_classes_from_pattern,
+)
+
+
+def complete_five_packet() -> dict[str, object]:
+    rich_classes = tuple(
+        (tuple(label for label in range(5) if label != center),)
+        for center in range(5)
+    )
+    rank = search_generating_seed(rich_classes, limit=3)
+    assert rank.generating_closure is not None
+    return {
+        "name": "complete_five_rich_classes",
+        "interpretation": "positive closure-rank sanity check",
+        "rank_search": asdict(rank),
+    }
+
+
+def c13_bootstrap_packet() -> dict[str, object]:
+    rich_classes = singleton_rich_classes_from_pattern(c13_sidon_rows())
+    rank = search_generating_seed(rich_classes, limit=3)
+    core = [0, 1, 2, 3]
+    audit = audit_bootstrap_core(core, rich_classes)
+    return {
+        "name": "C13_sidon_singleton_rich_classes",
+        "interpretation": (
+            "fixed-row incidence benchmark only; C13 is already killed across "
+            "all cyclic orders by the repo's Kalmanson/Farkas checker"
+        ),
+        "rank_search_limit_3": asdict(rank),
+        "core_audit": asdict(audit),
+    }
+
+
+def capacity_formula_packet() -> dict[str, object]:
+    n = 6
+    core = [0, 2, 4]
+    runs = outside_runs(core, n)
+    return {
+        "name": "cyclic_capacity_formula_smoke",
+        "n": n,
+        "core": core,
+        "outside_runs": runs,
+        "cyclic_capacity_sum": cyclic_capacity_sum(core, n),
+        "run_formula_capacity": cyclic_capacity_from_runs(runs),
+    }
+
+
+def all_packets() -> dict[str, object]:
+    return {
+        "type": "bootstrap_core_bridge_checks_v1",
+        "status": "BRIDGE_BOOKKEEPING_ONLY",
+        "packets": {
+            "complete_five": complete_five_packet(),
+            "c13_sidon_bootstrap": c13_bootstrap_packet(),
+            "capacity_formula": capacity_formula_packet(),
+        },
+        "interpretation": (
+            "These packets check rich-triple closure, bootstrap-core deletion "
+            "closures, private halos, and weighted cyclic capacity. They do "
+            "not claim a proof or counterexample."
+        ),
+    }
+
+
+def assert_expected(payload: dict[str, object]) -> None:
+    packets = payload["packets"]
+    if not isinstance(packets, dict):
+        raise AssertionError("packets must be a dict")
+
+    complete = packets["complete_five"]
+    if not isinstance(complete, dict):
+        raise AssertionError("complete_five packet must be a dict")
+    complete_rank = complete["rank_search"]
+    if not isinstance(complete_rank, dict):
+        raise AssertionError("complete_five rank search must be a dict")
+    if not complete_rank["rank_leq_limit"]:
+        raise AssertionError("complete five should have rank <= 3")
+    if complete_rank["generating_seed"] != [0, 1, 2]:
+        raise AssertionError("complete five should first generate from [0,1,2]")
+
+    c13 = packets["c13_sidon_bootstrap"]
+    if not isinstance(c13, dict):
+        raise AssertionError("C13 packet must be a dict")
+    c13_rank = c13["rank_search_limit_3"]
+    if not isinstance(c13_rank, dict):
+        raise AssertionError("C13 rank search must be a dict")
+    if c13_rank["rank_leq_limit"]:
+        raise AssertionError("C13 fixed-row singleton family should have rho > 3")
+    if c13_rank["checked_seed_count"] != 377:
+        raise AssertionError("C13 should check all 1-, 2-, and 3-seeds")
+
+    c13_audit = c13["core_audit"]
+    if not isinstance(c13_audit, dict):
+        raise AssertionError("C13 audit must be a dict")
+    if not c13_audit["core_generates_all"]:
+        raise AssertionError("C13 core should generate all labels")
+    if not c13_audit["inclusion_minimal"]:
+        raise AssertionError("C13 core should be inclusion-minimal")
+    if not c13_audit["private_halo_requirement_ok"]:
+        raise AssertionError("C13 core should satisfy private-halo requirements")
+    if c13_audit["private_pair_lower_bound"] != 4:
+        raise AssertionError("C13 lower bound should count one pair per core row")
+    if c13_audit["private_pair_count"] != 6:
+        raise AssertionError("C13 actual private-pair count should be 6")
+    if c13_audit["cyclic_capacity_sum"] != 36:
+        raise AssertionError("C13 cyclic capacity should be 36 in natural order")
+    if not c13_audit["weighted_capacity_ok"]:
+        raise AssertionError("C13 weighted capacity ledger should pass")
+
+    formula = packets["capacity_formula"]
+    if not isinstance(formula, dict):
+        raise AssertionError("capacity formula packet must be a dict")
+    if formula["cyclic_capacity_sum"] != formula["run_formula_capacity"]:
+        raise AssertionError("cyclic capacity and run formula should match")
+    if formula["cyclic_capacity_sum"] != 6:
+        raise AssertionError("interleaved three-outside capacity should be 6")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--write-certificate", help="write JSON to this path")
+    args = parser.parse_args()
+
+    payload = all_packets()
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        packets = payload["packets"]
+        assert isinstance(packets, dict)
+        c13 = packets["c13_sidon_bootstrap"]
+        assert isinstance(c13, dict)
+        c13_audit = c13["core_audit"]
+        assert isinstance(c13_audit, dict)
+        print("bootstrap-core bridge checks")
+        print("complete_five: rank <= 3")
+        print(
+            "C13_sidon: rho > 3, core [0,1,2,3], "
+            f"private_pairs={c13_audit['private_pair_count']}, "
+            f"capacity={c13_audit['cyclic_capacity_sum']}"
+        )
+        if args.assert_expected:
+            print("OK: bootstrap-core bridge expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_cores.py
+++ b/src/erdos97/bootstrap_cores.py
@@ -1,0 +1,431 @@
+"""Rich-triple closure and bootstrap-core capacity helpers.
+
+This module is bridge bookkeeping.  It treats the per-center rich classes as
+full distance classes, so distinct classes at the same center must be disjoint.
+The routines do not certify Euclidean realizability, a counterexample, or a
+general proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from math import comb
+from typing import Iterable, Sequence
+
+from erdos97.adaptive_blockers import (
+    RichClasses,
+    singleton_rich_classes_from_pattern,
+    validate_rich_classes,
+)
+
+
+@dataclass(frozen=True)
+class ClosureStep:
+    added_center: int
+    rich_class_index: int
+    rich_class: list[int]
+    trigger_witnesses: list[int]
+    closure_before: list[int]
+
+
+@dataclass(frozen=True)
+class ClosureResult:
+    seed: list[int]
+    closure: list[int]
+    order: list[int]
+    steps: list[ClosureStep]
+    generates_all: bool
+
+
+@dataclass(frozen=True)
+class RankSearchResult:
+    rank_leq_limit: bool
+    limit: int
+    generating_seed: list[int] | None
+    generating_closure: ClosureResult | None
+    checked_seed_count: int
+    largest_closure_size: int
+    largest_closure_seed: list[int] | None
+
+
+@dataclass(frozen=True)
+class RichClassPrivateSlice:
+    rich_class_index: int
+    rich_class: list[int]
+    intersection_with_deletion_closure: list[int]
+    private_halo_witnesses: list[int]
+    private_pair_count: int
+
+
+@dataclass(frozen=True)
+class DeletionClosureAudit:
+    core_vertex: int
+    seed: list[int]
+    closure: list[int]
+    core_vertex_not_generated: bool
+    private_halo: list[int]
+    rich_class_slices: list[RichClassPrivateSlice]
+
+
+@dataclass(frozen=True)
+class BootstrapCoreAudit:
+    core: list[int]
+    outside: list[int]
+    core_generates_all: bool
+    inclusion_minimal: bool
+    private_halo_requirement_ok: bool
+    deletion_closures: list[DeletionClosureAudit]
+    private_pair_lower_bound: int
+    private_pair_count: int
+    cyclic_capacity_sum: int
+    lower_bound_capacity_ok: bool
+    weighted_capacity_ok: bool
+    outside_runs: list[list[int]]
+
+
+def _mask(vertices: Iterable[int]) -> int:
+    out = 0
+    for vertex in vertices:
+        out |= 1 << int(vertex)
+    return out
+
+
+def _vertices(mask: int, n: int) -> list[int]:
+    return [vertex for vertex in range(n) if mask & (1 << vertex)]
+
+
+def _dedupe_vertices(vertices: Iterable[int], n: int, name: str) -> list[int]:
+    out: list[int] = []
+    seen: set[int] = set()
+    for raw_vertex in vertices:
+        vertex = int(raw_vertex)
+        if vertex < 0 or vertex >= n:
+            raise ValueError(f"{name} contains out-of-range label {vertex}")
+        if vertex not in seen:
+            out.append(vertex)
+            seen.add(vertex)
+    return out
+
+
+def validate_full_rich_classes(rich_classes: RichClasses) -> None:
+    """Validate finite full-rich-class data used by bootstrap-core tools."""
+
+    validate_rich_classes(rich_classes)
+    for center, classes in enumerate(rich_classes):
+        seen: set[int] = set()
+        for class_index, row in enumerate(classes):
+            row_set = {int(label) for label in row}
+            overlap = sorted(seen & row_set)
+            if overlap:
+                raise ValueError(
+                    f"center {center} rich class {class_index} overlaps "
+                    f"an earlier class at labels {overlap}"
+                )
+            seen.update(row_set)
+
+
+def closure(seed: Iterable[int], rich_classes: RichClasses) -> ClosureResult:
+    """Compute rich-triple closure from ``seed``.
+
+    A center is added once three current vertices lie in one of its full rich
+    classes.  The deterministic order is by smallest center, then smallest rich
+    class index.
+    """
+
+    validate_full_rich_classes(rich_classes)
+    n = len(rich_classes)
+    seed_vertices = _dedupe_vertices(seed, n, "seed")
+    closure_mask = _mask(seed_vertices)
+    row_masks = [
+        [_mask(int(label) for label in row) for row in classes]
+        for classes in rich_classes
+    ]
+    steps: list[ClosureStep] = []
+    order = list(seed_vertices)
+
+    changed = True
+    while changed:
+        changed = False
+        for center in range(n):
+            if closure_mask & (1 << center):
+                continue
+            for class_index, row_mask in enumerate(row_masks[center]):
+                internal_mask = row_mask & closure_mask
+                if internal_mask.bit_count() < 3:
+                    continue
+                trigger = _vertices(internal_mask, n)[:3]
+                steps.append(
+                    ClosureStep(
+                        added_center=center,
+                        rich_class_index=class_index,
+                        rich_class=[int(label) for label in rich_classes[center][class_index]],
+                        trigger_witnesses=trigger,
+                        closure_before=_vertices(closure_mask, n),
+                    )
+                )
+                closure_mask |= 1 << center
+                order.append(center)
+                changed = True
+                break
+
+    closure_vertices = _vertices(closure_mask, n)
+    return ClosureResult(
+        seed=seed_vertices,
+        closure=closure_vertices,
+        order=order,
+        steps=steps,
+        generates_all=len(closure_vertices) == n,
+    )
+
+
+def is_generator(seed: Iterable[int], rich_classes: RichClasses) -> bool:
+    """Return whether ``seed`` rich-triple-generates all labels."""
+
+    return closure(seed, rich_classes).generates_all
+
+
+def search_generating_seed(
+    rich_classes: RichClasses,
+    limit: int = 3,
+) -> RankSearchResult:
+    """Search all seeds of size at most ``limit`` for a generator."""
+
+    validate_full_rich_classes(rich_classes)
+    n = len(rich_classes)
+    checked = 0
+    largest_size = -1
+    largest_seed: list[int] | None = None
+
+    for size in range(1, min(limit, n) + 1):
+        for seed in combinations(range(n), size):
+            checked += 1
+            result = closure(seed, rich_classes)
+            if len(result.closure) > largest_size:
+                largest_size = len(result.closure)
+                largest_seed = list(seed)
+            if result.generates_all:
+                return RankSearchResult(
+                    rank_leq_limit=True,
+                    limit=limit,
+                    generating_seed=list(seed),
+                    generating_closure=result,
+                    checked_seed_count=checked,
+                    largest_closure_size=len(result.closure),
+                    largest_closure_seed=list(seed),
+                )
+
+    return RankSearchResult(
+        rank_leq_limit=False,
+        limit=limit,
+        generating_seed=None,
+        generating_closure=None,
+        checked_seed_count=checked,
+        largest_closure_size=max(largest_size, 0),
+        largest_closure_seed=largest_seed,
+    )
+
+
+def is_inclusion_minimal_generator(
+    core: Iterable[int],
+    rich_classes: RichClasses,
+) -> bool:
+    """Return whether ``core`` generates all labels and no proper deletion does."""
+
+    validate_full_rich_classes(rich_classes)
+    n = len(rich_classes)
+    core_vertices = _dedupe_vertices(core, n, "core")
+    if not closure(core_vertices, rich_classes).generates_all:
+        return False
+    return all(
+        not closure(
+            [vertex for vertex in core_vertices if vertex != removed],
+            rich_classes,
+        ).generates_all
+        for removed in core_vertices
+    )
+
+
+def outside_vertices(core: Iterable[int], n: int) -> list[int]:
+    """Return vertices outside ``core`` in label order."""
+
+    core_set = set(_dedupe_vertices(core, n, "core"))
+    return [vertex for vertex in range(n) if vertex not in core_set]
+
+
+def outside_runs(
+    core: Iterable[int],
+    n: int,
+    order: Sequence[int] | None = None,
+) -> list[list[int]]:
+    """Return maximal cyclic runs of outside vertices in ``order``."""
+
+    if order is None:
+        order = list(range(n))
+    if sorted(int(label) for label in order) != list(range(n)):
+        raise ValueError("order must be a permutation of range(n)")
+
+    core_set = set(_dedupe_vertices(core, n, "core"))
+    if not core_set:
+        raise ValueError("core must be nonempty")
+    outside_flags = [int(label) not in core_set for label in order]
+    if not any(outside_flags):
+        return []
+    if all(outside_flags):
+        return [[int(label) for label in order]]
+
+    start = next(idx for idx, is_outside in enumerate(outside_flags) if not is_outside)
+    runs: list[list[int]] = []
+    current: list[int] = []
+    for offset in range(1, n + 1):
+        idx = (start + offset) % n
+        label = int(order[idx])
+        if outside_flags[idx]:
+            current.append(label)
+        elif current:
+            runs.append(current)
+            current = []
+    if current:
+        runs.append(current)
+    return runs
+
+
+def cyclic_pair_capacity(
+    pair: tuple[int, int],
+    core: Iterable[int],
+    n: int,
+    order: Sequence[int] | None = None,
+) -> int:
+    """Return the number of open arcs between ``pair`` containing core labels."""
+
+    if order is None:
+        order = list(range(n))
+    if sorted(int(label) for label in order) != list(range(n)):
+        raise ValueError("order must be a permutation of range(n)")
+    a, b = int(pair[0]), int(pair[1])
+    if a == b:
+        raise ValueError("pair must contain two distinct labels")
+    if a < 0 or a >= n or b < 0 or b >= n:
+        raise ValueError("pair contains out-of-range label")
+
+    core_set = set(_dedupe_vertices(core, n, "core"))
+    if not core_set:
+        raise ValueError("core must be nonempty")
+    pos = {int(label): idx for idx, label in enumerate(order)}
+    a_pos, b_pos = pos[a], pos[b]
+    arc_ab = {
+        int(order[idx % n])
+        for idx in range(a_pos + 1, b_pos if a_pos < b_pos else b_pos + n)
+    }
+    arc_ba = set(range(n)) - arc_ab - {a, b}
+    return int(bool(arc_ab & core_set)) + int(bool(arc_ba & core_set))
+
+
+def cyclic_capacity_sum(
+    core: Iterable[int],
+    n: int,
+    order: Sequence[int] | None = None,
+) -> int:
+    """Return the total cyclic outside-pair capacity for ``core``."""
+
+    core_vertices = _dedupe_vertices(core, n, "core")
+    outside = outside_vertices(core_vertices, n)
+    return sum(
+        cyclic_pair_capacity((a, b), core_vertices, n, order)
+        for a, b in combinations(outside, 2)
+    )
+
+
+def cyclic_capacity_from_runs(runs: Sequence[Sequence[int]]) -> int:
+    """Return ``2*C(|O|,2) - sum_R C(|R|,2)`` from outside runs."""
+
+    outside_size = sum(len(run) for run in runs)
+    return 2 * comb(outside_size, 2) - sum(comb(len(run), 2) for run in runs)
+
+
+def audit_bootstrap_core(
+    core: Iterable[int],
+    rich_classes: RichClasses,
+    order: Sequence[int] | None = None,
+) -> BootstrapCoreAudit:
+    """Audit deletion closures, private halos, and weighted capacity."""
+
+    validate_full_rich_classes(rich_classes)
+    n = len(rich_classes)
+    core_vertices = _dedupe_vertices(core, n, "core")
+    outside = outside_vertices(core_vertices, n)
+    outside_set = set(outside)
+    core_closure = closure(core_vertices, rich_classes)
+    deletion_audits: list[DeletionClosureAudit] = []
+    private_pair_count = 0
+    private_pair_lower_bound = 0
+    private_halo_requirement_ok = True
+
+    for removed in core_vertices:
+        seed = [vertex for vertex in core_vertices if vertex != removed]
+        deletion = closure(seed, rich_classes)
+        deletion_set = set(deletion.closure)
+        private_halo = sorted(outside_set - deletion_set)
+        slices: list[RichClassPrivateSlice] = []
+        for class_index, row in enumerate(rich_classes[removed]):
+            row_vertices = [int(label) for label in row]
+            private_witnesses = sorted(set(row_vertices) & set(private_halo))
+            intersection = sorted(set(row_vertices) & deletion_set)
+            pair_count = comb(len(private_witnesses), 2)
+            private_pair_count += pair_count
+            private_pair_lower_bound += comb(max(len(row_vertices) - 2, 0), 2)
+            private_halo_requirement_ok = (
+                private_halo_requirement_ok
+                and len(intersection) <= 2
+                and len(private_witnesses) >= max(len(row_vertices) - 2, 0)
+            )
+            slices.append(
+                RichClassPrivateSlice(
+                    rich_class_index=class_index,
+                    rich_class=row_vertices,
+                    intersection_with_deletion_closure=intersection,
+                    private_halo_witnesses=private_witnesses,
+                    private_pair_count=pair_count,
+                )
+            )
+        deletion_audits.append(
+            DeletionClosureAudit(
+                core_vertex=removed,
+                seed=seed,
+                closure=deletion.closure,
+                core_vertex_not_generated=removed not in deletion_set,
+                private_halo=private_halo,
+                rich_class_slices=slices,
+            )
+        )
+
+    runs = outside_runs(core_vertices, n, order)
+    capacity = cyclic_capacity_sum(core_vertices, n, order)
+    run_capacity = cyclic_capacity_from_runs(runs)
+    if capacity != run_capacity:
+        raise AssertionError("cyclic capacity and run formula disagree")
+    return BootstrapCoreAudit(
+        core=core_vertices,
+        outside=outside,
+        core_generates_all=core_closure.generates_all,
+        inclusion_minimal=is_inclusion_minimal_generator(core_vertices, rich_classes),
+        private_halo_requirement_ok=private_halo_requirement_ok,
+        deletion_closures=deletion_audits,
+        private_pair_lower_bound=private_pair_lower_bound,
+        private_pair_count=private_pair_count,
+        cyclic_capacity_sum=capacity,
+        lower_bound_capacity_ok=private_pair_lower_bound <= capacity,
+        weighted_capacity_ok=private_pair_count <= capacity,
+        outside_runs=runs,
+    )
+
+
+def audit_fixed_selected_pattern_as_rich_classes(
+    selected_rows: Sequence[Sequence[int]],
+    core: Iterable[int],
+    order: Sequence[int] | None = None,
+) -> BootstrapCoreAudit:
+    """Audit one fixed selected row per center as a singleton rich family."""
+
+    rich_classes = singleton_rich_classes_from_pattern(selected_rows)
+    return audit_bootstrap_core(core, rich_classes, order)

--- a/tests/test_bootstrap_cores.py
+++ b/tests/test_bootstrap_cores.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.adaptive_blockers import singleton_rich_classes_from_pattern
+from erdos97.bootstrap_cores import (
+    audit_bootstrap_core,
+    closure,
+    cyclic_capacity_from_runs,
+    cyclic_capacity_sum,
+    outside_runs,
+    search_generating_seed,
+    validate_full_rich_classes,
+)
+from erdos97.bridge_negative_controls import c13_sidon_rows
+from scripts.check_bootstrap_core_bridge import all_packets, assert_expected
+
+
+def test_closure_rank_matches_ear_positive_sanity_case() -> None:
+    rich_classes = tuple(
+        (tuple(label for label in range(5) if label != center),)
+        for center in range(5)
+    )
+
+    result = closure([0, 1, 2], rich_classes)
+    rank = search_generating_seed(rich_classes, limit=3)
+
+    assert result.generates_all
+    assert result.order == [0, 1, 2, 3, 4]
+    assert rank.rank_leq_limit
+    assert rank.generating_seed == [0, 1, 2]
+
+
+def test_c13_fixed_row_bootstrap_core_packet() -> None:
+    rich_classes = singleton_rich_classes_from_pattern(c13_sidon_rows())
+
+    rank = search_generating_seed(rich_classes, limit=3)
+    audit = audit_bootstrap_core([0, 1, 2, 3], rich_classes)
+
+    assert not rank.rank_leq_limit
+    assert rank.checked_seed_count == 377
+    assert rank.largest_closure_size == 4
+    assert audit.core_generates_all
+    assert audit.inclusion_minimal
+    assert audit.private_halo_requirement_ok
+    assert audit.private_pair_lower_bound == 4
+    assert audit.private_pair_count == 6
+    assert audit.cyclic_capacity_sum == 36
+    assert audit.weighted_capacity_ok
+
+
+def test_cyclic_capacity_matches_outside_run_formula() -> None:
+    runs = outside_runs([0, 2, 4], 6)
+
+    assert runs == [[1], [3], [5]]
+    assert cyclic_capacity_sum([0, 2, 4], 6) == 6
+    assert cyclic_capacity_sum(iter([0, 2, 4]), 6) == 6
+    assert cyclic_capacity_from_runs(runs) == 6
+
+
+def test_cyclic_capacity_requires_nonempty_core() -> None:
+    with pytest.raises(ValueError, match="nonempty"):
+        outside_runs([], 5)
+
+    with pytest.raises(ValueError, match="nonempty"):
+        cyclic_capacity_sum([], 5)
+
+
+def test_full_rich_classes_reject_overlap_at_same_center() -> None:
+    rich_classes = (
+        ((1, 2, 3, 4), (4, 5, 6, 7)),
+        *((tuple(label for label in range(8) if label != center),) for center in range(1, 8)),
+    )
+
+    with pytest.raises(ValueError, match="overlaps"):
+        validate_full_rich_classes(rich_classes)
+
+
+def test_bootstrap_core_checker_packets() -> None:
+    assert_expected(all_packets())


### PR DESCRIPTION
## Summary

- Adds a proof-facing bootstrap-core bridge note: rich-triple closure rank, inclusion-minimal generating cores, private halos, and weighted cyclic outside-pair capacity.
- Adds `src/erdos97/bootstrap_cores.py` plus a smoke checker for rich-triple closure, C13 fixed-row bootstrap auditing, outside-run capacity, and full-rich-class validation.
- Updates the claims ledger, docs index, state/results/metadata, review priorities, and Codex backlog while keeping the result scoped as bridge bookkeeping only.

## Scope

This does not claim a general proof, a counterexample, or a finite-case promotion. The C13 packet is a fixed-row bookkeeping benchmark only; that fixed pattern remains retired by the existing Kalmanson/Farkas all-order checker.

## Validation

- `python scripts/check_bootstrap_core_bridge.py --assert-expected`
- `python -m pytest tests/test_bootstrap_cores.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`