### PR TITLE
[codex] Add row-circle fragile extension gate

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -87,6 +87,43 @@ fragile rows, subject to self-exclusion, four-uniformity, the two-circle cap,
 and the two-overlap crossing rule. Passing this extension check is still not a
 Euclidean realization certificate.
 
+## Row-circle full-extension gate
+
+The full-row extension condition has an additional geometric gate that is not
+captured by the fragile hypergraph checker. In any strictly convex
+counterexample, every selected row `S_i={w0,w1,w2,w3}` lies on one circle
+centered at `i`. If the witnesses are written in their cyclic order around
+`i`, then Ptolemy's theorem gives the exact row-circle identity
+
+```text
+d02*d13 = d01*d23 + d03*d12,
+```
+
+where `dab = |p_{wa}p_{wb}|`. Therefore a fragile-cover system from a minimal
+counterexample must admit at least one full selected-row extension that
+satisfies all such row-circle identities in the supplied cyclic order, in
+addition to the pair/crossing incidence checks above.
+
+One exact way this gate can reject a proposed full extension is the
+row-Ptolemy product-cancellation certificate from
+`docs/row-ptolemy-product-filter.md`. If selected-distance quotienting in the
+full extension forces, for example,
+
+```text
+d02 = d23
+d13 = d01,
+```
+
+then substituting into Ptolemy forces `d03*d12 = 0`, impossible for distinct
+strictly convex vertices.
+
+The quantifier is important. Killing one arbitrary full extension is not
+enough to reject a fragile-cover candidate: a minimal counterexample only
+requires existence of some full selected-row extension compatible with the
+fragile rows and all row-circle constraints. Thus a bridge proof using this
+gate must either check all relevant extensions or prove that every extension
+falls to a row-circle certificate.
+
 ## What This Does Not Prove
 
 The bridge is necessary, not sufficient. The checked block-6 family passes the

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,139 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 667 - Row-circle Full-extension Gate
+
+### Mathematical Subquestion
+
+The current minimal fragile-cover bridge has a full selected-row extension
+diagnostic, but that diagnostic is still incidence/order-only. The narrow
+bridge question for this cycle was:
+
+```text
+What exact row-circle condition must any full selected-row extension of a
+minimal-counterexample fragile cover also satisfy?
+```
+
+### Definitions and Assumptions
+
+Use the minimal fragile-cover bridge. A fragile-cover system from a minimal
+counterexample must extend to a full selected-witness incidence system by
+using each retained critical row at its fragile center and choosing one
+4-neighbor row at every other center.
+
+For a selected row `S_i={w0,w1,w2,w3}`, write the witnesses in cyclic order
+around the center `i`. Since they lie on one circle centered at `i`, Ptolemy's
+theorem gives the exact row-circle identity
+
+```text
+d02*d13 = d01*d23 + d03*d12,
+```
+
+where `dab=|p_{wa}p_{wb}|`.
+
+### Result Status
+
+Recorded necessary bridge gate:
+**Row-circle Full-extension Gate**.
+
+### Argument Or Obstruction
+
+Any full selected-row extension coming from a strictly convex
+counterexample must satisfy the row-circle Ptolemy identity for every selected
+row in the cyclic witness order. Therefore a fragile-cover candidate from a
+minimal counterexample cannot merely have an incidence/crossing full
+extension; it must have at least one full extension surviving all row-circle
+identities as well.
+
+The existing row-Ptolemy product-cancellation certificate gives one exact
+local rejection mechanism. If selected-distance quotienting in a proposed full
+extension forces, for example,
+
+```text
+d02 = d23
+d13 = d01,
+```
+
+then substituting into the row-circle identity forces `d03*d12=0`, impossible
+for distinct strictly convex vertices.
+
+The quantifier is the main guardrail: killing one arbitrary full extension is
+not enough to reject a fragile-cover family. A bridge proof using this gate
+must either check all relevant full extensions or prove that every extension
+has a row-circle certificate.
+
+### Exact Scope
+
+This is a necessary condition for minimal-counterexample fragile-cover
+extensions. It is not a complete fragile-cover obstruction, not a proof that
+the block-6 negative controls are impossible, not a proof of Erdos Problem
+#97, and not a counterexample.
+
+### Files Changed
+
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+The fragile-cover bridge now records a genuine geometric gate beyond the
+hypergraph and full-extension incidence checks. It also prevents a common
+overclaim: one killed extension is only evidence about that extension, not
+about the fragile rows unless all extensions are covered.
+
+### Next Lead
+
+Run an all-extension audit for the two-block fragile negative control: enumerate
+full selected-row extensions under pair/crossing constraints, then test each
+extension for exact row-Ptolemy product-cancellation or stronger row-circle
+certificates. The useful outcomes would be either a survivor extension or a
+finite all-extension obstruction certificate.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-667`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-667`.
+- The branch was started from `origin/main` at commit
+  `f93a262b9aec9d840e8beec2fe9940925e554b7e`, after PR #404 merged Cycle
+  666.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_fragile_hypergraph.py --blocks 1 --json`: passed; the single
+  block-6 fragile atom passes the abstract fragile-cover checks.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json`: passed;
+  the two-block negative control still passes the abstract fragile-cover
+  checks.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_bridge_negative_controls.py --assert-expected`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`:
+  passed; the artifact reports `26` hit assignments and `216` row-Ptolemy
+  certificates in its fixed `n=9` scope.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `586 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 666 - Finite Descent Trap
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

Cycle 667 records a geometric necessary condition for the minimal fragile-cover bridge: a fragile-cover system from a minimal counterexample must admit at least one full selected-row extension satisfying row-circle Ptolemy identities for every selected row.

This is proof-facing documentation only. It does not claim a proof of Erdos Problem #97 and does not claim a counterexample.

## What changed

- Adds a row-circle full-extension gate to `docs/minimal-fragile-cover-bridge.md`.
- Records Cycle 667 in `reports/codex_goal_erdos97_log.md`.

## Exact result

For a full selected-row extension, each row `S_i={w0,w1,w2,w3}` lies on one circle centered at `i`. In cyclic witness order, Ptolemy gives `d02*d13 = d01*d23 + d03*d12`.

Thus the incidence/crossing full-extension diagnostic is still only a necessary prefilter: any minimal-counterexample fragile cover must have some full extension that also survives all row-circle identities. The PR also records the quantifier guardrail: killing one arbitrary full extension is not enough to reject the fragile rows unless every relevant extension is covered.

## Validation

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_fragile_hypergraph.py --blocks 1 --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_bridge_negative_controls.py --assert-expected`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`586 passed, 278 deselected`)

## Remaining limitations

- This is a necessary bridge gate, not a complete fragile-cover obstruction.
- It does not prove the block-6 negative controls impossible.
- It does not provide an all-extension audit yet.
- The overarching proof/counterexample objective remains open.