### PR TITLE
[codex] Factor block6 paircross context covers

### DIFF
--- a/docs/block6-fragile-sixth-row-survivor-catalog.md
+++ b/docs/block6-fragile-sixth-row-survivor-catalog.md
@@ -607,6 +607,36 @@ blocker center orbit  incidences
 5,11                  24
 ```
 
+The per-context blocker summary further factors the thinning:
+
+```text
+context              raw  after  failed  blocker counts  blocker roles
+2,10:3,5 -> 1,5     6    3      3       1x1, 2x2        fixed 3, other-added 2
+2,10:3,6 -> 1,6     6    1      5       1x4, 2x1        fixed 2, other-added 4
+2,10:3,9 -> 1,9     6    0      6       1x2, 2x4        fixed 4, other-added 6
+4,8:0,9 -> 0,7      6    1      5       1x4, 2x1        fixed 2, other-added 4
+4,8:3,9 -> 3,7      6    0      6       1x2, 2x4        fixed 4, other-added 6
+4,8:9,11 -> 7,11    6    3      3       1x1, 2x2        fixed 3, other-added 2
+```
+
+Here `after` means after the pair/cross gate, and every after-pair/cross row
+also passes the pair-cap and indegree gates in this audit. The two zero-row
+contexts have the same coarse blocker profile: each has `6` raw candidates,
+`6` failures, `4` fixed-row blocker incidences from the `0,6` orbit, and `6`
+unchanged-added-row blocker incidences from the `5,11` orbit. For
+`2,10: 3,9 -> 1,9`, the unchanged added-row blocker is centered in the
+`5,11` orbit and repeatedly contributes the noncrossing target `1,9`; fixed
+rows in the `0,6` orbit cover the remaining variants. The block-swap mate is
+`4,8: 3,9 -> 3,7`, where the unchanged added-row blocker repeatedly
+contributes the noncrossing target `3,7`, again supplemented by fixed-row
+blockers in the `0,6` orbit.
+
+This finite pattern is the **Full Context Cover Obstruction**: in the two
+zero-survivor opposite-arc contexts, the unchanged added-row orbit and fixed
+row orbit together cover all six raw candidates before any can become a valid
+eighth row. It is an exact local obstruction in this audit, not a proof that
+the same cover is forced in every cyclic-order or metric setting.
+
 This gives a second exact obstruction to the naive converse of the
 opposite-arc rule: an opposite-arc substitution is necessary for repairing the
 changed-row conflict, but not sufficient for a globally pair/cross-admissible

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,138 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 659 - Full Context Cover Obstruction
+
+### Mathematical Subquestion
+
+Cycle 658 showed that only `8` of the `36` raw opposite-arc substitutions in
+the low-support block-6 terminal-edit audit survive the after-pair/cross gate.
+The next question was:
+
+```text
+Can the 42 other-row blocker incidences be factored by raw context, especially
+for the two contexts with zero surviving candidates?
+```
+
+### Definitions and Assumptions
+
+Use the Cycle 658 notation. A raw **opposite-arc substitution context** is
+specified by the source chord joining the changed center to the opened center,
+the old noncrossing target overlap with the terminal changed row, and the new
+crossing target overlap after the one-witness replacement.
+
+A **context cover** is the multiset of already assigned rows that block all
+raw candidates in one such context at the after-replacement pair/cross gate.
+Blockers are classified by:
+
+- blocker kind: noncrossing two-overlap or three-or-more overlap;
+- blocker role: fixed row or other unchanged added row;
+- blocker center orbit under the block-swap `i -> i+6 mod 12`.
+
+### Result Status
+
+Exact finite audit and obstruction:
+**Full Context Cover Obstruction**.
+
+### Argument Or Obstruction
+
+The checker now records a per-context summary in addition to the Cycle 658
+aggregate blocker counts. The six raw contexts split as follows:
+
+```text
+context              raw  after  valid  failed  blocker counts  blocker roles
+2,10:3,5 -> 1,5     6    3      3      3       1x1, 2x2        fixed 3, other-added 2
+2,10:3,6 -> 1,6     6    1      1      5       1x4, 2x1        fixed 2, other-added 4
+2,10:3,9 -> 1,9     6    0      0      6       1x2, 2x4        fixed 4, other-added 6
+4,8:0,9 -> 0,7      6    1      1      5       1x4, 2x1        fixed 2, other-added 4
+4,8:3,9 -> 3,7      6    0      0      6       1x2, 2x4        fixed 4, other-added 6
+4,8:9,11 -> 7,11    6    3      3      3       1x1, 2x2        fixed 3, other-added 2
+```
+
+The two zero-survivor contexts have the same coarse cover profile. In
+`2,10: 3,9 -> 1,9`, the `6` failed raw candidates have `10` blocker
+incidences: `4` from fixed rows in the `0,6` orbit and `6` from unchanged
+added rows in the `5,11` orbit. The unchanged added row repeatedly supplies
+the noncrossing target `1,9`, while fixed rows cover the remaining variants.
+
+The block-swap mate `4,8: 3,9 -> 3,7` has the same profile: `4` fixed-row
+blockers in the `0,6` orbit and `6` unchanged-added-row blockers in the
+`5,11` orbit. Here the repeated unchanged-added-row target is `3,7`.
+
+Thus, in these two exact contexts, the opposite-arc substitution repairs the
+changed-row conflict but the fixed row orbit plus unchanged added-row orbit
+cover every raw candidate before it can become a valid eighth row.
+
+### Exact Scope
+
+The counts are exact for the low-support two-block block-6 terminal-edit
+branch in the natural cyclic order. The result is not a Euclidean
+realizability statement, not a global theorem for Erdos Problem #97, and not a
+counterexample.
+
+### Files Changed
+
+- `docs/block6-fragile-sixth-row-survivor-catalog.md`
+- `scripts/check_block6_fragile_sixth_row_survivors.py`
+- `tests/test_block6_fragile_sixth_row_survivors.py`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This refines the Cycle 658 obstruction from an aggregate blocker census into a
+context-level cover pattern. It strengthens the fragile-cover bridge by
+identifying exactly where the naive opposite-arc repair route dies: two raw
+contexts are not merely sparse after pair/cross; they are fully covered by a
+small pair of blocker orbits.
+
+### Next Lead
+
+Try to turn the repeated unchanged-added-row targets `1,9` and `3,7` into a
+human-readable boundary-pair lemma. The useful subclaim would explain, from
+the source/target placement and the low-support row-content profile, why the
+unchanged added row must cover four of the six raw candidates in each
+zero-survivor context.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-659`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-659`.
+- The branch was started from `origin/main` at commit
+  `8f71aa46ce4b6088452f7d37f28a1189bedeadbd`, after PR #391 merged Cycle
+  658.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected
+  --json`: passed; recorded the six per-context summaries above.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_fragile_sixth_row_survivors.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check
+  scripts/check_block6_fragile_sixth_row_survivors.py
+  tests/test_block6_fragile_sixth_row_survivors.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 658 - Other-row Paircross Thinning Obstruction
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_fragile_sixth_row_survivors.py
+++ b/scripts/check_block6_fragile_sixth_row_survivors.py
@@ -926,6 +926,150 @@ EXPECTED_LOW_SUPPORT_TERMINAL_EDIT_DISTANCE_AUDIT = {
         "failed_paircross:4,8:3,9->3,7": 6,
         "failed_paircross:4,8:9,11->7,11": 3,
     },
+    "not_legal_opened_opposite_arc_paircross_context_summary": {
+        "2,10:3,5->1,5": {
+            "raw_options": 6,
+            "after_paircross": 3,
+            "after_valid": 3,
+            "failed_paircross": 3,
+            "blocker_count_distribution": {"1": 1, "2": 2},
+            "blocker_kind_distribution": {
+                "noncrossing_two_overlap": 4,
+                "three_or_more_overlap": 1,
+            },
+            "blocker_role_distribution": {"fixed_row": 3, "other_added_row": 2},
+            "blocker_center_orbit_distribution": {
+                "0,6": 1,
+                "3,9": 2,
+                "5,11": 2,
+            },
+            "blocker_source_target_distribution": {
+                "noncrossing_two_overlap:2,3->0,5": 1,
+                "noncrossing_two_overlap:2,3->4,5": 1,
+                "noncrossing_two_overlap:2,5->0,1": 1,
+                "noncrossing_two_overlap:2,5->1,11": 1,
+                "three_or_more_overlap:0,2->1,3,4": 1,
+            },
+        },
+        "2,10:3,6->1,6": {
+            "raw_options": 6,
+            "after_paircross": 1,
+            "after_valid": 1,
+            "failed_paircross": 5,
+            "blocker_count_distribution": {"1": 4, "2": 1},
+            "blocker_kind_distribution": {
+                "noncrossing_two_overlap": 5,
+                "three_or_more_overlap": 1,
+            },
+            "blocker_role_distribution": {"fixed_row": 2, "other_added_row": 4},
+            "blocker_center_orbit_distribution": {
+                "0,6": 1,
+                "3,9": 1,
+                "5,11": 4,
+            },
+            "blocker_source_target_distribution": {
+                "noncrossing_two_overlap:2,11->4,6": 1,
+                "noncrossing_two_overlap:2,11->6,7": 1,
+                "noncrossing_two_overlap:2,5->0,1": 1,
+                "noncrossing_two_overlap:2,5->1,11": 1,
+                "noncrossing_two_overlap:2,9->6,8": 1,
+                "three_or_more_overlap:0,2->1,3,4": 1,
+            },
+        },
+        "2,10:3,9->1,9": {
+            "raw_options": 6,
+            "after_paircross": 0,
+            "after_valid": 0,
+            "failed_paircross": 6,
+            "blocker_count_distribution": {"1": 2, "2": 4},
+            "blocker_kind_distribution": {
+                "noncrossing_two_overlap": 7,
+                "three_or_more_overlap": 3,
+            },
+            "blocker_role_distribution": {"fixed_row": 4, "other_added_row": 6},
+            "blocker_center_orbit_distribution": {"0,6": 4, "5,11": 6},
+            "blocker_source_target_distribution": {
+                "noncrossing_two_overlap:2,5->1,9": 4,
+                "noncrossing_two_overlap:2,6->7,9": 1,
+                "noncrossing_two_overlap:2,6->8,9": 1,
+                "noncrossing_two_overlap:2,6->9,10": 1,
+                "three_or_more_overlap:0,2->1,3,4": 1,
+                "three_or_more_overlap:2,5->0,1,9": 1,
+                "three_or_more_overlap:2,5->1,9,11": 1,
+            },
+        },
+        "4,8:0,9->0,7": {
+            "raw_options": 6,
+            "after_paircross": 1,
+            "after_valid": 1,
+            "failed_paircross": 5,
+            "blocker_count_distribution": {"1": 4, "2": 1},
+            "blocker_kind_distribution": {
+                "noncrossing_two_overlap": 5,
+                "three_or_more_overlap": 1,
+            },
+            "blocker_role_distribution": {"fixed_row": 2, "other_added_row": 4},
+            "blocker_center_orbit_distribution": {
+                "0,6": 1,
+                "3,9": 1,
+                "5,11": 4,
+            },
+            "blocker_source_target_distribution": {
+                "noncrossing_two_overlap:3,8->0,2": 1,
+                "noncrossing_two_overlap:5,8->0,1": 1,
+                "noncrossing_two_overlap:5,8->0,10": 1,
+                "noncrossing_two_overlap:8,11->5,7": 1,
+                "noncrossing_two_overlap:8,11->6,7": 1,
+                "three_or_more_overlap:6,8->7,9,10": 1,
+            },
+        },
+        "4,8:3,9->3,7": {
+            "raw_options": 6,
+            "after_paircross": 0,
+            "after_valid": 0,
+            "failed_paircross": 6,
+            "blocker_count_distribution": {"1": 2, "2": 4},
+            "blocker_kind_distribution": {
+                "noncrossing_two_overlap": 7,
+                "three_or_more_overlap": 3,
+            },
+            "blocker_role_distribution": {"fixed_row": 4, "other_added_row": 6},
+            "blocker_center_orbit_distribution": {"0,6": 4, "5,11": 6},
+            "blocker_source_target_distribution": {
+                "noncrossing_two_overlap:0,8->1,3": 1,
+                "noncrossing_two_overlap:0,8->2,3": 1,
+                "noncrossing_two_overlap:0,8->3,4": 1,
+                "noncrossing_two_overlap:8,11->3,7": 4,
+                "three_or_more_overlap:6,8->7,9,10": 1,
+                "three_or_more_overlap:8,11->3,5,7": 1,
+                "three_or_more_overlap:8,11->3,6,7": 1,
+            },
+        },
+        "4,8:9,11->7,11": {
+            "raw_options": 6,
+            "after_paircross": 3,
+            "after_valid": 3,
+            "failed_paircross": 3,
+            "blocker_count_distribution": {"1": 1, "2": 2},
+            "blocker_kind_distribution": {
+                "noncrossing_two_overlap": 4,
+                "three_or_more_overlap": 1,
+            },
+            "blocker_role_distribution": {"fixed_row": 3, "other_added_row": 2},
+            "blocker_center_orbit_distribution": {
+                "0,6": 1,
+                "3,9": 2,
+                "5,11": 2,
+            },
+            "blocker_source_target_distribution": {
+                "noncrossing_two_overlap:8,11->5,7": 1,
+                "noncrossing_two_overlap:8,11->6,7": 1,
+                "noncrossing_two_overlap:8,9->10,11": 1,
+                "noncrossing_two_overlap:8,9->6,11": 1,
+                "three_or_more_overlap:6,8->7,9,10": 1,
+            },
+        },
+    },
     "not_legal_opened_opposite_arc_paircross_blocker_count_distribution": {
         "1": 14,
         "2": 14,
@@ -1984,6 +2128,72 @@ def _label_tuple_key(labels: tuple[int, ...]) -> str:
     return ",".join(str(label) for label in labels)
 
 
+def _new_paircross_context_summary() -> dict[str, Any]:
+    return {
+        "raw_options": 0,
+        "after_paircross": 0,
+        "after_valid": 0,
+        "failed_paircross": 0,
+        "blocker_count_distribution": Counter(),
+        "blocker_kind_distribution": Counter(),
+        "blocker_role_distribution": Counter(),
+        "blocker_center_orbit_distribution": Counter(),
+        "blocker_source_target_distribution": Counter(),
+    }
+
+
+def _paircross_context_summary_payload(
+    summary_by_context: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    payload = {}
+    for context in sorted(summary_by_context):
+        summary = summary_by_context[context]
+        payload[context] = {
+            "raw_options": int(summary["raw_options"]),
+            "after_paircross": int(summary["after_paircross"]),
+            "after_valid": int(summary["after_valid"]),
+            "failed_paircross": int(summary["failed_paircross"]),
+            "blocker_count_distribution": _json_counter(
+                summary["blocker_count_distribution"]
+            ),
+            "blocker_kind_distribution": {
+                key: int(summary["blocker_kind_distribution"][key])
+                for key in sorted(summary["blocker_kind_distribution"])
+            },
+            "blocker_role_distribution": {
+                key: int(summary["blocker_role_distribution"][key])
+                for key in sorted(summary["blocker_role_distribution"])
+            },
+            "blocker_center_orbit_distribution": {
+                key: int(summary["blocker_center_orbit_distribution"][key])
+                for key in sorted(summary["blocker_center_orbit_distribution"])
+            },
+            "blocker_source_target_distribution": {
+                key: int(summary["blocker_source_target_distribution"][key])
+                for key in sorted(summary["blocker_source_target_distribution"])
+            },
+        }
+    return payload
+
+
+def _merge_paircross_context_summary(
+    total: dict[str, dict[str, Any]],
+    addition: Mapping[str, Mapping[str, Any]],
+) -> None:
+    for context, summary in addition.items():
+        entry = total.setdefault(context, _new_paircross_context_summary())
+        for key in ("raw_options", "after_paircross", "after_valid", "failed_paircross"):
+            entry[key] += summary[key]
+        for key in (
+            "blocker_count_distribution",
+            "blocker_kind_distribution",
+            "blocker_role_distribution",
+            "blocker_center_orbit_distribution",
+            "blocker_source_target_distribution",
+        ):
+            entry[key].update(summary[key])
+
+
 def _source_side(source: tuple[int, int], label: int) -> str:
     a, b = normalize_chord(*source)
     return "inside" if a < label < b else "outside"
@@ -2075,6 +2285,7 @@ def _not_legal_opened_paircross_profile(
     opposite_arc_paircross_blocker_roles: Counter[str] = Counter()
     opposite_arc_paircross_blocker_center_orbits: Counter[str] = Counter()
     opposite_arc_paircross_blocker_source_targets: Counter[str] = Counter()
+    opposite_arc_paircross_context_summary: dict[str, dict[str, Any]] = {}
     noncrossing_substitution_targets: Counter[str] = Counter()
     noncrossing_deletion_targets: Counter[str] = Counter()
     three_or_more_deletion_targets: Counter[str] = Counter()
@@ -2111,10 +2322,17 @@ def _not_legal_opened_paircross_profile(
                 f"{_chord_key(source)}:{_chord_key(old_target)}"
                 f"->{_chord_key(new_target)}"
             )
+            context_summary = opposite_arc_paircross_context_summary.setdefault(
+                context_key,
+                _new_paircross_context_summary(),
+            )
+            context_summary["raw_options"] += 1
             opposite_arc_paircross_contexts[f"all_options:{context_key}"] += 1
             blockers = _paircross_blockers(opened_center, row, assigned_after)
             if blockers:
+                context_summary["failed_paircross"] += 1
                 opposite_arc_paircross_contexts[f"failed_paircross:{context_key}"] += 1
+                context_summary["blocker_count_distribution"][len(blockers)] += 1
                 opposite_arc_paircross_blocker_counts[len(blockers)] += 1
                 for blocker_center, blocker_source, blocker_target, kind in blockers:
                     if blocker_center == changed_center:
@@ -2128,6 +2346,14 @@ def _not_legal_opened_paircross_profile(
                         if kind == "noncrossing_two_overlap"
                         else _label_tuple_key(blocker_target)
                     )
+                    context_summary["blocker_kind_distribution"][kind] += 1
+                    context_summary["blocker_role_distribution"][role] += 1
+                    context_summary["blocker_center_orbit_distribution"][
+                        _center_orbit_key(blocker_center)
+                    ] += 1
+                    context_summary["blocker_source_target_distribution"][
+                        f"{kind}:{_chord_key(blocker_source)}->{target_key}"
+                    ] += 1
                     opposite_arc_paircross_blocker_kinds[kind] += 1
                     opposite_arc_paircross_blocker_roles[role] += 1
                     opposite_arc_paircross_blocker_center_orbits[
@@ -2137,6 +2363,9 @@ def _not_legal_opened_paircross_profile(
                         f"{kind}:{_chord_key(blocker_source)}->{target_key}"
                     ] += 1
             else:
+                context_summary["after_paircross"] += 1
+                if row in after_valid_row_set:
+                    context_summary["after_valid"] += 1
                 opposite_arc_paircross_contexts[f"after_paircross:{context_key}"] += 1
         if row in after_paircross_row_set:
             substitution_layer_arcs[f"after_paircross:{layer_key}"] += 1
@@ -2243,6 +2472,9 @@ def _not_legal_opened_paircross_profile(
         "noncrossing_substitution_arcs": noncrossing_substitution_arcs,
         "substitution_layer_arcs": substitution_layer_arcs,
         "opposite_arc_paircross_contexts": opposite_arc_paircross_contexts,
+        "opposite_arc_paircross_context_summary": (
+            opposite_arc_paircross_context_summary
+        ),
         "opposite_arc_paircross_blocker_counts": (
             opposite_arc_paircross_blocker_counts
         ),
@@ -2351,6 +2583,10 @@ def _low_support_terminal_edit_distance_audit(
     not_legal_opened_opposite_arc_paircross_blocker_source_target_counts: Counter[
         str
     ] = Counter()
+    not_legal_opened_opposite_arc_paircross_context_summary: dict[
+        str,
+        dict[str, Any],
+    ] = {}
     not_legal_opened_noncrossing_substitution_target_counts: Counter[str] = Counter()
     not_legal_opened_noncrossing_deletion_target_counts: Counter[str] = Counter()
     not_legal_opened_three_or_more_deletion_target_counts: Counter[str] = Counter()
@@ -2529,6 +2765,10 @@ def _low_support_terminal_edit_distance_audit(
                         not_legal_opened_opposite_arc_paircross_context_counts.update(
                             switch_profile["opposite_arc_paircross_contexts"]
                         )
+                        _merge_paircross_context_summary(
+                            not_legal_opened_opposite_arc_paircross_context_summary,
+                            switch_profile["opposite_arc_paircross_context_summary"],
+                        )
                         not_legal_opened_opposite_arc_paircross_blocker_counts.update(
                             switch_profile["opposite_arc_paircross_blocker_counts"]
                         )
@@ -2700,6 +2940,11 @@ def _low_support_terminal_edit_distance_audit(
             key: int(not_legal_opened_opposite_arc_paircross_context_counts[key])
             for key in sorted(not_legal_opened_opposite_arc_paircross_context_counts)
         },
+        "not_legal_opened_opposite_arc_paircross_context_summary": (
+            _paircross_context_summary_payload(
+                not_legal_opened_opposite_arc_paircross_context_summary
+            )
+        ),
         "not_legal_opened_opposite_arc_paircross_blocker_count_distribution": (
             _json_counter(not_legal_opened_opposite_arc_paircross_blocker_counts)
         ),

--- a/tests/test_block6_fragile_sixth_row_survivors.py
+++ b/tests/test_block6_fragile_sixth_row_survivors.py
@@ -398,6 +398,53 @@ def test_block6_sixth_row_survivor_catalog_matches_expected() -> None:
         "failed_paircross:4,8:3,9->3,7": 6,
         "failed_paircross:4,8:9,11->7,11": 3,
     }
+    context_summary = edit_distance_audit[
+        "not_legal_opened_opposite_arc_paircross_context_summary"
+    ]
+    assert context_summary["2,10:3,9->1,9"] == {
+        "raw_options": 6,
+        "after_paircross": 0,
+        "after_valid": 0,
+        "failed_paircross": 6,
+        "blocker_count_distribution": {"1": 2, "2": 4},
+        "blocker_kind_distribution": {
+            "noncrossing_two_overlap": 7,
+            "three_or_more_overlap": 3,
+        },
+        "blocker_role_distribution": {"fixed_row": 4, "other_added_row": 6},
+        "blocker_center_orbit_distribution": {"0,6": 4, "5,11": 6},
+        "blocker_source_target_distribution": {
+            "noncrossing_two_overlap:2,5->1,9": 4,
+            "noncrossing_two_overlap:2,6->7,9": 1,
+            "noncrossing_two_overlap:2,6->8,9": 1,
+            "noncrossing_two_overlap:2,6->9,10": 1,
+            "three_or_more_overlap:0,2->1,3,4": 1,
+            "three_or_more_overlap:2,5->0,1,9": 1,
+            "three_or_more_overlap:2,5->1,9,11": 1,
+        },
+    }
+    assert context_summary["4,8:3,9->3,7"] == {
+        "raw_options": 6,
+        "after_paircross": 0,
+        "after_valid": 0,
+        "failed_paircross": 6,
+        "blocker_count_distribution": {"1": 2, "2": 4},
+        "blocker_kind_distribution": {
+            "noncrossing_two_overlap": 7,
+            "three_or_more_overlap": 3,
+        },
+        "blocker_role_distribution": {"fixed_row": 4, "other_added_row": 6},
+        "blocker_center_orbit_distribution": {"0,6": 4, "5,11": 6},
+        "blocker_source_target_distribution": {
+            "noncrossing_two_overlap:0,8->1,3": 1,
+            "noncrossing_two_overlap:0,8->2,3": 1,
+            "noncrossing_two_overlap:0,8->3,4": 1,
+            "noncrossing_two_overlap:8,11->3,7": 4,
+            "three_or_more_overlap:6,8->7,9,10": 1,
+            "three_or_more_overlap:8,11->3,5,7": 1,
+            "three_or_more_overlap:8,11->3,6,7": 1,
+        },
+    }
     assert edit_distance_audit[
         "not_legal_opened_opposite_arc_paircross_blocker_count_distribution"
     ] == {"1": 14, "2": 14}


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 659 for the block-6 low-support terminal-edit audit. It factors the 42 other-row blocker incidences from the Cycle 658 opposite-arc pair/cross thinning result into per-context summaries.

Named result: **Full Context Cover Obstruction**.

Exact local finding: in the two zero-survivor raw opposite-arc contexts, `2,10:3,9 -> 1,9` and `4,8:3,9 -> 3,7`, all 6 raw candidates are blocked after replacement. Each context has 10 blocker incidences: 4 fixed-row blockers in the `0,6` orbit and 6 unchanged-added-row blockers in the `5,11` orbit.

This remains a bounded exact audit result in the natural cyclic order. It is not a proof of Erdos Problem #97 and not a counterexample.

## Files changed

- `scripts/check_block6_fragile_sixth_row_survivors.py`: adds nested per-context pair/cross blocker summaries.
- `tests/test_block6_fragile_sixth_row_survivors.py`: pins the two fully killed contexts.
- `docs/block6-fragile-sixth-row-survivor-catalog.md`: documents the per-context split and obstruction.
- `reports/codex_goal_erdos97_log.md`: records Cycle 659 with scope, limitations, validation, and next lead.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_fragile_sixth_row_survivors.py -q` (`2 passed`)
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check scripts/check_block6_fragile_sixth_row_survivors.py tests/test_block6_fragile_sixth_row_survivors.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`562 passed, 278 deselected`)

## Remaining limitations

- Exact only for the low-support two-block block-6 terminal-edit branch in the natural cyclic order.
- Does not establish Euclidean realizability or non-realizability.
- Does not prove or refute the global Erdos97 problem.
- Next lead is to explain the repeated unchanged-added-row targets `1,9` and `3,7` by a human-readable boundary-pair lemma.