### PR TITLE
[codex] Prove paircross-gate source-arc lemma

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -551,6 +551,24 @@ witness with the changed row. The `2` three-or-more cases are a second
 crossing-creation mechanism: deleting the removed endpoint leaves the crossing
 target `1,7` across source `2,8`.
 
+This opposite-arc conclusion is forced by the pair/cross gate, not by raw row
+availability alone. In general, suppose a one-witness replacement changes row
+`R` to `R' = R - {r} + {a}`, an opened candidate row `Q` has old overlap
+`R cap Q = {r,s}`, and `Q` contains the added endpoint `a`. Then
+`R' cap Q = {a,s}`. If `a` and `s` lie in the same source arc of the chord
+joining the changed center to the opened center, the new target chord
+`{a,s}` is noncrossing. Since after-valid rows have already passed the
+pair/cross gate against `R'`, this same-arc substitution is impossible in the
+after-valid layer. The exact audit records the boundary:
+
+```text
+substitution layer and arc relation                         candidate rows
+all options, same source arc -> noncrossing two-overlap      60
+all options, opposite source arcs -> crossing two-overlap    36
+after pair/cross, opposite source arcs -> crossing two-overlap 8
+after valid, opposite source arcs -> crossing two-overlap      8
+```
+
 For example, the terminal state
 
 ```text

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,144 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 657 - Paircross-gate Source-arc Lemma
+
+### Mathematical Subquestion
+
+Cycle 656 left the following proposed local lemma:
+
+```text
+If an after-valid candidate row contains the added endpoint and its old
+noncrossing target contains the removed endpoint, then the added endpoint and
+the surviving old endpoint lie in opposite source arcs.
+```
+
+The question for this cycle was whether that statement needs a finite table,
+or whether it follows from a reusable definition-level gate.
+
+### Definitions and Assumptions
+
+Let `R` be the terminal changed row, and let
+`R' = R - {r} + {a}` be a one-witness nearest replacement. Let `Q` be a
+candidate row for an opened center. The source chord is the chord joining the
+changed center to the opened center.
+
+Assume:
+
+- `R cap Q = {r,s}` is a noncrossing two-overlap with the old row;
+- `Q` contains the added endpoint `a`;
+- `Q` is after-pair/cross admissible against the state containing `R'`.
+
+Call `s` the surviving old endpoint. The pair/cross gate is the row
+admissibility condition that any two-overlap between the new row and an
+assigned row must cross its source chord.
+
+### Result Status
+
+Proved lemma:
+**Paircross-gate Source-arc Lemma**.
+
+### Argument Or Obstruction
+
+Because the old overlap is exactly `{r,s}` and `a` is not in `R`, the new
+overlap is exactly:
+
+```text
+R' cap Q = {a,s}.
+```
+
+If `a` and `s` lie in the same open source arc, then the target chord `{a,s}`
+is noncrossing with the source chord. That contradicts after-pair/cross
+admissibility of `Q` against the state containing `R'`. Therefore every
+after-pair/cross candidate satisfying the hypotheses has `a` and `s` in
+opposite source arcs. In particular, every after-valid candidate row satisfying
+the hypotheses has the same opposite-arc conclusion.
+
+This proves that the Cycle 656 opposite-arc phenomenon is not a special
+numerical table accident; it is forced by the pair/cross gate once the
+replacement has reduced the overlap to `{a,s}`.
+
+The exact audit also shows why the stronger raw-row statement is false:
+
+```text
+substitution layer and arc relation                           candidate rows
+all options, same source arc -> noncrossing two-overlap        60
+all options, opposite source arcs -> crossing two-overlap      36
+after pair/cross, opposite source arcs -> crossing two-overlap 8
+after valid, opposite source arcs -> crossing two-overlap      8
+```
+
+So same-arc substitutions exist among raw row options, but all are rejected
+before the after-pair/cross layer.
+
+### Exact Scope
+
+The proof of the lemma is definition-level for one-witness replacements and
+the pair/cross gate. The recorded `60/36/8/8` counts are exact only for the
+low-support two-block block-6 terminal-edit branch. This is not a Euclidean
+realizability result, not a proof of Erdos Problem #97, and not a
+counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+The source-arc substitution lead is now discharged. The crossing creation in
+Cycle 656 follows from the existing pair/cross admissibility rule, while the
+raw-row counteraudit shows that pair/cross is genuinely doing the work. The
+next proof effort should move one layer earlier: explain why only `8` of the
+`36` raw opposite-arc substitutions survive the after-pair/cross gate, or
+extract a reusable condition that predicts after-pair/cross survival without
+enumerating row options.
+
+### Next Lead
+
+Analyze the `36 -> 8` opposite-arc thinning at the after-pair/cross gate. A
+useful next lemma would characterize which opposite-arc substitutions avoid
+new forbidden two-overlaps with the other assigned rows.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-657`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-657`.
+- The branch was started from `origin/main` at commit
+  `dedb9e49754e0cf717499b4481f3ddd4416e753a`, after PR #387 merged Cycle
+  656.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; recorded the `60/36/8/8` layer distribution above.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `562 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 656 - Block-6 Crossing-creation Mechanism Audit
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -898,6 +898,16 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
     "not_legal_opened_noncrossing_substitution_arc_distribution": {
         "candidate_contains_added:opposite_source_arcs->crossing_two_overlap": 8,
     },
+    "not_legal_opened_substitution_layer_arc_distribution": {
+        "after_paircross:candidate_contains_added:"
+        "opposite_source_arcs->crossing_two_overlap": 8,
+        "after_valid:candidate_contains_added:"
+        "opposite_source_arcs->crossing_two_overlap": 8,
+        "all_options:candidate_contains_added:"
+        "opposite_source_arcs->crossing_two_overlap": 36,
+        "all_options:candidate_contains_added:"
+        "same_source_arc->noncrossing_two_overlap": 60,
+    },
     "not_legal_opened_noncrossing_substitution_target_distribution": {
         "2,10:3,5->1,5": 3,
         "2,10:3,6->1,6": 1,
@@ -1978,9 +1988,38 @@ def _not_legal_opened_paircross_profile(
     three_or_more_switches: Counter[str] = Counter()
     crossing_creation_mechanisms: Counter[str] = Counter()
     noncrossing_substitution_arcs: Counter[str] = Counter()
+    substitution_layer_arcs: Counter[str] = Counter()
     noncrossing_substitution_targets: Counter[str] = Counter()
     noncrossing_deletion_targets: Counter[str] = Counter()
     three_or_more_deletion_targets: Counter[str] = Counter()
+    after_paircross_row_set = set(after_paircross_rows)
+    after_valid_row_set = set(after_valid_rows)
+    for row in center_options:
+        before_relation = _changed_row_relation(
+            changed_center,
+            opened_center,
+            terminal_changed_row,
+            row,
+        )
+        if before_relation != "noncrossing_two_overlap" or added_label not in row:
+            continue
+        before_overlap = tuple(sorted(set(terminal_changed_row) & set(row)))
+        if removed_label not in before_overlap:
+            continue
+        after_relation = _changed_row_relation(
+            changed_center,
+            opened_center,
+            extendable_changed_row,
+            row,
+        )
+        survivor = next(label for label in before_overlap if label != removed_label)
+        side_relation = _source_side_relation(source, survivor, added_label)
+        layer_key = f"candidate_contains_added:{side_relation}->{after_relation}"
+        substitution_layer_arcs[f"all_options:{layer_key}"] += 1
+        if row in after_paircross_row_set:
+            substitution_layer_arcs[f"after_paircross:{layer_key}"] += 1
+        if row in after_valid_row_set:
+            substitution_layer_arcs[f"after_valid:{layer_key}"] += 1
     for row in after_valid_rows:
         before_relation = _changed_row_relation(
             changed_center,
@@ -2080,6 +2119,7 @@ def _not_legal_opened_paircross_profile(
         "three_or_more_switches": three_or_more_switches,
         "crossing_creation_mechanisms": crossing_creation_mechanisms,
         "noncrossing_substitution_arcs": noncrossing_substitution_arcs,
+        "substitution_layer_arcs": substitution_layer_arcs,
         "noncrossing_substitution_targets": noncrossing_substitution_targets,
         "noncrossing_deletion_targets": noncrossing_deletion_targets,
         "three_or_more_deletion_targets": three_or_more_deletion_targets,
@@ -2163,6 +2203,7 @@ def _low_support_terminal_edit_distance_audit(
     not_legal_opened_three_or_more_switch_counts: Counter[str] = Counter()
     not_legal_opened_crossing_creation_mechanism_counts: Counter[str] = Counter()
     not_legal_opened_noncrossing_substitution_arc_counts: Counter[str] = Counter()
+    not_legal_opened_substitution_layer_arc_counts: Counter[str] = Counter()
     not_legal_opened_noncrossing_substitution_target_counts: Counter[str] = Counter()
     not_legal_opened_noncrossing_deletion_target_counts: Counter[str] = Counter()
     not_legal_opened_three_or_more_deletion_target_counts: Counter[str] = Counter()
@@ -2344,6 +2385,9 @@ def _low_support_terminal_edit_distance_audit(
                         not_legal_opened_noncrossing_substitution_arc_counts.update(
                             switch_profile["noncrossing_substitution_arcs"]
                         )
+                        not_legal_opened_substitution_layer_arc_counts.update(
+                            switch_profile["substitution_layer_arcs"]
+                        )
                         not_legal_opened_noncrossing_substitution_target_counts.update(
                             switch_profile["noncrossing_substitution_targets"]
                         )
@@ -2489,6 +2533,10 @@ def _low_support_terminal_edit_distance_audit(
         "not_legal_opened_noncrossing_substitution_arc_distribution": {
             key: int(not_legal_opened_noncrossing_substitution_arc_counts[key])
             for key in sorted(not_legal_opened_noncrossing_substitution_arc_counts)
+        },
+        "not_legal_opened_substitution_layer_arc_distribution": {
+            key: int(not_legal_opened_substitution_layer_arc_counts[key])
+            for key in sorted(not_legal_opened_substitution_layer_arc_counts)
         },
         "not_legal_opened_noncrossing_substitution_target_distribution": {
             key: int(not_legal_opened_noncrossing_substitution_target_counts[key])

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -362,6 +362,26 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "candidate_contains_added:opposite_source_arcs->crossing_two_overlap": 8,
     }
     assert edit_distance_audit[
+        "not_legal_opened_substitution_layer_arc_distribution"
+    ] == {
+        (
+            "after_paircross:candidate_contains_added:"
+            "opposite_source_arcs->crossing_two_overlap"
+        ): 8,
+        (
+            "after_valid:candidate_contains_added:"
+            "opposite_source_arcs->crossing_two_overlap"
+        ): 8,
+        (
+            "all_options:candidate_contains_added:"
+            "opposite_source_arcs->crossing_two_overlap"
+        ): 36,
+        (
+            "all_options:candidate_contains_added:"
+            "same_source_arc->noncrossing_two_overlap"
+        ): 60,
+    }
+    assert edit_distance_audit[
         "not_legal_opened_noncrossing_substitution_target_distribution"
     ] == {
         "2,10:3,5->1,5": 3,


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 657 of the Erdos97 research log. It proves the local **Paircross-gate Source-arc Lemma** for one-witness replacements and records an exact block-6 audit boundary showing that the pair/cross gate, not raw row availability, forces the opposite-arc conclusion.

No general proof or counterexample is claimed.

## Main result

If a one-witness replacement changes `R` to `R' = R - {r} + {a}`, a candidate opened row `Q` has old overlap `R cap Q = {r,s}`, and `Q` contains `a`, then `R' cap Q = {a,s}`. If `a` and `s` lie in the same source arc, the new target chord is noncrossing, contradicting after-pair/cross admissibility. Therefore every after-pair/cross, hence every after-valid, candidate satisfying the hypotheses has the added endpoint and surviving old endpoint in opposite source arcs.

The exact finite audit records the boundary in the low-support block-6 branch:

- all options, same source arc -> noncrossing two-overlap: 60
- all options, opposite source arcs -> crossing two-overlap: 36
- after pair/cross, opposite source arcs -> crossing two-overlap: 8
- after valid, opposite source arcs -> crossing two-overlap: 8

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds exact substitution layer/arc counters.
- `tests/test_block6_fragile_sixth_row_survivors.py`: asserts the new layer distribution.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: records the lemma and audit boundary.
- `reports/codex_goal_erdos97_log.md`: records Cycle 657 with proof, limitations, validation, and next lead.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q` -> `2 passed in 53.21s`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `562 passed, 278 deselected in 128.22s`

## Limitations

The lemma is local to one-witness replacements and pair/cross admissibility. The `60/36/8/8` counts are exact only for the low-support two-block block-6 terminal-edit branch. This does not prove Erdos Problem #97 and does not produce a counterexample. The global proof/counterexample objective remains open.