### PR TITLE
[codex] Crosscheck n9 local lemma scan

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -357,6 +357,32 @@ family: F16
 covered assignments: 2
 ```
 
+## Focused-note crosscheck
+
+The aggregate checker also cross-checks the proof-facing focused notes that
+have already been extracted from the packet catalog:
+
+```text
+T03/F05,F15 -> docs/n9-vertex-circle-t03-self-edge-lemma.md
+T04/F13     -> docs/n9-vertex-circle-t04-self-edge-lemma.md
+T10/F12     -> docs/n9-vertex-circle-t10-strict-cycle-lemma.md
+T11/F07     -> docs/n9-vertex-circle-t11-strict-cycle-lemma.md
+T12/F16     -> docs/n9-vertex-circle-t12-strict-cycle-lemma.md
+```
+
+For T03, T10, T11, and T12 the scan loads the focused JSON packets and checks
+that the aggregate family rows, strict inequalities, equality paths, cycle
+steps, and assignment counts match the focused packet used by the note. T04 has
+no separate focused packet; its note is backed directly by the T04 family
+record in the self-edge template packet, and the aggregate scan checks that
+record instead.
+
+This crosscheck is intentionally modest. It says the aggregate proof-mining
+summary agrees with the focused proof-note packets and source template record.
+It does not independently prove that the template packets cover all `n=9`
+frontier assignments, and it does not promote the review-pending exhaustive
+checker.
+
 ## Scan summary
 
 The current local-lemma scan covers these review-pending template-packet

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -25,6 +25,18 @@ DEFAULT_SELF_EDGE_PACKET = (
 DEFAULT_STRICT_CYCLE_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
 )
+DEFAULT_T03_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t03_self_edge_lemma_packet.json"
+)
+DEFAULT_T10_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
+)
+DEFAULT_T11_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t11_strict_cycle_lemma_packet.json"
+)
+DEFAULT_T12_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t12_strict_cycle_lemma_packet.json"
+)
 
 
 def load_artifact(path: Path) -> Any:
@@ -37,12 +49,22 @@ def scan_payload(
     *,
     self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
     strict_cycle_packet_path: Path = DEFAULT_STRICT_CYCLE_PACKET,
+    t03_packet_path: Path = DEFAULT_T03_PACKET,
+    t10_packet_path: Path = DEFAULT_T10_PACKET,
+    t11_packet_path: Path = DEFAULT_T11_PACKET,
+    t12_packet_path: Path = DEFAULT_T12_PACKET,
 ) -> dict[str, Any]:
     """Load source artifacts and return the local-lemma scan payload."""
 
     return local_lemma_scan_payload(
         load_artifact(self_edge_packet_path),
         load_artifact(strict_cycle_packet_path),
+        focused_packets={
+            "T03": load_artifact(t03_packet_path),
+            "T10": load_artifact(t10_packet_path),
+            "T11": load_artifact(t11_packet_path),
+            "T12": load_artifact(t12_packet_path),
+        },
     )
 
 
@@ -68,6 +90,12 @@ def summary_lines(payload: dict[str, Any]) -> list[str]:
             f"{lemma['covered_assignment_count']} assignments, "
             f"families {','.join(lemma['family_ids'])}"
         )
+    for item in payload["focused_note_crosscheck"]:
+        lines.append(
+            f"focused {item['template_id']}: {item['check_status']} "
+            f"against {item['proof_note_path']} "
+            f"families {','.join(item['family_ids'])}"
+        )
     special = payload["direct_two_row_nested_spoke_special_case"]
     lines.append(
         f"{special['lemma_id']}: {special['instance_count']} exact direct instances"
@@ -90,6 +118,30 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to n9 strict-cycle template packet JSON.",
     )
     parser.add_argument(
+        "--t03-packet",
+        type=Path,
+        default=DEFAULT_T03_PACKET,
+        help="Path to focused T03 self-edge lemma packet JSON.",
+    )
+    parser.add_argument(
+        "--t10-packet",
+        type=Path,
+        default=DEFAULT_T10_PACKET,
+        help="Path to focused T10 strict-cycle lemma packet JSON.",
+    )
+    parser.add_argument(
+        "--t11-packet",
+        type=Path,
+        default=DEFAULT_T11_PACKET,
+        help="Path to focused T11 strict-cycle lemma packet JSON.",
+    )
+    parser.add_argument(
+        "--t12-packet",
+        type=Path,
+        default=DEFAULT_T12_PACKET,
+        help="Path to focused T12 strict-cycle lemma packet JSON.",
+    )
+    parser.add_argument(
         "--assert-expected",
         action="store_true",
         help="Assert the currently expected local-lemma scan counts.",
@@ -100,6 +152,10 @@ def main(argv: list[str] | None = None) -> int:
     payload = scan_payload(
         self_edge_packet_path=args.self_edge_packet,
         strict_cycle_packet_path=args.strict_cycle_packet,
+        t03_packet_path=args.t03_packet,
+        t10_packet_path=args.t10_packet,
+        t11_packet_path=args.t11_packet,
+        t12_packet_path=args.t12_packet,
     )
     if args.assert_expected:
         assert_expected_local_lemma_scan(payload)

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -8,7 +8,7 @@ vertex-circle checker.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
 from erdos97.vertex_circle_quotient_replay import (
@@ -79,11 +79,64 @@ EXPECTED_SUMMARY = {
     },
 }
 EXPECTED_DIRECT_TWO_ROW_INSTANCE_COUNT = 0
+EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
+    T03_SELECTED_PATH_SELF_EDGE: {
+        "template_id": "T03",
+        "family_ids": ["F05", "F15"],
+        "proof_note_path": "docs/n9-vertex-circle-t03-self-edge-lemma.md",
+        "source_kind": "focused_packet",
+        "packet_key": "T03",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json"
+        ),
+    },
+    T04_SELECTED_PATH_SELF_EDGE: {
+        "template_id": "T04",
+        "family_ids": ["F13"],
+        "proof_note_path": "docs/n9-vertex-circle-t04-self-edge-lemma.md",
+        "source_kind": "template_packet",
+        "packet_key": None,
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_self_edge_template_packet.json"
+        ),
+    },
+    T10_STRICT_CYCLE_LEMMA: {
+        "template_id": "T10",
+        "family_ids": ["F12"],
+        "proof_note_path": "docs/n9-vertex-circle-t10-strict-cycle-lemma.md",
+        "source_kind": "focused_packet",
+        "packet_key": "T10",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
+        ),
+    },
+    T11_STRICT_CYCLE_LEMMA: {
+        "template_id": "T11",
+        "family_ids": ["F07"],
+        "proof_note_path": "docs/n9-vertex-circle-t11-strict-cycle-lemma.md",
+        "source_kind": "focused_packet",
+        "packet_key": "T11",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json"
+        ),
+    },
+    T12_STRICT_CYCLE_LEMMA: {
+        "template_id": "T12",
+        "family_ids": ["F16"],
+        "proof_note_path": "docs/n9-vertex-circle-t12-strict-cycle-lemma.md",
+        "source_kind": "focused_packet",
+        "packet_key": "T12",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json"
+        ),
+    },
+}
 
 
 def local_lemma_scan_payload(
     self_edge_packet: dict[str, Any],
     strict_cycle_packet: dict[str, Any],
+    focused_packets: Mapping[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Return a JSON-safe scan of reusable local-lemma instances."""
 
@@ -183,6 +236,11 @@ def local_lemma_scan_payload(
         T04_SELECTED_PATH_SELF_EDGE: t04_selected_path,
         **strict_cycle_instances,
     }
+    focused_note_crosscheck = _focused_note_crosscheck(
+        lemma_instances,
+        self_edge_packet,
+        focused_packets or {},
+    )
 
     return {
         "schema": SCHEMA,
@@ -229,6 +287,7 @@ def local_lemma_scan_payload(
             lemma_instances,
             source_family_assignments,
         ),
+        "focused_note_crosscheck": focused_note_crosscheck,
         "interpretation": (
             "The listed local shapes are reusable obstruction candidates: each "
             "one produces either a reflexive strict edge or a directed strict "
@@ -259,6 +318,249 @@ def _source_family_assignments(
                 f"{previous} != {assignment_count}"
             )
     return assignments
+
+
+def _focused_note_crosscheck(
+    lemma_instances: Mapping[str, Sequence[dict[str, Any]]],
+    self_edge_packet: Mapping[str, Any],
+    focused_packets: Mapping[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Cross-check aggregate records against focused proof-note packets."""
+
+    records = []
+    for lemma_id, expected in EXPECTED_FOCUSED_NOTE_CROSSCHECK.items():
+        family_ids = list(expected["family_ids"])
+        aggregate_instances = _instances_by_family(
+            lemma_instances.get(lemma_id, ()),
+            family_ids,
+        )
+        if expected["source_kind"] == "focused_packet":
+            packet_key = str(expected["packet_key"])
+            focused_packet = focused_packets.get(packet_key)
+            if focused_packet is None:
+                records.append(
+                    {
+                        "lemma_id": lemma_id,
+                        **expected,
+                        "check_status": "not_loaded",
+                        "families_checked": [],
+                        "covered_assignment_count": 0,
+                        "note": (
+                            "Focused packet was not supplied; aggregate scan "
+                            "still derives this lemma from the template packets."
+                        ),
+                    }
+                )
+                continue
+            check_summary = _check_focused_packet(
+                lemma_id,
+                expected,
+                aggregate_instances,
+                focused_packet,
+            )
+        else:
+            check_summary = _check_t04_template_record(
+                expected,
+                aggregate_instances,
+                self_edge_packet,
+            )
+        records.append(
+            {
+                "lemma_id": lemma_id,
+                **expected,
+                "check_status": "checked",
+                **check_summary,
+            }
+        )
+    return records
+
+
+def _instances_by_family(
+    instances: Sequence[dict[str, Any]],
+    family_ids: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    by_family = {
+        str(instance["family_id"]): instance
+        for instance in instances
+        if isinstance(instance, dict) and "family_id" in instance
+    }
+    missing = [family_id for family_id in family_ids if family_id not in by_family]
+    if missing:
+        raise AssertionError(f"aggregate scan missing focused families: {missing!r}")
+    return {family_id: by_family[family_id] for family_id in family_ids}
+
+
+def _check_focused_packet(
+    lemma_id: str,
+    expected: Mapping[str, Any],
+    aggregate_instances: Mapping[str, dict[str, Any]],
+    focused_packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    template_id = str(expected["template_id"])
+    if focused_packet.get("template_id") != template_id:
+        raise AssertionError(f"{template_id} focused packet template mismatch")
+    if focused_packet.get("status") != "REVIEW_PENDING_DIAGNOSTIC_ONLY":
+        raise AssertionError(f"{template_id} focused packet status mismatch")
+    if focused_packet.get("trust") != TRUST:
+        raise AssertionError(f"{template_id} focused packet trust mismatch")
+    claim_scope = str(focused_packet.get("claim_scope", ""))
+    for forbidden in ("proof of n=9", "counterexample", "global status update"):
+        if f"not a {forbidden}" not in claim_scope and f"not an {forbidden}" not in claim_scope:
+            raise AssertionError(
+                f"{template_id} focused packet must explicitly reject {forbidden!r}"
+            )
+
+    family_packets = focused_packet.get("family_packets")
+    if not isinstance(family_packets, list):
+        raise AssertionError(f"{template_id} focused packet must contain family_packets")
+    packets_by_family = {
+        str(packet["family_id"]): packet
+        for packet in family_packets
+        if isinstance(packet, dict) and "family_id" in packet
+    }
+
+    checked = []
+    for family_id, aggregate in aggregate_instances.items():
+        packet = packets_by_family.get(family_id)
+        if packet is None:
+            raise AssertionError(f"{template_id} focused packet missing {family_id}")
+        _assert_family_common_fields(template_id, family_id, aggregate, packet)
+        if lemma_id in {T03_SELECTED_PATH_SELF_EDGE, T04_SELECTED_PATH_SELF_EDGE}:
+            _assert_self_edge_family_match(template_id, family_id, aggregate, packet)
+        else:
+            _assert_strict_cycle_family_match(template_id, family_id, aggregate, packet)
+        checked.append(
+            {
+                "family_id": family_id,
+                "assignment_count": int(aggregate["assignment_count"]),
+                "orbit_size": int(aggregate["orbit_size"]),
+            }
+        )
+
+    return {
+        "families_checked": checked,
+        "covered_assignment_count": sum(item["assignment_count"] for item in checked),
+        "interpretation": (
+            "Aggregate scan instance matches the focused packet used by the "
+            "proof-facing note; this is a packet consistency check, not an "
+            "independent n=9 completeness proof."
+        ),
+    }
+
+
+def _check_t04_template_record(
+    expected: Mapping[str, Any],
+    aggregate_instances: Mapping[str, dict[str, Any]],
+    self_edge_packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    family_id = "F13"
+    aggregate = aggregate_instances[family_id]
+    family = _template_family_record(
+        self_edge_packet,
+        template_id=str(expected["template_id"]),
+        family_id=family_id,
+    )
+    _assert_family_common_fields(str(expected["template_id"]), family_id, aggregate, family)
+    _assert_self_edge_family_match(str(expected["template_id"]), family_id, aggregate, family)
+    return {
+        "families_checked": [
+            {
+                "family_id": family_id,
+                "assignment_count": int(aggregate["assignment_count"]),
+                "orbit_size": int(aggregate["orbit_size"]),
+            }
+        ],
+        "covered_assignment_count": int(aggregate["assignment_count"]),
+        "interpretation": (
+            "The T04 proof note is backed directly by the self-edge template "
+            "packet; the aggregate scan matches that source family record."
+        ),
+    }
+
+
+def _template_family_record(
+    packet: Mapping[str, Any],
+    *,
+    template_id: str,
+    family_id: str,
+) -> Mapping[str, Any]:
+    templates = packet.get("templates")
+    if not isinstance(templates, list):
+        raise AssertionError("self-edge packet must contain templates")
+    for template in templates:
+        if not isinstance(template, dict) or template.get("template_id") != template_id:
+            continue
+        records = template.get("family_records")
+        if not isinstance(records, list):
+            raise AssertionError(f"{template_id} must contain family_records")
+        for family in records:
+            if isinstance(family, dict) and family.get("family_id") == family_id:
+                return family
+    raise AssertionError(f"missing {template_id}/{family_id} family record")
+
+
+def _assert_family_common_fields(
+    template_id: str,
+    family_id: str,
+    aggregate: Mapping[str, Any],
+    packet: Mapping[str, Any],
+) -> None:
+    if aggregate.get("template_id") != template_id:
+        raise AssertionError(f"{family_id} aggregate template mismatch")
+    if "template_id" in packet and packet.get("template_id") != template_id:
+        raise AssertionError(f"{family_id} focused packet template mismatch")
+    for key in ("assignment_count", "orbit_size", "core_selected_rows"):
+        if aggregate.get(key) != packet.get(key):
+            raise AssertionError(f"{family_id} focused packet {key} mismatch")
+
+
+def _assert_self_edge_family_match(
+    template_id: str,
+    family_id: str,
+    aggregate: Mapping[str, Any],
+    packet: Mapping[str, Any],
+) -> None:
+    aggregate_strict = aggregate.get("strict_inequality")
+    packet_strict = packet.get("strict_inequality")
+    if not isinstance(aggregate_strict, Mapping) or not isinstance(packet_strict, Mapping):
+        raise AssertionError(f"{family_id} focused packet strict_inequality mismatch")
+    for key in (
+        "row",
+        "witness_order",
+        "outer_interval",
+        "inner_interval",
+        "outer_pair",
+        "inner_pair",
+        "outer_span",
+        "inner_span",
+    ):
+        if aggregate_strict.get(key) != packet_strict.get(key):
+            raise AssertionError(f"{family_id} focused packet strict_inequality mismatch")
+    if aggregate_strict.get("outer_class") != aggregate_strict.get("inner_class"):
+        raise AssertionError(f"{family_id} aggregate strict edge must be reflexive")
+    if packet_strict.get("outer_class") != packet_strict.get("inner_class"):
+        raise AssertionError(f"{family_id} focused packet strict edge must be reflexive")
+    equality = packet.get("distance_equality")
+    if aggregate.get("distance_equality") != equality:
+        raise AssertionError(f"{family_id} focused packet distance_equality mismatch")
+    if aggregate.get("direct_conditions", {}).get("holds") is not True:
+        variant = aggregate.get("direct_conditions", {}).get("variant")
+        if template_id in {"T03", "T04"} or variant == "selected_path_self_edge":
+            raise AssertionError(f"{family_id} selected-path conditions must hold")
+
+
+def _assert_strict_cycle_family_match(
+    template_id: str,
+    family_id: str,
+    aggregate: Mapping[str, Any],
+    packet: Mapping[str, Any],
+) -> None:
+    if aggregate.get("cycle_steps") != packet.get("cycle_steps"):
+        raise AssertionError(f"{family_id} focused packet cycle_steps mismatch")
+    if aggregate.get("replay_status") != "strict_cycle":
+        raise AssertionError(f"{family_id} aggregate replay_status mismatch")
+    if packet.get("cycle_length") != len(packet.get("cycle_steps", [])):
+        raise AssertionError(f"{family_id} focused packet cycle length mismatch")
 
 
 def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
@@ -340,6 +642,40 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         "F16",
     ]:
         raise AssertionError("covered_family_ids mismatch")
+
+    crosscheck = payload.get("focused_note_crosscheck")
+    if not isinstance(crosscheck, list):
+        raise AssertionError("focused_note_crosscheck must be a list")
+    by_lemma = {
+        str(item.get("lemma_id")): item
+        for item in crosscheck
+        if isinstance(item, dict) and "lemma_id" in item
+    }
+    if set(by_lemma) != set(EXPECTED_FOCUSED_NOTE_CROSSCHECK):
+        raise AssertionError(f"focused-note lemma ids mismatch: {sorted(by_lemma)!r}")
+    for lemma_id, expected in EXPECTED_FOCUSED_NOTE_CROSSCHECK.items():
+        item = by_lemma[lemma_id]
+        for key in (
+            "template_id",
+            "family_ids",
+            "proof_note_path",
+            "source_kind",
+            "packet_path",
+        ):
+            if item.get(key) != expected[key]:
+                raise AssertionError(
+                    f"{lemma_id} focused-note {key} mismatch: "
+                    f"expected {expected[key]!r}, got {item.get(key)!r}"
+                )
+        if item.get("check_status") != "checked":
+            raise AssertionError(f"{lemma_id} focused-note crosscheck was not checked")
+        checked_families = [
+            str(checked.get("family_id"))
+            for checked in item.get("families_checked", [])
+            if isinstance(checked, dict)
+        ]
+        if checked_families != expected["family_ids"]:
+            raise AssertionError(f"{lemma_id} checked family ids mismatch")
 
 
 def _order_from_packet(packet: dict[str, Any]) -> tuple[int, ...]:
@@ -537,6 +873,7 @@ def _self_edge_instance(
         "orbit_size": int(family["orbit_size"]),
         "core_selected_rows": _rows_to_json(rows),
         "strict_inequality": _edge_to_json(edge),
+        "distance_equality": family.get("distance_equality"),
         "direct_conditions": direct_conditions,
         "simple_filter_violations": _simple_filter_violations(rows, order),
     }
@@ -622,6 +959,8 @@ def _rows_to_json(rows: Sequence[SelectedRow]) -> list[list[int]]:
 
 
 def _edge_to_json(edge: StrictInequality) -> dict[str, Any]:
+    outer_span = int(edge.outer_interval[1]) - int(edge.outer_interval[0])
+    inner_span = int(edge.inner_interval[1]) - int(edge.inner_interval[0])
     return {
         "row": edge.row,
         "witness_order": list(edge.witness_order),
@@ -631,6 +970,8 @@ def _edge_to_json(edge: StrictInequality) -> dict[str, Any]:
         "inner_pair": list(edge.inner_pair),
         "outer_class": list(edge.outer_class),
         "inner_class": list(edge.inner_class),
+        "outer_span": outer_span,
+        "inner_span": inner_span,
     }
 
 

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -555,11 +555,19 @@ def _assert_strict_cycle_family_match(
     aggregate: Mapping[str, Any],
     packet: Mapping[str, Any],
 ) -> None:
-    if aggregate.get("cycle_steps") != packet.get("cycle_steps"):
+    cycle_steps = packet.get("cycle_steps")
+    if not isinstance(cycle_steps, list):
         raise AssertionError(f"{family_id} focused packet cycle_steps mismatch")
+    if aggregate.get("cycle_steps") != cycle_steps:
+        raise AssertionError(f"{family_id} focused packet cycle_steps mismatch")
+    if aggregate.get("cycle_length") != packet.get("cycle_length"):
+        raise AssertionError(f"{family_id} focused packet cycle_length mismatch")
     if aggregate.get("replay_status") != "strict_cycle":
         raise AssertionError(f"{family_id} aggregate replay_status mismatch")
-    if packet.get("cycle_length") != len(packet.get("cycle_steps", [])):
+    replay = packet.get("replay")
+    if not isinstance(replay, Mapping) or replay.get("status") != "strict_cycle":
+        raise AssertionError(f"{family_id} focused packet replay status mismatch")
+    if packet.get("cycle_length") != len(cycle_steps):
         raise AssertionError(f"{family_id} focused packet cycle length mismatch")
 
 
@@ -887,6 +895,7 @@ def _strict_cycle_instance(
 ) -> dict[str, Any]:
     rows = parse_selected_rows(family["core_selected_rows"])
     replay = replay_vertex_circle_quotient(int(template.get("n", 9)), order, rows)
+    cycle_steps = family["cycle_steps"]
     return {
         "lemma_id": lemma_id,
         "template_id": str(template["template_id"]),
@@ -895,7 +904,8 @@ def _strict_cycle_instance(
         "assignment_count": int(family["assignment_count"]),
         "orbit_size": int(family["orbit_size"]),
         "core_selected_rows": _rows_to_json(rows),
-        "cycle_steps": family["cycle_steps"],
+        "cycle_length": int(family.get("cycle_length", len(cycle_steps))),
+        "cycle_steps": cycle_steps,
         "replay_status": replay.status,
         "cycle_edges": [_edge_to_json(edge) for edge in replay.cycle_edges],
         "simple_filter_violations": _simple_filter_violations(rows, order),

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -447,6 +447,25 @@ def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
         )
 
 
+def test_focused_packet_crosscheck_rejects_t10_replay_status_drift() -> None:
+    self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
+    strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
+    t10_packet = load_artifact(DEFAULT_T10_PACKET)
+    t10_packet["family_packets"][0]["replay"]["status"] = "unknown"
+
+    with pytest.raises(AssertionError, match="F12 focused packet replay status mismatch"):
+        local_lemma_scan_payload(
+            self_edge_packet,
+            strict_cycle_packet,
+            focused_packets={
+                "T03": load_artifact(DEFAULT_T03_PACKET),
+                "T10": t10_packet,
+                "T11": load_artifact(DEFAULT_T11_PACKET),
+                "T12": load_artifact(DEFAULT_T12_PACKET),
+            },
+        )
+
+
 def test_local_lemma_scan_cli_json() -> None:
     result = subprocess.run(
         [

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -16,10 +16,16 @@ from erdos97.n9_vertex_circle_local_lemmas import (
     T11_STRICT_CYCLE_LEMMA,
     T12_STRICT_CYCLE_LEMMA,
     assert_expected_local_lemma_scan,
+    local_lemma_scan_payload,
 )
 from scripts.check_n9_vertex_circle_local_lemmas import (
     DEFAULT_SELF_EDGE_PACKET,
     DEFAULT_STRICT_CYCLE_PACKET,
+    DEFAULT_T03_PACKET,
+    DEFAULT_T10_PACKET,
+    DEFAULT_T11_PACKET,
+    DEFAULT_T12_PACKET,
+    load_artifact,
     scan_payload,
 )
 
@@ -90,6 +96,113 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
             "F16": [T12_STRICT_CYCLE_LEMMA],
         },
     }
+    assert payload["focused_note_crosscheck"] == [  # type: ignore[index]
+        {
+            "lemma_id": T03_SELECTED_PATH_SELF_EDGE,
+            "template_id": "T03",
+            "family_ids": ["F05", "F15"],
+            "proof_note_path": "docs/n9-vertex-circle-t03-self-edge-lemma.md",
+            "source_kind": "focused_packet",
+            "packet_key": "T03",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F05", "assignment_count": 18, "orbit_size": 18},
+                {"family_id": "F15", "assignment_count": 2, "orbit_size": 2},
+            ],
+            "covered_assignment_count": 20,
+            "interpretation": (
+                "Aggregate scan instance matches the focused packet used by the "
+                "proof-facing note; this is a packet consistency check, not an "
+                "independent n=9 completeness proof."
+            ),
+        },
+        {
+            "lemma_id": T04_SELECTED_PATH_SELF_EDGE,
+            "template_id": "T04",
+            "family_ids": ["F13"],
+            "proof_note_path": "docs/n9-vertex-circle-t04-self-edge-lemma.md",
+            "source_kind": "template_packet",
+            "packet_key": None,
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_self_edge_template_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F13", "assignment_count": 2, "orbit_size": 2},
+            ],
+            "covered_assignment_count": 2,
+            "interpretation": (
+                "The T04 proof note is backed directly by the self-edge template "
+                "packet; the aggregate scan matches that source family record."
+            ),
+        },
+        {
+            "lemma_id": T10_STRICT_CYCLE_LEMMA,
+            "template_id": "T10",
+            "family_ids": ["F12"],
+            "proof_note_path": "docs/n9-vertex-circle-t10-strict-cycle-lemma.md",
+            "source_kind": "focused_packet",
+            "packet_key": "T10",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F12", "assignment_count": 18, "orbit_size": 18},
+            ],
+            "covered_assignment_count": 18,
+            "interpretation": (
+                "Aggregate scan instance matches the focused packet used by the "
+                "proof-facing note; this is a packet consistency check, not an "
+                "independent n=9 completeness proof."
+            ),
+        },
+        {
+            "lemma_id": T11_STRICT_CYCLE_LEMMA,
+            "template_id": "T11",
+            "family_ids": ["F07"],
+            "proof_note_path": "docs/n9-vertex-circle-t11-strict-cycle-lemma.md",
+            "source_kind": "focused_packet",
+            "packet_key": "T11",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F07", "assignment_count": 6, "orbit_size": 6},
+            ],
+            "covered_assignment_count": 6,
+            "interpretation": (
+                "Aggregate scan instance matches the focused packet used by the "
+                "proof-facing note; this is a packet consistency check, not an "
+                "independent n=9 completeness proof."
+            ),
+        },
+        {
+            "lemma_id": T12_STRICT_CYCLE_LEMMA,
+            "template_id": "T12",
+            "family_ids": ["F16"],
+            "proof_note_path": "docs/n9-vertex-circle-t12-strict-cycle-lemma.md",
+            "source_kind": "focused_packet",
+            "packet_key": "T12",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F16", "assignment_count": 2, "orbit_size": 2},
+            ],
+            "covered_assignment_count": 2,
+            "interpretation": (
+                "Aggregate scan instance matches the focused packet used by the "
+                "proof-facing note; this is a packet consistency check, not an "
+                "independent n=9 completeness proof."
+            ),
+        },
+    ]
 
 
 def test_shared_endpoint_instances_are_t02_families(payload: dict[str, object]) -> None:
@@ -105,6 +218,8 @@ def test_shared_endpoint_instances_are_t02_families(payload: dict[str, object]) 
         edge = instance["strict_inequality"]
         assert edge["outer_interval"] == [0, 3]
         assert edge["inner_interval"] == [0, 1]
+        assert edge["outer_span"] == 3
+        assert edge["inner_span"] == 1
         assert edge["outer_class"] == edge["inner_class"]
 
 
@@ -123,6 +238,8 @@ def test_nested_spoke_instances_use_quotient_not_direct_two_row(
         edge = instance["strict_inequality"]
         assert edge["outer_interval"] == [0, 3]
         assert edge["inner_interval"] == [1, 2]
+        assert edge["outer_span"] == 3
+        assert edge["inner_span"] == 1
         assert set(edge["outer_pair"]).isdisjoint(edge["inner_pair"])
         assert edge["outer_class"] == edge["inner_class"]
 
@@ -309,6 +426,25 @@ def test_assert_expected_rejects_count_drift(payload: dict[str, object]) -> None
 
     with pytest.raises(AssertionError, match="covered_assignment_count mismatch"):
         assert_expected_local_lemma_scan(tampered)
+
+
+def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
+    self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
+    strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
+    t03_packet = load_artifact(DEFAULT_T03_PACKET)
+    t03_packet["family_packets"][0]["core_selected_rows"][0][1] = 8
+
+    with pytest.raises(AssertionError, match="F05 focused packet core_selected_rows mismatch"):
+        local_lemma_scan_payload(
+            self_edge_packet,
+            strict_cycle_packet,
+            focused_packets={
+                "T03": t03_packet,
+                "T10": load_artifact(DEFAULT_T10_PACKET),
+                "T11": load_artifact(DEFAULT_T11_PACKET),
+                "T12": load_artifact(DEFAULT_T12_PACKET),
+            },
+        )
 
 
 def test_local_lemma_scan_cli_json() -> None:


### PR DESCRIPTION
## Summary

- Add a focused-note crosscheck to the aggregate n=9 vertex-circle local-lemma scan for T03/T04/T10/T11/T12.
- Load focused packets for T03/T10/T11/T12 and the source T04 template record, then validate rows, strict inequalities, equality paths, replay status, cycle lengths/steps, and covered-assignment counts against the aggregate scan.
- Update the aggregate note to keep the result scoped as review-pending proof-mining scaffolding, not an n=9 completeness proof, counterexample, or global status update.

## Validation

- `python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemmas.py -q` (`12 passed`)
- `python -m ruff check src/erdos97/n9_vertex_circle_local_lemmas.py scripts/check_n9_vertex_circle_local_lemmas.py tests/test_n9_vertex_circle_local_lemmas.py`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `make verify-fast` is unavailable in this PowerShell environment, so I ran the raw fast tier from AGENTS.md/README.md:
  - `python scripts/check_text_clean.py`
  - `python scripts/check_status_consistency.py`
  - `python scripts/check_artifact_provenance.py`
  - `git diff --check`
  - `python -m ruff check .`
  - `python -m pytest -q` (`576 passed, 278 deselected`)

## Scope guardrails

This PR does not claim a proof of n=9, a counterexample, or a global result for Erdos #97. It keeps the aggregate local-lemma scan in the review-pending proof-mining layer and does not promote the exhaustive checker.