### PR TITLE
[codex] Close F13 local scan gap

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -17,12 +17,13 @@ that justifies doing it anyway.
 
 Use this queue when no more specific issue is selected.
 
-1. Close the remaining `n=9` vertex-circle self-edge local-template gap in the
-   aggregate local-lemma scan. The open packet family is `F13`, coming from
-   the T04 self-edge side.
-2. Review the aggregate `n=9` vertex-circle local-lemma scan against the
-   focused T10/T11/T12 strict-cycle proof notes, keeping it scoped as
-   proof-mining scaffolding rather than an `n=9` proof.
+1. Review the aggregate `n=9` vertex-circle local-lemma scan against the
+   focused T03/T04 self-edge proof notes and the focused T10/T11/T12
+   strict-cycle proof notes, keeping it scoped as proof-mining scaffolding
+   rather than an `n=9` proof.
+2. Audit whether the aggregate local-template coverage can be checked from the
+   stored packet JSON by a second, simpler replay that does not share the
+   current quotient-replay helper.
 3. Strengthen the minimal fragile-cover bridge with one geometric necessary
    condition and test it against the block-6 negative controls.
 4. Apply the bootstrap-core/private-halo weighted capacity checker to current

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -189,7 +189,38 @@ families: F05, F15
 covered assignments: 20
 ```
 
-## Lemma D: T10/F12 two-edge strict cycle
+## Lemma D: T04/F13 selected-path self-edge
+
+The T04/F13 local core is:
+
+```text
+0 -> {1,2,5,7}
+1 -> {2,3,6,8}
+3 -> {1,4,5,8}
+5 -> {1,3,6,7}
+```
+
+The selected-distance path gives:
+
+```text
+D_15 = D_35 = D_13 = D_12.
+```
+
+At center `0`, the witness order `1,2,5,7` gives:
+
+```text
+D_15 > D_12.
+```
+
+Thus the selected-distance quotient again has a reflexive strict edge. The
+checker finds this exact selected-path self-edge pattern in:
+
+```text
+family: F13
+covered assignments: 2
+```
+
+## Lemma E: T10/F12 two-edge strict cycle
 
 The T10/F12 local core is:
 
@@ -240,7 +271,7 @@ covered assignments: 18
 Again, the local core has no two-circle cap violation and no crossing-bisector
 order violation before the vertex-circle quotient step.
 
-## Lemma E: T11/F07 three-edge strict cycle
+## Lemma F: T11/F07 three-edge strict cycle
 
 The T11/F07 local core is:
 
@@ -283,7 +314,7 @@ family: F07
 covered assignments: 6
 ```
 
-## Lemma F: T12/F16 three-edge strict cycle
+## Lemma G: T12/F16 three-edge strict cycle
 
 The T12/F16 local core is:
 
@@ -332,21 +363,22 @@ The current local-lemma scan covers these review-pending template-packet
 families:
 
 ```text
-F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F14, F15, F16
+F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F13, F14, F15, F16
 ```
 
 The de-duplicated assignment coverage is:
 
 ```text
-182 of the 184 n=9 pre-vertex-circle assignments
+184 of the 184 n=9 pre-vertex-circle assignments
 ```
 
-The currently uncovered packet families are:
+There are no uncovered packet families in this aggregate scan:
 
 ```text
-F13
+none
 ```
 
 This is useful proof-mining coverage, not an `n=9` completeness proof. The
-remaining local family still needs proof-facing extraction from the T04
-self-edge side of the stored packet scan.
+aggregate scan treats the stored review-pending template packets as input data
+and does not independently prove that every `n=9` frontier assignment reduces
+to one of these local templates.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -158,12 +158,18 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json` to
   replay the focused review-pending T03 multi-family self-edge local lemma
   packet;
+- use `docs/n9-vertex-circle-t04-self-edge-lemma.md` to review the focused
+  T04/F13 four-row selected-path self-edge proof note against the aggregate
+  local-lemma scan;
 - use `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T10/F12 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T11/F07 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T12/F16 strict-cycle local lemma packet;
+- review the aggregate local-lemma scan after the T03/T04 self-edge and
+  T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
+  coverage of stored packets rather than an independent `n=9` proof;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,163 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 662 - T04/F13 Aggregate Local-scan Closure
+
+### Mathematical Subquestion
+
+Cycle 661 left exactly one aggregate local-lemma scan gap: family `F13`,
+coming from the T04 self-edge packet. The focused T04 proof note already
+records a four-row local self-edge contradiction. The narrow question was:
+
+```text
+Can the aggregate local-lemma scan absorb the existing T04/F13 proof note
+through the same selected-path self-edge criterion, without changing the
+review-pending scope?
+```
+
+### Definitions and Assumptions
+
+Use the stored review-pending `n=9` self-edge template packet
+`data/certificates/n9_vertex_circle_self_edge_template_packet.json`. A
+**selected-path self-edge** is a local core with:
+
+- a vertex-circle strict edge `p > q`; and
+- a selected-distance equality path identifying `p` and `q`.
+
+The equality path gives `D(p) = D(q)`, while the strict edge gives
+`D(p) > D(q)`, so the selected-distance quotient has a reflexive strict edge.
+The aggregate scan treats the stored packet as input data; it does not
+independently enumerate all `n=9` selected-witness assignments.
+
+### Result Status
+
+Exact finite aggregation/refinement:
+**T04/F13 Aggregate Local-scan Closure**.
+
+### Argument Or Obstruction
+
+The T04/F13 local core consists of the four selected rows:
+
+```text
+0 -> {1,2,5,7}
+1 -> {2,3,6,8}
+3 -> {1,4,5,8}
+5 -> {1,3,6,7}
+```
+
+The selected-distance path gives:
+
+```text
+D_15 = D_35 = D_13 = D_12.
+```
+
+At center `0`, the witness order `1,2,5,7` gives:
+
+```text
+D_15 > D_12.
+```
+
+Thus the quotient has a reflexive strict edge. The aggregate scan now adds the
+named local-lemma id `t04_selected_path_self_edge` for the stored `F13`
+packet. The exact aggregate summary becomes:
+
+```text
+source families: 16
+source assignments: 184
+covered families: 16
+covered assignments: 184
+uncovered families: none
+uncovered assignments: 0
+```
+
+### Exact Scope
+
+This result is exact for the stored review-pending T04/F13 packet and the
+natural cyclic order of the stored `n=9` template scan. It is not an
+independent review of the exhaustive checker, not a proof of the full `n=9`
+finite case, not a general proof of Erdos Problem #97, and not a
+counterexample.
+
+### Files Changed
+
+- `src/erdos97/n9_vertex_circle_local_lemmas.py`
+- `tests/test_n9_vertex_circle_local_lemmas.py`
+- `docs/n9-vertex-circle-local-lemmas.md`
+- `docs/codex-backlog.md`
+- `docs/review-priorities.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This closes the aggregate local-template coverage gap for the stored
+review-pending `n=9` vertex-circle template packets: every one of the `184`
+stored pre-vertex-circle assignments is now represented by a named local
+self-edge or strict-cycle lemma candidate in the aggregate scan. The result is
+useful proof-mining scaffolding because it turns the packet list into a
+smaller menu of local proof shapes, but it does not bridge arbitrary
+counterexamples to those shapes and does not independently validate the
+exhaustive `n=9` frontier.
+
+### Next Lead
+
+Audit the completed aggregate local-lemma scan against the focused proof notes
+with a second, simpler replay that treats the packet JSON as input but avoids
+sharing the current quotient-replay helper. A stronger mathematical lead is to
+abstract the T03/T04 selected-path self-edge mechanism into one cyclic-order
+lemma with explicit incidence hypotheses and no template names.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-662`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-662`.
+- The branch was started from `origin/main` at commit
+  `2aa9e53449b0ca8b8227388d855e18cab58f36e1`, after PR #395 merged Cycle
+  661.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`:
+  passed; recorded `184` covered assignments from `16` families and no
+  uncovered families.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_self_edge_template_packet.py --check
+  --assert-expected --json`: passed; the self-edge packet reports `T04: 2`,
+  self-edge template count `9`, and no validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed; the catalog reports `184` covered
+  assignments, `12` templates, and no validation errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_n9_vertex_circle_local_lemmas.py -q`: passed, `10 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_n9_vertex_circle_self_edge_template_packet.py -q -m artifact`:
+  passed, `3 passed, 11 deselected`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check
+  src/erdos97/n9_vertex_circle_local_lemmas.py
+  tests/test_n9_vertex_circle_local_lemmas.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `572 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 661 - T03 Selected-path Self-edge Scan Closure
 
 ### Mathematical Subquestion

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -30,6 +30,7 @@ CLAIM_SCOPE = (
 SHARED_ENDPOINT_LEMMA = "shared_endpoint_nested_self_edge"
 NESTED_SPOKE_LEMMA = "nested_spoke_quotient_self_edge"
 T03_SELECTED_PATH_SELF_EDGE = "t03_selected_path_self_edge"
+T04_SELECTED_PATH_SELF_EDGE = "t04_selected_path_self_edge"
 T10_STRICT_CYCLE_LEMMA = "t10_two_edge_strict_cycle"
 T11_STRICT_CYCLE_LEMMA = "t11_three_edge_strict_cycle"
 T12_STRICT_CYCLE_LEMMA = "t12_three_edge_strict_cycle"
@@ -55,6 +56,11 @@ EXPECTED_SUMMARY = {
         "family_ids": ["F05", "F15"],
         "instance_count": 2,
         "covered_assignment_count": 20,
+    },
+    T04_SELECTED_PATH_SELF_EDGE: {
+        "family_ids": ["F13"],
+        "instance_count": 1,
+        "covered_assignment_count": 2,
     },
     T10_STRICT_CYCLE_LEMMA: {
         "family_ids": ["F12"],
@@ -92,6 +98,7 @@ def local_lemma_scan_payload(
     shared_endpoint: list[dict[str, Any]] = []
     nested_spoke: list[dict[str, Any]] = []
     t03_selected_path: list[dict[str, Any]] = []
+    t04_selected_path: list[dict[str, Any]] = []
     direct_two_row: list[dict[str, Any]] = []
 
     for template, family in _self_edge_family_records(self_edge_packet):
@@ -130,10 +137,19 @@ def local_lemma_scan_payload(
                             "lemma_id": DIRECT_TWO_ROW_VARIANT,
                         }
                     )
-            if _is_t03_selected_path_self_edge_shape(template, family, edge):
-                t03_selected_path.append(
+            selected_path_lemma_id = _selected_path_self_edge_lemma_id(
+                template,
+                family,
+                edge,
+            )
+            if selected_path_lemma_id is not None:
+                selected_path_instances = {
+                    T03_SELECTED_PATH_SELF_EDGE: t03_selected_path,
+                    T04_SELECTED_PATH_SELF_EDGE: t04_selected_path,
+                }
+                selected_path_instances[selected_path_lemma_id].append(
                     _self_edge_instance(
-                        lemma_id=T03_SELECTED_PATH_SELF_EDGE,
+                        lemma_id=selected_path_lemma_id,
                         template=template,
                         family=family,
                         rows=rows,
@@ -164,6 +180,7 @@ def local_lemma_scan_payload(
         SHARED_ENDPOINT_LEMMA: shared_endpoint,
         NESTED_SPOKE_LEMMA: nested_spoke,
         T03_SELECTED_PATH_SELF_EDGE: t03_selected_path,
+        T04_SELECTED_PATH_SELF_EDGE: t04_selected_path,
         **strict_cycle_instances,
     }
 
@@ -190,6 +207,7 @@ def local_lemma_scan_payload(
             _lemma_summary(SHARED_ENDPOINT_LEMMA, shared_endpoint),
             _lemma_summary(NESTED_SPOKE_LEMMA, nested_spoke),
             _lemma_summary(T03_SELECTED_PATH_SELF_EDGE, t03_selected_path),
+            _lemma_summary(T04_SELECTED_PATH_SELF_EDGE, t04_selected_path),
             *(
                 _lemma_summary(lemma_id, strict_cycle_instances[lemma_id])
                 for lemma_id in STRICT_CYCLE_LEMMA_BY_TEMPLATE.values()
@@ -293,15 +311,15 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         raise AssertionError("source_family_count mismatch")
     if coverage.get("source_assignment_count") != 184:
         raise AssertionError("source_assignment_count mismatch")
-    if coverage.get("covered_family_count") != 15:
+    if coverage.get("covered_family_count") != 16:
         raise AssertionError("covered_family_count mismatch")
-    if coverage.get("covered_assignment_count") != 182:
+    if coverage.get("covered_assignment_count") != 184:
         raise AssertionError("covered_assignment_count mismatch")
-    if coverage.get("uncovered_family_count") != 1:
+    if coverage.get("uncovered_family_count") != 0:
         raise AssertionError("uncovered_family_count mismatch")
-    if coverage.get("uncovered_assignment_count") != 2:
+    if coverage.get("uncovered_assignment_count") != 0:
         raise AssertionError("uncovered_assignment_count mismatch")
-    if coverage.get("uncovered_family_ids") != ["F13"]:
+    if coverage.get("uncovered_family_ids") != []:
         raise AssertionError("uncovered_family_ids mismatch")
     if coverage.get("covered_family_ids") != [
         "F01",
@@ -316,6 +334,7 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         "F10",
         "F11",
         "F12",
+        "F13",
         "F14",
         "F15",
         "F16",
@@ -455,23 +474,30 @@ def _direct_nested_spoke_conditions(
     }
 
 
-def _is_t03_selected_path_self_edge_shape(
+def _selected_path_self_edge_lemma_id(
     template: dict[str, Any],
     family: dict[str, Any],
     edge: StrictInequality,
-) -> bool:
-    """Return whether the record is one of the checked T03 self-edge paths."""
+) -> str | None:
+    """Return the selected-path self-edge lemma id for checked packet records."""
 
-    if str(template.get("template_id")) != "T03":
-        return False
+    template_to_lemma = {
+        "T03": T03_SELECTED_PATH_SELF_EDGE,
+        "T04": T04_SELECTED_PATH_SELF_EDGE,
+    }
+    lemma_id = template_to_lemma.get(str(template.get("template_id")))
+    if lemma_id is None:
+        return None
     equality = family.get("distance_equality")
     if not isinstance(equality, dict):
-        return False
-    return (
+        return None
+    if (
         edge.outer_class == edge.inner_class
         and _pair_list(edge.outer_pair) == _pair_list(equality.get("start_pair"))
         and _pair_list(edge.inner_pair) == _pair_list(equality.get("end_pair"))
-    )
+    ):
+        return lemma_id
+    return None
 
 
 def _selected_path_conditions(family: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -11,6 +11,7 @@ from erdos97.n9_vertex_circle_local_lemmas import (
     NESTED_SPOKE_LEMMA,
     SHARED_ENDPOINT_LEMMA,
     T03_SELECTED_PATH_SELF_EDGE,
+    T04_SELECTED_PATH_SELF_EDGE,
     T10_STRICT_CYCLE_LEMMA,
     T11_STRICT_CYCLE_LEMMA,
     T12_STRICT_CYCLE_LEMMA,
@@ -47,8 +48,8 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
     assert payload["coverage_summary"] == {  # type: ignore[index]
         "source_assignment_count": 184,
         "source_family_count": 16,
-        "covered_assignment_count": 182,
-        "covered_family_count": 15,
+        "covered_assignment_count": 184,
+        "covered_family_count": 16,
         "covered_family_ids": [
             "F01",
             "F02",
@@ -62,13 +63,14 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
             "F10",
             "F11",
             "F12",
+            "F13",
             "F14",
             "F15",
             "F16",
         ],
-        "uncovered_assignment_count": 2,
-        "uncovered_family_count": 1,
-        "uncovered_family_ids": ["F13"],
+        "uncovered_assignment_count": 0,
+        "uncovered_family_count": 0,
+        "uncovered_family_ids": [],
         "family_to_lemmas": {
             "F01": [SHARED_ENDPOINT_LEMMA],
             "F02": [NESTED_SPOKE_LEMMA],
@@ -82,6 +84,7 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
             "F10": [NESTED_SPOKE_LEMMA],
             "F11": [NESTED_SPOKE_LEMMA],
             "F12": [T10_STRICT_CYCLE_LEMMA],
+            "F13": [T04_SELECTED_PATH_SELF_EDGE],
             "F14": [SHARED_ENDPOINT_LEMMA],
             "F15": [T03_SELECTED_PATH_SELF_EDGE],
             "F16": [T12_STRICT_CYCLE_LEMMA],
@@ -209,6 +212,39 @@ def test_t03_selected_path_self_edge_instances(payload: dict[str, object]) -> No
     }
 
 
+def test_t04_selected_path_self_edge_instance(payload: dict[str, object]) -> None:
+    lemma = _lemma(payload, T04_SELECTED_PATH_SELF_EDGE)
+
+    assert lemma["instance_count"] == 1
+    assert lemma["covered_assignment_count"] == 2
+    assert lemma["family_ids"] == ["F13"]
+    assert lemma["template_ids"] == ["T04"]
+    instance = lemma["instances"][0]  # type: ignore[index]
+    assert instance["assignment_count"] == 2
+    assert instance["simple_filter_violations"] == []
+    assert instance["core_selected_rows"] == [
+        [0, 1, 2, 5, 7],
+        [1, 2, 3, 6, 8],
+        [3, 1, 4, 5, 8],
+        [5, 1, 3, 6, 7],
+    ]
+    assert instance["strict_inequality"]["row"] == 0
+    assert instance["strict_inequality"]["outer_pair"] == [1, 5]
+    assert instance["strict_inequality"]["inner_pair"] == [1, 2]
+    assert instance["direct_conditions"] == {
+        "variant": "selected_path_self_edge",
+        "start_pair": [1, 5],
+        "end_pair": [1, 2],
+        "path": [
+            {"row": 5, "next_pair": [3, 5]},
+            {"row": 3, "next_pair": [1, 3]},
+            {"row": 1, "next_pair": [1, 2]},
+        ],
+        "path_length": 3,
+        "holds": True,
+    }
+
+
 def test_t11_strict_cycle_instance(payload: dict[str, object]) -> None:
     lemma = _lemma(payload, T11_STRICT_CYCLE_LEMMA)
 
@@ -295,5 +331,5 @@ def test_local_lemma_scan_cli_json() -> None:
 
     parsed = json.loads(result.stdout)
     assert parsed["schema"] == "erdos97.n9_vertex_circle_local_lemmas.v1"
-    assert parsed["coverage_summary"]["covered_assignment_count"] == 182
-    assert parsed["coverage_summary"]["uncovered_family_ids"] == ["F13"]
+    assert parsed["coverage_summary"]["covered_assignment_count"] == 184
+    assert parsed["coverage_summary"]["uncovered_family_ids"] == []


### PR DESCRIPTION
## Mathematical scope

Cycle 662 integrates the existing T04/F13 selected-path self-edge proof note into the aggregate `n=9` vertex-circle local-lemma scan.

This is proof-mining scaffolding only. It does not claim a proof of the full `n=9` finite case, does not claim a proof of Erdos Problem #97, and does not claim a counterexample.

## What changed

- Adds `t04_selected_path_self_edge` to the aggregate scan.
- Counts T04/F13 as a selected-path self-edge local instance.
- Updates tests to assert the exact F13 rows, strict edge, and equality path.
- Updates the local-lemma note, backlog, review priorities, and running research log.

## Exact result

The aggregate scan now reports:

```text
source families: 16
source assignments: 184
covered families: 16
covered assignments: 184
uncovered families: none
uncovered assignments: 0
```

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_n9_vertex_circle_local_lemmas.py -q` (`10 passed`)
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_n9_vertex_circle_self_edge_template_packet.py -q -m artifact` (`3 passed, 11 deselected`)
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`572 passed, 278 deselected`)

## Remaining limitations

- The aggregate scan treats stored review-pending packet JSON as input data.
- This is not an independent review of the exhaustive `n=9` checker.
- It does not prove that arbitrary counterexamples reduce to these local templates.
- The overarching proof/counterexample objective remains open.