### PR TITLE
[codex] Add T03 to n9 local scan

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -17,9 +17,9 @@ that justifies doing it anyway.
 
 Use this queue when no more specific issue is selected.
 
-1. Close one remaining `n=9` vertex-circle self-edge local-template gap in the
-   aggregate local-lemma scan. The open packet families are `F05`, `F13`, and
-   `F15`, coming from the T03/T04 self-edge side.
+1. Close the remaining `n=9` vertex-circle self-edge local-template gap in the
+   aggregate local-lemma scan. The open packet family is `F13`, coming from
+   the T04 self-edge side.
 2. Review the aggregate `n=9` vertex-circle local-lemma scan against the
    focused T10/T11/T12 strict-cycle proof notes, keeping it scoped as
    proof-mining scaffolding rather than an `n=9` proof.

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -135,7 +135,61 @@ strict-edge instances: 8
 Those instances use longer selected-distance quotient paths rather than the
 two-row shortcut.
 
-## Lemma C: T10/F12 two-edge strict cycle
+## Lemma C: T03 selected-path self-edge
+
+The T03 packet has two four-row local cores. For `F05`, the rows are:
+
+```text
+1 -> {2,5,7,8}
+2 -> {1,3,4,8}
+3 -> {0,2,4,7}
+6 -> {1,3,5,7}
+```
+
+The selected-distance path gives:
+
+```text
+D_37 = D_23 = D_12 = D_17.
+```
+
+At center `6`, the witness order `7,1,3,5` gives:
+
+```text
+D_37 > D_17.
+```
+
+Thus the quotient has a reflexive strict edge.
+
+For `F15`, the rows are:
+
+```text
+0 -> {1,3,4,8}
+1 -> {0,2,4,5}
+2 -> {1,3,5,6}
+3 -> {2,4,6,7}
+```
+
+The selected-distance path gives:
+
+```text
+D_14 = D_12 = D_23 = D_34.
+```
+
+At center `0`, the witness order `1,3,4,8` gives:
+
+```text
+D_14 > D_34.
+```
+
+Again the quotient has a reflexive strict edge. The checker finds this exact
+selected-path self-edge pattern in:
+
+```text
+families: F05, F15
+covered assignments: 20
+```
+
+## Lemma D: T10/F12 two-edge strict cycle
 
 The T10/F12 local core is:
 
@@ -186,7 +240,7 @@ covered assignments: 18
 Again, the local core has no two-circle cap violation and no crossing-bisector
 order violation before the vertex-circle quotient step.
 
-## Lemma D: T11/F07 three-edge strict cycle
+## Lemma E: T11/F07 three-edge strict cycle
 
 The T11/F07 local core is:
 
@@ -229,7 +283,7 @@ family: F07
 covered assignments: 6
 ```
 
-## Lemma E: T12/F16 three-edge strict cycle
+## Lemma F: T12/F16 three-edge strict cycle
 
 The T12/F16 local core is:
 
@@ -278,21 +332,21 @@ The current local-lemma scan covers these review-pending template-packet
 families:
 
 ```text
-F01, F02, F03, F04, F06, F07, F08, F09, F10, F11, F12, F14, F16
+F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F14, F15, F16
 ```
 
 The de-duplicated assignment coverage is:
 
 ```text
-162 of the 184 n=9 pre-vertex-circle assignments
+182 of the 184 n=9 pre-vertex-circle assignments
 ```
 
 The currently uncovered packet families are:
 
 ```text
-F05, F13, F15
+F13
 ```
 
 This is useful proof-mining coverage, not an `n=9` completeness proof. The
-remaining local families still need proof-facing extraction; all remaining
-families come from the T03/T04 self-edge side of the stored packet scan.
+remaining local family still needs proof-facing extraction from the T04
+self-edge side of the stored packet scan.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -155,8 +155,9 @@ Next steps:
   the first focused review-pending T01/F09 self-edge local lemma packet;
 - use `data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json` as
   the next focused review-pending T02 multi-family self-edge local lemma packet;
-- use `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json` as
-  the next focused review-pending T03 multi-family self-edge local lemma packet;
+- use `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json` to
+  replay the focused review-pending T03 multi-family self-edge local lemma
+  packet;
 - use `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T10/F12 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json`

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,160 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 661 - T03 Selected-path Self-edge Scan Closure
+
+### Mathematical Subquestion
+
+Cycle 660 left three aggregate local-lemma scan gaps: `F05`, `F13`, and
+`F15`. The earlier focused T03 packet already records local self-edge proof
+notes for `F05` and `F15`, so the narrow question was:
+
+```text
+Can the aggregate local-lemma scan absorb the existing T03/F05 and T03/F15
+selected-path self-edge packet without changing the review-pending scope?
+```
+
+### Definitions and Assumptions
+
+Use the stored review-pending `n=9` self-edge template packet
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json`. A
+**selected-path self-edge** is a local core with:
+
+- a vertex-circle strict edge `p > q`; and
+- a selected-distance equality path identifying `p` and `q`.
+
+The equality path gives `D(p) = D(q)`, while the strict edge gives
+`D(p) > D(q)`, so the selected-distance quotient has a reflexive strict edge.
+This is a local contradiction only after the packet has already certified both
+the path and the strict edge.
+
+### Result Status
+
+Exact finite aggregation/refinement:
+**T03 Selected-path Self-edge Scan Closure**.
+
+### Argument Or Obstruction
+
+The focused T03 packet covers two families:
+
+```text
+T03/F05: 18 assignments
+T03/F15: 2 assignments
+```
+
+For `F05`, the selected rows force:
+
+```text
+D_37 = D_23 = D_12 = D_17,
+```
+
+and row `6` with witness order `7,1,3,5` forces:
+
+```text
+D_37 > D_17.
+```
+
+For `F15`, the selected rows force:
+
+```text
+D_14 = D_12 = D_23 = D_34,
+```
+
+and row `0` with witness order `1,3,4,8` forces:
+
+```text
+D_14 > D_34.
+```
+
+The aggregate scan now adds the named local-lemma id
+`t03_selected_path_self_edge` for these two families. The exact aggregate
+summary becomes:
+
+```text
+source families: 16
+source assignments: 184
+covered families: 15
+covered assignments: 182
+uncovered families: F13
+uncovered assignments: 2
+```
+
+### Exact Scope
+
+This result is exact for the stored review-pending T03 packet and the natural
+cyclic order of the stored `n=9` template scan. It is not an independent
+review of the exhaustive checker, not a proof of the full `n=9` finite case,
+not a general proof of Erdos Problem #97, and not a counterexample.
+
+### Files Changed
+
+- `src/erdos97/n9_vertex_circle_local_lemmas.py`
+- `tests/test_n9_vertex_circle_local_lemmas.py`
+- `docs/n9-vertex-circle-local-lemmas.md`
+- `docs/codex-backlog.md`
+- `docs/review-priorities.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This resolves whether `F05` and `F15` were genuinely missing or just missing
+from the aggregate scan: they were a bookkeeping/integration gap, since their
+focused packet and proof note already provided the local contradiction. The
+aggregate `n=9` local-lemma bridge is now one family away from covering all
+stored template-packet families.
+
+### Next Lead
+
+Attack `F13`, the last uncovered aggregate family. It comes from the T04
+self-edge packet and has only `2` assignments, so the next useful subquestion
+is whether its focused T04 proof note can be represented by the same
+selected-path self-edge criterion or needs its own named aggregate lemma id.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-661`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-661`.
+- The branch was started from `origin/main` at commit
+  `4346a4155c923ae05a038d5c81c37e42b1af9737`, after PR #394 merged Cycle
+  660.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`:
+  passed; recorded `182` covered assignments from `15` families and uncovered
+  `F13`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check
+  --assert-expected --json`: passed; T03/F05 and T03/F15 have `20` total
+  assignments and replay status `self_edge`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_n9_vertex_circle_local_lemmas.py -q`: passed, `9 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check
+  src/erdos97/n9_vertex_circle_local_lemmas.py
+  tests/test_n9_vertex_circle_local_lemmas.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `571 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 660 - Strict-cycle Local-template Coverage Closure
 
 ### Mathematical Subquestion

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -29,6 +29,7 @@ CLAIM_SCOPE = (
 
 SHARED_ENDPOINT_LEMMA = "shared_endpoint_nested_self_edge"
 NESTED_SPOKE_LEMMA = "nested_spoke_quotient_self_edge"
+T03_SELECTED_PATH_SELF_EDGE = "t03_selected_path_self_edge"
 T10_STRICT_CYCLE_LEMMA = "t10_two_edge_strict_cycle"
 T11_STRICT_CYCLE_LEMMA = "t11_three_edge_strict_cycle"
 T12_STRICT_CYCLE_LEMMA = "t12_three_edge_strict_cycle"
@@ -49,6 +50,11 @@ EXPECTED_SUMMARY = {
         "family_ids": ["F02", "F03", "F06", "F09", "F10", "F11"],
         "instance_count": 8,
         "covered_assignment_count": 96,
+    },
+    T03_SELECTED_PATH_SELF_EDGE: {
+        "family_ids": ["F05", "F15"],
+        "instance_count": 2,
+        "covered_assignment_count": 20,
     },
     T10_STRICT_CYCLE_LEMMA: {
         "family_ids": ["F12"],
@@ -85,6 +91,7 @@ def local_lemma_scan_payload(
 
     shared_endpoint: list[dict[str, Any]] = []
     nested_spoke: list[dict[str, Any]] = []
+    t03_selected_path: list[dict[str, Any]] = []
     direct_two_row: list[dict[str, Any]] = []
 
     for template, family in _self_edge_family_records(self_edge_packet):
@@ -123,6 +130,18 @@ def local_lemma_scan_payload(
                             "lemma_id": DIRECT_TWO_ROW_VARIANT,
                         }
                     )
+            if _is_t03_selected_path_self_edge_shape(template, family, edge):
+                t03_selected_path.append(
+                    _self_edge_instance(
+                        lemma_id=T03_SELECTED_PATH_SELF_EDGE,
+                        template=template,
+                        family=family,
+                        rows=rows,
+                        order=order,
+                        edge=edge,
+                        direct_conditions=_selected_path_conditions(family),
+                    )
+                )
 
     strict_cycle_instances: dict[str, list[dict[str, Any]]] = {
         lemma_id: [] for lemma_id in STRICT_CYCLE_LEMMA_BY_TEMPLATE.values()
@@ -144,6 +163,7 @@ def local_lemma_scan_payload(
     lemma_instances = {
         SHARED_ENDPOINT_LEMMA: shared_endpoint,
         NESTED_SPOKE_LEMMA: nested_spoke,
+        T03_SELECTED_PATH_SELF_EDGE: t03_selected_path,
         **strict_cycle_instances,
     }
 
@@ -169,6 +189,7 @@ def local_lemma_scan_payload(
         "lemmas": [
             _lemma_summary(SHARED_ENDPOINT_LEMMA, shared_endpoint),
             _lemma_summary(NESTED_SPOKE_LEMMA, nested_spoke),
+            _lemma_summary(T03_SELECTED_PATH_SELF_EDGE, t03_selected_path),
             *(
                 _lemma_summary(lemma_id, strict_cycle_instances[lemma_id])
                 for lemma_id in STRICT_CYCLE_LEMMA_BY_TEMPLATE.values()
@@ -272,21 +293,22 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         raise AssertionError("source_family_count mismatch")
     if coverage.get("source_assignment_count") != 184:
         raise AssertionError("source_assignment_count mismatch")
-    if coverage.get("covered_family_count") != 13:
+    if coverage.get("covered_family_count") != 15:
         raise AssertionError("covered_family_count mismatch")
-    if coverage.get("covered_assignment_count") != 162:
+    if coverage.get("covered_assignment_count") != 182:
         raise AssertionError("covered_assignment_count mismatch")
-    if coverage.get("uncovered_family_count") != 3:
+    if coverage.get("uncovered_family_count") != 1:
         raise AssertionError("uncovered_family_count mismatch")
-    if coverage.get("uncovered_assignment_count") != 22:
+    if coverage.get("uncovered_assignment_count") != 2:
         raise AssertionError("uncovered_assignment_count mismatch")
-    if coverage.get("uncovered_family_ids") != ["F05", "F13", "F15"]:
+    if coverage.get("uncovered_family_ids") != ["F13"]:
         raise AssertionError("uncovered_family_ids mismatch")
     if coverage.get("covered_family_ids") != [
         "F01",
         "F02",
         "F03",
         "F04",
+        "F05",
         "F06",
         "F07",
         "F08",
@@ -295,6 +317,7 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         "F11",
         "F12",
         "F14",
+        "F15",
         "F16",
     ]:
         raise AssertionError("covered_family_ids mismatch")
@@ -432,6 +455,43 @@ def _direct_nested_spoke_conditions(
     }
 
 
+def _is_t03_selected_path_self_edge_shape(
+    template: dict[str, Any],
+    family: dict[str, Any],
+    edge: StrictInequality,
+) -> bool:
+    """Return whether the record is one of the checked T03 self-edge paths."""
+
+    if str(template.get("template_id")) != "T03":
+        return False
+    equality = family.get("distance_equality")
+    if not isinstance(equality, dict):
+        return False
+    return (
+        edge.outer_class == edge.inner_class
+        and _pair_list(edge.outer_pair) == _pair_list(equality.get("start_pair"))
+        and _pair_list(edge.inner_pair) == _pair_list(equality.get("end_pair"))
+    )
+
+
+def _selected_path_conditions(family: dict[str, Any]) -> dict[str, Any]:
+    equality = family["distance_equality"]
+    return {
+        "variant": "selected_path_self_edge",
+        "start_pair": _pair_list(equality["start_pair"]),
+        "end_pair": _pair_list(equality["end_pair"]),
+        "path": [
+            {
+                "row": int(step["row"]),
+                "next_pair": _pair_list(step["next_pair"]),
+            }
+            for step in equality["path"]
+        ],
+        "path_length": int(family["path_length"]),
+        "holds": True,
+    }
+
+
 def _self_edge_instance(
     *,
     lemma_id: str,
@@ -546,6 +606,15 @@ def _edge_to_json(edge: StrictInequality) -> dict[str, Any]:
         "outer_class": list(edge.outer_class),
         "inner_class": list(edge.inner_class),
     }
+
+
+def _pair_list(raw_pair: Any) -> list[int]:
+    if not isinstance(raw_pair, Sequence) or isinstance(raw_pair, str):
+        raise ValueError(f"expected pair sequence, got {raw_pair!r}")
+    values = [int(value) for value in raw_pair]
+    if len(values) != 2:
+        raise ValueError(f"expected pair length 2, got {raw_pair!r}")
+    return sorted(values)
 
 
 def _simple_filter_violations(

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -10,6 +10,7 @@ import pytest
 from erdos97.n9_vertex_circle_local_lemmas import (
     NESTED_SPOKE_LEMMA,
     SHARED_ENDPOINT_LEMMA,
+    T03_SELECTED_PATH_SELF_EDGE,
     T10_STRICT_CYCLE_LEMMA,
     T11_STRICT_CYCLE_LEMMA,
     T12_STRICT_CYCLE_LEMMA,
@@ -46,13 +47,14 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
     assert payload["coverage_summary"] == {  # type: ignore[index]
         "source_assignment_count": 184,
         "source_family_count": 16,
-        "covered_assignment_count": 162,
-        "covered_family_count": 13,
+        "covered_assignment_count": 182,
+        "covered_family_count": 15,
         "covered_family_ids": [
             "F01",
             "F02",
             "F03",
             "F04",
+            "F05",
             "F06",
             "F07",
             "F08",
@@ -61,16 +63,18 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
             "F11",
             "F12",
             "F14",
+            "F15",
             "F16",
         ],
-        "uncovered_assignment_count": 22,
-        "uncovered_family_count": 3,
-        "uncovered_family_ids": ["F05", "F13", "F15"],
+        "uncovered_assignment_count": 2,
+        "uncovered_family_count": 1,
+        "uncovered_family_ids": ["F13"],
         "family_to_lemmas": {
             "F01": [SHARED_ENDPOINT_LEMMA],
             "F02": [NESTED_SPOKE_LEMMA],
             "F03": [NESTED_SPOKE_LEMMA],
             "F04": [SHARED_ENDPOINT_LEMMA],
+            "F05": [T03_SELECTED_PATH_SELF_EDGE],
             "F06": [NESTED_SPOKE_LEMMA],
             "F07": [T11_STRICT_CYCLE_LEMMA],
             "F08": [SHARED_ENDPOINT_LEMMA],
@@ -79,6 +83,7 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
             "F11": [NESTED_SPOKE_LEMMA],
             "F12": [T10_STRICT_CYCLE_LEMMA],
             "F14": [SHARED_ENDPOINT_LEMMA],
+            "F15": [T03_SELECTED_PATH_SELF_EDGE],
             "F16": [T12_STRICT_CYCLE_LEMMA],
         },
     }
@@ -144,6 +149,66 @@ def test_t10_strict_cycle_instance(payload: dict[str, object]) -> None:
     assert [edge["inner_pair"] for edge in instance["cycle_edges"]] == [[0, 3], [0, 1]]
 
 
+def test_t03_selected_path_self_edge_instances(payload: dict[str, object]) -> None:
+    lemma = _lemma(payload, T03_SELECTED_PATH_SELF_EDGE)
+
+    assert lemma["instance_count"] == 2
+    assert lemma["covered_assignment_count"] == 20
+    assert lemma["family_ids"] == ["F05", "F15"]
+    assert lemma["template_ids"] == ["T03"]
+    instances = {instance["family_id"]: instance for instance in lemma["instances"]}  # type: ignore[index]
+
+    f05 = instances["F05"]
+    assert f05["assignment_count"] == 18
+    assert f05["simple_filter_violations"] == []
+    assert f05["core_selected_rows"] == [
+        [1, 2, 5, 7, 8],
+        [2, 1, 3, 4, 8],
+        [3, 0, 2, 4, 7],
+        [6, 1, 3, 5, 7],
+    ]
+    assert f05["strict_inequality"]["row"] == 6
+    assert f05["strict_inequality"]["outer_pair"] == [3, 7]
+    assert f05["strict_inequality"]["inner_pair"] == [1, 7]
+    assert f05["direct_conditions"] == {
+        "variant": "selected_path_self_edge",
+        "start_pair": [3, 7],
+        "end_pair": [1, 7],
+        "path": [
+            {"row": 3, "next_pair": [2, 3]},
+            {"row": 2, "next_pair": [1, 2]},
+            {"row": 1, "next_pair": [1, 7]},
+        ],
+        "path_length": 3,
+        "holds": True,
+    }
+
+    f15 = instances["F15"]
+    assert f15["assignment_count"] == 2
+    assert f15["simple_filter_violations"] == []
+    assert f15["core_selected_rows"] == [
+        [0, 1, 3, 4, 8],
+        [1, 0, 2, 4, 5],
+        [2, 1, 3, 5, 6],
+        [3, 2, 4, 6, 7],
+    ]
+    assert f15["strict_inequality"]["row"] == 0
+    assert f15["strict_inequality"]["outer_pair"] == [1, 4]
+    assert f15["strict_inequality"]["inner_pair"] == [3, 4]
+    assert f15["direct_conditions"] == {
+        "variant": "selected_path_self_edge",
+        "start_pair": [1, 4],
+        "end_pair": [3, 4],
+        "path": [
+            {"row": 1, "next_pair": [1, 2]},
+            {"row": 2, "next_pair": [2, 3]},
+            {"row": 3, "next_pair": [3, 4]},
+        ],
+        "path_length": 3,
+        "holds": True,
+    }
+
+
 def test_t11_strict_cycle_instance(payload: dict[str, object]) -> None:
     lemma = _lemma(payload, T11_STRICT_CYCLE_LEMMA)
 
@@ -204,7 +269,7 @@ def test_t12_strict_cycle_instance(payload: dict[str, object]) -> None:
 
 def test_assert_expected_rejects_count_drift(payload: dict[str, object]) -> None:
     tampered = json.loads(json.dumps(payload))
-    tampered["coverage_summary"]["covered_assignment_count"] = 161
+    tampered["coverage_summary"]["covered_assignment_count"] = 181
 
     with pytest.raises(AssertionError, match="covered_assignment_count mismatch"):
         assert_expected_local_lemma_scan(tampered)
@@ -230,5 +295,5 @@ def test_local_lemma_scan_cli_json() -> None:
 
     parsed = json.loads(result.stdout)
     assert parsed["schema"] == "erdos97.n9_vertex_circle_local_lemmas.v1"
-    assert parsed["coverage_summary"]["covered_assignment_count"] == 162
-    assert parsed["coverage_summary"]["uncovered_family_ids"] == ["F05", "F13", "F15"]
+    assert parsed["coverage_summary"]["covered_assignment_count"] == 182
+    assert parsed["coverage_summary"]["uncovered_family_ids"] == ["F13"]


### PR DESCRIPTION
## Mathematical scope

Cycle 661 integrates the existing T03/F05 and T03/F15 selected-path self-edge packet into the aggregate `n=9` vertex-circle local-lemma scan.

This is proof-mining scaffolding only. It does not claim a proof of the full `n=9` finite case, does not claim a proof of Erdos Problem #97, and does not claim a counterexample.

## What changed

- Adds `t03_selected_path_self_edge` to the aggregate scan.
- Counts T03/F05 and T03/F15 as selected-path self-edge local instances.
- Updates tests to assert the exact selected rows, strict edges, and equality paths.
- Updates the local-lemma note, backlog, review priorities, and running research log.

## Exact result

The aggregate scan now reports:

```text
source families: 16
source assignments: 184
covered families: 15
covered assignments: 182
uncovered families: F13
uncovered assignments: 2
```

The remaining aggregate gap is the T04/F13 self-edge side.

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_n9_vertex_circle_local_lemmas.py -q` (`9 passed`)
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`571 passed, 278 deselected`)

## Remaining limitations

- The aggregate scan treats stored review-pending packet JSON as input data.
- This is not an independent review of the exhaustive `n=9` checker.
- It does not enumerate all `n=9` selected-witness systems.
- The overarching proof/counterexample objective remains open.