### PR TITLE
[codex] Abstract selected path self-edge

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -135,7 +135,55 @@ strict-edge instances: 8
 Those instances use longer selected-distance quotient paths rather than the
 two-row shortcut.
 
-## Lemma C: T03 selected-path self-edge
+## Lemma C: selected-path self-edge criterion
+
+For an unordered pair `u,v`, write
+
+```text
+D_uv = |p_u - p_v|^2.
+```
+
+A **selected-distance path** from pair `P_0` to pair `P_m` is a sequence
+
+```text
+P_0, r_1, P_1, r_2, ..., r_m, P_m
+```
+
+such that each step has the form
+
+```text
+P_{t-1} = {r_t, x_t},
+P_t     = {r_t, y_t},
+x_t, y_t in S_{r_t}.
+```
+
+Each step is justified by the selected row `S_{r_t}`, so the path forces
+
+```text
+D(P_0) = D(P_1) = ... = D(P_m).
+```
+
+Now suppose a selected row `S_c` has four witnesses in angular order, up to
+reversal, such that the chord with endpoint pair `P_0` strictly contains the
+chord with endpoint pair `P_m` on the circle centered at `c`. Vertex-circle
+monotonicity gives
+
+```text
+D(P_0) > D(P_m).
+```
+
+The selected-distance path therefore forces a reflexive strict edge in the
+distance quotient:
+
+```text
+D(P_0) > D(P_m) = D(P_0),
+```
+
+which is impossible. This criterion is local and template-name-free: it only
+uses the displayed selected rows, the cyclic order around the strict row, and
+the selected-distance path.
+
+### T03 selected-path instances
 
 The T03 packet has two four-row local cores. For `F05`, the rows are:
 
@@ -189,7 +237,7 @@ families: F05, F15
 covered assignments: 20
 ```
 
-## Lemma D: T04/F13 selected-path self-edge
+### T04/F13 selected-path instance
 
 The T04/F13 local core is:
 
@@ -220,7 +268,7 @@ family: F13
 covered assignments: 2
 ```
 
-## Lemma E: T10/F12 two-edge strict cycle
+## Lemma D: T10/F12 two-edge strict cycle
 
 The T10/F12 local core is:
 
@@ -271,7 +319,7 @@ covered assignments: 18
 Again, the local core has no two-circle cap violation and no crossing-bisector
 order violation before the vertex-circle quotient step.
 
-## Lemma F: T11/F07 three-edge strict cycle
+## Lemma E: T11/F07 three-edge strict cycle
 
 The T11/F07 local core is:
 
@@ -314,7 +362,7 @@ family: F07
 covered assignments: 6
 ```
 
-## Lemma G: T12/F16 three-edge strict cycle
+## Lemma F: T12/F16 three-edge strict cycle
 
 The T12/F16 local core is:
 

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,128 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 663 - Selected-path Self-edge Criterion
+
+### Mathematical Subquestion
+
+Cycles 661 and 662 integrated the T03 and T04 selected-path self-edge packets
+into the aggregate local-lemma scan. The narrow question for this cycle was:
+
+```text
+Can the T03/T04 packet-specific selected-path arguments be replaced by a
+single template-name-free local criterion?
+```
+
+### Definitions and Assumptions
+
+For an unordered pair `u,v`, write `D_uv = |p_u - p_v|^2`. A
+**selected-distance path** from pair `P_0` to pair `P_m` is a sequence
+
+```text
+P_0, r_1, P_1, r_2, ..., r_m, P_m
+```
+
+such that each step has
+
+```text
+P_{t-1} = {r_t, x_t},
+P_t     = {r_t, y_t},
+x_t, y_t in S_{r_t}.
+```
+
+The selected row `S_{r_t}` gives `D(P_{t-1}) = D(P_t)`.
+
+### Result Status
+
+Proved local lemma:
+**Selected-path Self-edge Criterion**.
+
+### Argument Or Obstruction
+
+If row `S_c` has selected witnesses whose angular order makes the chord with
+endpoint pair `P_0` strictly contain the chord with endpoint pair `P_m`, then
+vertex-circle monotonicity gives
+
+```text
+D(P_0) > D(P_m).
+```
+
+If there is also a selected-distance path from `P_0` to `P_m`, the path gives
+
+```text
+D(P_0) = D(P_m).
+```
+
+Together these imply a reflexive strict edge,
+
+```text
+D(P_0) > D(P_m) = D(P_0),
+```
+
+which is impossible. This criterion is independent of the T03/T04 template
+names once the selected rows, the cyclic order around the strict row, and the
+selected-distance path are displayed.
+
+### Exact Scope
+
+This is a local obstruction criterion for selected-witness systems in a
+strictly convex polygon. It is not an independent review of the exhaustive
+`n=9` checker, not a proof of the full `n=9` finite case, not a general proof
+of Erdos Problem #97, and not a counterexample. It explains the T03/T04
+selected-path self-edge instances already recorded by the aggregate scan.
+
+### Files Changed
+
+- `docs/n9-vertex-circle-local-lemmas.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This reduces a packet-specific proof-mining step to a reusable local lemma:
+any future packet or bridge argument only needs to exhibit a selected-distance
+path whose endpoints are separated by a strict vertex-circle containment edge.
+The result does not close the global scope gap; it only makes one local
+obstruction mechanism more portable and easier to review.
+
+### Next Lead
+
+Try the analogous abstraction for directed strict cycles: state a
+template-name-free quotient-cycle criterion and list T10/T11/T12 as instances.
+The stronger bridge question remains how to force arbitrary counterexamples
+to contain one of these quotient self-edge or strict-cycle structures.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-663`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-663`.
+- The branch was started from `origin/main` at commit
+  `08027ea84c74d33cc986fcdfbbd769ad7e842c02`, after PR #397 merged Cycle
+  662.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `574 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 662 - T04/F13 Aggregate Local-scan Closure
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

Cycle 663 abstracts the repeated T03/T04 selected-path self-edge mechanism into a template-name-free local criterion.

This is proof-facing documentation only. It does not claim a proof of the full `n=9` finite case, does not claim a proof of Erdos Problem #97, and does not claim a counterexample.

## What changed

- Adds a selected-distance path definition to the local-lemma note.
- States the selected-path self-edge criterion independent of T03/T04 template names.
- Recasts T03 and T04/F13 as instances of that criterion.
- Records the research cycle in the running log.

## Exact result

If a selected-distance path identifies two ordinary pair distances `D(P_0)` and `D(P_m)`, while a selected row's vertex-circle chord containment gives `D(P_0) > D(P_m)`, the local core is impossible by a reflexive strict edge.

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`574 passed, 278 deselected`)

## Remaining limitations

- This only abstracts a local obstruction mechanism.
- It does not bridge arbitrary counterexamples to the local templates.
- It does not independently review the exhaustive `n=9` checker.
- The overarching proof/counterexample objective remains open.