### PR TITLE
[codex] Audit block6 removed-endpoint source arcs

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -504,6 +504,35 @@ So the previously not-legal openings are pure crossing-gate switches: the
 replacement either destroys a forbidden noncrossing two-overlap or changes it
 into an allowed crossing two-overlap.
 
+The switch is even more rigid. Every one of the `46` before-replacement
+forbidden overlaps contains the removed witness endpoint. Among the `44`
+noncrossing two-overlaps, the old target chord is always contained in a
+non-short side of the source chord `(changed center, opened center)`: `30`
+lie in the long open arc and `14` lie in one of the two equal arcs of the
+diameter source `2,8`. None lie in a short open arc.
+
+```text
+source -> old target chord  candidate rows
+2,10 -> 3,5                5
+2,10 -> 3,6                2
+2,5  -> 0,11               2
+2,5  -> 1,11               6
+2,8  -> 0,11               2
+2,8  -> 1,11               5
+2,8  -> 5,6                2
+2,8  -> 5,7                5
+4,8  -> 0,9                2
+4,8  -> 9,11               5
+8,11 -> 5,6                2
+8,11 -> 5,7                6
+```
+
+For those `44` noncrossing two-overlaps, omitting the added endpoint gives
+`36` zero/one-overlap rows after replacement, while containing the added
+endpoint gives `8` crossing two-overlap rows. The remaining `2`
+three-or-more overlaps also contain the removed endpoint and collapse to
+crossing two-overlaps after replacement.
+
 For example, the terminal state
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,188 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 655 - Block-6 Removed-endpoint Source-arc Audit
+
+### Mathematical Subquestion
+
+Cycle 654 showed that the `6` not-legal opened-center incidences are pure
+pair/crossing-gate switches. The next precise question was:
+
+```text
+For the `44` before-replacement noncrossing two-overlap rows, how is the old
+target chord positioned relative to the source chord `(changed center,
+opened center)`, and which endpoint of the changed row is responsible for the
+switch?
+```
+
+### Definitions and Assumptions
+
+Use the same low-support block-6 branch, terminal clean seven-row states,
+same-class nearest terminal-to-extendable transitions, and not-legal opened
+eighth-center incidences from Cycle 654.
+
+For a not-legal opened center, let:
+
+- the **source chord** be the center pair `(changed center, opened center)`;
+- the **old target chord** be the two-label intersection of the terminal
+  changed row and an after-valid candidate eighth row, when that intersection
+  has size two;
+- the **removed endpoint** be the unique witness label removed from the
+  terminal changed row in the nearest one-row replacement;
+- the **added endpoint** be the unique witness label added by that
+  replacement.
+
+For a source chord in the natural cyclic order, a noncrossing old target chord
+is classified as lying in the long open arc, short open arc, or one of the two
+equal arcs when the source is a diameter.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 Removed-endpoint Source-arc Audit**.
+
+### Argument Or Obstruction
+
+Every one of the `46` before-replacement forbidden overlaps among after-valid
+candidate rows contains the removed endpoint:
+
+```text
+before relation          removed endpoint status    candidate rows
+noncrossing two-overlap  contains removed endpoint  44
+three-or-more overlap    contains removed endpoint   2
+```
+
+Thus the not-legal opening is not caused by an arbitrary change elsewhere in
+the terminal row. The replacement removes one endpoint from every local
+before-replacement obstruction seen by the after-valid rows.
+
+Among the `44` noncrossing two-overlaps, the old target chord never lies in a
+short open arc of the source chord:
+
+```text
+old target arc class  candidate rows
+long arc              30
+diameter arc          14
+```
+
+The exact source-to-target distribution is:
+
+```text
+source -> old target chord  candidate rows
+2,10 -> 3,5                5
+2,10 -> 3,6                2
+2,5  -> 0,11               2
+2,5  -> 1,11               6
+2,8  -> 0,11               2
+2,8  -> 1,11               5
+2,8  -> 5,6                2
+2,8  -> 5,7                5
+4,8  -> 0,9                2
+4,8  -> 9,11               5
+8,11 -> 5,6                2
+8,11 -> 5,7                6
+```
+
+The after-replacement switch is also exact:
+
+```text
+noncrossing two-overlap switch                 candidate rows
+candidate omits added endpoint -> zero/one     36
+candidate contains added endpoint -> crossing   8
+
+three-or-more switch                            candidate rows
+contains removed endpoint -> crossing           2
+```
+
+So the finite mechanism has a compact form. The removed endpoint participates
+in every forbidden before-replacement overlap. Removing it either deletes the
+two-overlap entirely, or, in the cases where a two-overlap remains, leaves a
+crossing pair with the same source chord. The old noncrossing targets are
+confined to long or diameter arcs, never the short arc.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers the `46` after-valid
+candidate eighth rows attached to the `6` Cycle 654 not-legal opened-center
+incidences. It is not a Euclidean realizability result, is not a proof of
+Erdos Problem #97, and is not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+Cycle 654 reduced the not-legal openings to a crossing-gate switch. This cycle
+identifies the switch's local shape: the removed endpoint is the active
+endpoint in every before-replacement obstruction, and the old target chord is
+never on the short side of the source. A proof-facing version would be a
+cyclic-order lemma saying that a terminal row is fragile exactly when one
+removable endpoint hits all prospective eighth-row noncrossing targets in a
+long-or-diameter source arc.
+
+### Next Lead
+
+Try to prove or refute the following local conjecture in the block-6
+normal form:
+
+```text
+If a nearest one-row replacement opens a previously not-legal eighth center,
+then every after-valid candidate row had its before-replacement obstruction
+through the removed endpoint, and every old noncrossing target chord lies in a
+non-short source arc.
+```
+
+The smallest possible disproof would be an exact terminal-to-extendable
+transition in the same branch with a short-arc target or with an old
+noncrossing target omitting the removed endpoint.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-655`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-655`.
+- The branch was started from `origin/main` at commit
+  `3f96e3090f792d18893713d3fb6e34d46171c872`, after PR #381 merged Cycle
+  654.
+- Before updating the PR branch, it was rebased onto `origin/main` at commit
+  `07a2f3b61f8a3a4fcc53fb687d2d5f75da5da549`; the intervening main commit
+  touched n9 vertex-circle files and did not overlap this cycle's files.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported all `46` before-replacement forbidden overlaps
+  contain the removed endpoint, and all `44` noncrossing target chords are in
+  long or diameter arcs.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed on the rebased branch, `560 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 654 - Block-6 Not-legal Opening Crossing-gate Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -862,6 +862,35 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
         "crossing_two_overlap": 10,
         "zero_or_one_overlap": 36,
     },
+    "not_legal_opened_before_forbidden_overlap_removed_endpoint_distribution": {
+        "noncrossing_two_overlap:contains_removed_endpoint": 44,
+        "three_or_more_overlap:contains_removed_endpoint": 2,
+    },
+    "not_legal_opened_noncrossing_target_arc_distribution": {
+        "diameter_arc": 14,
+        "long_arc": 30,
+    },
+    "not_legal_opened_noncrossing_switch_distribution": {
+        "candidate_contains_added->crossing_two_overlap": 8,
+        "candidate_omits_added->zero_or_one_overlap": 36,
+    },
+    "not_legal_opened_noncrossing_source_target_distribution": {
+        "2,10->3,5": 5,
+        "2,10->3,6": 2,
+        "2,5->0,11": 2,
+        "2,5->1,11": 6,
+        "2,8->0,11": 2,
+        "2,8->1,11": 5,
+        "2,8->5,6": 2,
+        "2,8->5,7": 5,
+        "4,8->0,9": 2,
+        "4,8->9,11": 5,
+        "8,11->5,6": 2,
+        "8,11->5,7": 6,
+    },
+    "not_legal_opened_three_or_more_switch_distribution": {
+        "contains_removed_endpoint->crossing_two_overlap": 2,
+    },
     "class_summary": {
         (
             "2,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
@@ -1824,6 +1853,30 @@ def _changed_row_relation(
     return "noncrossing_two_overlap"
 
 
+def _chord_key(chord: tuple[int, int]) -> str:
+    return f"{chord[0]},{chord[1]}"
+
+
+def _source_arc_class(source: tuple[int, int], target: tuple[int, int]) -> str:
+    source = normalize_chord(*source)
+    target = normalize_chord(*target)
+    if set(source) & set(target):
+        return "shares_source_endpoint"
+    a, b = source
+    inside_len = b - a - 1
+    outside_len = N - (b - a) - 1
+    target_inside = [a < endpoint < b for endpoint in target]
+    if target_inside[0] != target_inside[1]:
+        return "split_arcs"
+    target_side_len = inside_len if target_inside[0] else outside_len
+    other_side_len = outside_len if target_inside[0] else inside_len
+    if target_side_len > other_side_len:
+        return "long_arc"
+    if target_side_len < other_side_len:
+        return "short_arc"
+    return "diameter_arc"
+
+
 def _not_legal_opened_paircross_profile(
     terminal: SevenState,
     extendable: SevenState,
@@ -1862,6 +1915,58 @@ def _not_legal_opened_paircross_profile(
         if _pair_cap_ok(row, pair_counts_before)
         and _indegree_ok(row, indegrees_before)
     ]
+    removed_labels = sorted(set(terminal_changed_row) - set(extendable_changed_row))
+    added_labels = sorted(set(extendable_changed_row) - set(terminal_changed_row))
+    if len(removed_labels) != 1 or len(added_labels) != 1:
+        raise AssertionError(
+            "not-legal opening audit expects a one-for-one replacement: "
+            f"{terminal_changed_row!r} -> {extendable_changed_row!r}"
+        )
+    removed_label = removed_labels[0]
+    added_label = added_labels[0]
+    source = normalize_chord(changed_center, opened_center)
+    before_forbidden_overlap_removed_endpoint: Counter[str] = Counter()
+    noncrossing_target_arcs: Counter[str] = Counter()
+    noncrossing_switches: Counter[str] = Counter()
+    noncrossing_source_targets: Counter[str] = Counter()
+    three_or_more_switches: Counter[str] = Counter()
+    for row in after_valid_rows:
+        before_relation = _changed_row_relation(
+            changed_center,
+            opened_center,
+            terminal_changed_row,
+            row,
+        )
+        after_relation = _changed_row_relation(
+            changed_center,
+            opened_center,
+            extendable_changed_row,
+            row,
+        )
+        before_overlap = tuple(sorted(set(terminal_changed_row) & set(row)))
+        endpoint_status = (
+            "contains_removed_endpoint"
+            if removed_label in before_overlap
+            else "omits_removed_endpoint"
+        )
+        if before_relation in {"noncrossing_two_overlap", "three_or_more_overlap"}:
+            before_forbidden_overlap_removed_endpoint[
+                f"{before_relation}:{endpoint_status}"
+            ] += 1
+        if before_relation == "noncrossing_two_overlap":
+            target = normalize_chord(*before_overlap)
+            added_status = (
+                "candidate_contains_added"
+                if added_label in row
+                else "candidate_omits_added"
+            )
+            noncrossing_target_arcs[_source_arc_class(source, target)] += 1
+            noncrossing_switches[f"{added_status}->{after_relation}"] += 1
+            noncrossing_source_targets[
+                f"{_chord_key(source)}->{_chord_key(target)}"
+            ] += 1
+        elif before_relation == "three_or_more_overlap":
+            three_or_more_switches[f"{endpoint_status}->{after_relation}"] += 1
     return {
         "before_paircross": len(before_paircross_rows),
         "before_valid": len(before_valid_rows),
@@ -1885,6 +1990,13 @@ def _not_legal_opened_paircross_profile(
             )
             for row in after_valid_rows
         ),
+        "before_forbidden_overlap_removed_endpoint": (
+            before_forbidden_overlap_removed_endpoint
+        ),
+        "noncrossing_target_arcs": noncrossing_target_arcs,
+        "noncrossing_switches": noncrossing_switches,
+        "noncrossing_source_targets": noncrossing_source_targets,
+        "three_or_more_switches": three_or_more_switches,
     }
 
 
@@ -1958,6 +2070,11 @@ def _low_support_terminal_edit_distance_audit(
     not_legal_opened_paircross_profile_counts: Counter[str] = Counter()
     not_legal_opened_before_relation_counts: Counter[str] = Counter()
     not_legal_opened_after_relation_counts: Counter[str] = Counter()
+    not_legal_opened_before_removed_endpoint_counts: Counter[str] = Counter()
+    not_legal_opened_noncrossing_arc_counts: Counter[str] = Counter()
+    not_legal_opened_noncrossing_switch_counts: Counter[str] = Counter()
+    not_legal_opened_noncrossing_source_target_counts: Counter[str] = Counter()
+    not_legal_opened_three_or_more_switch_counts: Counter[str] = Counter()
     nearest_transition_count = 0
     opened_center_instance_count = 0
     not_legal_opened_instance_count = 0
@@ -2113,6 +2230,23 @@ def _low_support_terminal_edit_distance_audit(
                         not_legal_opened_after_relation_counts.update(
                             switch_profile["after_changed_row_relations"]
                         )
+                        not_legal_opened_before_removed_endpoint_counts.update(
+                            switch_profile[
+                                "before_forbidden_overlap_removed_endpoint"
+                            ]
+                        )
+                        not_legal_opened_noncrossing_arc_counts.update(
+                            switch_profile["noncrossing_target_arcs"]
+                        )
+                        not_legal_opened_noncrossing_switch_counts.update(
+                            switch_profile["noncrossing_switches"]
+                        )
+                        not_legal_opened_noncrossing_source_target_counts.update(
+                            switch_profile["noncrossing_source_targets"]
+                        )
+                        not_legal_opened_three_or_more_switch_counts.update(
+                            switch_profile["three_or_more_switches"]
+                        )
                 opened_center_prior_status_by_transition[
                     ";".join(
                         f"{status}:{transition_prior_statuses[status]}"
@@ -2221,6 +2355,26 @@ def _low_support_terminal_edit_distance_audit(
         "not_legal_opened_after_changed_row_relation_distribution": {
             key: int(not_legal_opened_after_relation_counts[key])
             for key in sorted(not_legal_opened_after_relation_counts)
+        },
+        "not_legal_opened_before_forbidden_overlap_removed_endpoint_distribution": {
+            key: int(not_legal_opened_before_removed_endpoint_counts[key])
+            for key in sorted(not_legal_opened_before_removed_endpoint_counts)
+        },
+        "not_legal_opened_noncrossing_target_arc_distribution": {
+            key: int(not_legal_opened_noncrossing_arc_counts[key])
+            for key in sorted(not_legal_opened_noncrossing_arc_counts)
+        },
+        "not_legal_opened_noncrossing_switch_distribution": {
+            key: int(not_legal_opened_noncrossing_switch_counts[key])
+            for key in sorted(not_legal_opened_noncrossing_switch_counts)
+        },
+        "not_legal_opened_noncrossing_source_target_distribution": {
+            key: int(not_legal_opened_noncrossing_source_target_counts[key])
+            for key in sorted(not_legal_opened_noncrossing_source_target_counts)
+        },
+        "not_legal_opened_three_or_more_switch_distribution": {
+            key: int(not_legal_opened_three_or_more_switch_counts[key])
+            for key in sorted(not_legal_opened_three_or_more_switch_counts)
         },
         "class_summary": class_summary,
         "by_terminal": by_terminal,

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -311,6 +311,45 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "crossing_two_overlap": 10,
         "zero_or_one_overlap": 36,
     }
+    assert edit_distance_audit[
+        "not_legal_opened_before_forbidden_overlap_removed_endpoint_distribution"
+    ] == {
+        "noncrossing_two_overlap:contains_removed_endpoint": 44,
+        "three_or_more_overlap:contains_removed_endpoint": 2,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_noncrossing_target_arc_distribution"
+    ] == {
+        "diameter_arc": 14,
+        "long_arc": 30,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_noncrossing_switch_distribution"
+    ] == {
+        "candidate_contains_added->crossing_two_overlap": 8,
+        "candidate_omits_added->zero_or_one_overlap": 36,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_noncrossing_source_target_distribution"
+    ] == {
+        "2,10->3,5": 5,
+        "2,10->3,6": 2,
+        "2,5->0,11": 2,
+        "2,5->1,11": 6,
+        "2,8->0,11": 2,
+        "2,8->1,11": 5,
+        "2,8->5,6": 2,
+        "2,8->5,7": 5,
+        "4,8->0,9": 2,
+        "4,8->9,11": 5,
+        "8,11->5,6": 2,
+        "8,11->5,7": 6,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_three_or_more_switch_distribution"
+    ] == {
+        "contains_removed_endpoint->crossing_two_overlap": 2,
+    }
     assert edit_distance_audit["changed_row_count_distribution_for_first_nearest"] == {
         "1": 12
     }


### PR DESCRIPTION
## Mathematical scope

Cycle 655 refines the Cycle 654 not-legal opening audit. It classifies the before-replacement forbidden overlaps for the six not-legal opened-center incidences by the removed endpoint and by the old target chord's position relative to the source chord `(changed center, opened center)`.

Main audited facts:

- All `46` before-replacement forbidden overlaps among after-valid candidate rows contain the removed endpoint.
- Among the `44` noncrossing two-overlaps, old target chords lie only in long or diameter source arcs: `30` long-arc and `14` diameter-arc cases, with zero short-arc cases.
- The exact source-to-target distribution is recorded in the checker, test, docs, and goal log.
- For the `44` noncrossing two-overlaps, omitting the added endpoint gives `36` zero/one-overlap rows after replacement, while containing the added endpoint gives `8` crossing two-overlap rows.
- The remaining `2` three-or-more overlaps also contain the removed endpoint and collapse to crossing two-overlaps after replacement.

This preserves the finite low-support block-6 scope and does not claim a proof or counterexample.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds exact counters for removed-endpoint, source-arc, source-target, and switch distributions.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts the new exact distributions.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the source-arc classification.
- `reports/codex_goal_erdos97_log.md`: adds Cycle 655 with scope, limitations, validation, and next lead.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q` -> `2 passed`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` on the rebased branch -> `560 passed, 278 deselected`

## Remaining limitations

This is an exact finite audit within the repo-local low-support two-block block-6 selected-row extension tree. It is not a Euclidean realizability result, not a proof of Erdos Problem #97, and not a counterexample. The overarching proof/counterexample goal remains open.