### PR TITLE
[codex] Extract T12 strict-cycle lemma candidate

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -534,6 +534,41 @@ promotion of the review-pending exhaustive checker, and not a proof of Erdos
 Problem #97. Check the focused packet with
 `python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`.
 
+### Vertex-circle T12/F16 strict-cycle local lemma candidate
+
+Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
+
+In a strictly convex nonagon with cyclic order `0,1,2,3,4,5,6,7,8`, suppose the
+following six selected rows are present:
+
+```text
+center 0: {1,3,6,7}
+center 1: {2,4,7,8}
+center 2: {0,3,5,8}
+center 3: {0,1,4,6}
+center 4: {1,2,5,7}
+center 8: {0,2,5,6}
+```
+
+The row-`2` witness order `[3,5,8,0]` gives `[0,3] > [0,8]`, and row `8`
+forces `[0,8] = [2,8]`. The row-`1` witness order `[2,4,7,8]` gives
+`[2,8] > [2,4]`, while rows `4` and `1` force
+`[2,4] = [1,4] = [1,7]`. The row-`0` witness order `[1,3,6,7]` gives
+`[1,7] > [1,3]`, and row `3` forces `[1,3] = [0,3]`. After
+selected-distance quotienting, these become
+
+```text
+[0,3] > [2,8] > [1,7] > [0,3].
+```
+
+Thus the strict quotient graph has a directed three-edge cycle, and no
+strictly convex realization can satisfy these exact local hypotheses. The
+packet label `T12/F16` is navigation only; the hypotheses are the displayed
+cyclic order and selected rows. This is not an `n=9` completeness proof, not a
+promotion of the review-pending exhaustive checker, and not a proof of Erdos
+Problem #97. Check the focused packet with
+`python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json`.
+
 ### Low-angle ascent for middle witnesses
 
 Let `alpha_p` be the interior angle at a bad vertex `p`, and let

--- a/docs/n9-vertex-circle-t12-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t12-strict-cycle-lemma.md
@@ -1,202 +1,183 @@
-# n=9 Vertex-circle T12 Strict-cycle Local Lemma Packet
+# n=9 Vertex-circle T12 Strict-cycle Local Lemma Candidate
 
-Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
 
-This note records one focused proof-mining packet for the single-family `T12`
-strict-cycle motif. It does not claim a proof of `n=9`, does not claim a
-counterexample, does not complete independent review of the exhaustive
-checker, and does not update the official/global status.
+This note extracts one proof-facing local obstruction from the review-pending
+`n=9` vertex-circle diagnostics. It does not claim a proof of `n=9`, does not
+claim a counterexample, does not complete independent review of the exhaustive
+checker, and does not update the official/global status of Erdos Problem #97.
 
-## Packet scope
+The labels `T12` and `F16` are retained only as packet/catalog navigation. They
+are not theorem hypotheses.
 
-The checked artifact is
-`data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`.
-It is derived from:
+## Exact Local Hypotheses
 
-- `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
-- `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
-
-The packet covers 2 assignment ids in one family:
+Let `p_0,...,p_8` be distinct vertices of a strictly convex nonagon in cyclic
+order
 
 ```text
-F16: 2 assignments
+0,1,2,3,4,5,6,7,8.
 ```
 
-The family has a six-row core and replays to a directed strict cycle with 54
-strict edges, three cycle edges, and no self-edge conflict. The local
-obstruction is a three-step quotient cycle, not a reflexive self-edge.
-
-## Family core
-
-`F16`:
+Assume the following six selected witness rows are present:
 
 ```text
-[0, 1, 3, 6, 7]
-[1, 2, 4, 7, 8]
-[2, 0, 3, 5, 8]
-[3, 0, 1, 4, 6]
-[4, 1, 2, 5, 7]
-[8, 0, 2, 5, 6]
-
-strict: [0, 3] > [0, 8] from row 2
-path:   [0, 8] -> [2, 8]
-
-strict: [2, 8] > [2, 4] from row 1
-path:   [2, 4] -> [1, 4] -> [1, 7]
-
-strict: [1, 7] > [1, 3] from row 0
-path:   [1, 3] -> [0, 3]
+center 0: {1,3,6,7}
+center 1: {2,4,7,8}
+center 2: {0,3,5,8}
+center 3: {0,1,4,6}
+center 4: {1,2,5,7}
+center 8: {0,2,5,6}
 ```
 
-Thus the packet isolates the directed cycle
+The selected-row hypothesis means that each listed center is equidistant from
+the four listed witnesses. In pair-distance notation, the rows used below give
+the selected-distance connector chains
 
 ```text
-[0, 3] > [0, 8] = [2, 8] > [2, 4] = [1, 4] = [1, 7] > [1, 3] = [0, 3].
+row 8: [0,8] = [2,8]
+
+row 4: [2,4] = [1,4]
+row 1: [1,4] = [1,7]
+
+row 3: [1,3] = [0,3]
 ```
 
-## Local lemma
-
-The following local obstruction is independent of the exhaustive `n=9`
-brancher once the six displayed rows are assumed.
-
-Assume a strictly convex polygon has labels appearing in cyclic order
+or equivalently
 
 ```text
-0,1,2,3,4,5,6,7,8
+[0,8] = [2,8],
+[2,4] = [1,4] = [1,7],
+[1,3] = [0,3].
 ```
 
-and contains the six selected rows
+The checked packet recording this local shape is
+`data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`. It is
+derived from the strict-cycle template packet and the template lemma catalog,
+but the local argument below uses only the six displayed selected rows plus
+the displayed cyclic order.
+
+## Vertex-circle Strict Inequalities
+
+At vertex `2`, the selected witnesses occur in boundary/angular order
 
 ```text
-S_0 = {1,3,6,7}
-S_1 = {2,4,7,8}
-S_2 = {0,3,5,8}
-S_3 = {0,1,4,6}
-S_4 = {1,2,5,7}
-S_8 = {0,2,5,6}
+[3,5,8,0].
 ```
 
-Then these six rows cannot be realized.
+Since the nonagon is strictly convex, boundary order agrees with angular order
+inside the vertex cone at `2`. The witnesses in row `2` lie on one circle
+centered at `p_2`, and chord length on that circle is strictly increasing with
+central angle below `pi`.
 
-First use row `2`. Its selected witnesses occur in cyclic order
+The chord `[0,3]` spans witness positions `0` to `3`, while `[0,8]` spans the
+proper subinterval `2` to `3`. Therefore
 
 ```text
-3,5,8,0.
+[0,3] > [0,8].                         (1)
 ```
 
-In a strictly convex polygon, the rays from a vertex to the other vertices
-occur in the polygon's cyclic order inside an angle smaller than `pi`. Since
-the row-`2` witnesses lie on one circle centered at vertex `2`, chord length
-on that circle is strictly increasing with the enclosed central angle in this
-range. The chord `[0,3]` strictly contains `[0,8]` in the row-`2` witness
-order, so
+Using the selected-distance connector from row `8`,
 
 ```text
-d(0,3) > d(0,8).                         (1)
+[0,8] = [2,8],
 ```
 
-Row `8` identifies the inner chord in (1) with the next outer chord:
+inequality (1) becomes
 
 ```text
-d(0,8) = d(2,8)      from row 8.
+[0,3] > [2,8].                         (2)
 ```
 
-Thus
+At vertex `1`, the selected witnesses occur in boundary/angular order
 
 ```text
-d(0,3) > d(2,8).                         (2)
+[2,4,7,8].
 ```
 
-Next use row `1`. Its selected witnesses occur in cyclic order
+The chord `[2,8]` spans witness positions `0` to `3`, while `[2,4]` spans the
+proper subinterval `0` to `1`. The same vertex-circle monotonicity gives
 
 ```text
-2,4,7,8.
+[2,8] > [2,4].                         (3)
 ```
 
-The chord `[2,8]` strictly contains `[2,4]` in this row-`1` witness order, so
+Using the selected-distance connector from rows `4` and `1`,
 
 ```text
-d(2,8) > d(2,4).                         (3)
+[2,4] = [1,4] = [1,7],
 ```
 
-Rows `4` and `1` identify this inner chord with the next outer chord:
+inequality (3) becomes
 
 ```text
-d(2,4) = d(1,4)      from row 4,
-d(1,4) = d(1,7)      from row 1.
+[2,8] > [1,7].                         (4)
 ```
 
-Therefore
+At vertex `0`, the selected witnesses occur in boundary/angular order
 
 ```text
-d(2,8) > d(1,7).                         (4)
+[1,3,6,7].
 ```
 
-Finally use row `0`. Its selected witnesses occur in cyclic order
+The chord `[1,7]` spans witness positions `0` to `3`, while `[1,3]` spans the
+proper subinterval `0` to `1`. Hence
 
 ```text
-1,3,6,7.
+[1,7] > [1,3].                         (5)
 ```
 
-The chord `[1,7]` strictly contains `[1,3]` in this row-`0` witness order, so
+Using the selected-distance connector from row `3`,
 
 ```text
-d(1,7) > d(1,3).                         (5)
+[1,3] = [0,3],
 ```
 
-Row `3` identifies this inner chord with the first outer chord:
+inequality (5) becomes
 
 ```text
-d(1,3) = d(0,3)      from row 3.
+[1,7] > [0,3].                         (6)
 ```
 
-Combining this equality with (5) gives
+## Contradiction
+
+The quotient inequalities (2), (4), and (6) form the directed strict cycle
 
 ```text
-d(1,7) > d(0,3).                         (6)
+[0,3] > [2,8] > [1,7] > [0,3].
 ```
 
-The strict inequalities (2), (4), and (6) produce the impossible cycle
+Equivalently, after quotienting ordinary pair distances by the selected-row
+equalities, the strict quotient graph has a directed three-edge cycle. No
+Euclidean strictly convex realization satisfying the stated local hypotheses
+can exist.
 
-```text
-d(0,3) > d(2,8) > d(1,7) > d(0,3).
-```
+## Packet Replay
 
-Equivalently, after quotienting ordinary pair distances by the selected
-distance equalities, rows `2`, `1`, and `0` create a directed strict cycle of
-length three.
-
-The lemma is local: it rules out any selected-witness system containing these
-six rows in the stated cyclic order. It does not prove the full `n=9` finite
-case, because the exhaustive checker is still needed to show that every
-frontier assignment contains one of the recorded local obstruction templates.
-
-## Commands
-
-Generate and check the packet:
+The compact checker treats the JSON packet and its source packets as input
+data. It checks that the source packets are valid, verifies each selected-row
+equality connector, verifies that each strict inequality is supported by the
+stated row and cyclic witness interval, replays the vertex-circle quotient
+graph from the six local rows, and reports validation errors if the packet no
+longer supports the stated local lemma candidate.
 
 ```bash
-python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py \
-  --assert-expected \
-  --write
-
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py \
   --check \
   --assert-expected \
   --json
 ```
 
-Run the targeted artifact tests:
+Targeted artifact test:
 
 ```bash
 python -m pytest tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py -q -m "artifact"
 ```
 
-## Review standard
+## What This Does Not Prove
 
-Before treating this as a reusable local lemma, a reviewer should restate the
-incidence and cyclic-order hypotheses without relying on `T12` as a theorem
-name, then prove directly for the `F16` core that the listed rows force the
-three strict inequalities and the three nonempty connector chains. The packet
-is a small replay aid for that review, not an independent proof of the `n=9`
-case.
+This local lemma candidate rules out only configurations satisfying the exact
+cyclic order and six selected rows displayed above. It does not enumerate all
+`n=9` selected-witness systems, does not promote the review-pending exhaustive
+`n=9` checker, does not rule out other vertex-circle templates, does not prove
+Erdos Problem #97, and does not produce or certify a counterexample.

--- a/scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py
@@ -49,10 +49,15 @@ from erdos97.n9_vertex_circle_t12_strict_cycle_lemma_packet import (  # noqa: E4
     STATUS,
     TRUST,
     assert_expected_t12_strict_cycle_lemma_packet,
+    equality_chain,
+    equality_steps,
     source_artifacts,
     t12_strict_cycle_lemma_packet_payload,
+    validate_strict_inequality_support,
 )
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path  # noqa: E402
 from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import pair  # noqa: E402
 
 DEFAULT_ARTIFACT = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t12_strict_cycle_lemma_packet.json"
@@ -215,6 +220,26 @@ def _validate_local_lemma(packet: dict[str, Any], errors: list[str]) -> None:
     selected_equalities = lemma.get("selected_distance_equalities")
     if not isinstance(selected_equalities, list) or len(selected_equalities) != EXPECTED_CYCLE_LENGTH:
         errors.append("F16 local_lemma selected_distance_equalities must have three cycle steps")
+    elif isinstance(packet.get("cycle_steps"), list):
+        try:
+            expected_steps = [
+                {
+                    "cycle_step": index,
+                    "equality_steps": equality_steps(
+                        step["equality_to_next_outer_pair"]
+                    ),
+                }
+                for index, step in enumerate(packet["cycle_steps"])
+            ]
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(f"F16 local_lemma selected_distance_equalities unsupported: {exc}")
+        else:
+            expect_equal(
+                errors,
+                "F16 local_lemma selected_distance_equalities",
+                selected_equalities,
+                expected_steps,
+            )
     strict_statements = lemma.get("strict_inequality_statements")
     if not isinstance(strict_statements, list) or len(strict_statements) != EXPECTED_CYCLE_LENGTH:
         errors.append("F16 local_lemma strict_inequality_statements must have three entries")
@@ -229,6 +254,91 @@ def _validate_local_lemma(packet: dict[str, Any], errors: list[str]) -> None:
         errors.append("F16 local_lemma contradiction must mention a directed strict cycle")
     if "reflexive strict edge" in contradiction or "self-edge" in contradiction:
         errors.append("F16 local_lemma contradiction must not describe a self-edge")
+
+
+def _expected_cycle_pair_chain(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "cycle_step": index,
+            "strict_from_outer_pair": step["strict_inequality"]["outer_pair"],
+            "strict_to_inner_pair": step["strict_inequality"]["inner_pair"],
+            "equality_chain_to_next_outer_pair": equality_chain(
+                step["equality_to_next_outer_pair"]
+            ),
+            "next_outer_pair": steps[(index + 1) % len(steps)]["strict_inequality"][
+                "outer_pair"
+            ],
+        }
+        for index, step in enumerate(steps)
+    ]
+
+
+def _validate_cycle_step_support(
+    packet: dict[str, Any],
+    errors: list[str],
+    *,
+    order: Any,
+) -> None:
+    rows = packet.get("core_selected_rows")
+    steps = packet.get("cycle_steps")
+    if not isinstance(rows, list):
+        errors.append("F16 core_selected_rows must be a list")
+        return
+    if not isinstance(steps, list):
+        errors.append("F16 cycle_steps must be a list")
+        return
+    if len(steps) != EXPECTED_CYCLE_LENGTH:
+        errors.append("F16 cycle_steps must have three entries")
+        return
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            errors.append(f"F16 cycle_steps[{index}] must be an object")
+            continue
+        strict = step.get("strict_inequality")
+        equality = step.get("equality_to_next_outer_pair")
+        if not isinstance(strict, dict):
+            errors.append(f"F16 cycle_steps[{index}] strict_inequality must be an object")
+            continue
+        if not isinstance(equality, dict):
+            errors.append(
+                f"F16 cycle_steps[{index}] equality_to_next_outer_pair must be an object"
+            )
+            continue
+        try:
+            validate_strict_inequality_support(rows, strict, order=order)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(
+                f"F16 cycle step {index} strict_inequality is not supported by "
+                f"selected rows: {exc}"
+            )
+        try:
+            validate_equality_path(rows, equality)
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(
+                f"F16 cycle step {index} equality connector is not supported by "
+                f"selected rows: {exc}"
+            )
+        try:
+            next_strict = steps[(index + 1) % len(steps)]["strict_inequality"]
+            if pair(*equality["start_pair"]) != pair(*strict["inner_pair"]):
+                errors.append(
+                    f"F16 cycle step {index} equality must start at current inner pair"
+                )
+            if pair(*equality["end_pair"]) != pair(*next_strict["outer_pair"]):
+                errors.append(
+                    f"F16 cycle step {index} equality must end at next outer pair"
+                )
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(f"F16 cycle step {index} closure validation failed: {exc}")
+    try:
+        expect_equal(
+            errors,
+            "F16 cycle_pair_chain",
+            packet.get("cycle_pair_chain"),
+            _expected_cycle_pair_chain(steps),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"F16 cycle_pair_chain unsupported: {exc}")
 
 
 def _validate_replay(packet: dict[str, Any], errors: list[str]) -> None:
@@ -279,7 +389,12 @@ def _validate_replay(packet: dict[str, Any], errors: list[str]) -> None:
             errors.append("F16 replay cycle edges must not include source-only spans")
 
 
-def _validate_family_packet(packet: dict[str, Any], errors: list[str]) -> None:
+def _validate_family_packet(
+    packet: dict[str, Any],
+    errors: list[str],
+    *,
+    order: Any,
+) -> None:
     if set(packet) != EXPECTED_FAMILY_PACKET_KEYS:
         errors.append(
             "F16 keys mismatch: "
@@ -314,6 +429,7 @@ def _validate_family_packet(packet: dict[str, Any], errors: list[str]) -> None:
         [list(row) for row in EXPECTED_CORE_SELECTED_ROWS],
     )
     expect_equal(errors, "F16 cycle_steps", packet.get("cycle_steps"), EXPECTED_CYCLE_STEPS)
+    _validate_cycle_step_support(packet, errors, order=order)
     _validate_local_lemma(packet, errors)
     _validate_replay(packet, errors)
 
@@ -384,8 +500,9 @@ def validate_payload(
         if not any("three directed strict inequalities" in item for item in interpretation):
             errors.append("interpretation must preserve the strict-cycle scope")
 
+    order = payload.get("cyclic_order", list(range(9)))
     for packet in _family_packets_by_id(payload, errors).values():
-        _validate_family_packet(packet, errors)
+        _validate_family_packet(packet, errors, order=order)
 
     _validate_sources(source_payloads, errors)
     expected_payload = None if errors else _expected_payload(source_payloads, errors)

--- a/src/erdos97/n9_vertex_circle_t12_strict_cycle_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t12_strict_cycle_lemma_packet.py
@@ -201,6 +201,74 @@ def equality_steps(equality: Mapping[str, Any]) -> list[dict[str, Any]]:
     return steps
 
 
+def _strict_interval_pair(
+    witness_order: Sequence[int],
+    interval: Sequence[int],
+) -> list[int]:
+    if len(interval) != 2:
+        raise AssertionError(f"strict interval must have two endpoints: {interval!r}")
+    start = int(interval[0])
+    end = int(interval[1])
+    if not 0 <= start < end < len(witness_order):
+        raise AssertionError(f"strict interval out of range: {interval!r}")
+    return [int(value) for value in pair(witness_order[start], witness_order[end])]
+
+
+def validate_strict_inequality_support(
+    rows: Sequence[Sequence[int]],
+    strict: Mapping[str, Any],
+    *,
+    order: Sequence[int],
+) -> None:
+    """Validate that a strict inequality is supported by one selected row."""
+
+    parsed_rows = parse_selected_rows(rows)
+    row_map = {row.center: row for row in parsed_rows}
+    strict_row = int(strict["row"])
+    if strict_row not in row_map:
+        raise AssertionError(f"strict row {strict_row} is not selected")
+    order_tuple = tuple(int(label) for label in order)
+    if sorted(order_tuple) != list(range(len(order_tuple))):
+        raise AssertionError("cyclic order must be a permutation of 0..n-1")
+    positions = {label: index for index, label in enumerate(order_tuple)}
+    witnesses = tuple(
+        sorted(
+            row_map[strict_row].witnesses,
+            key=lambda witness: (positions[witness] - positions[strict_row])
+            % len(order_tuple),
+        )
+    )
+    if list(witnesses) != [int(label) for label in strict["witness_order"]]:
+        raise AssertionError("strict witness order is not supported by the selected row")
+
+    outer_interval = [int(value) for value in strict["outer_interval"]]
+    inner_interval = [int(value) for value in strict["inner_interval"]]
+    if not (
+        outer_interval[0] <= inner_interval[0]
+        and inner_interval[1] <= outer_interval[1]
+        and (
+            outer_interval[0] < inner_interval[0]
+            or inner_interval[1] < outer_interval[1]
+        )
+    ):
+        raise AssertionError("strict outer interval must properly contain inner interval")
+
+    outer_pair = _strict_interval_pair(witnesses, outer_interval)
+    inner_pair = _strict_interval_pair(witnesses, inner_interval)
+    if outer_pair != [int(value) for value in pair(*strict["outer_pair"])]:
+        raise AssertionError("strict outer pair is not supported by its interval")
+    if inner_pair != [int(value) for value in pair(*strict["inner_pair"])]:
+        raise AssertionError("strict inner pair is not supported by its interval")
+    outer_span = outer_interval[1] - outer_interval[0]
+    inner_span = inner_interval[1] - inner_interval[0]
+    if outer_span <= inner_span:
+        raise AssertionError("strict outer span must be larger than inner span")
+    if int(strict["outer_span"]) != outer_span:
+        raise AssertionError("strict outer span mismatch")
+    if int(strict["inner_span"]) != inner_span:
+        raise AssertionError("strict inner span mismatch")
+
+
 def source_artifacts(
     strict_cycle_packet: dict[str, Any],
     template_catalog: dict[str, Any],
@@ -273,6 +341,7 @@ def _assert_cycle_steps(rows: Sequence[Sequence[int]], steps: Sequence[dict[str,
         edge = step["strict_inequality"]
         equality = step["equality_to_next_outer_pair"]
         next_edge = steps[(index + 1) % len(steps)]["strict_inequality"]
+        validate_strict_inequality_support(rows, edge, order=list(n9.ORDER))
         if pair(*equality["start_pair"]) != pair(*edge["inner_pair"]):
             raise AssertionError("cycle equality must start at current inner pair")
         if pair(*equality["end_pair"]) != pair(*next_edge["outer_pair"]):

--- a/tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py
@@ -161,6 +161,7 @@ def test_t12_strict_cycle_lemma_packet_rejects_tampered_step0_connector() -> Non
     errors = validate_payload(payload, recompute=False)
 
     assert any("F16 cycle_steps mismatch" in error for error in errors)
+    assert any("equality must end at next outer pair" in error for error in errors)
     assert any("expected T12 strict-cycle lemma packet" in error for error in errors)
 
 
@@ -174,6 +175,29 @@ def test_t12_strict_cycle_lemma_packet_rejects_tampered_step1_closure() -> None:
     assert any("F16 cycle_steps mismatch" in error for error in errors)
 
 
+def test_t12_strict_cycle_lemma_packet_rejects_unsupported_strict_interval() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f16(payload)
+    packet["cycle_steps"][2]["strict_inequality"]["outer_interval"] = [0, 1]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F16 cycle_steps mismatch" in error for error in errors)
+    assert any("strict_inequality is not supported" in error for error in errors)
+
+
+def test_t12_strict_cycle_lemma_packet_rejects_tampered_local_lemma_steps() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f16(payload)
+    packet["local_lemma"]["selected_distance_equalities"][1]["equality_steps"][0][  # type: ignore[index]
+        "row"
+    ] = 8
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("local_lemma selected_distance_equalities" in error for error in errors)
+
+
 def test_t12_strict_cycle_lemma_packet_rejects_tampered_strict_row() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     packet = _f16(payload)
@@ -182,6 +206,7 @@ def test_t12_strict_cycle_lemma_packet_rejects_tampered_strict_row() -> None:
     errors = validate_payload(payload, recompute=False)
 
     assert any("F16 cycle_steps mismatch" in error for error in errors)
+    assert any("strict_inequality is not supported" in error for error in errors)
 
 
 def test_t12_strict_cycle_lemma_packet_rejects_tampered_core_rows() -> None:


### PR DESCRIPTION
## Summary

- Rewrites the focused T12/F16 strict-cycle note as a proof-facing local lemma candidate with exact cyclic-order and six-row selected-witness hypotheses.
- Adds a conservative claims-ledger entry for the local directed three-edge quotient-cycle obstruction, explicitly not an n=9 completeness proof.
- Hardens the compact T12 checker so it validates selected-row equality connectors, strict witness intervals, local lemma equality-step fields, and cycle closure from packet data.

## Validation

- `python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py -q -m "artifact"`
- `python -m pytest tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py -q`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`
- Raw fast tier because `make` is unavailable in this PowerShell environment:
  - `python scripts/check_text_clean.py`
  - `python scripts/check_status_consistency.py`
  - `python scripts/check_artifact_provenance.py`
  - `git diff --check`
  - `python -m ruff check .`
  - `python -m pytest -q`