### PR TITLE
[codex] Add bootstrap-core frontier crosswalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
 - For the rich-triple closure / bootstrap-core bridge fork, read
   [`docs/bootstrap-core-bridge.md`](docs/bootstrap-core-bridge.md).
+- For the bootstrap-core rank/capacity crosswalk on current fixed-row
+  frontier motifs, read
+  [`docs/bootstrap-core-crosswalk.md`](docs/bootstrap-core-crosswalk.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -134,6 +134,14 @@ necessary bridge target only; it is not a proof of Erdos Problem #97 and not a
 counterexample. See `docs/bootstrap-core-bridge.md` and
 `scripts/check_bootstrap_core_bridge.py`.
 
+The checked bootstrap-core crosswalk applies the same singleton-rich
+bookkeeping to current fixed-row frontier motifs. All eight audited cyclic-order
+cases have rank greater than 3, and none violates the weighted private-halo
+capacity ledger. This is negative diagnostic information only, not evidence of
+realizability; see `docs/bootstrap-core-crosswalk.md`,
+`scripts/check_bootstrap_core_crosswalk.py`, and
+`data/certificates/bootstrap_core_crosswalk.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -49,7 +49,10 @@ equivalent to bootstrap rank at most 3. Failure of that rank condition yields
 inclusion-minimal generating cores with deletion closures, private halos, and a
 weighted cyclic outside-pair capacity ledger. This is still only bridge
 bookkeeping, not a contradiction or counterexample. See
-`docs/bootstrap-core-bridge.md`.
+`docs/bootstrap-core-bridge.md`. A follow-up crosswalk applies this ledger to
+current fixed-row frontier motifs and records that the audited singleton-rich
+cases have rank greater than 3 but still pass the weighted capacity check; see
+`docs/bootstrap-core-crosswalk.md`.
 
 ## New exact fixed-pattern obstructions
 

--- a/data/certificates/bootstrap_core_crosswalk.json
+++ b/data/certificates/bootstrap_core_crosswalk.json
@@ -1,0 +1,3821 @@
+{
+  "base_apex_d3_reference": {
+    "bootstrap_core_audited": false,
+    "capacity_deficit": 3,
+    "escape_class_count": 8,
+    "incidence_state": "UNKNOWN",
+    "profile_multiset_count": 11,
+    "realizability_state": "UNKNOWN",
+    "reason_not_audited": "The D=3 packet records base-apex profile/capacity ledgers rather than full selected rows or full rich classes, so it is included as a capacity-reference packet only.",
+    "representative_count": 88,
+    "schema": "erdos97.n9_base_apex_d3_incidence_capacity_packet.v1",
+    "source_artifact": "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json",
+    "status": "EXPLORATORY_LEDGER_ONLY",
+    "target_capacity_total": 60,
+    "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF"
+  },
+  "claim_scope": "Bootstrap-core rank and private-halo capacity crosswalk for selected fixed-row frontier motifs; not a proof of the bridge, not a proof of Erdos Problem #97, not a counterexample, and not a global status update.",
+  "interpretation_warnings": [
+    "The fixed-row records use singleton rich classes, not full geometric rich-class data.",
+    "Capacity margins are necessary-condition ledgers only; positive margins do not certify realizability.",
+    "The base-apex D=3 packet is referenced but not bootstrap-core audited because it is not a full selected-row object.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_core_crosswalk.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_core_crosswalk.py",
+    "sources": [
+      "data/patterns/candidate_patterns.json",
+      "data/certificates/bridge_lemma_frontier.json",
+      "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json"
+    ]
+  },
+  "records": [
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 30,
+        "core": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "core_generates_all": true,
+        "core_size": 4,
+        "cyclic_capacity_sum": 36,
+        "deletion_closures": [
+          {
+            "closure_size": 3,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              2,
+              3
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ],
+            "private_halo_size": 9,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1,
+                  2
+                ],
+                "private_halo_witnesses": [
+                  4,
+                  10
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              3
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ],
+            "private_halo_size": 9,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  2,
+                  3
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  11
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              3
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ],
+            "private_halo_size": 8,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  3,
+                  12
+                ],
+                "private_halo_witnesses": [
+                  4,
+                  6
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 3,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ],
+            "private_halo_size": 9,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  0
+                ],
+                "private_halo_witnesses": [
+                  4,
+                  5,
+                  7
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 32,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12
+        ],
+        "outside_run_lengths": [
+          9
+        ],
+        "outside_runs": [
+          [
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12
+          ]
+        ],
+        "outside_size": 9,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 6,
+        "private_pair_lower_bound": 4,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "C13_sidon_1_2_4_10:natural",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 378,
+        "first_generator": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12
+          ],
+          "closure_size": 13,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            2,
+            3,
+            12,
+            11,
+            10,
+            9,
+            8,
+            6,
+            7,
+            4,
+            5
+          ],
+          "seed": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "step_count": 9
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "largest_closure_size_before_stop": 13,
+        "minimum_rank": 4
+      },
+      "n": 13,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "order_label": "natural",
+      "pattern": "C13_sidon_1_2_4_10",
+      "pattern_status": {
+        "family": "circulant",
+        "formula": "S_i = i + [1, 2, 4, 10] mod 13",
+        "lifecycle": "retired_all_order_obstruction",
+        "status": "abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as historical numerical evidence",
+        "trust": "EXACT_OBSTRUCTION"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 377,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          1,
+          3
+        ],
+        "largest_closure_size": 4,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          1,
+          2,
+          4,
+          10
+        ],
+        [
+          2,
+          3,
+          5,
+          11
+        ],
+        [
+          3,
+          4,
+          6,
+          12
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          7,
+          8,
+          10
+        ],
+        [
+          4,
+          8,
+          9,
+          11
+        ],
+        [
+          5,
+          9,
+          10,
+          12
+        ],
+        [
+          0,
+          6,
+          10,
+          11
+        ],
+        [
+          1,
+          7,
+          11,
+          12
+        ],
+        [
+          0,
+          2,
+          8,
+          12
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ]
+      ],
+      "source": "data/patterns/candidate_patterns.json",
+      "source_record_id": "C13_sidon_1_2_4_10",
+      "source_status": "abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as historical numerical evidence"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 50,
+        "core": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "core_generates_all": true,
+        "core_size": 4,
+        "cyclic_capacity_sum": 56,
+        "deletion_closures": [
+          {
+            "closure_size": 3,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              2,
+              3
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ],
+            "private_halo_size": 9,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1,
+                  2
+                ],
+                "private_halo_witnesses": [
+                  4,
+                  10
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              3
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ],
+            "private_halo_size": 9,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  2,
+                  3
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  11
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              3
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ],
+            "private_halo_size": 8,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  3,
+                  12
+                ],
+                "private_halo_witnesses": [
+                  4,
+                  6
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 3,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2
+            ],
+            "private_halo": [
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ],
+            "private_halo_size": 9,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  0
+                ],
+                "private_halo_witnesses": [
+                  4,
+                  5,
+                  7
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 52,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12
+        ],
+        "outside_run_lengths": [
+          6,
+          2,
+          1
+        ],
+        "outside_runs": [
+          [
+            10,
+            8,
+            9,
+            7,
+            4,
+            6
+          ],
+          [
+            11,
+            12
+          ],
+          [
+            5
+          ]
+        ],
+        "outside_size": 9,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 6,
+        "private_pair_lower_bound": 4,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "C13_sidon_1_2_4_10:sample_full_filter_survivor",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 378,
+        "first_generator": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12
+          ],
+          "closure_size": 13,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            2,
+            3,
+            12,
+            11,
+            10,
+            9,
+            8,
+            6,
+            7,
+            4,
+            5
+          ],
+          "seed": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "step_count": 9
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "largest_closure_size_before_stop": 13,
+        "minimum_rank": 4
+      },
+      "n": 13,
+      "order": [
+        5,
+        0,
+        10,
+        8,
+        9,
+        7,
+        4,
+        6,
+        2,
+        11,
+        12,
+        3,
+        1
+      ],
+      "order_label": "sample_full_filter_survivor",
+      "pattern": "C13_sidon_1_2_4_10",
+      "pattern_status": {
+        "family": "circulant",
+        "formula": "S_i = i + [1, 2, 4, 10] mod 13",
+        "lifecycle": "retired_all_order_obstruction",
+        "status": "abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as historical numerical evidence",
+        "trust": "EXACT_OBSTRUCTION"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 377,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          1,
+          3
+        ],
+        "largest_closure_size": 4,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          1,
+          2,
+          4,
+          10
+        ],
+        [
+          2,
+          3,
+          5,
+          11
+        ],
+        [
+          3,
+          4,
+          6,
+          12
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          7,
+          8,
+          10
+        ],
+        [
+          4,
+          8,
+          9,
+          11
+        ],
+        [
+          5,
+          9,
+          10,
+          12
+        ],
+        [
+          0,
+          6,
+          10,
+          11
+        ],
+        [
+          1,
+          7,
+          11,
+          12
+        ],
+        [
+          0,
+          2,
+          8,
+          12
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ]
+      ],
+      "source": "data/patterns/candidate_patterns.json",
+      "source_record_id": "C13_sidon_1_2_4_10",
+      "source_status": "abstract-incidence status: exactly killed across all cyclic orders by the two-inequality Kalmanson inverse-pair order search; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance; every nonzero residue appears exactly once as a difference of D, so |S_a cap S_b| = 1 for every a != b; SLSQP strict-convexity plateau retained as historical numerical evidence"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 115,
+        "core": [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        "core_generates_all": true,
+        "core_size": 5,
+        "cyclic_capacity_sum": 134,
+        "deletion_closures": [
+          {
+            "closure_size": 6,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              2,
+              6,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              12,
+              13,
+              14,
+              15,
+              17,
+              18
+            ],
+            "private_halo_size": 12,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  11,
+                  16
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  9
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 5,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              6,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              17,
+              18
+            ],
+            "private_halo_size": 13,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  6
+                ],
+                "private_halo_witnesses": [
+                  10,
+                  12,
+                  17
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              6,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18
+            ],
+            "private_halo_size": 14,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  7,
+                  11,
+                  13,
+                  18
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 6,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18
+            ],
+            "private_halo_size": 14,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  3,
+                  11,
+                  15,
+                  17
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 8,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2,
+              6
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18
+            ],
+            "private_halo_size": 14,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  0
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  13,
+                  17
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 129,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          3,
+          4,
+          5,
+          7,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18
+        ],
+        "outside_run_lengths": [
+          3,
+          1,
+          10
+        ],
+        "outside_runs": [
+          [
+            3,
+            4,
+            5
+          ],
+          [
+            7
+          ],
+          [
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18
+          ]
+        ],
+        "outside_size": 14,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 19,
+        "private_pair_lower_bound": 5,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "C19_skew:natural",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 5079,
+        "first_generator": [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18
+          ],
+          "closure_size": 19,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            2,
+            6,
+            8,
+            16,
+            11,
+            14,
+            3,
+            5,
+            9,
+            17,
+            12,
+            15,
+            4,
+            7,
+            10,
+            13,
+            18
+          ],
+          "seed": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "step_count": 14
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        "largest_closure_size_before_stop": 19,
+        "minimum_rank": 5
+      },
+      "n": 19,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18
+      ],
+      "order_label": "natural",
+      "pattern": "C19_skew",
+      "pattern_status": {
+        "family": "circulant",
+        "formula": "S_i = i + [-8, -3, 5, 9] mod 19",
+        "lifecycle": "retired_all_order_obstruction",
+        "status": "abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance",
+        "trust": "EXACT_OBSTRUCTION"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 1159,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          2,
+          7
+        ],
+        "largest_closure_size": 4,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          5,
+          9,
+          11,
+          16
+        ],
+        [
+          6,
+          10,
+          12,
+          17
+        ],
+        [
+          7,
+          11,
+          13,
+          18
+        ],
+        [
+          0,
+          8,
+          12,
+          14
+        ],
+        [
+          1,
+          9,
+          13,
+          15
+        ],
+        [
+          2,
+          10,
+          14,
+          16
+        ],
+        [
+          3,
+          11,
+          15,
+          17
+        ],
+        [
+          4,
+          12,
+          16,
+          18
+        ],
+        [
+          0,
+          5,
+          13,
+          17
+        ],
+        [
+          1,
+          6,
+          14,
+          18
+        ],
+        [
+          0,
+          2,
+          7,
+          15
+        ],
+        [
+          1,
+          3,
+          8,
+          16
+        ],
+        [
+          2,
+          4,
+          9,
+          17
+        ],
+        [
+          3,
+          5,
+          10,
+          18
+        ],
+        [
+          0,
+          4,
+          6,
+          11
+        ],
+        [
+          1,
+          5,
+          7,
+          12
+        ],
+        [
+          2,
+          6,
+          8,
+          13
+        ],
+        [
+          3,
+          7,
+          9,
+          14
+        ],
+        [
+          4,
+          8,
+          10,
+          15
+        ]
+      ],
+      "source": "data/patterns/candidate_patterns.json",
+      "source_record_id": "C19_skew",
+      "source_status": "abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 137,
+        "core": [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        "core_generates_all": true,
+        "core_size": 5,
+        "cyclic_capacity_sum": 156,
+        "deletion_closures": [
+          {
+            "closure_size": 6,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              2,
+              6,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              12,
+              13,
+              14,
+              15,
+              17,
+              18
+            ],
+            "private_halo_size": 12,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  11,
+                  16
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  9
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 5,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              6,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              17,
+              18
+            ],
+            "private_halo_size": 13,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  6
+                ],
+                "private_halo_witnesses": [
+                  10,
+                  12,
+                  17
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              6,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18
+            ],
+            "private_halo_size": 14,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  7,
+                  11,
+                  13,
+                  18
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 6,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2,
+              8
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18
+            ],
+            "private_halo_size": 14,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  3,
+                  11,
+                  15,
+                  17
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 8,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2,
+              6
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18
+            ],
+            "private_halo_size": 14,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  0
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  13,
+                  17
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 151,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          3,
+          4,
+          5,
+          7,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18
+        ],
+        "outside_run_lengths": [
+          5,
+          5,
+          4
+        ],
+        "outside_runs": [
+          [
+            3,
+            5,
+            9,
+            14,
+            11
+          ],
+          [
+            13,
+            4,
+            16,
+            12,
+            15
+          ],
+          [
+            18,
+            10,
+            7,
+            17
+          ]
+        ],
+        "outside_size": 14,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 19,
+        "private_pair_lower_bound": 5,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "C19_skew:vertex_circle_survivor",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 5079,
+        "first_generator": [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18
+          ],
+          "closure_size": 19,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            2,
+            6,
+            8,
+            16,
+            11,
+            14,
+            3,
+            5,
+            9,
+            17,
+            12,
+            15,
+            4,
+            7,
+            10,
+            13,
+            18
+          ],
+          "seed": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "step_count": 14
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          2,
+          6,
+          8
+        ],
+        "largest_closure_size_before_stop": 19,
+        "minimum_rank": 5
+      },
+      "n": 19,
+      "order": [
+        18,
+        10,
+        7,
+        17,
+        6,
+        3,
+        5,
+        9,
+        14,
+        11,
+        2,
+        13,
+        4,
+        16,
+        12,
+        15,
+        0,
+        8,
+        1
+      ],
+      "order_label": "vertex_circle_survivor",
+      "pattern": "C19_skew",
+      "pattern_status": {
+        "family": "circulant",
+        "formula": "S_i = i + [-8, -3, 5, 9] mod 19",
+        "lifecycle": "retired_all_order_obstruction",
+        "status": "abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance",
+        "trust": "EXACT_OBSTRUCTION"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 1159,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          2,
+          7
+        ],
+        "largest_closure_size": 4,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          5,
+          9,
+          11,
+          16
+        ],
+        [
+          6,
+          10,
+          12,
+          17
+        ],
+        [
+          7,
+          11,
+          13,
+          18
+        ],
+        [
+          0,
+          8,
+          12,
+          14
+        ],
+        [
+          1,
+          9,
+          13,
+          15
+        ],
+        [
+          2,
+          10,
+          14,
+          16
+        ],
+        [
+          3,
+          11,
+          15,
+          17
+        ],
+        [
+          4,
+          12,
+          16,
+          18
+        ],
+        [
+          0,
+          5,
+          13,
+          17
+        ],
+        [
+          1,
+          6,
+          14,
+          18
+        ],
+        [
+          0,
+          2,
+          7,
+          15
+        ],
+        [
+          1,
+          3,
+          8,
+          16
+        ],
+        [
+          2,
+          4,
+          9,
+          17
+        ],
+        [
+          3,
+          5,
+          10,
+          18
+        ],
+        [
+          0,
+          4,
+          6,
+          11
+        ],
+        [
+          1,
+          5,
+          7,
+          12
+        ],
+        [
+          2,
+          6,
+          8,
+          13
+        ],
+        [
+          3,
+          7,
+          9,
+          14
+        ],
+        [
+          4,
+          8,
+          10,
+          15
+        ]
+      ],
+      "source": "data/patterns/candidate_patterns.json",
+      "source_record_id": "C19_skew",
+      "source_status": "abstract-incidence status: exactly killed across all cyclic orders by the Z3 two-inequality Kalmanson inverse-pair certificate; natural-order Altman and registered non-natural fixed-order Kalmanson/Farkas certificates retained as provenance"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 191,
+        "core": [
+          0,
+          1,
+          3,
+          4,
+          7,
+          8
+        ],
+        "core_generates_all": true,
+        "core_size": 6,
+        "cyclic_capacity_sum": 221,
+        "deletion_closures": [
+          {
+            "closure_size": 7,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              3,
+              4,
+              7,
+              8
+            ],
+            "private_halo": [
+              2,
+              5,
+              6,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              20,
+              21,
+              22,
+              23
+            ],
+            "private_halo_size": 17,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  2,
+                  5,
+                  9,
+                  14
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 6,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              3,
+              4,
+              7,
+              8
+            ],
+            "private_halo": [
+              2,
+              5,
+              6,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              24
+            ],
+            "private_halo_size": 18,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  3
+                ],
+                "private_halo_witnesses": [
+                  6,
+                  10,
+                  15
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 6,
+            "core_vertex": 3,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              4,
+              7,
+              8
+            ],
+            "private_halo": [
+              2,
+              5,
+              6,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "private_halo_size": 18,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  8
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  12,
+                  17
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 6,
+            "core_vertex": 4,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              3,
+              7,
+              8
+            ],
+            "private_halo": [
+              2,
+              5,
+              6,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              24
+            ],
+            "private_halo_size": 18,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  6,
+                  9,
+                  13,
+                  18
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 7,
+            "core_vertex": 7,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              3,
+              4,
+              8
+            ],
+            "private_halo": [
+              2,
+              5,
+              6,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              20,
+              21,
+              22,
+              23
+            ],
+            "private_halo_size": 17,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  9,
+                  12,
+                  16,
+                  21
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 6,
+            "core_vertex": 8,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              3,
+              4,
+              7
+            ],
+            "private_halo": [
+              2,
+              5,
+              6,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              24
+            ],
+            "private_halo_size": 18,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  10,
+                  13,
+                  17,
+                  22
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 215,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          2,
+          5,
+          6,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24
+        ],
+        "outside_run_lengths": [
+          1,
+          2,
+          16
+        ],
+        "outside_runs": [
+          [
+            2
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24
+          ]
+        ],
+        "outside_size": 19,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 30,
+        "private_pair_lower_bound": 6,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "C25_sidon_2_5_9_14:natural",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 69983,
+        "first_generator": [
+          0,
+          1,
+          3,
+          4,
+          7,
+          8
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24
+          ],
+          "closure_size": 25,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            3,
+            4,
+            7,
+            8,
+            23,
+            24,
+            19,
+            14,
+            5,
+            21,
+            12,
+            16,
+            2,
+            10,
+            18,
+            9,
+            20,
+            11,
+            15,
+            22,
+            6,
+            13,
+            17
+          ],
+          "seed": [
+            0,
+            1,
+            3,
+            4,
+            7,
+            8
+          ],
+          "step_count": 19
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          3,
+          4,
+          7,
+          8
+        ],
+        "largest_closure_size_before_stop": 25,
+        "minimum_rank": 6
+      },
+      "n": 25,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24
+      ],
+      "order_label": "natural",
+      "pattern": "C25_sidon_2_5_9_14",
+      "pattern_status": {
+        "family": "circulant",
+        "formula": "S_i = i + [2, 5, 9, 14] mod 25",
+        "lifecycle": "fixed_order_diagnostic",
+        "status": "natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the step-7 Kalmanson-filter survivor is exactly killed by vertex-circle and Altman filters; no all-order obstruction for the abstract C25 pattern is claimed; D = {2,5,9,14} is Sidon: 12 pairwise differences distinct mod 25; |S_a cap S_b| in {0,1} for every a != b",
+        "trust": "INCIDENCE_PATTERN"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 2625,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          3,
+          7
+        ],
+        "largest_closure_size": 4,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          2,
+          5,
+          9,
+          14
+        ],
+        [
+          3,
+          6,
+          10,
+          15
+        ],
+        [
+          4,
+          7,
+          11,
+          16
+        ],
+        [
+          5,
+          8,
+          12,
+          17
+        ],
+        [
+          6,
+          9,
+          13,
+          18
+        ],
+        [
+          7,
+          10,
+          14,
+          19
+        ],
+        [
+          8,
+          11,
+          15,
+          20
+        ],
+        [
+          9,
+          12,
+          16,
+          21
+        ],
+        [
+          10,
+          13,
+          17,
+          22
+        ],
+        [
+          11,
+          14,
+          18,
+          23
+        ],
+        [
+          12,
+          15,
+          19,
+          24
+        ],
+        [
+          0,
+          13,
+          16,
+          20
+        ],
+        [
+          1,
+          14,
+          17,
+          21
+        ],
+        [
+          2,
+          15,
+          18,
+          22
+        ],
+        [
+          3,
+          16,
+          19,
+          23
+        ],
+        [
+          4,
+          17,
+          20,
+          24
+        ],
+        [
+          0,
+          5,
+          18,
+          21
+        ],
+        [
+          1,
+          6,
+          19,
+          22
+        ],
+        [
+          2,
+          7,
+          20,
+          23
+        ],
+        [
+          3,
+          8,
+          21,
+          24
+        ],
+        [
+          0,
+          4,
+          9,
+          22
+        ],
+        [
+          1,
+          5,
+          10,
+          23
+        ],
+        [
+          2,
+          6,
+          11,
+          24
+        ],
+        [
+          0,
+          3,
+          7,
+          12
+        ],
+        [
+          1,
+          4,
+          8,
+          13
+        ]
+      ],
+      "source": "data/patterns/candidate_patterns.json",
+      "source_record_id": "C25_sidon_2_5_9_14",
+      "source_status": "natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the step-7 Kalmanson-filter survivor is exactly killed by vertex-circle and Altman filters; no all-order obstruction for the abstract C25 pattern is claimed; D = {2,5,9,14} is Sidon: 12 pairwise differences distinct mod 25; |S_a cap S_b| in {0,1} for every a != b"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 473,
+        "core": [
+          0,
+          2,
+          8,
+          17,
+          23
+        ],
+        "core_generates_all": true,
+        "core_size": 5,
+        "cyclic_capacity_sum": 494,
+        "deletion_closures": [
+          {
+            "closure_size": 6,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              2,
+              8,
+              17,
+              23
+            ],
+            "private_halo": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              18,
+              19,
+              20,
+              21,
+              22,
+              24,
+              25,
+              26,
+              27,
+              28
+            ],
+            "private_halo_size": 22,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1
+                ],
+                "private_halo_witnesses": [
+                  3,
+                  7,
+                  15
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 5,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              8,
+              17,
+              23
+            ],
+            "private_halo": [
+              1,
+              3,
+              4,
+              5,
+              6,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              18,
+              19,
+              20,
+              21,
+              24,
+              25,
+              26,
+              27,
+              28
+            ],
+            "private_halo_size": 23,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  17
+                ],
+                "private_halo_witnesses": [
+                  3,
+                  5,
+                  9
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 5,
+            "core_vertex": 8,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              17,
+              23
+            ],
+            "private_halo": [
+              1,
+              3,
+              4,
+              5,
+              6,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              18,
+              19,
+              20,
+              21,
+              22,
+              24,
+              25,
+              26,
+              27,
+              28
+            ],
+            "private_halo_size": 23,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  23
+                ],
+                "private_halo_witnesses": [
+                  9,
+                  11,
+                  15
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 5,
+            "core_vertex": 17,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              8,
+              23
+            ],
+            "private_halo": [
+              1,
+              3,
+              4,
+              5,
+              6,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              18,
+              19,
+              20,
+              21,
+              24,
+              25,
+              26,
+              27,
+              28
+            ],
+            "private_halo_size": 23,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  3,
+                  18,
+                  20,
+                  24
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 23,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              8,
+              17
+            ],
+            "private_halo": [
+              1,
+              3,
+              4,
+              5,
+              6,
+              7,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              18,
+              19,
+              20,
+              21,
+              22,
+              24,
+              25,
+              26,
+              27,
+              28
+            ],
+            "private_halo_size": 24,
+            "private_pair_count": 6,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [],
+                "private_halo_witnesses": [
+                  1,
+                  9,
+                  24,
+                  26
+                ],
+                "private_pair_count": 6,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 489,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          1,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          18,
+          19,
+          20,
+          21,
+          22,
+          24,
+          25,
+          26,
+          27,
+          28
+        ],
+        "outside_run_lengths": [
+          1,
+          5,
+          8,
+          5,
+          5
+        ],
+        "outside_runs": [
+          [
+            1
+          ],
+          [
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          [
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16
+          ],
+          [
+            18,
+            19,
+            20,
+            21,
+            22
+          ],
+          [
+            24,
+            25,
+            26,
+            27,
+            28
+          ]
+        ],
+        "outside_size": 24,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 21,
+        "private_pair_lower_bound": 5,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "C29_sidon_1_3_7_15:natural",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 32165,
+        "first_generator": [
+          0,
+          2,
+          8,
+          17,
+          23
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28
+          ],
+          "closure_size": 29,
+          "generates_all": true,
+          "order": [
+            0,
+            2,
+            8,
+            17,
+            23,
+            16,
+            22,
+            1,
+            15,
+            14,
+            28,
+            7,
+            13,
+            21,
+            27,
+            6,
+            12,
+            20,
+            26,
+            5,
+            11,
+            19,
+            25,
+            4,
+            10,
+            18,
+            24,
+            3,
+            9
+          ],
+          "seed": [
+            0,
+            2,
+            8,
+            17,
+            23
+          ],
+          "step_count": 24
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          2,
+          8,
+          17,
+          23
+        ],
+        "largest_closure_size_before_stop": 29,
+        "minimum_rank": 5
+      },
+      "n": 29,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28
+      ],
+      "order_label": "natural",
+      "pattern": "C29_sidon_1_3_7_15",
+      "pattern_status": {
+        "family": "circulant",
+        "formula": "S_i = i + [1, 3, 7, 15] mod 29",
+        "lifecycle": "fixed_order_diagnostic",
+        "status": "natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the fixed order [0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16] escaped weaker filters but is now exactly killed by the 165-row Kalmanson/Farkas fixed-order certificate; no all-order obstruction for the abstract C29 pattern is claimed; D = {1,3,7,15} is Sidon: 12 pairwise differences distinct mod 29; |S_a cap S_b| in {0,1} for every a != b",
+        "trust": "INCIDENCE_PATTERN"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 4089,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          2,
+          6
+        ],
+        "largest_closure_size": 4,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          1,
+          3,
+          7,
+          15
+        ],
+        [
+          2,
+          4,
+          8,
+          16
+        ],
+        [
+          3,
+          5,
+          9,
+          17
+        ],
+        [
+          4,
+          6,
+          10,
+          18
+        ],
+        [
+          5,
+          7,
+          11,
+          19
+        ],
+        [
+          6,
+          8,
+          12,
+          20
+        ],
+        [
+          7,
+          9,
+          13,
+          21
+        ],
+        [
+          8,
+          10,
+          14,
+          22
+        ],
+        [
+          9,
+          11,
+          15,
+          23
+        ],
+        [
+          10,
+          12,
+          16,
+          24
+        ],
+        [
+          11,
+          13,
+          17,
+          25
+        ],
+        [
+          12,
+          14,
+          18,
+          26
+        ],
+        [
+          13,
+          15,
+          19,
+          27
+        ],
+        [
+          14,
+          16,
+          20,
+          28
+        ],
+        [
+          0,
+          15,
+          17,
+          21
+        ],
+        [
+          1,
+          16,
+          18,
+          22
+        ],
+        [
+          2,
+          17,
+          19,
+          23
+        ],
+        [
+          3,
+          18,
+          20,
+          24
+        ],
+        [
+          4,
+          19,
+          21,
+          25
+        ],
+        [
+          5,
+          20,
+          22,
+          26
+        ],
+        [
+          6,
+          21,
+          23,
+          27
+        ],
+        [
+          7,
+          22,
+          24,
+          28
+        ],
+        [
+          0,
+          8,
+          23,
+          25
+        ],
+        [
+          1,
+          9,
+          24,
+          26
+        ],
+        [
+          2,
+          10,
+          25,
+          27
+        ],
+        [
+          3,
+          11,
+          26,
+          28
+        ],
+        [
+          0,
+          4,
+          12,
+          27
+        ],
+        [
+          1,
+          5,
+          13,
+          28
+        ],
+        [
+          0,
+          2,
+          6,
+          14
+        ]
+      ],
+      "source": "data/patterns/candidate_patterns.json",
+      "source_record_id": "C29_sidon_1_3_7_15",
+      "source_status": "natural-order status: exactly killed by Altman linear certificate; abstract-order diagnostic: the fixed order [0,27,11,4,19,5,26,12,6,21,13,28,14,2,20,18,7,24,10,25,17,3,9,15,1,22,8,23,16] escaped weaker filters but is now exactly killed by the 165-row Kalmanson/Farkas fixed-order certificate; no all-order obstruction for the abstract C29 pattern is claimed; D = {1,3,7,15} is Sidon: 12 pairwise differences distinct mod 29; |S_a cap S_b| in {0,1} for every a != b"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 8,
+        "core": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "core_generates_all": true,
+        "core_size": 4,
+        "cyclic_capacity_sum": 14,
+        "deletion_closures": [
+          {
+            "closure_size": 3,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              2,
+              4
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              7,
+              8
+            ],
+            "private_halo_size": 5,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1
+                ],
+                "private_halo_witnesses": [
+                  3,
+                  6,
+                  7
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              4
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              7,
+              8
+            ],
+            "private_halo_size": 5,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  2,
+                  4
+                ],
+                "private_halo_witnesses": [
+                  7,
+                  8
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 5,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              4
+            ],
+            "private_halo": [
+              5,
+              7,
+              8
+            ],
+            "private_halo_size": 3,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  0,
+                  3
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  8
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 4,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              7,
+              8
+            ],
+            "private_halo_size": 5,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1,
+                  2
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  7
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 10,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          3,
+          5,
+          6,
+          7,
+          8
+        ],
+        "outside_run_lengths": [
+          1,
+          4
+        ],
+        "outside_runs": [
+          [
+            3
+          ],
+          [
+            5,
+            6,
+            7,
+            8
+          ]
+        ],
+        "outside_size": 5,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 6,
+        "private_pair_lower_bound": 4,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "n9_vertex_circle_assignment_81:natural",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 131,
+        "first_generator": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "closure_size": 9,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            2,
+            4,
+            3,
+            6,
+            8,
+            5,
+            7
+          ],
+          "seed": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "step_count": 5
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "largest_closure_size_before_stop": 9,
+        "minimum_rank": 4
+      },
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "order_label": "natural",
+      "pattern": "n9_vertex_circle_assignment_81",
+      "pattern_status": {
+        "lifecycle": "n9_vertex_circle_frontier_assignment",
+        "source": "src/erdos97/n9_vertex_circle_exhaustive.py",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 129,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          1,
+          4
+        ],
+        "largest_closure_size": 5,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "source": "data/certificates/bridge_lemma_frontier.json",
+      "source_record_id": 81,
+      "source_status": "review-pending vertex-circle strict_cycle"
+    },
+    {
+      "bootstrap_core_audit": {
+        "capacity_margin": 6,
+        "core": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "core_generates_all": true,
+        "core_size": 4,
+        "cyclic_capacity_sum": 14,
+        "deletion_closures": [
+          {
+            "closure_size": 3,
+            "core_vertex": 0,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              1,
+              2,
+              4
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              7,
+              8
+            ],
+            "private_halo_size": 5,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  2
+                ],
+                "private_halo_witnesses": [
+                  3,
+                  6,
+                  8
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 1,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              2,
+              4
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              7,
+              8
+            ],
+            "private_halo_size": 5,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  0,
+                  4
+                ],
+                "private_halo_witnesses": [
+                  3,
+                  7
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 4,
+            "core_vertex": 2,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              4
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              8
+            ],
+            "private_halo_size": 4,
+            "private_pair_count": 1,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1,
+                  4
+                ],
+                "private_halo_witnesses": [
+                  5,
+                  8
+                ],
+                "private_pair_count": 1,
+                "rich_class_index": 0
+              }
+            ]
+          },
+          {
+            "closure_size": 3,
+            "core_vertex": 4,
+            "core_vertex_not_generated": true,
+            "deletion_seed": [
+              0,
+              1,
+              2
+            ],
+            "private_halo": [
+              3,
+              5,
+              6,
+              7,
+              8
+            ],
+            "private_halo_size": 5,
+            "private_pair_count": 3,
+            "rich_class_private_slices": [
+              {
+                "intersection_with_deletion_closure": [
+                  1
+                ],
+                "private_halo_witnesses": [
+                  3,
+                  6,
+                  7
+                ],
+                "private_pair_count": 3,
+                "rich_class_index": 0
+              }
+            ]
+          }
+        ],
+        "inclusion_minimal": true,
+        "lower_bound_capacity_margin": 10,
+        "lower_bound_capacity_ok": true,
+        "outside": [
+          3,
+          5,
+          6,
+          7,
+          8
+        ],
+        "outside_run_lengths": [
+          1,
+          4
+        ],
+        "outside_runs": [
+          [
+            3
+          ],
+          [
+            5,
+            6,
+            7,
+            8
+          ]
+        ],
+        "outside_size": 5,
+        "private_halo_requirement_ok": true,
+        "private_pair_count": 8,
+        "private_pair_lower_bound": 4,
+        "weighted_capacity_ok": true
+      },
+      "case_id": "n9_vertex_circle_assignment_151:natural",
+      "interpretation": "Fixed selected-row singleton-rich diagnostic only. Passing the bootstrap-core capacity ledger is not a Euclidean realization certificate.",
+      "minimum_generator": {
+        "checked_seed_count": 131,
+        "first_generator": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "found": true,
+        "generating_closure": {
+          "closure": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "closure_size": 9,
+          "generates_all": true,
+          "order": [
+            0,
+            1,
+            2,
+            4,
+            7,
+            8,
+            5,
+            6,
+            3
+          ],
+          "seed": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "step_count": 5
+        },
+        "largest_closure_seed_before_stop": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "largest_closure_size_before_stop": 9,
+        "minimum_rank": 4
+      },
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "order_label": "natural",
+      "pattern": "n9_vertex_circle_assignment_151",
+      "pattern_status": {
+        "lifecycle": "n9_vertex_circle_frontier_assignment",
+        "source": "src/erdos97/n9_vertex_circle_exhaustive.py",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC"
+      },
+      "rank_search_limit_3": {
+        "checked_seed_count": 129,
+        "generating_seed": null,
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "rank_leq_limit": false
+      },
+      "selected_rows": [
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source": "data/certificates/bridge_lemma_frontier.json",
+      "source_record_id": 151,
+      "source_status": "review-pending vertex-circle strict_cycle"
+    }
+  ],
+  "schema": "erdos97.bootstrap_core_crosswalk.v1",
+  "status": "BOOTSTRAP_CORE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "minimum_rank_counts": {
+      "4": 4,
+      "5": 3,
+      "6": 1
+    },
+    "order_case_count": 8,
+    "rank_gt_3_order_cases": 8,
+    "unique_selected_pattern_names": [
+      "C13_sidon_1_2_4_10",
+      "C19_skew",
+      "C25_sidon_2_5_9_14",
+      "C29_sidon_1_3_7_15",
+      "n9_vertex_circle_assignment_151",
+      "n9_vertex_circle_assignment_81"
+    ],
+    "unique_selected_patterns": 6,
+    "weighted_capacity_obstruction_count": 0,
+    "weighted_capacity_survivor_count": 8
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-core-bridge.md
+++ b/docs/bootstrap-core-bridge.md
@@ -196,3 +196,9 @@ python scripts/check_bootstrap_core_bridge.py --assert-expected
 The checked `C13_sidon_1_2_4_10` fixed-row benchmark is used only as a
 bookkeeping negative control. That fixed selected-witness pattern is already
 killed across all cyclic orders by the repo's exact Kalmanson/Farkas search.
+
+The follow-up diagnostic `docs/bootstrap-core-crosswalk.md` applies the same
+singleton-rich bookkeeping to current sparse/frontier fixed-row motifs. It
+records that these audited cases have rank greater than 3 but still pass the
+weighted private-halo capacity ledger, so the ledger is a bridge target rather
+than an obstruction by itself.

--- a/docs/bootstrap-core-crosswalk.md
+++ b/docs/bootstrap-core-crosswalk.md
@@ -1,0 +1,86 @@
+# Bootstrap-Core Crosswalk
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note applies the rich-triple closure and private-halo capacity ledger from
+`docs/bootstrap-core-bridge.md` to current fixed selected-row frontier motifs.
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_core_crosswalk.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_core_crosswalk.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_core_crosswalk.json`.
+
+## Scope
+
+The records use singleton rich classes: each selected row is treated as the
+only rich class at its center. This makes the crosswalk a fixed-selection
+diagnostic. Passing the bootstrap-core ledger is not a Euclidean realization
+certificate, and positive capacity margin is not evidence for a counterexample.
+
+The crosswalk covers:
+
+- natural-order sparse fixed-row motifs `C13_sidon_1_2_4_10`, `C19_skew`,
+  `C25_sidon_2_5_9_14`, and `C29_sidon_1_3_7_15`;
+- the registered non-natural survivor orders for `C13_sidon_1_2_4_10` and
+  `C19_skew`, retained as fixed-pattern provenance even though both abstract
+  patterns are now killed across all cyclic orders by Kalmanson/Farkas
+  certificates;
+- the two non-ear-orderable `n=9` vertex-circle frontier assignments from the
+  review-pending bridge-lemma frontier packet.
+
+The existing base-apex D=3 incidence-capacity packet is included only as a
+reference row. It records profile/capacity ledgers rather than full selected
+rows or full rich classes, so it is not bootstrap-core audited here.
+
+## Results
+
+Every audited fixed-row order case has bootstrap rank greater than 3, so none
+enters the ear-orderable bridge in this singleton-rich interpretation. The
+weighted private-halo capacity ledger kills none of them.
+
+| Case | n | minimum rank | first core | private pairs | cyclic capacity | margin | outside run lengths |
+|---|---:|---:|---|---:|---:|---:|---|
+| `C13_sidon_1_2_4_10:natural` | 13 | 4 | `[0,1,2,3]` | 6 | 36 | 30 | `[9]` |
+| `C13_sidon_1_2_4_10:sample_full_filter_survivor` | 13 | 4 | `[0,1,2,3]` | 6 | 56 | 50 | `[6,2,1]` |
+| `C19_skew:natural` | 19 | 5 | `[0,1,2,6,8]` | 19 | 134 | 115 | `[3,1,10]` |
+| `C19_skew:vertex_circle_survivor` | 19 | 5 | `[0,1,2,6,8]` | 19 | 156 | 137 | `[5,5,4]` |
+| `C25_sidon_2_5_9_14:natural` | 25 | 6 | `[0,1,3,4,7,8]` | 30 | 221 | 191 | `[1,2,16]` |
+| `C29_sidon_1_3_7_15:natural` | 29 | 5 | `[0,2,8,17,23]` | 21 | 494 | 473 | `[1,5,8,5,5]` |
+| `n9_vertex_circle_assignment_81:natural` | 9 | 4 | `[0,1,2,4]` | 6 | 14 | 8 | `[1,4]` |
+| `n9_vertex_circle_assignment_151:natural` | 9 | 4 | `[0,1,2,4]` | 8 | 14 | 6 | `[1,4]` |
+
+The small `n=9` assignments are the tightest current rows for this ledger:
+their capacity margins are `8` and `6`. The sparse circulant cases have much
+larger margins, so this private-pair ledger alone is too weak to explain their
+known exact Kalmanson/Farkas obstructions.
+
+## Reading
+
+The useful negative conclusion is narrow:
+
+```text
+singleton-rich fixed-row stuck motifs
+  -> bootstrap rank > 3
+  -> private-halo capacity still has slack
+```
+
+Thus the next bridge strengthening should not be "try the same capacity ledger
+harder" on sparse singleton rows. It should add an exact ingredient that
+reduces capacity or creates additional private-pair demand: for example,
+metric/order restrictions on where private halos can sit, compatibility with
+full rich-class alternatives, or a coupling to the vertex-circle/Kalmanson
+quotient inequalities that already kill the retired sparse leads.
+
+The base-apex D=3 reference remains a separate bookkeeping frontier: it has 88
+representative packet rows, realizability state `UNKNOWN`, and incidence state
+`UNKNOWN`. It needs full selected-row or full rich-class data before the
+bootstrap-core checker can audit it directly.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -418,6 +418,12 @@ cyclic order. This strengthens the one-pair-per-center radius-blocker bound
 but is still only a bridge target, not a proof of Erdos Problem #97. See
 `docs/bootstrap-core-bridge.md`.
 
+The companion crosswalk in `docs/bootstrap-core-crosswalk.md` applies this
+bookkeeping to current singleton-rich fixed-row frontier motifs. It records
+that the audited cases have rank greater than 3 but still pass weighted
+capacity, so it is negative diagnostic information about the strength of the
+ledger, not a new obstruction theorem.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -26,8 +26,10 @@ Use this queue when no more specific issue is selected.
    current quotient-replay helper.
 3. Strengthen the minimal fragile-cover bridge with one geometric necessary
    condition and test it against the block-6 negative controls.
-4. Apply the bootstrap-core/private-halo weighted capacity checker to current
-   stuck/frontier motifs and record which packets survive the sharper ledger.
+4. Use the bootstrap-core crosswalk in
+   `docs/bootstrap-core-crosswalk.md` to design a sharper condition that
+   reduces private-halo capacity slack or adds private-pair demand; the current
+   singleton-rich stuck/frontier motifs all survive the weighted ledger.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,9 @@ put detailed reconciliation in the canonical synthesis.
   adaptive selected-witness peeling versus radius-blocker bridge fork.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
+- [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked
+  singleton-rich bootstrap-core rank/capacity crosswalk for current fixed-row
+  frontier motifs.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -308,6 +308,11 @@ condition that the surviving multi-block family does not automatically satisfy:
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.
+- bootstrap-core crosswalk evidence, as recorded in
+  `docs/bootstrap-core-crosswalk.md`, showing that the current singleton-rich
+  sparse/frontier motifs have rank greater than 3 but retain positive weighted
+  capacity margin; any useful next condition should reduce that slack or add
+  additional private-pair demand.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -143,6 +143,11 @@ local_repo:
       status: "one fixed order escaped weaker diagnostics but is now killed by a full Kalmanson/Farkas fixed-order certificate"
       artifact: "data/certificates/c29_sidon_fixed_order_kalmanson_165_unsat.json"
       claim_scope: "fixed-order exact obstruction only; not an all-order obstruction for the abstract pattern"
+    - pattern: "bootstrap_core_crosswalk"
+      status: "singleton-rich bootstrap-core rank/capacity crosswalk for current fixed-row frontier motifs"
+      artifact: "data/certificates/bootstrap_core_crosswalk.json"
+      verifier: "scripts/check_bootstrap_core_crosswalk.py"
+      claim_scope: "fixed selected-row bridge diagnostic only; all audited cases have rank greater than 3 and survive weighted private-halo capacity; not a proof or counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"
@@ -164,6 +169,8 @@ local_repo:
     - "docs/round2/round2_merged_report.md"
     - "docs/phi4-rectangle-trap.md"
     - "docs/minimal-fragile-cover-bridge.md"
+    - "docs/bootstrap-core-bridge.md"
+    - "docs/bootstrap-core-crosswalk.md"
     - "docs/reproduction-log.md"
     - "docs/verification-contract.md"
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1786,6 +1786,44 @@ artifacts:
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
 
+  - id: bootstrap_core_crosswalk
+    path: data/certificates/bootstrap_core_crosswalk.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_core_crosswalk.py
+    command: python scripts/check_bootstrap_core_crosswalk.py --write --assert-expected
+    checker: scripts/check_bootstrap_core_crosswalk.py
+    check_command: python scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Bootstrap-core rank and private-halo capacity crosswalk for selected fixed-row frontier motifs; not a proof of the bridge, not a proof of Erdos Problem #97, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_core_crosswalk.v1
+      status: BOOTSTRAP_CORE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.unique_selected_patterns: 6
+      summary.order_case_count: 8
+      summary.rank_gt_3_order_cases: 8
+      summary.minimum_rank_counts:
+        "4": 4
+        "5": 3
+        "6": 1
+      summary.weighted_capacity_obstruction_count: 0
+      summary.weighted_capacity_survivor_count: 8
+      base_apex_d3_reference.representative_count: 88
+      base_apex_d3_reference.bootstrap_core_audited: false
+      provenance.generator: scripts/check_bootstrap_core_crosswalk.py
+      provenance.command: python scripts/check_bootstrap_core_crosswalk.py --write --assert-expected
+    forbidden_claims:
+      - bootstrap-core capacity proves the bridge
+      - singleton-rich fixed rows certify Euclidean realizability
+      - positive capacity margin is a counterexample
+      - n=9 is proved
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_core_crosswalk.py
+++ b/scripts/check_bootstrap_core_crosswalk.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Check the bootstrap-core frontier crosswalk artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_core_crosswalk import (  # noqa: E402
+    assert_expected_payload,
+    build_crosswalk_payload,
+)
+
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "bootstrap_core_crosswalk.json"
+
+
+def load_artifact(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("bootstrap-core crosswalk artifact must be a JSON object")
+    return payload
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    base_apex = payload["base_apex_d3_reference"]
+    if not isinstance(base_apex, dict):
+        raise AssertionError("base-apex reference must be a mapping")
+    print("bootstrap-core crosswalk")
+    print(f"order cases: {summary['order_case_count']}")
+    print(f"rank > 3 cases: {summary['rank_gt_3_order_cases']}")
+    print(f"minimum-rank counts: {summary['minimum_rank_counts']}")
+    print(
+        "weighted-capacity survivors: "
+        f"{summary['weighted_capacity_survivor_count']}; "
+        "obstructions: "
+        f"{summary['weighted_capacity_obstruction_count']}"
+    )
+    print(
+        "base-apex D=3 reference rows: "
+        f"{base_apex['representative_count']} "
+        f"({base_apex['reason_not_audited']})"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned crosswalk counts")
+    args = parser.parse_args()
+
+    generated = build_crosswalk_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated crosswalk")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap-core crosswalk matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap-core crosswalk expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_core_crosswalk.py
+++ b/src/erdos97/bootstrap_core_crosswalk.py
@@ -1,0 +1,542 @@
+"""Bootstrap-core crosswalk diagnostics for current frontier motifs.
+
+This module applies the rich-triple closure and private-halo capacity ledger to
+fixed selected-row benchmark patterns.  It is finite bridge bookkeeping only:
+it does not prove Erdos Problem #97, does not refute any bridge theorem, and
+does not claim a counterexample.
+"""
+
+from __future__ import annotations
+
+import json
+from itertools import combinations
+from pathlib import Path
+from typing import Sequence
+
+from erdos97.adaptive_blockers import RichClasses, singleton_rich_classes_from_pattern
+from erdos97.bootstrap_cores import (
+    BootstrapCoreAudit,
+    ClosureResult,
+    audit_bootstrap_core,
+    closure,
+    validate_full_rich_classes,
+)
+from erdos97.search import PatternInfo, built_in_patterns
+
+
+SCHEMA = "erdos97.bootstrap_core_crosswalk.v1"
+STATUS = "BOOTSTRAP_CORE_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Bootstrap-core rank and private-halo capacity crosswalk for selected "
+    "fixed-row frontier motifs; not a proof of the bridge, not a proof of "
+    "Erdos Problem #97, not a counterexample, and not a global status update."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_APEX_D3_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "n9_base_apex_d3_incidence_capacity_packet.json"
+)
+BRIDGE_LEMMA_FRONTIER_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bridge_lemma_frontier.json"
+)
+
+REGISTERED_ORDER_CASES: dict[str, dict[str, list[int]]] = {
+    "C13_sidon_1_2_4_10": {
+        "sample_full_filter_survivor": [5, 0, 10, 8, 9, 7, 4, 6, 2, 11, 12, 3, 1],
+    },
+    "C19_skew": {
+        "vertex_circle_survivor": [
+            18,
+            10,
+            7,
+            17,
+            6,
+            3,
+            5,
+            9,
+            14,
+            11,
+            2,
+            13,
+            4,
+            16,
+            12,
+            15,
+            0,
+            8,
+            1,
+        ],
+    },
+}
+
+N9_NON_EAR_FRONTIER_IDS = (81, 151)
+
+
+def _closure_json(result: ClosureResult) -> dict[str, object]:
+    return {
+        "seed": result.seed,
+        "closure_size": len(result.closure),
+        "closure": result.closure,
+        "order": result.order,
+        "step_count": len(result.steps),
+        "generates_all": result.generates_all,
+    }
+
+
+def _mask(vertices: Sequence[int]) -> int:
+    out = 0
+    for vertex in vertices:
+        out |= 1 << int(vertex)
+    return out
+
+
+def _vertices(mask: int, n: int) -> list[int]:
+    return [vertex for vertex in range(n) if mask & (1 << vertex)]
+
+
+def _row_masks(rich_classes: RichClasses) -> list[list[int]]:
+    return [
+        [_mask([int(label) for label in row]) for row in classes]
+        for classes in rich_classes
+    ]
+
+
+def _fast_closure(seed: Sequence[int], row_masks: Sequence[Sequence[int]], n: int) -> list[int]:
+    """Return closure vertices with prevalidated rows and precomputed masks."""
+
+    closure_mask = _mask(seed)
+    changed = True
+    while changed:
+        changed = False
+        for center in range(n):
+            if closure_mask & (1 << center):
+                continue
+            for row_mask in row_masks[center]:
+                if (row_mask & closure_mask).bit_count() >= 3:
+                    closure_mask |= 1 << center
+                    changed = True
+                    break
+    return _vertices(closure_mask, n)
+
+
+def search_rank_limit_summary(
+    rich_classes: RichClasses,
+    limit: int = 3,
+) -> dict[str, object]:
+    """Fast rank-at-most-limit summary for crosswalk records."""
+
+    validate_full_rich_classes(rich_classes)
+    n = len(rich_classes)
+    row_masks = _row_masks(rich_classes)
+    checked = 0
+    largest_closure_size = 0
+    largest_closure_seed: list[int] | None = None
+    for size in range(1, min(limit, n) + 1):
+        for seed in combinations(range(n), size):
+            checked += 1
+            closed = _fast_closure(seed, row_masks, n)
+            if len(closed) > largest_closure_size:
+                largest_closure_size = len(closed)
+                largest_closure_seed = list(seed)
+            if len(closed) == n:
+                return {
+                    "rank_leq_limit": True,
+                    "checked_seed_count": checked,
+                    "largest_closure_size": len(closed),
+                    "largest_closure_seed": list(seed),
+                    "generating_seed": list(seed),
+                }
+    return {
+        "rank_leq_limit": False,
+        "checked_seed_count": checked,
+        "largest_closure_size": largest_closure_size,
+        "largest_closure_seed": largest_closure_seed,
+        "generating_seed": None,
+    }
+
+
+def _audit_json(audit: BootstrapCoreAudit) -> dict[str, object]:
+    deletion_summaries = []
+    for deletion in audit.deletion_closures:
+        private_pair_count = sum(
+            rich_slice.private_pair_count
+            for rich_slice in deletion.rich_class_slices
+        )
+        deletion_summaries.append(
+            {
+                "core_vertex": deletion.core_vertex,
+                "deletion_seed": deletion.seed,
+                "closure_size": len(deletion.closure),
+                "core_vertex_not_generated": deletion.core_vertex_not_generated,
+                "private_halo": deletion.private_halo,
+                "private_halo_size": len(deletion.private_halo),
+                "private_pair_count": private_pair_count,
+                "rich_class_private_slices": [
+                    {
+                        "rich_class_index": rich_slice.rich_class_index,
+                        "intersection_with_deletion_closure": (
+                            rich_slice.intersection_with_deletion_closure
+                        ),
+                        "private_halo_witnesses": rich_slice.private_halo_witnesses,
+                        "private_pair_count": rich_slice.private_pair_count,
+                    }
+                    for rich_slice in deletion.rich_class_slices
+                ],
+            }
+        )
+
+    return {
+        "core": audit.core,
+        "core_size": len(audit.core),
+        "outside_size": len(audit.outside),
+        "outside": audit.outside,
+        "core_generates_all": audit.core_generates_all,
+        "inclusion_minimal": audit.inclusion_minimal,
+        "private_halo_requirement_ok": audit.private_halo_requirement_ok,
+        "private_pair_lower_bound": audit.private_pair_lower_bound,
+        "private_pair_count": audit.private_pair_count,
+        "cyclic_capacity_sum": audit.cyclic_capacity_sum,
+        "capacity_margin": audit.cyclic_capacity_sum - audit.private_pair_count,
+        "lower_bound_capacity_margin": (
+            audit.cyclic_capacity_sum - audit.private_pair_lower_bound
+        ),
+        "lower_bound_capacity_ok": audit.lower_bound_capacity_ok,
+        "weighted_capacity_ok": audit.weighted_capacity_ok,
+        "outside_runs": audit.outside_runs,
+        "outside_run_lengths": [len(run) for run in audit.outside_runs],
+        "deletion_closures": deletion_summaries,
+    }
+
+
+def search_first_minimum_generator(
+    rich_classes: RichClasses,
+    max_size: int | None = None,
+) -> dict[str, object]:
+    """Return the first generator after exhausting all smaller seed sizes."""
+
+    validate_full_rich_classes(rich_classes)
+    n = len(rich_classes)
+    row_masks = _row_masks(rich_classes)
+    if max_size is None:
+        max_size = n
+
+    checked = 0
+    largest_closure_size = 0
+    largest_closure_seed: list[int] | None = None
+    for size in range(1, min(max_size, n) + 1):
+        for seed in combinations(range(n), size):
+            checked += 1
+            closed = _fast_closure(seed, row_masks, n)
+            if len(closed) > largest_closure_size:
+                largest_closure_size = len(closed)
+                largest_closure_seed = list(seed)
+            if len(closed) == n:
+                result = closure(seed, rich_classes)
+                return {
+                    "found": True,
+                    "minimum_rank": size,
+                    "first_generator": list(seed),
+                    "checked_seed_count": checked,
+                    "largest_closure_size_before_stop": largest_closure_size,
+                    "largest_closure_seed_before_stop": largest_closure_seed,
+                    "generating_closure": _closure_json(result),
+                }
+
+    return {
+        "found": False,
+        "minimum_rank": None,
+        "first_generator": None,
+        "checked_seed_count": checked,
+        "largest_closure_size_before_stop": largest_closure_size,
+        "largest_closure_seed_before_stop": largest_closure_seed,
+        "generating_closure": None,
+    }
+
+
+def _pattern_status(pattern: PatternInfo) -> dict[str, object]:
+    return {
+        "family": pattern.family,
+        "formula": pattern.formula,
+        "status": pattern.status,
+        "trust": pattern.trust,
+        "lifecycle": pattern.lifecycle,
+    }
+
+
+def _bridge_frontier_n9_records() -> list[dict[str, object]]:
+    """Return selected n=9 non-ear records from the bridge-frontier artifact."""
+
+    payload = json.loads(BRIDGE_LEMMA_FRONTIER_ARTIFACT.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("bridge-lemma frontier artifact must be a JSON object")
+    targets = payload.get("proof_mining_targets")
+    if not isinstance(targets, list):
+        raise AssertionError("bridge-lemma frontier artifact has no proof_mining_targets")
+    by_id: dict[int, dict[str, object]] = {}
+    for target in targets:
+        if not isinstance(target, dict) or int(target.get("n", -1)) != 9:
+            continue
+        source_record_id = target.get("source_record_id")
+        if not isinstance(source_record_id, int):
+            continue
+        by_id[source_record_id] = target
+    missing = [record_id for record_id in N9_NON_EAR_FRONTIER_IDS if record_id not in by_id]
+    if missing:
+        raise AssertionError(f"missing n=9 bridge-frontier records {missing}")
+    return [by_id[record_id] for record_id in N9_NON_EAR_FRONTIER_IDS]
+
+
+def _analyze_rows(
+    *,
+    name: str,
+    selected_rows: Sequence[Sequence[int]],
+    order_label: str,
+    order: Sequence[int],
+    source: str,
+    source_record_id: int | str | None,
+    source_status: str,
+    pattern_status: dict[str, object] | None = None,
+) -> dict[str, object]:
+    rich_classes = singleton_rich_classes_from_pattern(selected_rows)
+    rank3 = search_rank_limit_summary(rich_classes, limit=3)
+    minimum = search_first_minimum_generator(rich_classes)
+    if not minimum["found"]:
+        raise AssertionError(f"{name} has no generating core")
+    core = minimum["first_generator"]
+    if not isinstance(core, list):
+        raise AssertionError(f"{name} generator core is malformed")
+    audit = audit_bootstrap_core(core, rich_classes, order=order)
+    return {
+        "case_id": f"{name}:{order_label}",
+        "pattern": name,
+        "source": source,
+        "source_record_id": source_record_id,
+        "source_status": source_status,
+        "order_label": order_label,
+        "order": [int(label) for label in order],
+        "n": len(selected_rows),
+        "selected_rows": [[int(label) for label in row] for row in selected_rows],
+        "pattern_status": pattern_status or {},
+        "rank_search_limit_3": {
+            "rank_leq_limit": rank3["rank_leq_limit"],
+            "checked_seed_count": rank3["checked_seed_count"],
+            "largest_closure_size": rank3["largest_closure_size"],
+            "largest_closure_seed": rank3["largest_closure_seed"],
+            "generating_seed": rank3["generating_seed"],
+        },
+        "minimum_generator": minimum,
+        "bootstrap_core_audit": _audit_json(audit),
+        "interpretation": (
+            "Fixed selected-row singleton-rich diagnostic only. Passing the "
+            "bootstrap-core capacity ledger is not a Euclidean realization "
+            "certificate."
+        ),
+    }
+
+
+def fixed_row_order_cases() -> list[dict[str, object]]:
+    """Return bootstrap-core records for current fixed-row motifs."""
+
+    patterns = built_in_patterns()
+    rows: list[dict[str, object]] = []
+
+    for name in (
+        "C13_sidon_1_2_4_10",
+        "C19_skew",
+        "C25_sidon_2_5_9_14",
+        "C29_sidon_1_3_7_15",
+    ):
+        pattern = patterns[name]
+        source_status = pattern.status or "registered fixed selected-row pattern"
+        source = "data/patterns/candidate_patterns.json"
+        row_cases = {"natural": list(range(pattern.n))}
+        row_cases.update(REGISTERED_ORDER_CASES.get(name, {}))
+        for order_label, order in row_cases.items():
+            rows.append(
+                _analyze_rows(
+                    name=name,
+                    selected_rows=pattern.S,
+                    order_label=order_label,
+                    order=order,
+                    source=source,
+                    source_record_id=name,
+                    source_status=source_status,
+                    pattern_status=_pattern_status(pattern),
+                )
+            )
+
+    for record in _bridge_frontier_n9_records():
+        selected_rows = record["selected_rows"]
+        if not isinstance(selected_rows, list):
+            raise AssertionError("n9 selected rows are malformed")
+        source_record_id = record["source_record_id"]
+        name = f"n9_vertex_circle_assignment_{source_record_id}"
+        vertex_status = str(record["vertex_circle_status"])
+        rows.append(
+            _analyze_rows(
+                name=name,
+                selected_rows=selected_rows,
+                order_label="natural",
+                order=list(range(len(selected_rows))),
+                source="data/certificates/bridge_lemma_frontier.json",
+                source_record_id=source_record_id,
+                source_status=f"review-pending vertex-circle {vertex_status}",
+                pattern_status={
+                    "trust": "REVIEW_PENDING_DIAGNOSTIC",
+                    "lifecycle": "n9_vertex_circle_frontier_assignment",
+                    "source": record["source"],
+                },
+            )
+        )
+
+    return rows
+
+
+def base_apex_d3_reference() -> dict[str, object]:
+    """Return the existing base-apex D=3 packet summary as a reference row."""
+
+    packet = json.loads(BASE_APEX_D3_ARTIFACT.read_text(encoding="utf-8"))
+    if not isinstance(packet, dict):
+        raise AssertionError("D=3 base-apex packet must be a JSON object")
+    return {
+        "source_artifact": "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json",
+        "schema": packet["schema"],
+        "status": packet["status"],
+        "trust": packet["trust"],
+        "representative_count": packet["representative_count"],
+        "profile_multiset_count": packet["profile_multiset_count"],
+        "escape_class_count": packet["escape_class_count"],
+        "capacity_deficit": packet["capacity_deficit"],
+        "target_capacity_total": packet["target_capacity_total"],
+        "realizability_state": packet["realizability_state"],
+        "incidence_state": packet["incidence_state"],
+        "bootstrap_core_audited": False,
+        "reason_not_audited": (
+            "The D=3 packet records base-apex profile/capacity ledgers rather "
+            "than full selected rows or full rich classes, so it is included "
+            "as a capacity-reference packet only."
+        ),
+    }
+
+
+def build_crosswalk_payload() -> dict[str, object]:
+    """Build the deterministic bootstrap-core frontier crosswalk payload."""
+
+    records = fixed_row_order_cases()
+    rank_counts: dict[str, int] = {}
+    capacity_obstructions = 0
+    for record in records:
+        rank = record["minimum_generator"]["minimum_rank"]  # type: ignore[index]
+        rank_counts[str(rank)] = rank_counts.get(str(rank), 0) + 1
+        audit = record["bootstrap_core_audit"]  # type: ignore[assignment]
+        if not isinstance(audit, dict):
+            raise AssertionError("bootstrap audit record is malformed")
+        if not audit["weighted_capacity_ok"]:
+            capacity_obstructions += 1
+
+    unique_patterns = sorted({str(record["pattern"]) for record in records})
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "The fixed-row records use singleton rich classes, not full geometric rich-class data.",
+            "Capacity margins are necessary-condition ledgers only; positive margins do not certify realizability.",
+            "The base-apex D=3 packet is referenced but not bootstrap-core audited because it is not a full selected-row object.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "summary": {
+            "unique_selected_patterns": len(unique_patterns),
+            "unique_selected_pattern_names": unique_patterns,
+            "order_case_count": len(records),
+            "rank_gt_3_order_cases": sum(
+                1
+                for record in records
+                if not record["rank_search_limit_3"]["rank_leq_limit"]  # type: ignore[index]
+            ),
+            "minimum_rank_counts": dict(sorted(rank_counts.items())),
+            "weighted_capacity_obstruction_count": capacity_obstructions,
+            "weighted_capacity_survivor_count": len(records) - capacity_obstructions,
+        },
+        "records": records,
+        "base_apex_d3_reference": base_apex_d3_reference(),
+        "provenance": {
+            "generator": "scripts/check_bootstrap_core_crosswalk.py",
+            "command": (
+                "python scripts/check_bootstrap_core_crosswalk.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/patterns/candidate_patterns.json",
+                "data/certificates/bridge_lemma_frontier.json",
+                "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json",
+            ],
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def assert_expected_payload(payload: dict[str, object]) -> None:
+    """Assert the current expected crosswalk counts and guardrails."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap-core crosswalk schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap-core crosswalk status")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "unique_selected_patterns": 6,
+        "order_case_count": 8,
+        "rank_gt_3_order_cases": 8,
+        "minimum_rank_counts": {"4": 4, "5": 3, "6": 1},
+        "weighted_capacity_obstruction_count": 0,
+        "weighted_capacity_survivor_count": 8,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    by_case = {record["case_id"]: record for record in records}
+    expected_cases = {
+        "C13_sidon_1_2_4_10:natural": (4, 6, 36),
+        "C13_sidon_1_2_4_10:sample_full_filter_survivor": (4, 6, 56),
+        "C19_skew:natural": (5, 19, 134),
+        "C19_skew:vertex_circle_survivor": (5, 19, 156),
+        "C25_sidon_2_5_9_14:natural": (6, 30, 221),
+        "C29_sidon_1_3_7_15:natural": (5, 21, 494),
+        "n9_vertex_circle_assignment_81:natural": (4, 6, 14),
+        "n9_vertex_circle_assignment_151:natural": (4, 8, 14),
+    }
+    if set(by_case) != set(expected_cases):
+        raise AssertionError("unexpected crosswalk case set")
+    for case_id, (rank, private_pairs, capacity) in expected_cases.items():
+        record = by_case[case_id]
+        rank3 = record["rank_search_limit_3"]
+        minimum = record["minimum_generator"]
+        audit = record["bootstrap_core_audit"]
+        if rank3["rank_leq_limit"]:
+            raise AssertionError(f"{case_id} unexpectedly has rank <= 3")
+        if minimum["minimum_rank"] != rank:
+            raise AssertionError(f"{case_id} minimum rank changed")
+        if audit["private_pair_count"] != private_pairs:
+            raise AssertionError(f"{case_id} private pair count changed")
+        if audit["cyclic_capacity_sum"] != capacity:
+            raise AssertionError(f"{case_id} cyclic capacity changed")
+        if not audit["weighted_capacity_ok"]:
+            raise AssertionError(f"{case_id} should pass weighted capacity")
+
+    base_apex = payload.get("base_apex_d3_reference")
+    if not isinstance(base_apex, dict):
+        raise AssertionError("base-apex reference must be a mapping")
+    if base_apex.get("representative_count") != 88:
+        raise AssertionError("unexpected D=3 base-apex representative count")
+    if base_apex.get("bootstrap_core_audited") is not False:
+        raise AssertionError("base-apex D=3 packet should be reference-only")

--- a/tests/test_bootstrap_core_crosswalk.py
+++ b/tests/test_bootstrap_core_crosswalk.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_core_crosswalk import (
+    assert_expected_payload,
+    build_crosswalk_payload,
+    search_first_minimum_generator,
+)
+from erdos97.adaptive_blockers import singleton_rich_classes_from_pattern
+from erdos97.bridge_negative_controls import c13_sidon_rows
+
+
+def test_bootstrap_core_crosswalk_expected_payload() -> None:
+    payload = build_crosswalk_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["order_case_count"] == 8
+    assert summary["rank_gt_3_order_cases"] == 8
+    assert summary["weighted_capacity_obstruction_count"] == 0
+
+
+def test_bootstrap_core_crosswalk_records_order_sensitive_capacity() -> None:
+    payload = build_crosswalk_payload()
+    by_case = {record["case_id"]: record for record in payload["records"]}
+
+    natural = by_case["C13_sidon_1_2_4_10:natural"]["bootstrap_core_audit"]
+    registered = by_case[
+        "C13_sidon_1_2_4_10:sample_full_filter_survivor"
+    ]["bootstrap_core_audit"]
+
+    assert natural["core"] == registered["core"]
+    assert natural["cyclic_capacity_sum"] == 36
+    assert registered["cyclic_capacity_sum"] == 56
+    assert registered["capacity_margin"] > natural["capacity_margin"]
+
+
+def test_first_minimum_generator_exhausts_smaller_seeds() -> None:
+    rich_classes = singleton_rich_classes_from_pattern(c13_sidon_rows())
+
+    result = search_first_minimum_generator(rich_classes)
+
+    assert result["found"]
+    assert result["minimum_rank"] == 4
+    assert result["first_generator"] == [0, 1, 2, 3]
+    assert result["generating_closure"]["generates_all"]
+
+
+def test_bootstrap_core_crosswalk_expected_payload_rejects_drift() -> None:
+    payload = build_crosswalk_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["weighted_capacity_obstruction_count"] = 1
+
+    with pytest.raises(AssertionError, match="weighted_capacity_obstruction_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- Add a reproducible bootstrap-core crosswalk for current fixed-row frontier motifs.
- Record rank, first generating core, private-halo pair demand, cyclic capacity, and capacity margins for sparse/frontier singleton-rich cases.
- Include the existing n=9 base-apex D=3 packet as a reference-only capacity object, explicitly not a bootstrap-core audit.

## Scope

This is bridge bookkeeping only. It does not prove the bridge, prove Erdos Problem #97, certify Euclidean realizability, or claim a counterexample.

## Validation

- `python scripts/check_bootstrap_core_crosswalk.py --check --assert-expected`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_bootstrap_core_crosswalk.py tests/test_bootstrap_cores.py -q`
- `python -m pytest -q`