### PR TITLE
[codex] Close n9 strict-cycle local scan

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -17,12 +17,12 @@ that justifies doing it anyway.
 
 Use this queue when no more specific issue is selected.
 
-1. Extract one `n=9` vertex-circle self-edge local template into a
-   proof-facing lemma candidate and compact verifier. Start with the focused
-   T01/F09 packet unless another packet has a clearer review target.
-2. Extract one `n=9` strict-cycle local template into a proof-facing lemma
-   candidate and compact verifier. The T10/F12 packet is the first natural
-   target.
+1. Close one remaining `n=9` vertex-circle self-edge local-template gap in the
+   aggregate local-lemma scan. The open packet families are `F05`, `F13`, and
+   `F15`, coming from the T03/T04 self-edge side.
+2. Review the aggregate `n=9` vertex-circle local-lemma scan against the
+   focused T10/T11/T12 strict-cycle proof notes, keeping it scoped as
+   proof-mining scaffolding rather than an `n=9` proof.
 3. Strengthen the minimal fragile-cover bridge with one geometric necessary
    condition and test it against the block-6 negative controls.
 4. Apply the bootstrap-core/private-halo weighted capacity checker to current

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -186,21 +186,113 @@ covered assignments: 18
 Again, the local core has no two-circle cap violation and no crossing-bisector
 order violation before the vertex-circle quotient step.
 
+## Lemma D: T11/F07 three-edge strict cycle
+
+The T11/F07 local core is:
+
+```text
+0 -> {1,2,4,8}
+1 -> {0,2,3,5}
+5 -> {0,3,4,7}
+6 -> {1,5,7,8}
+```
+
+At center `1`, the row order gives:
+
+```text
+D_02 > D_03,
+D_03 > D_05.
+```
+
+Row `5` identifies `D_05 = D_57`. At center `6`, the row order gives:
+
+```text
+D_57 > D_15.
+```
+
+Rows `1` and `0` identify:
+
+```text
+D_15 = D_01 = D_02.
+```
+
+Combining these gives the directed strict cycle
+
+```text
+D_02 > D_03 > D_57 > D_02.
+```
+
+The checker finds this exact strict-cycle local core in:
+
+```text
+family: F07
+covered assignments: 6
+```
+
+## Lemma E: T12/F16 three-edge strict cycle
+
+The T12/F16 local core is:
+
+```text
+0 -> {1,3,6,7}
+1 -> {2,4,7,8}
+2 -> {0,3,5,8}
+3 -> {0,1,4,6}
+4 -> {1,2,5,7}
+8 -> {0,2,5,6}
+```
+
+At centers `2`, `1`, and `0`, respectively, vertex-circle chord monotonicity
+gives:
+
+```text
+D_03 > D_08,
+D_28 > D_24,
+D_17 > D_13.
+```
+
+The selected-row quotient identifies:
+
+```text
+D_08 = D_28,
+D_24 = D_14 = D_17,
+D_13 = D_03.
+```
+
+Combining these gives the directed strict cycle
+
+```text
+D_03 > D_28 > D_17 > D_03.
+```
+
+The checker finds this exact strict-cycle local core in:
+
+```text
+family: F16
+covered assignments: 2
+```
+
 ## Scan summary
 
 The current local-lemma scan covers these review-pending template-packet
 families:
 
 ```text
-F01, F02, F03, F04, F06, F08, F09, F10, F11, F12, F14
+F01, F02, F03, F04, F06, F07, F08, F09, F10, F11, F12, F14, F16
 ```
 
 The de-duplicated assignment coverage is:
 
 ```text
-154 of the 184 n=9 pre-vertex-circle assignments
+162 of the 184 n=9 pre-vertex-circle assignments
+```
+
+The currently uncovered packet families are:
+
+```text
+F05, F13, F15
 ```
 
 This is useful proof-mining coverage, not an `n=9` completeness proof. The
-remaining local families still need proof-facing extraction, especially the
-T03/T04 self-edge packets and the T11/T12 strict-cycle packets.
+remaining local families still need proof-facing extraction; all remaining
+families come from the T03/T04 self-edge side of the stored packet scan.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -132,8 +132,8 @@ be irreflexive and acyclic.
 Next steps:
 
 - classify the 13 self-edge dihedral incidence families into local lemmas;
-- classify the 3 strict-cycle dihedral incidence families into directed
-  quotient-cycle templates;
+- review the 3 strict-cycle dihedral incidence families as directed
+  quotient-cycle local templates, using the focused T10/T11/T12 notes;
 - use `docs/n9-vertex-circle-local-cores.md` as the row-local certificate list
   to keep those lemmas small;
 - use `data/certificates/n9_vertex_circle_self_edge_path_join.json` as the
@@ -158,11 +158,11 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json` as
   the next focused review-pending T03 multi-family self-edge local lemma packet;
 - use `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
-  as the next focused review-pending T10/F12 strict-cycle local lemma packet;
+  to replay the focused review-pending T10/F12 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json`
-  as the next focused review-pending T11/F07 strict-cycle local lemma packet;
+  to replay the focused review-pending T11/F07 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`
-  as the next focused review-pending T12/F16 strict-cycle local lemma packet;
+  to replay the focused review-pending T12/F16 strict-cycle local lemma packet;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,164 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 660 - Strict-cycle Local-template Coverage Closure
+
+### Mathematical Subquestion
+
+The aggregate `n=9` vertex-circle local-lemma scan already covered the
+T10/F12 strict-cycle packet but left the focused T11/F07 and T12/F16
+strict-cycle proof packets outside the aggregate count. The precise question
+was:
+
+```text
+Can the aggregate local-lemma scan absorb the existing T11 and T12
+strict-cycle packets so that every stored strict-cycle local template is
+covered by a named review-pending local lemma?
+```
+
+### Definitions and Assumptions
+
+Use the stored review-pending `n=9` template packets:
+
+- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
+- `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+
+A **strict-cycle local-template instance** is a packet family whose selected
+rows force strict vertex-circle inequalities and whose selected-distance
+quotient identifies the inner pair of each strict edge with the next outer
+pair, producing a directed strict cycle. The aggregate scan is proof-mining
+scaffolding only: it treats the packet JSON as input data and does not
+enumerate all `n=9` selected-witness assignments.
+
+### Result Status
+
+Exact finite aggregation/refinement:
+**Strict-cycle Local-template Coverage Closure**.
+
+### Argument Or Obstruction
+
+The focused packet checkers already replay the two three-edge strict-cycle
+local lemmas:
+
+```text
+T11/F07: 6 assignments, 4 core rows, replay status strict_cycle
+T12/F16: 2 assignments, 6 core rows, replay status strict_cycle
+```
+
+The aggregate checker now maps strict-cycle template ids to three named local
+lemma ids:
+
+```text
+T10 -> t10_two_edge_strict_cycle
+T11 -> t11_three_edge_strict_cycle
+T12 -> t12_three_edge_strict_cycle
+```
+
+For T11/F07, the replayed local rows force:
+
+```text
+D_02 > D_03 > D_57 > D_02.
+```
+
+For T12/F16, the replayed local rows force:
+
+```text
+D_03 > D_28 > D_17 > D_03.
+```
+
+After adding T11 and T12 to the aggregate scan, the exact scan summary is:
+
+```text
+source families: 16
+source assignments: 184
+covered families: 13
+covered assignments: 162
+uncovered families: F05, F13, F15
+uncovered assignments: 22
+```
+
+Thus the stored strict-cycle side of the local-template packet scan is now
+fully represented in the aggregate local-lemma scan. The remaining aggregate
+gaps are all on the T03/T04 self-edge side.
+
+### Exact Scope
+
+This result is exact for the stored review-pending `n=9` vertex-circle
+template packets and their natural cyclic order. It is not an independent
+review of the exhaustive checker, not a proof of the full `n=9` finite case,
+not a general proof of Erdos Problem #97, and not a counterexample.
+
+### Files Changed
+
+- `src/erdos97/n9_vertex_circle_local_lemmas.py`
+- `scripts/check_n9_vertex_circle_local_lemmas.py`
+- `tests/test_n9_vertex_circle_local_lemmas.py`
+- `docs/n9-vertex-circle-local-lemmas.md`
+- `docs/codex-backlog.md`
+- `docs/review-priorities.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This closes the aggregate strict-cycle bookkeeping gap and leaves a sharper
+next target: the `22` uncovered review-pending assignments in `F05`, `F13`,
+and `F15`. The route toward a human-readable `n=9` bridge is now less vague:
+all strict-cycle packets are covered by local strict-cycle lemmas, while the
+remaining aggregate work is self-edge extraction.
+
+### Next Lead
+
+Attack `F05` and `F15` together because both come from T03 self-edge packets.
+The useful subquestion is whether their self-edge quotient paths share a
+single incidence lemma or whether one of them needs a distinct selected-row
+connector pattern.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-660`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-660`.
+- The branch was started from `origin/main` at commit
+  `04d871d0b29040c513f22aebaba4865643de820b`, after PR #392 merged Cycle
+  659.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`:
+  passed; recorded `162` covered assignments from `13` families and
+  uncovered `F05`, `F13`, `F15`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check
+  --assert-expected --json`: passed; T11/F07 has `6` assignments and replay
+  status `strict_cycle`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check
+  --assert-expected --json`: passed; T12/F16 has `2` assignments and replay
+  status `strict_cycle`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_n9_vertex_circle_local_lemmas.py -q`: passed, `8 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `570 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 659 - Full Context Cover Obstruction
 
 ### Mathematical Subquestion

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -53,8 +53,13 @@ def summary_lines(payload: dict[str, Any]) -> list[str]:
     lines = [
         f"schema: {payload['schema']}",
         f"status: {payload['status']}",
+        f"source families: {coverage['source_family_count']}",
+        f"source assignments: {coverage['source_assignment_count']}",
         f"covered families: {coverage['covered_family_count']}",
         f"covered assignments: {coverage['covered_assignment_count']}",
+        f"uncovered families: {coverage['uncovered_family_count']}",
+        f"uncovered assignments: {coverage['uncovered_assignment_count']}",
+        f"uncovered family ids: {','.join(coverage['uncovered_family_ids'])}",
     ]
     for lemma in payload["lemmas"]:
         lines.append(

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -30,7 +30,14 @@ CLAIM_SCOPE = (
 SHARED_ENDPOINT_LEMMA = "shared_endpoint_nested_self_edge"
 NESTED_SPOKE_LEMMA = "nested_spoke_quotient_self_edge"
 T10_STRICT_CYCLE_LEMMA = "t10_two_edge_strict_cycle"
+T11_STRICT_CYCLE_LEMMA = "t11_three_edge_strict_cycle"
+T12_STRICT_CYCLE_LEMMA = "t12_three_edge_strict_cycle"
 DIRECT_TWO_ROW_VARIANT = "nested_spoke_direct_two_row_special_case"
+STRICT_CYCLE_LEMMA_BY_TEMPLATE = {
+    "T10": T10_STRICT_CYCLE_LEMMA,
+    "T11": T11_STRICT_CYCLE_LEMMA,
+    "T12": T12_STRICT_CYCLE_LEMMA,
+}
 
 EXPECTED_SUMMARY = {
     SHARED_ENDPOINT_LEMMA: {
@@ -47,6 +54,16 @@ EXPECTED_SUMMARY = {
         "family_ids": ["F12"],
         "instance_count": 1,
         "covered_assignment_count": 18,
+    },
+    T11_STRICT_CYCLE_LEMMA: {
+        "family_ids": ["F07"],
+        "instance_count": 1,
+        "covered_assignment_count": 6,
+    },
+    T12_STRICT_CYCLE_LEMMA: {
+        "family_ids": ["F16"],
+        "instance_count": 1,
+        "covered_assignment_count": 2,
     },
 }
 EXPECTED_DIRECT_TWO_ROW_INSTANCE_COUNT = 0
@@ -107,16 +124,27 @@ def local_lemma_scan_payload(
                         }
                     )
 
-    t10_instances = [
-        _strict_cycle_instance(template, family, order)
-        for template, family in _strict_cycle_family_records(strict_cycle_packet)
-        if template.get("template_id") == "T10"
-    ]
+    strict_cycle_instances: dict[str, list[dict[str, Any]]] = {
+        lemma_id: [] for lemma_id in STRICT_CYCLE_LEMMA_BY_TEMPLATE.values()
+    }
+    for template, family in _strict_cycle_family_records(strict_cycle_packet):
+        template_id = str(template.get("template_id"))
+        lemma_id = STRICT_CYCLE_LEMMA_BY_TEMPLATE.get(template_id)
+        if lemma_id is None:
+            continue
+        strict_cycle_instances[lemma_id].append(
+            _strict_cycle_instance(template, family, order, lemma_id)
+        )
+
+    source_family_assignments = _source_family_assignments(
+        self_edge_packet,
+        strict_cycle_packet,
+    )
 
     lemma_instances = {
         SHARED_ENDPOINT_LEMMA: shared_endpoint,
         NESTED_SPOKE_LEMMA: nested_spoke,
-        T10_STRICT_CYCLE_LEMMA: t10_instances,
+        **strict_cycle_instances,
     }
 
     return {
@@ -141,7 +169,10 @@ def local_lemma_scan_payload(
         "lemmas": [
             _lemma_summary(SHARED_ENDPOINT_LEMMA, shared_endpoint),
             _lemma_summary(NESTED_SPOKE_LEMMA, nested_spoke),
-            _lemma_summary(T10_STRICT_CYCLE_LEMMA, t10_instances),
+            *(
+                _lemma_summary(lemma_id, strict_cycle_instances[lemma_id])
+                for lemma_id in STRICT_CYCLE_LEMMA_BY_TEMPLATE.values()
+            ),
         ],
         "direct_two_row_nested_spoke_special_case": {
             "lemma_id": DIRECT_TWO_ROW_VARIANT,
@@ -155,7 +186,10 @@ def local_lemma_scan_payload(
             "instance_count": len(direct_two_row),
             "instances": direct_two_row,
         },
-        "coverage_summary": _coverage_summary(lemma_instances),
+        "coverage_summary": _coverage_summary(
+            lemma_instances,
+            source_family_assignments,
+        ),
         "interpretation": (
             "The listed local shapes are reusable obstruction candidates: each "
             "one produces either a reflexive strict edge or a directed strict "
@@ -164,6 +198,28 @@ def local_lemma_scan_payload(
             "selected-witness assignments."
         ),
     }
+
+
+def _source_family_assignments(
+    self_edge_packet: dict[str, Any],
+    strict_cycle_packet: dict[str, Any],
+) -> dict[str, int]:
+    """Return source packet family assignment counts keyed by family id."""
+
+    assignments: dict[str, int] = {}
+    for _template, family in (
+        *_self_edge_family_records(self_edge_packet),
+        *_strict_cycle_family_records(strict_cycle_packet),
+    ):
+        family_id = str(family["family_id"])
+        assignment_count = int(family["assignment_count"])
+        previous = assignments.setdefault(family_id, assignment_count)
+        if previous != assignment_count:
+            raise ValueError(
+                f"inconsistent assignment count for family {family_id}: "
+                f"{previous} != {assignment_count}"
+            )
+    return assignments
 
 
 def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
@@ -212,22 +268,34 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
     coverage = payload.get("coverage_summary")
     if not isinstance(coverage, dict):
         raise AssertionError("coverage_summary must be an object")
-    if coverage.get("covered_family_count") != 11:
+    if coverage.get("source_family_count") != 16:
+        raise AssertionError("source_family_count mismatch")
+    if coverage.get("source_assignment_count") != 184:
+        raise AssertionError("source_assignment_count mismatch")
+    if coverage.get("covered_family_count") != 13:
         raise AssertionError("covered_family_count mismatch")
-    if coverage.get("covered_assignment_count") != 154:
+    if coverage.get("covered_assignment_count") != 162:
         raise AssertionError("covered_assignment_count mismatch")
+    if coverage.get("uncovered_family_count") != 3:
+        raise AssertionError("uncovered_family_count mismatch")
+    if coverage.get("uncovered_assignment_count") != 22:
+        raise AssertionError("uncovered_assignment_count mismatch")
+    if coverage.get("uncovered_family_ids") != ["F05", "F13", "F15"]:
+        raise AssertionError("uncovered_family_ids mismatch")
     if coverage.get("covered_family_ids") != [
         "F01",
         "F02",
         "F03",
         "F04",
         "F06",
+        "F07",
         "F08",
         "F09",
         "F10",
         "F11",
         "F12",
         "F14",
+        "F16",
     ]:
         raise AssertionError("covered_family_ids mismatch")
 
@@ -392,11 +460,12 @@ def _strict_cycle_instance(
     template: dict[str, Any],
     family: dict[str, Any],
     order: Sequence[int],
+    lemma_id: str,
 ) -> dict[str, Any]:
     rows = parse_selected_rows(family["core_selected_rows"])
     replay = replay_vertex_circle_quotient(int(template.get("n", 9)), order, rows)
     return {
-        "lemma_id": T10_STRICT_CYCLE_LEMMA,
+        "lemma_id": lemma_id,
         "template_id": str(template["template_id"]),
         "template_key": str(template["template_key"]),
         "family_id": str(family["family_id"]),
@@ -431,6 +500,7 @@ def _lemma_summary(lemma_id: str, instances: Sequence[dict[str, Any]]) -> dict[s
 
 def _coverage_summary(
     lemma_instances: dict[str, Sequence[dict[str, Any]]],
+    source_family_assignments: dict[str, int],
 ) -> dict[str, Any]:
     family_to_assignments: dict[str, int] = {}
     family_to_lemmas: dict[str, list[str]] = defaultdict(list)
@@ -440,10 +510,20 @@ def _coverage_summary(
             family_to_assignments[family_id] = int(instance["assignment_count"])
             if lemma_id not in family_to_lemmas[family_id]:
                 family_to_lemmas[family_id].append(lemma_id)
+    uncovered_family_ids = sorted(
+        set(source_family_assignments) - set(family_to_assignments)
+    )
     return {
+        "source_family_count": len(source_family_assignments),
+        "source_assignment_count": sum(source_family_assignments.values()),
         "covered_family_count": len(family_to_assignments),
         "covered_family_ids": sorted(family_to_assignments),
         "covered_assignment_count": sum(family_to_assignments.values()),
+        "uncovered_family_count": len(uncovered_family_ids),
+        "uncovered_family_ids": uncovered_family_ids,
+        "uncovered_assignment_count": sum(
+            source_family_assignments[family_id] for family_id in uncovered_family_ids
+        ),
         "family_to_lemmas": {
             family_id: sorted(lemmas)
             for family_id, lemmas in sorted(family_to_lemmas.items())

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -11,6 +11,8 @@ from erdos97.n9_vertex_circle_local_lemmas import (
     NESTED_SPOKE_LEMMA,
     SHARED_ENDPOINT_LEMMA,
     T10_STRICT_CYCLE_LEMMA,
+    T11_STRICT_CYCLE_LEMMA,
+    T12_STRICT_CYCLE_LEMMA,
     assert_expected_local_lemma_scan,
 )
 from scripts.check_n9_vertex_circle_local_lemmas import (
@@ -42,33 +44,42 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
     assert "not a counterexample" in payload["claim_scope"]  # type: ignore[operator]
     assert "not a global status update" in payload["claim_scope"]  # type: ignore[operator]
     assert payload["coverage_summary"] == {  # type: ignore[index]
-        "covered_assignment_count": 154,
-        "covered_family_count": 11,
+        "source_assignment_count": 184,
+        "source_family_count": 16,
+        "covered_assignment_count": 162,
+        "covered_family_count": 13,
         "covered_family_ids": [
             "F01",
             "F02",
             "F03",
             "F04",
             "F06",
+            "F07",
             "F08",
             "F09",
             "F10",
             "F11",
             "F12",
             "F14",
+            "F16",
         ],
+        "uncovered_assignment_count": 22,
+        "uncovered_family_count": 3,
+        "uncovered_family_ids": ["F05", "F13", "F15"],
         "family_to_lemmas": {
             "F01": [SHARED_ENDPOINT_LEMMA],
             "F02": [NESTED_SPOKE_LEMMA],
             "F03": [NESTED_SPOKE_LEMMA],
             "F04": [SHARED_ENDPOINT_LEMMA],
             "F06": [NESTED_SPOKE_LEMMA],
+            "F07": [T11_STRICT_CYCLE_LEMMA],
             "F08": [SHARED_ENDPOINT_LEMMA],
             "F09": [NESTED_SPOKE_LEMMA],
             "F10": [NESTED_SPOKE_LEMMA],
             "F11": [NESTED_SPOKE_LEMMA],
             "F12": [T10_STRICT_CYCLE_LEMMA],
             "F14": [SHARED_ENDPOINT_LEMMA],
+            "F16": [T12_STRICT_CYCLE_LEMMA],
         },
     }
 
@@ -133,9 +144,67 @@ def test_t10_strict_cycle_instance(payload: dict[str, object]) -> None:
     assert [edge["inner_pair"] for edge in instance["cycle_edges"]] == [[0, 3], [0, 1]]
 
 
+def test_t11_strict_cycle_instance(payload: dict[str, object]) -> None:
+    lemma = _lemma(payload, T11_STRICT_CYCLE_LEMMA)
+
+    assert lemma["instance_count"] == 1
+    assert lemma["covered_assignment_count"] == 6
+    assert lemma["family_ids"] == ["F07"]
+    assert lemma["template_ids"] == ["T11"]
+    instance = lemma["instances"][0]  # type: ignore[index]
+    assert instance["replay_status"] == "strict_cycle"
+    assert instance["simple_filter_violations"] == []
+    assert instance["core_selected_rows"] == [
+        [0, 1, 2, 4, 8],
+        [1, 0, 2, 3, 5],
+        [5, 0, 3, 4, 7],
+        [6, 1, 5, 7, 8],
+    ]
+    assert [edge["outer_pair"] for edge in instance["cycle_edges"]] == [
+        [0, 2],
+        [0, 3],
+        [5, 7],
+    ]
+    assert [edge["inner_pair"] for edge in instance["cycle_edges"]] == [
+        [0, 3],
+        [0, 5],
+        [1, 5],
+    ]
+
+
+def test_t12_strict_cycle_instance(payload: dict[str, object]) -> None:
+    lemma = _lemma(payload, T12_STRICT_CYCLE_LEMMA)
+
+    assert lemma["instance_count"] == 1
+    assert lemma["covered_assignment_count"] == 2
+    assert lemma["family_ids"] == ["F16"]
+    assert lemma["template_ids"] == ["T12"]
+    instance = lemma["instances"][0]  # type: ignore[index]
+    assert instance["replay_status"] == "strict_cycle"
+    assert instance["simple_filter_violations"] == []
+    assert instance["core_selected_rows"] == [
+        [0, 1, 3, 6, 7],
+        [1, 2, 4, 7, 8],
+        [2, 0, 3, 5, 8],
+        [3, 0, 1, 4, 6],
+        [4, 1, 2, 5, 7],
+        [8, 0, 2, 5, 6],
+    ]
+    assert [edge["outer_pair"] for edge in instance["cycle_edges"]] == [
+        [0, 3],
+        [2, 8],
+        [1, 7],
+    ]
+    assert [edge["inner_pair"] for edge in instance["cycle_edges"]] == [
+        [0, 8],
+        [2, 4],
+        [1, 3],
+    ]
+
+
 def test_assert_expected_rejects_count_drift(payload: dict[str, object]) -> None:
     tampered = json.loads(json.dumps(payload))
-    tampered["coverage_summary"]["covered_assignment_count"] = 153
+    tampered["coverage_summary"]["covered_assignment_count"] = 161
 
     with pytest.raises(AssertionError, match="covered_assignment_count mismatch"):
         assert_expected_local_lemma_scan(tampered)
@@ -161,4 +230,5 @@ def test_local_lemma_scan_cli_json() -> None:
 
     parsed = json.loads(result.stdout)
     assert parsed["schema"] == "erdos97.n9_vertex_circle_local_lemmas.v1"
-    assert parsed["coverage_summary"]["covered_assignment_count"] == 154
+    assert parsed["coverage_summary"]["covered_assignment_count"] == 162
+    assert parsed["coverage_summary"]["uncovered_family_ids"] == ["F05", "F13", "F15"]


### PR DESCRIPTION
## Mathematical scope

Cycle 660 integrates the existing T11/F07 and T12/F16 focused strict-cycle local-lemma packets into the aggregate `n=9` vertex-circle local-lemma scan.

This is proof-mining scaffolding only. It does not claim a proof of the full `n=9` finite case, does not claim a proof of Erdos Problem #97, and does not claim a counterexample.

## What changed

- Adds named aggregate scan entries for:
  - `t11_three_edge_strict_cycle` covering T11/F07, 6 assignments.
  - `t12_three_edge_strict_cycle` covering T12/F16, 2 assignments.
- Extends the aggregate coverage summary to report source and uncovered family/assignment counts.
- Updates tests to assert T11/T12 strict-cycle rows and cycle edges.
- Updates the local-lemma note, backlog, review priorities, and running research log.

## Exact result

The aggregate scan now reports:

```text
source families: 16
source assignments: 184
covered families: 13
covered assignments: 162
uncovered families: F05, F13, F15
uncovered assignments: 22
```

The remaining aggregate gaps are on the T03/T04 self-edge side.

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_n9_vertex_circle_local_lemmas.py -q` (`8 passed`)
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`570 passed, 278 deselected`)

## Remaining limitations

- The aggregate scan treats stored review-pending packet JSON as input data.
- This is not an independent review of the exhaustive `n=9` checker.
- It does not enumerate all `n=9` selected-witness systems.
- The overarching proof/counterexample objective remains open.