### PR TITLE
[codex] Audit block6 crossing-creation mechanisms

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -533,6 +533,24 @@ endpoint gives `8` crossing two-overlap rows. The remaining `2`
 three-or-more overlaps also contain the removed endpoint and collapse to
 crossing two-overlaps after replacement.
 
+The `8` noncrossing-to-crossing switches are exactly removed-to-added
+substitutions: the candidate row already contains the added endpoint, and the
+surviving old target endpoint and added endpoint lie in opposite source arcs.
+
+```text
+source: old target -> new target  candidate rows
+2,10: 3,5 -> 1,5                 3
+2,10: 3,6 -> 1,6                 1
+4,8: 0,9 -> 0,7                  1
+4,8: 9,11 -> 7,11                3
+```
+
+The other `36` noncrossing two-overlaps are deletions: the candidate row omits
+the added endpoint, so removing the active endpoint leaves at most one common
+witness with the changed row. The `2` three-or-more cases are a second
+crossing-creation mechanism: deleting the removed endpoint leaves the crossing
+target `1,7` across source `2,8`.
+
 For example, the terminal state
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,166 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 656 - Block-6 Crossing-creation Mechanism Audit
+
+### Mathematical Subquestion
+
+Cycle 655 showed that every before-replacement forbidden overlap in the
+not-legal opening audit contains the removed endpoint. The next precise
+question was:
+
+```text
+Among the after-valid candidate rows, what distinguishes destroying a
+noncrossing two-overlap from converting it into an allowed crossing
+two-overlap?
+```
+
+### Definitions and Assumptions
+
+Use the same low-support block-6 branch, terminal clean seven-row states,
+same-class nearest terminal-to-extendable transitions, and not-legal opened
+eighth-center incidences from Cycles 654-655.
+
+For a noncrossing before-replacement two-overlap, the **surviving old endpoint**
+is the endpoint of the old target chord other than the removed endpoint. A
+**removed-to-added substitution** is the case where the candidate row also
+contains the added endpoint, so after replacement the new two-overlap is the
+chord joining the surviving old endpoint to the added endpoint.
+
+### Result Status
+
+Exact finite audit:
+**Block-6 Crossing-creation Mechanism Audit**.
+
+### Argument Or Obstruction
+
+The `10` crossing two-overlaps created after replacement split into exactly
+two mechanisms:
+
+```text
+crossing creation mechanism                 candidate rows
+noncrossing removed-to-added substitution    8
+three-or-more removed-endpoint deletion      2
+```
+
+For noncrossing two-overlaps, containing the added endpoint is exactly the
+substitution case in this finite audit. In all `8` substitution rows, the
+surviving old endpoint and the added endpoint lie in opposite source arcs, so
+the new target chord crosses the source:
+
+```text
+substitution arc relation                              candidate rows
+candidate contains added, opposite source arcs -> cross 8
+```
+
+The exact noncrossing substitution targets are:
+
+```text
+source: old target -> new target  candidate rows
+2,10: 3,5 -> 1,5                 3
+2,10: 3,6 -> 1,6                 1
+4,8: 0,9 -> 0,7                  1
+4,8: 9,11 -> 7,11                3
+```
+
+The remaining `36` noncrossing two-overlaps are deletion cases: the candidate
+row omits the added endpoint, so removing the active endpoint leaves at most
+one common witness with the changed row.
+
+The two three-or-more cases form a second crossing-creation mechanism:
+
+```text
+source: old overlap -> new target  candidate rows
+2,8: 1,5,7 -> 1,7                 1
+2,8: 1,7,11 -> 1,7                1
+```
+
+Thus, within this finite branch, a not-legal opening creates a crossing
+two-overlap only by either substituting the added endpoint across the source
+arc or by deleting the removed endpoint from a size-three overlap. Otherwise
+the obstruction is simply destroyed.
+
+### Exact Scope
+
+This is an exact finite audit inside the low-support two-block block-6
+natural-order selected-row extension tree. It covers the `46` after-valid
+candidate eighth rows attached to the `6` Cycle 654 not-legal opened-center
+incidences. It refines the Cycle 655 endpoint/arc audit. It is not a
+Euclidean realizability result, is not a proof of Erdos Problem #97, and is
+not a counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+Cycle 655 identified the removed endpoint as the active endpoint in every
+before-replacement obstruction. This cycle explains the remaining fork:
+either the candidate row omits the added endpoint and the obstruction
+disappears, or the candidate row contains the added endpoint on the opposite
+source arc and the obstruction becomes an allowed crossing. That is a more
+local cyclic-order target than the earlier broad terminality question.
+
+### Next Lead
+
+Try to prove the following source-arc substitution lemma in the block-6
+normal form:
+
+```text
+If an after-valid candidate row contains the added endpoint and its old
+noncrossing target contains the removed endpoint, then the added endpoint and
+the surviving old endpoint lie in opposite source arcs.
+```
+
+A disproof would be an exact not-legal opening row where the candidate
+contains the added endpoint but the substituted target remains noncrossing.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-656`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-656`.
+- The branch was started from `origin/main` at commit
+  `bad44e1f6afba839b6eddb47e1639cc3c0524fa7`, after PR #384 merged Cycle
+  655.
+- Before updating the PR branch, it was rebased onto `origin/main` at commit
+  `2d1befac0a37a3a68e6664c56975d4b0e88db576`; the intervening main commit
+  touched n9 vertex-circle files and did not overlap this cycle's block-6
+  audit files.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; reported `8` noncrossing removed-to-added substitution
+  crossing creations and `2` three-or-more deletion crossing creations.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed on the rebased branch, `562 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 655 - Block-6 Removed-endpoint Source-arc Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -891,6 +891,37 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
     "not_legal_opened_three_or_more_switch_distribution": {
         "contains_removed_endpoint->crossing_two_overlap": 2,
     },
+    "not_legal_opened_crossing_creation_mechanism_distribution": {
+        "noncrossing_removed_to_added_substitution": 8,
+        "three_or_more_removed_endpoint_deletion": 2,
+    },
+    "not_legal_opened_noncrossing_substitution_arc_distribution": {
+        "candidate_contains_added:opposite_source_arcs->crossing_two_overlap": 8,
+    },
+    "not_legal_opened_noncrossing_substitution_target_distribution": {
+        "2,10:3,5->1,5": 3,
+        "2,10:3,6->1,6": 1,
+        "4,8:0,9->0,7": 1,
+        "4,8:9,11->7,11": 3,
+    },
+    "not_legal_opened_noncrossing_deletion_target_distribution": {
+        "2,10:3,5->zero_or_one_overlap": 2,
+        "2,10:3,6->zero_or_one_overlap": 1,
+        "2,5:0,11->zero_or_one_overlap": 2,
+        "2,5:1,11->zero_or_one_overlap": 6,
+        "2,8:0,11->zero_or_one_overlap": 2,
+        "2,8:1,11->zero_or_one_overlap": 5,
+        "2,8:5,6->zero_or_one_overlap": 2,
+        "2,8:5,7->zero_or_one_overlap": 5,
+        "4,8:0,9->zero_or_one_overlap": 1,
+        "4,8:9,11->zero_or_one_overlap": 2,
+        "8,11:5,6->zero_or_one_overlap": 2,
+        "8,11:5,7->zero_or_one_overlap": 6,
+    },
+    "not_legal_opened_three_or_more_deletion_target_distribution": {
+        "2,8:1,5,7->1,7": 1,
+        "2,8:1,7,11->1,7": 1,
+    },
     "class_summary": {
         (
             "2,10,11|same_u=5,same_i=0,0,1,same_d=1,1,1,1,2|"
@@ -1857,6 +1888,21 @@ def _chord_key(chord: tuple[int, int]) -> str:
     return f"{chord[0]},{chord[1]}"
 
 
+def _label_tuple_key(labels: tuple[int, ...]) -> str:
+    return ",".join(str(label) for label in labels)
+
+
+def _source_side(source: tuple[int, int], label: int) -> str:
+    a, b = normalize_chord(*source)
+    return "inside" if a < label < b else "outside"
+
+
+def _source_side_relation(source: tuple[int, int], left: int, right: int) -> str:
+    if _source_side(source, left) == _source_side(source, right):
+        return "same_source_arc"
+    return "opposite_source_arcs"
+
+
 def _source_arc_class(source: tuple[int, int], target: tuple[int, int]) -> str:
     source = normalize_chord(*source)
     target = normalize_chord(*target)
@@ -1930,6 +1976,11 @@ def _not_legal_opened_paircross_profile(
     noncrossing_switches: Counter[str] = Counter()
     noncrossing_source_targets: Counter[str] = Counter()
     three_or_more_switches: Counter[str] = Counter()
+    crossing_creation_mechanisms: Counter[str] = Counter()
+    noncrossing_substitution_arcs: Counter[str] = Counter()
+    noncrossing_substitution_targets: Counter[str] = Counter()
+    noncrossing_deletion_targets: Counter[str] = Counter()
+    three_or_more_deletion_targets: Counter[str] = Counter()
     for row in after_valid_rows:
         before_relation = _changed_row_relation(
             changed_center,
@@ -1955,6 +2006,7 @@ def _not_legal_opened_paircross_profile(
             ] += 1
         if before_relation == "noncrossing_two_overlap":
             target = normalize_chord(*before_overlap)
+            after_overlap = tuple(sorted(set(extendable_changed_row) & set(row)))
             added_status = (
                 "candidate_contains_added"
                 if added_label in row
@@ -1965,8 +2017,37 @@ def _not_legal_opened_paircross_profile(
             noncrossing_source_targets[
                 f"{_chord_key(source)}->{_chord_key(target)}"
             ] += 1
+            source_target = f"{_chord_key(source)}:{_chord_key(target)}"
+            if added_label in row:
+                survivor = next(label for label in before_overlap if label != removed_label)
+                side_relation = _source_side_relation(source, survivor, added_label)
+                noncrossing_substitution_arcs[
+                    f"candidate_contains_added:{side_relation}->{after_relation}"
+                ] += 1
+                if len(after_overlap) == 2:
+                    new_target = normalize_chord(*after_overlap)
+                    noncrossing_substitution_targets[
+                        f"{source_target}->{_chord_key(new_target)}"
+                    ] += 1
+                if after_relation == "crossing_two_overlap":
+                    crossing_creation_mechanisms[
+                        "noncrossing_removed_to_added_substitution"
+                    ] += 1
+            else:
+                noncrossing_deletion_targets[
+                    f"{source_target}->{after_relation}"
+                ] += 1
         elif before_relation == "three_or_more_overlap":
             three_or_more_switches[f"{endpoint_status}->{after_relation}"] += 1
+            after_overlap = tuple(sorted(set(extendable_changed_row) & set(row)))
+            if after_relation == "crossing_two_overlap":
+                crossing_creation_mechanisms[
+                    "three_or_more_removed_endpoint_deletion"
+                ] += 1
+                three_or_more_deletion_targets[
+                    f"{_chord_key(source)}:{_label_tuple_key(before_overlap)}"
+                    f"->{_label_tuple_key(after_overlap)}"
+                ] += 1
     return {
         "before_paircross": len(before_paircross_rows),
         "before_valid": len(before_valid_rows),
@@ -1997,6 +2078,11 @@ def _not_legal_opened_paircross_profile(
         "noncrossing_switches": noncrossing_switches,
         "noncrossing_source_targets": noncrossing_source_targets,
         "three_or_more_switches": three_or_more_switches,
+        "crossing_creation_mechanisms": crossing_creation_mechanisms,
+        "noncrossing_substitution_arcs": noncrossing_substitution_arcs,
+        "noncrossing_substitution_targets": noncrossing_substitution_targets,
+        "noncrossing_deletion_targets": noncrossing_deletion_targets,
+        "three_or_more_deletion_targets": three_or_more_deletion_targets,
     }
 
 
@@ -2075,6 +2161,11 @@ def _low_support_terminal_edit_distance_audit(
     not_legal_opened_noncrossing_switch_counts: Counter[str] = Counter()
     not_legal_opened_noncrossing_source_target_counts: Counter[str] = Counter()
     not_legal_opened_three_or_more_switch_counts: Counter[str] = Counter()
+    not_legal_opened_crossing_creation_mechanism_counts: Counter[str] = Counter()
+    not_legal_opened_noncrossing_substitution_arc_counts: Counter[str] = Counter()
+    not_legal_opened_noncrossing_substitution_target_counts: Counter[str] = Counter()
+    not_legal_opened_noncrossing_deletion_target_counts: Counter[str] = Counter()
+    not_legal_opened_three_or_more_deletion_target_counts: Counter[str] = Counter()
     nearest_transition_count = 0
     opened_center_instance_count = 0
     not_legal_opened_instance_count = 0
@@ -2247,6 +2338,21 @@ def _low_support_terminal_edit_distance_audit(
                         not_legal_opened_three_or_more_switch_counts.update(
                             switch_profile["three_or_more_switches"]
                         )
+                        not_legal_opened_crossing_creation_mechanism_counts.update(
+                            switch_profile["crossing_creation_mechanisms"]
+                        )
+                        not_legal_opened_noncrossing_substitution_arc_counts.update(
+                            switch_profile["noncrossing_substitution_arcs"]
+                        )
+                        not_legal_opened_noncrossing_substitution_target_counts.update(
+                            switch_profile["noncrossing_substitution_targets"]
+                        )
+                        not_legal_opened_noncrossing_deletion_target_counts.update(
+                            switch_profile["noncrossing_deletion_targets"]
+                        )
+                        not_legal_opened_three_or_more_deletion_target_counts.update(
+                            switch_profile["three_or_more_deletion_targets"]
+                        )
                 opened_center_prior_status_by_transition[
                     ";".join(
                         f"{status}:{transition_prior_statuses[status]}"
@@ -2375,6 +2481,26 @@ def _low_support_terminal_edit_distance_audit(
         "not_legal_opened_three_or_more_switch_distribution": {
             key: int(not_legal_opened_three_or_more_switch_counts[key])
             for key in sorted(not_legal_opened_three_or_more_switch_counts)
+        },
+        "not_legal_opened_crossing_creation_mechanism_distribution": {
+            key: int(not_legal_opened_crossing_creation_mechanism_counts[key])
+            for key in sorted(not_legal_opened_crossing_creation_mechanism_counts)
+        },
+        "not_legal_opened_noncrossing_substitution_arc_distribution": {
+            key: int(not_legal_opened_noncrossing_substitution_arc_counts[key])
+            for key in sorted(not_legal_opened_noncrossing_substitution_arc_counts)
+        },
+        "not_legal_opened_noncrossing_substitution_target_distribution": {
+            key: int(not_legal_opened_noncrossing_substitution_target_counts[key])
+            for key in sorted(not_legal_opened_noncrossing_substitution_target_counts)
+        },
+        "not_legal_opened_noncrossing_deletion_target_distribution": {
+            key: int(not_legal_opened_noncrossing_deletion_target_counts[key])
+            for key in sorted(not_legal_opened_noncrossing_deletion_target_counts)
+        },
+        "not_legal_opened_three_or_more_deletion_target_distribution": {
+            key: int(not_legal_opened_three_or_more_deletion_target_counts[key])
+            for key in sorted(not_legal_opened_three_or_more_deletion_target_counts)
         },
         "class_summary": class_summary,
         "by_terminal": by_terminal,

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -350,6 +350,47 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
     ] == {
         "contains_removed_endpoint->crossing_two_overlap": 2,
     }
+    assert edit_distance_audit[
+        "not_legal_opened_crossing_creation_mechanism_distribution"
+    ] == {
+        "noncrossing_removed_to_added_substitution": 8,
+        "three_or_more_removed_endpoint_deletion": 2,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_noncrossing_substitution_arc_distribution"
+    ] == {
+        "candidate_contains_added:opposite_source_arcs->crossing_two_overlap": 8,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_noncrossing_substitution_target_distribution"
+    ] == {
+        "2,10:3,5->1,5": 3,
+        "2,10:3,6->1,6": 1,
+        "4,8:0,9->0,7": 1,
+        "4,8:9,11->7,11": 3,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_noncrossing_deletion_target_distribution"
+    ] == {
+        "2,10:3,5->zero_or_one_overlap": 2,
+        "2,10:3,6->zero_or_one_overlap": 1,
+        "2,5:0,11->zero_or_one_overlap": 2,
+        "2,5:1,11->zero_or_one_overlap": 6,
+        "2,8:0,11->zero_or_one_overlap": 2,
+        "2,8:1,11->zero_or_one_overlap": 5,
+        "2,8:5,6->zero_or_one_overlap": 2,
+        "2,8:5,7->zero_or_one_overlap": 5,
+        "4,8:0,9->zero_or_one_overlap": 1,
+        "4,8:9,11->zero_or_one_overlap": 2,
+        "8,11:5,6->zero_or_one_overlap": 2,
+        "8,11:5,7->zero_or_one_overlap": 6,
+    }
+    assert edit_distance_audit[
+        "not_legal_opened_three_or_more_deletion_target_distribution"
+    ] == {
+        "2,8:1,5,7->1,7": 1,
+        "2,8:1,7,11->1,7": 1,
+    }
     assert edit_distance_audit["changed_row_count_distribution_for_first_nearest"] == {
         "1": 12
     }


### PR DESCRIPTION
## Mathematical scope

This replaces draft PR #386 with the same reviewed branch head because the connector's mark-ready mutation is currently failing and local `gh` auth is invalid in this environment.

This PR records Cycle 656 of the Erdos97 research log. It audits the exact finite mechanism by which low-support block-6 rows that were noncrossing before the terminal edit become allowable after the edit.

No general proof or counterexample is claimed.

## Main result

Named audit: **Block-6 Crossing-creation Mechanism Audit**.

For the already cataloged after-valid low-support block-6 candidate rows:

- 8 cases are `noncrossing_removed_to_added_substitution` cases: replacing the removed terminal endpoint by the added endpoint turns a noncrossing two-overlap into a crossing two-overlap.
- 2 cases are `three_or_more_removed_endpoint_deletion` cases: deleting the removed endpoint from a three-or-more overlap leaves an allowed crossing two-overlap.
- In all 8 substitution cases, the old noncrossing target arc contains the added endpoint and its endpoints lie on opposite source arcs.
- The exact target distributions are recorded in the script assertions, focused test, documentation table, and log entry.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds exact mechanism counters and expected distributions.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts the new distributions.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the audit outcome.
- `reports/codex_goal_erdos97_log.md`: records Cycle 656 with limitations, rebase traceability, validation, and next lead.

## Validation run

After rebasing onto `origin/main` at `2d1befac0a37a3a68e6664c56975d4b0e88db576`:

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q` -> `2 passed in 53.42s`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `562 passed, 278 deselected in 126.75s`
- Hosted `tests` workflow on PR #386 for the same head passed on Python 3.10, 3.11, and 3.12.

## Limitations

This is an exact finite audit inside the current low-support block-6 survivor catalog. It does not prove Erdos Problem #97 and does not produce a counterexample. The global proof/counterexample objective remains open.