### PR TITLE
[codex] Add n8 reviewer packet

### DIFF
--- a/docs/boundary-atlas.md
+++ b/docs/boundary-atlas.md
@@ -1,0 +1,323 @@
+# Boundary Atlas
+
+Status: organizing vocabulary only; not mathematical evidence.
+
+This atlas groups common degeneration and obstruction modes for Erdos Problem
+#97 work in this repository. It is meant to help reviewers and future agents
+classify failures without promoting numerical artifacts, fixed-pattern
+obstructions, or review-pending finite-case artifacts beyond their recorded
+scope.
+
+For claim status, use `STATE.md`, `RESULTS.md`, `docs/claims.md`, and
+`metadata/erdos97.yaml`.
+
+## How To Use This Atlas
+
+- Record which boundary stratum a candidate or proof attempt hits.
+- Link to exact checkers or artifacts when a failure is certified.
+- Keep numerical warnings separate from exact obstructions.
+- Do not infer a global theorem from one stratum unless a separate bridge
+  proves that every counterexample must enter it.
+
+## Strata
+
+### COLLISION_BOUNDARY
+
+Two labels coincide, or a pair distance tends to zero.
+
+Typical signal:
+
+- exact midpoint or algebraic equations force `p_i = p_j`;
+- a numerical run reports tiny minimum pair distance;
+- a real-root decoder finds only coincident or lower-cardinality
+  configurations.
+
+Current examples:
+
+- `B12_3x4_danzer_lift` fixed selected pattern, killed by mutual-rhombus
+  midpoint equations.
+- Some archived C12 numerical artifacts, retained as rejected provenance.
+
+Relevant files:
+
+- `docs/mutual-rhombus-filter.md`
+- `data/runs/best_B12_slsqp_m1e-6.json`
+- `scripts/check_mutual_rhombus_filter.py`
+
+Claim role: exact obstruction when equality is proved by a checker; numerical
+warning when seen only in floating-point runs.
+
+### NONSTRICT_CONVEX_BOUNDARY
+
+The polygon loses strict convexity: an orientation margin reaches zero,
+vertices become collinear, or a realization lies on a non-strict boundary.
+
+Typical signal:
+
+- convexity margin is nonpositive or near zero;
+- exact algebraic branches produce collinear or non-strict configurations;
+- a proof branch ends by showing a required point lies in the wrong strict
+  half-plane or in a strict interior position.
+
+Current examples:
+
+- `n=8` survivor classes killed by strict-convexity failure.
+- The historical B12 near-miss with convexity margin near `1e-6`.
+- The review-pending n=9 real-root decoder follow-up, where accepted real
+  configurations are degenerate rather than strictly convex.
+
+Relevant files:
+
+- `docs/n8-exact-survivors.md`
+- `docs/n9-groebner-decoders.md`
+- `docs/verification-contract.md`
+- `scripts/verify_candidate.py`
+
+Claim role: exact obstruction only when the branch certificate proves
+non-strictness; otherwise a numerical warning.
+
+### COLLINEAR_WITNESS_BOUNDARY
+
+Witness or center constraints force collinearity that is incompatible with
+strict convexity or with the intended circle/circumcenter argument.
+
+Typical signal:
+
+- an exact survivor certificate reports collinearity;
+- a circumcenter or radical-axis argument degenerates;
+- the selected witness triple no longer determines a proper circle.
+
+Current examples:
+
+- Named `n=8` survivor-class certificates in the exact survivor pass.
+
+Relevant files:
+
+- `docs/n8-exact-survivors.md`
+- `scripts/analyze_n8_exact_survivors.py`
+- `certificates/n8_exact_analysis.json`
+
+Claim role: exact obstruction for the certified branch only.
+
+### MIDPOINT_COLLAPSE
+
+Perpendicular-bisector or mutual-rhombus equations force midpoint identities
+that collapse distinct labels.
+
+Typical signal:
+
+- reciprocal common-witness chords give equations
+  `p_x + p_y = p_a + p_b`;
+- rational row reduction forces equal coordinates for distinct labels.
+
+Current examples:
+
+- `B12_3x4_danzer_lift`
+- `B20_4x5_FR_lift`
+- several fixed `C*_pm_*` patterns recorded in the mutual-rhombus filter.
+
+Relevant files:
+
+- `docs/mutual-rhombus-filter.md`
+- `scripts/check_mutual_rhombus_filter.py`
+
+Claim role: exact fixed-pattern obstruction when replayed from the stated
+pattern data.
+
+### RANK_DROP_LOCUS
+
+The selected squared-distance system has a Jacobian rank drop beyond the
+generic diagnostic rank, or a rank argument depends on exact solutions rather
+than numerical non-solutions.
+
+Typical signal:
+
+- the Jacobian has the translation, rotation, and scaling kernels at exact
+  solutions;
+- generic rank `2n - 3` at non-solutions is detected but cannot prove
+  nonexistence.
+
+Current examples:
+
+- The generic rank route is recorded as a failed or conditional program.
+
+Relevant files:
+
+- `docs/claims.md`
+- `docs/exactification-plan.md`
+- `docs/failed-ideas.md`
+
+Claim role: diagnostic or conditional unless paired with a proved bridge and
+exact solution-space argument.
+
+### DISTANCE_QUOTIENT_SELF_EDGE
+
+Selected-distance equalities quotient ordinary pair distances, and a
+vertex-circle monotonicity inequality forces a strict self-edge.
+
+Typical signal:
+
+- quotienting identifies `[a,b]` and `[c,d]`;
+- cyclic order around one center forces `[a,b] > [c,d]`;
+- the two classes are equal in the quotient.
+
+Current examples:
+
+- n=9 vertex-circle T01/F09 self-edge local lemma candidate.
+- Many review-pending n=9 exhaustive-checker self-edge kills.
+
+Relevant files:
+
+- `docs/vertex-circle-order-filter.md`
+- `docs/n9-vertex-circle-t01-self-edge-lemma.md`
+- `data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json`
+
+Claim role: exact local obstruction for the displayed hypotheses; review
+status follows the referenced packet.
+
+### DISTANCE_QUOTIENT_CYCLE
+
+Selected-distance quotienting and vertex-circle monotonicity produce a directed
+cycle of strict inequalities among distance classes.
+
+Typical signal:
+
+- a quotient graph contains a cycle using strict inequalities;
+- the cycle length is often 2 or 3 in current n=9 packets.
+
+Current examples:
+
+- n=9 T10/F12, T11/F07, and T12/F16 strict-cycle local lemma packets.
+- Review-pending n=9 exhaustive-checker strict-cycle kills.
+
+Relevant files:
+
+- `docs/n9-vertex-circle-obstruction-shapes.md`
+- `docs/n9-vertex-circle-strict-cycle-template-packet.md` if added later
+- `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
+- `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`
+
+Claim role: exact local obstruction for certified hypotheses; not an n=9
+completeness proof by itself.
+
+### CYCLIC_ORDER_FORBIDDEN
+
+A supplied cyclic order violates exact cyclic-order constraints: crossing
+requirements, Kalmanson inverse pairs, Altman diagonal sums, vertex-circle
+order, or related order filters.
+
+Typical signal:
+
+- the cyclic crossing CSP is UNSAT;
+- a Kalmanson/Farkas certificate sums strict inequalities to zero;
+- an all-order search shows every cyclic order contains a forbidden ordered
+  quadrilateral pair for one fixed pattern.
+
+Current examples:
+
+- C13 Sidon all-order Kalmanson obstruction.
+- C19 skew all-order Kalmanson/Z3 obstruction.
+- P24 cyclic crossing CSP.
+- P18 vertex-circle order obstruction.
+
+Relevant files:
+
+- `docs/cyclic-crossing-csp.md`
+- `docs/kalmanson-two-order-search.md`
+- `docs/round2/kalmanson_distance_filter.md`
+- `docs/vertex-circle-order-filter.md`
+
+Claim role: fixed-order or fixed-pattern obstruction according to the checker
+scope; never a global proof without a separate bridge.
+
+### INCIDENCE_OVERLAP_BOUNDARY
+
+The selected-witness incidence pattern violates necessary pair-sharing,
+triple-sharing, crossing, indegree, or count constraints before geometry is
+fully considered.
+
+Typical signal:
+
+- adjacent rows share too many selected witnesses;
+- row pairs violate the two-circle cap;
+- an indegree or pair-count equality case is impossible.
+
+Current examples:
+
+- Small-case incidence exclusions through `n <= 8`.
+- Fixed patterns killed by adjacent-row two-overlap rules.
+
+Relevant files:
+
+- `docs/n8-incidence-enumeration.md`
+- `docs/claims.md`
+- `src/erdos97/incidence_filters.py`
+
+Claim role: exact obstruction when the necessary incidence lemma applies to
+the stated pattern or finite enumeration.
+
+### SOLVER_TRUST_BOUNDARY
+
+A finite abstraction has a solver-backed UNSAT replay, but not yet an
+independent proof object or second implementation.
+
+Typical signal:
+
+- Z3 replays a stored UNSAT certificate;
+- no DIMACS/DRAT/LRAT, SMT proof, or pure finite-order checker exists yet;
+- a review priority asks for a solver-independent replay path.
+
+Current examples:
+
+- C19 all-order Kalmanson order UNSAT certificate.
+
+Relevant files:
+
+- `docs/kalmanson-two-order-search.md`
+- `docs/review-priorities.md`
+- `data/certificates/c19_skew_all_orders_kalmanson_z3.json`
+
+Claim role: exact within the current solver-backed artifact scope, with
+remaining independent-replay review risk explicitly recorded.
+
+### LITERATURE_RISK_BOUNDARY
+
+A statement could be mis-scoped because nearby literature concerns a different
+problem, such as `k=3`, common-radius unit distances, lower-bound
+constructions, or informal/unpublished claims.
+
+Typical signal:
+
+- a source proves a nearby but not equivalent statement;
+- a literature summary has not been pinned to a primary source;
+- official/global status needs rechecking before public claims.
+
+Current examples:
+
+- Danzer and Fishburn-Reeds `k=3` constructions.
+- Erdos 1975 all-`k` Danzer report, treated as unverified literature risk.
+- Unit-distance lower-bound constructions that do not resolve the
+  variable-radius selected-witness problem.
+
+Relevant files:
+
+- `docs/literature-risk.md`
+- `references/source_manifest.yml`
+- `metadata/erdos97.yaml`
+
+Claim role: audit warning only.
+
+## Adding A New Boundary Entry
+
+New entries should include:
+
+- a stable all-caps name;
+- the failure mode in one sentence;
+- typical signals;
+- current examples, if any;
+- exact files or commands that check it;
+- whether the entry is an exact obstruction, numerical warning, review risk,
+  or open bridge target.
+
+Do not add a boundary entry to `STATE.md` or `RESULTS.md` unless it changes a
+source-of-truth claim after the usual review process.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,254 @@
+# Glossary
+
+Status: navigation aid only; not mathematical evidence.
+
+This glossary standardizes local vocabulary used across the repository. It is
+not a source of truth for claim status. When a definition matters for a proof,
+prefer the linked proof-facing document, `STATE.md`, `RESULTS.md`,
+`docs/claims.md`, or `metadata/erdos97.yaml`.
+
+## Problem Language
+
+### Bad vertex
+
+A vertex `v` of a strictly convex polygon is bad when at least four other
+vertices lie at the same Euclidean distance from `v`. In selected-witness
+language, one chosen 4-set witnessing this is denoted `S_v`.
+
+Source: `README.md`, `STATE.md`.
+
+### Counterexample
+
+A strictly convex polygon in which every vertex is bad. This repository claims
+no counterexample. A certified counterexample would need exact coordinates, or
+an exact algebraic certificate, checking both selected distance equalities and
+strict convexity.
+
+Source: `docs/verification-contract.md`.
+
+### Selected-witness system
+
+For each center `i`, a 4-element set `S_i` of other labels whose squared
+distances from `i` are required to be equal. The selected sets may vary with
+the center, and the directed incidence graph need not be symmetric.
+
+Source: `README.md`, `STATE.md`.
+
+### Strictly convex polygon
+
+A polygon whose vertices are in cyclic order with no three consecutive or
+nonconsecutive vertices collinear on the boundary, and with every other vertex
+strictly on the same side of each oriented edge. In code, strict convexity is
+checked through edge-line orientation margins.
+
+Source: `scripts/verify_candidate.py`, `docs/verification-contract.md`.
+
+## Claim Scope
+
+### Official/global status
+
+The status of Erdos Problem #97 outside this repository. It remains
+falsifiable/open unless manually rechecked and updated from the official
+problem page.
+
+Source: `metadata/erdos97.yaml`, `docs/upstream-alignment.md`.
+
+### Repo-local finite-case artifact
+
+A machine-checked finite-case result maintained by this repository. The
+current source-of-truth finite-case result is the selected-witness exclusion
+for `n <= 8`, pending independent review before paper-style or public
+theorem-style use.
+
+Source: `STATE.md`, `RESULTS.md`.
+
+### Review-pending artifact
+
+A checked or replayable artifact that is kept separate from the strongest
+source-of-truth result until independent review validates the mathematical
+argument, implementation, data conventions, and claim scope.
+
+Source: `docs/review-priorities.md`.
+
+### Fixed selected-witness pattern
+
+An abstract directed 4-neighbor incidence pattern, independent of a particular
+geometric realization. Obstructing one fixed pattern does not obstruct other
+possible selected-witness systems.
+
+Source: `docs/candidate-patterns.md`.
+
+### Fixed cyclic order
+
+A single cyclic ordering of labels for a fixed pattern. A fixed-order
+obstruction applies only to that supplied order unless a separate all-order
+search or proof is provided.
+
+Source: `docs/round2/kalmanson_distance_filter.md`.
+
+### All-order fixed-pattern obstruction
+
+An obstruction that checks every cyclic order for one fixed abstract
+selected-witness pattern. It is still not a global proof of Erdos Problem #97.
+
+Source: `docs/kalmanson-two-order-search.md`.
+
+## Core Obstructions
+
+### Two-circle cap
+
+For distinct centers `a,b`, the selected rows satisfy
+`|S_a cap S_b| <= 2`; otherwise two Euclidean circles would share at least
+three points.
+
+Source: `docs/claims.md`.
+
+### Radical-axis crossing / bisection
+
+If two selected rows share exactly two witnesses `{a,b}`, then the line through
+the two centers is the perpendicular bisector of segment `ab`, and the source
+chord crosses the common-witness chord in the cyclic order.
+
+Source: `docs/claims.md`, `docs/mutual-rhombus-filter.md`.
+
+### Mutual-rhombus midpoint obstruction
+
+When two chords are mutual common-witness images, the corresponding midpoint
+equations can force label coincidences. If exact rational row reduction forces
+two labels to coincide, the fixed pattern is impossible in a strictly convex
+polygon.
+
+Source: `docs/mutual-rhombus-filter.md`.
+
+### Kalmanson inequality
+
+A strict convex distance inequality attached to an ordered quadrilateral in a
+cyclic order. The repository uses exact positive combinations of such
+inequalities, after quotienting selected-distance equalities, to produce
+fixed-order or fixed-pattern obstructions.
+
+Source: `docs/round2/kalmanson_distance_filter.md`,
+`docs/kalmanson-two-order-search.md`.
+
+### Farkas certificate
+
+An exact positive linear combination of strict inequalities whose coefficient
+vector sums to zero after the selected-distance quotient. Summing the strict
+inequalities then gives a contradiction of the form `0 > 0`.
+
+Source: `docs/round2/kalmanson_distance_filter.md`.
+
+### Vertex-circle self-edge
+
+A vertex-circle obstruction where selected-distance quotienting identifies two
+ordinary chord distances, but cyclic order around a center forces one of them
+to be strictly larger than itself.
+
+Source: `docs/vertex-circle-order-filter.md`,
+`docs/n9-vertex-circle-local-lemmas.md`.
+
+### Vertex-circle strict cycle
+
+A directed cycle of strict chord inequalities in the selected-distance
+quotient. A realizable strict inequality graph must be acyclic and irreflexive.
+
+Source: `docs/vertex-circle-order-filter.md`,
+`docs/n9-vertex-circle-obstruction-shapes.md`.
+
+### Altman diagonal-order obstruction
+
+For a natural cyclic order, chord-length sums by cyclic distance are strictly
+ordered. A natural-order cyclic-offset selected pattern forcing equality of two
+different diagonal-order sums is impossible.
+
+Source: `docs/altman-diagonal-sums.md`.
+
+### Row-circle Ptolemy diagnostic
+
+A diagnostic using the fact that four selected witnesses for one center lie on
+a circle centered at that vertex. Current nonlinear instances are numerical
+diagnostics unless exactified.
+
+Source: `docs/row-circle-ptolemy-nlp.md`,
+`docs/row-ptolemy-product-filter.md`.
+
+## Bridge Vocabulary
+
+### Minimal counterexample
+
+A counterexample with the minimum possible number of vertices. Minimality
+forces every deleted vertex to be essential to some remaining vertex's exact
+critical 4-tie, but this is not by itself a contradiction.
+
+Source: `docs/claims.md`.
+
+### Critical 4-tie
+
+An exact distance class of size exactly 4 at a center. In a minimal
+counterexample, every vertex belongs to one such class for some remaining
+center after deletion.
+
+Source: `docs/minimal-fragile-cover-bridge.md`.
+
+### Fragile-cover witness system
+
+A partial selected-witness system produced from minimal-counterexample
+critical ties. It is necessary structure for minimal counterexamples, but the
+current hypergraph constraints alone are too weak to prove the problem.
+
+Source: `docs/minimal-fragile-cover-bridge.md`,
+`docs/bridge-negative-controls.md`.
+
+### Bootstrap core
+
+Local or partial structure meant to bootstrap a global contradiction. Use this
+term only with an explicit bridge statement, data source, and non-claim.
+
+Source: `docs/codex-strategy-instructions.md`.
+
+### Radius-blocker
+
+A set encountered by adaptive peeling in which every rich distance class at
+each retained center has at most two witnesses inside the set. It is an open
+bridge target, not a solved obstruction.
+
+Source: `docs/adaptive-radius-blocker-bridge.md`.
+
+## Evidence And Certificates
+
+### Numerical near-miss
+
+A floating-point artifact with small residuals or small convexity margin.
+Near-misses are not counterexamples and cannot certify exact equality.
+
+Source: `STATE.md`, `docs/verification-contract.md`.
+
+### Exactification
+
+The process of replacing numerical or heuristic evidence with exact
+coordinates, exact algebraic certificates, interval certificates, SMT
+certificates, or formal proofs.
+
+Source: `docs/exactification-plan.md`.
+
+### Interval certificate
+
+A certificate that proves stated inequalities or residual bounds over intervals.
+It does not prove exact equality unless the interval method actually supplies
+an exact acceptance condition.
+
+Source: `docs/exactification-plan.md`, `docs/codex-backlog.md`.
+
+### SMT certificate
+
+A finite solver certificate or replay artifact. In this repository, SMT-backed
+results must keep solver scope explicit and should prefer independently
+checkable proof objects when available.
+
+Source: `docs/sat-smt-plan.md`, `docs/review-priorities.md`.
+
+### Boundary stratum
+
+A named degeneracy or failure surface where candidate systems collapse,
+violate strictness, lose rank, or hit an exact obstruction. See
+`docs/boundary-atlas.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,12 +24,18 @@ put detailed reconciliation in the canonical synthesis.
 - [`canonical-synthesis.md`](canonical-synthesis.md): long-form canonical
   synthesis, claim taxonomy, failed-route reconciliation, and source/hash
   inventory.
+- [`glossary.md`](glossary.md): local vocabulary for selected witnesses,
+  claim scopes, exact obstructions, review-pending artifacts, and bridge
+  terms; navigation only, not mathematical evidence.
 - [`../RESULTS.md`](../RESULTS.md): compact results ledger.
 
 ## Claims and obstructions
 
 - [`claims.md`](claims.md): proved local facts, conditional programs, and
   proof-facing caveats.
+- [`boundary-atlas.md`](boundary-atlas.md): organized vocabulary for
+  degenerations, exact obstruction modes, solver-trust boundaries, and
+  literature-risk boundaries; not a source of claim status.
 - [`mutual-rhombus-filter.md`](mutual-rhombus-filter.md): crossing-bisector and
   mutual-midpoint filters for fixed selected-witness patterns.
 - [`phi4-rectangle-trap.md`](phi4-rectangle-trap.md): exact even
@@ -232,6 +238,12 @@ put detailed reconciliation in the canonical synthesis.
   killed incidence patterns.
 - [`verification-contract.md`](verification-contract.md): requirements for
   numerical candidates and certified counterexamples.
+- [`review-packet-template.md`](review-packet-template.md): claim-neutral
+  template for packaging finite-case artifacts, fixed-pattern certificates, and
+  local lemma candidates for independent review.
+- [`../papers/n8-reviewer-packet.md`](../papers/n8-reviewer-packet.md):
+  claim-neutral reviewer packet for the repo-local machine-checked `n=8`
+  selected-witness finite-case artifact.
 - [`../requirements-lock.txt`](../requirements-lock.txt): known-good direct
   dependency snapshot for reproduction.
 - [`exactification-plan.md`](exactification-plan.md): route from numerical

--- a/docs/review-packet-template.md
+++ b/docs/review-packet-template.md
@@ -1,0 +1,120 @@
+# Reviewer Packet Template
+
+Status: template only; not mathematical evidence.
+
+Use this template when packaging a finite-case artifact, fixed-pattern
+certificate, local lemma candidate, or review-pending bridge result for
+independent review. A reviewer packet should be printable, linkable, and
+replayable, but it does not change claim status by itself.
+
+Recommended target path:
+
+```text
+papers/<short-name>-reviewer-packet.md
+```
+
+If a PDF is produced later, generate it from the Markdown source and keep the
+source as the version-controlled object.
+
+## Packet Skeleton
+
+```markdown
+# <Artifact Name> Reviewer Packet
+
+Status: <claim-neutral packet status>
+Claim scope: <repo-local finite case | fixed order | fixed pattern | all-order fixed pattern | local lemma candidate | bridge target>
+Source of truth: `STATE.md`, `RESULTS.md`, `docs/claims.md`, `metadata/erdos97.yaml`
+Last reviewed: <YYYY-MM-DD or unreviewed>
+
+## Non-Claims
+
+- This packet does not prove Erdos Problem #97.
+- This packet does not claim a counterexample.
+- This packet does not update the official/global status.
+- This packet does not promote review-pending artifacts without independent
+  review and source-of-truth updates.
+
+## Claim Being Reviewed
+
+State the exact local claim, including all hypotheses and scope limits.
+
+## Files To Inspect
+
+- `<source document>`
+- `<checker script>`
+- `<certificate or JSON artifact>`
+- `<tests, if any>`
+
+## Reproduction Commands
+
+```bash
+<command 1>
+<command 2>
+```
+
+## Expected Outputs
+
+Record stable invariants rather than long terminal transcripts.
+
+- status:
+- count:
+- exact certificate field:
+- expected uncertainty field, if any:
+
+## Mathematical Proof Sketch
+
+Explain why the checker output implies the scoped claim. Keep informal
+motivation separate from exact proof dependencies.
+
+## Certificate Schema
+
+Describe the trusted input fields, derived fields, and fields that are only
+diagnostic.
+
+## Independent Review Checklist
+
+- Does the checker treat checked-in artifacts as input data?
+- Are all cyclic-order, incidence, or algebraic hypotheses explicit?
+- Does the proof use only necessary geometric conditions?
+- Are symmetry reductions justified?
+- Is every solver-backed step replayed or clearly marked as solver-trust risk?
+- Are numerical values excluded from exact claim support unless certified?
+
+## Known Weak Points
+
+- <mathematical gap, if any>
+- <implementation trust gap, if any>
+- <literature or terminology risk, if any>
+
+## Relation To Other Artifacts
+
+Explain which artifacts this packet supersedes, supports, or leaves unchanged.
+
+## Status-Update Rules
+
+State exactly what review result would be required before any update to
+`STATE.md`, `RESULTS.md`, `docs/claims.md`, or `metadata/erdos97.yaml`.
+```
+
+## Packet Rules
+
+- Keep the first screen scoped: status, claim scope, source-of-truth files, and
+  non-claims.
+- Prefer short expected-output invariants over copied logs.
+- Link every proof-facing statement to a checker, certificate, or existing
+  source-of-truth document.
+- Mark heuristic, numerical, sampled-window, fixed-order, fixed-pattern, and
+  all-order fixed-pattern claims separately.
+- Include negative review outcomes. A failed packet is useful if it prevents
+  repeated work.
+
+## First Good Targets
+
+The highest-value initial packets are:
+
+- `n=8` selected-witness finite-case artifact;
+- `n=8` class `14` standalone obstruction;
+- C19 all-order Kalmanson/Z3 certificate, with solver-trust boundary called
+  out explicitly;
+- n=9 vertex-circle T01/F09 and T10/F12 local lemma candidates;
+- n=10 singleton-slice draft, as an audit packet only.

--- a/papers/README.md
+++ b/papers/README.md
@@ -1,0 +1,13 @@
+# Papers And Reviewer Packets
+
+Status: navigation only; not mathematical evidence.
+
+This directory contains paper-style drafts and reviewer packets. Source-of-truth
+status remains in `../STATE.md`, `../RESULTS.md`, `../docs/claims.md`, and
+`../metadata/erdos97.yaml`.
+
+- [`small-counterexamples-erdos97.md`](small-counterexamples-erdos97.md):
+  proof-note draft for small counterexamples, pending independent review.
+- [`n8-reviewer-packet.md`](n8-reviewer-packet.md): claim-neutral reviewer
+  packet for the repo-local machine-checked `n=8` selected-witness finite-case
+  artifact.

--- a/papers/n8-reviewer-packet.md
+++ b/papers/n8-reviewer-packet.md
@@ -1,0 +1,293 @@
+# n=8 Selected-Witness Reviewer Packet
+
+Status: claim-neutral reviewer packet; not mathematical evidence by itself.
+Claim scope: repo-local selected-witness finite case for `n=8`, supporting
+the current repo-local `n <= 8` machine-checked result.
+Source of truth: `STATE.md`, `RESULTS.md`, `docs/claims.md`,
+`metadata/erdos97.yaml`.
+Last reviewed: unreviewed packet draft, 2026-05-10.
+
+This packet packages the current `n=8` selected-witness finite-case artifacts
+for independent review. It does not change the repository status. No general
+proof and no counterexample are claimed, and the official/global status remains
+falsifiable/open. The repository's `n <= 8` result is repo-local,
+machine-checked, and pending independent review before any paper-style or
+public theorem-style claim.
+
+## Non-Claims
+
+- This packet does not prove Erdos Problem #97.
+- This packet does not claim or certify a counterexample.
+- This packet does not update the official/global status.
+- This packet does not promote `n=9`, `n=10`, fixed-pattern, or all-order
+  fixed-pattern artifacts.
+- This packet does not replace `STATE.md`, `RESULTS.md`, `docs/claims.md`, or
+  `metadata/erdos97.yaml` as source-of-truth files.
+- This packet does not claim independent external review has already happened.
+- Numerical near-misses, including historical B12 artifacts, are not used.
+
+## Claim Being Reviewed
+
+Scoped claim: within the selected-witness formulation, there is no strictly
+convex `n=8` counterexample satisfying one chosen 4-witness row at every
+center. The incidence layer derives all necessary `n=8` selected-witness
+survivors and reduces them to 15 canonical classes. The exact survivor layer
+then kills all 15 by finite cyclic-order constraints, exact
+perpendicular-bisector algebra, selected equal-distance algebra, duplicate
+vertices, collinearity, or strict-convexity failure.
+
+This is a finite selected-witness artifact. It is not a bridge to arbitrary
+large `n`, not a counterexample, and not a claim that nearby fixed-pattern
+obstructions solve the global problem.
+
+## Files To Inspect
+
+- `README.md`, `STATE.md`, `RESULTS.md`, and `metadata/erdos97.yaml` for
+  claim status and source-of-truth wording.
+- `docs/claims.md`, `docs/reviewer-guide.md`,
+  `docs/verification-contract.md`, `docs/glossary.md`, and
+  `docs/boundary-atlas.md` for trust labels and review vocabulary.
+- `docs/n8-incidence-enumeration.md` for the incidence-completeness argument.
+- `docs/n8-exact-survivors.md` for the 15-class exact obstruction pass.
+- `data/incidence/n8_incidence_completeness.json` for generated incidence
+  counts and canonical survivor classes.
+- `data/incidence/n8_reconstructed_15_survivors.json` for the checked-in
+  survivor class list.
+- `data/incidence/n8_compatible_orders.json` for compatible cyclic orders.
+- `certificates/n8_exact_analysis.json` and
+  `certificates/n8_polynomial_systems.txt` for exact survivor certificates and
+  expanded systems.
+- `scripts/enumerate_n8_incidence.py` and `src/erdos97/n8_incidence.py` for
+  incidence regeneration.
+- `scripts/analyze_n8_exact_survivors.py` for the exact obstruction verifier.
+- `scripts/independent_check_n8_incidence_json.py`,
+  `scripts/independent_check_n8_artifacts.py`, and
+  `scripts/independent_n8_obstruction_recheck.py` for artifact-facing
+  cross-checks.
+- `tests/test_n8_incidence.py`, `tests/test_n8_exact_survivors_artifact.py`,
+  `tests/test_n8_artifact_audit.py`,
+  `tests/test_n8_independent_incidence_json.py`, and
+  `tests/test_n8_independent_obstruction.py` for regression coverage.
+
+## Reproduction Commands
+
+Install the development environment first, or use the version-matched
+dependency snapshot described in `README.md`.
+
+```bash
+python scripts/independent_check_n8_artifacts.py --check --json
+python scripts/enumerate_n8_incidence.py --summary
+python scripts/enumerate_n8_incidence.py --check-data data/incidence/n8_incidence_completeness.json
+python scripts/analyze_n8_exact_survivors.py --check --json
+python scripts/analyze_n8_exact_survivors.py --check --json --check-compatible-orders-data data/incidence/n8_compatible_orders.json --check-exact-analysis-data certificates/n8_exact_analysis.json
+python scripts/independent_check_n8_incidence_json.py --json
+python scripts/independent_n8_obstruction_recheck.py --check --json
+python -m pytest tests/test_n8_incidence.py tests/test_n8_exact_survivors_artifact.py tests/test_n8_artifact_audit.py tests/test_n8_independent_incidence_json.py tests/test_n8_independent_obstruction.py -q
+```
+
+After documentation edits, also run the repository fast tier:
+
+```bash
+python scripts/check_text_clean.py
+python scripts/check_status_consistency.py
+python scripts/check_artifact_provenance.py
+git diff --check
+python -m ruff check .
+python -m pytest -q
+```
+
+## Expected Output Invariants
+
+For `python scripts/independent_check_n8_artifacts.py --check --json`:
+
+- `verified` is `true`.
+- `overall_status` is
+  `n8_artifacts_verified_repo_local_pending_external_review`.
+- `survivor_json.record_count` is `15`.
+- `completeness_artifact.canonical_class_count` is `15`.
+- `exact_obstruction_artifacts.all_reconstructed_15_rejected` is `true`.
+- `exact_obstruction_artifacts.compatible_orders_artifact.verified` is `true`.
+- `exact_obstruction_artifacts.exact_analysis_artifact.verified` is `true`.
+- `does_not_check` includes full independent regeneration of the incidence
+  enumeration, independent external review, a general proof, and a
+  counterexample.
+
+For `python scripts/enumerate_n8_incidence.py --summary`:
+
+- `n` is `8`.
+- `status` is `INCIDENCE_COMPLETENESS`.
+- `balanced_cap_matrices_with_row0_fixed` is `117072`.
+- `forced_perpendicular_survivors_with_row0_fixed` is `4560`.
+- `canonical_survivor_class_count` is `15`.
+- `matches_existing_reconstructed_survivors` is `true`.
+
+For `python scripts/analyze_n8_exact_survivors.py --check --json`:
+
+- `status` is `exact_obstruction_artifact_pending_independent_review`.
+- `survivor_classes` is `15`.
+- `cyclic_order_killed_ids` is `[12]`.
+- `cyclic_order_remaining_count` is `14`.
+- `pb_y2_span_ids_verified` is
+  `[0, 1, 2, 6, 7, 8, 9, 10, 11, 13]`.
+- `class3_duplicate_vertex_certificate_verified` is `true`.
+- `class4_collinearity_certificate_verified` is `true`.
+- `class5_groebner_contains_y2_after_exact_substitution` is `true`.
+- `class14_pb_ed_groebner_basis_verified` is `true`.
+- `class14_solution_branches_solve_pb_ed` is `true`.
+- `class14_strict_interior_certificate_verified` is `true`.
+
+For `python scripts/independent_n8_obstruction_recheck.py --check --json`:
+
+- `verified` is `true`.
+- `classes_killed_independently` is
+  `[0, 1, 2, 6, 7, 8, 9, 10, 11, 12, 13]`.
+- `classes_requiring_groebner_machinery` is `[3, 4, 5, 14]`.
+- `does_not_check` explicitly lists the Groebner-dependent classes and the
+  incidence-completeness step.
+
+## Mathematical Proof Sketch
+
+Assume a selected-witness `n=8` counterexample exists. Each row has four
+selected witnesses and excludes its own center. The two-circle cap gives
+`|S_i cap S_j| <= 2` for distinct centers. The witness-pair cap says any
+unordered pair of labels can co-occur in at most two selected rows, because all
+centers seeing that pair lie on one perpendicular bisector line.
+
+For `n=8`, the witness-pair cap forces every witness indegree to be exactly
+four: a fixed vertex appearing in `d` rows contributes `3d` witness pairs, at
+most two per possible partner, so `3d <= 14` and `d <= 4`; the total indegree
+is `32`, hence all eight indegrees equal four.
+
+The incidence enumerator then checks all binary selected-witness matrices with
+zero diagonal, row sums four, derived column sums four, row-pair intersections
+at most two, column-pair co-occurrences at most two, no odd forced
+perpendicularity cycle, and no same-color forced-parallel chord class sharing
+an endpoint. With row `0` fixed to witnesses `{1,2,3,4}` by relabeling, the
+enumeration leaves 15 canonical classes up to simultaneous relabeling.
+
+For each survivor class, whenever two rows share exactly two witnesses, the
+center chord is the perpendicular bisector of the common-witness chord. The
+exact survivor checker translates those implications into polynomial
+dot-product and midpoint-line equations under the gauge
+`p_0=(0,0)`, `p_1=(1,0)`, `y_2 != 0`, then adds full selected equal-distance
+equations where needed.
+
+Class `12` has no compatible cyclic order. Ten classes are killed by exact
+rational linear algebra because `y_2` lies in the rational span of the
+perpendicular-bisector equations, contradicting the gauge. Class `3` forces a
+duplicate vertex, class `4` forces three collinear vertices, class `5` has a
+Groebner contradiction after exact substitutions, and class `14` has four real
+algebraic branches, each with only four hull vertices and four strict interior
+points. Therefore all 15 incidence survivors are exactly obstructed within
+the selected-witness `n=8` scope.
+
+## Certificate Schema
+
+Trusted input data:
+
+- `data/incidence/n8_reconstructed_15_survivors.json` stores 15 survivor
+  records, each with an integer `id` and an `8 x 8` binary `rows` matrix.
+- `data/incidence/n8_incidence_completeness.json` stores the regeneration
+  counts, the row-0 symmetry break, the column-sum derivation, filter names,
+  and canonical survivor classes.
+- `data/incidence/n8_compatible_orders.json` stores normalized compatible
+  cyclic orders, modulo rotation and reversal.
+- `certificates/n8_exact_analysis.json` stores the cyclic filter summary,
+  expanded systems for classes not killed by cyclic order, contradiction IDs,
+  and final exact-geometry status.
+
+Derived fields to recheck:
+
+- row sums, zero diagonal, column sums, row-pair caps, and column-pair caps;
+- brute-force canonical representatives under all `8!` simultaneous
+  relabelings;
+- forced-perpendicularity graph bipartiteness and same-color endpoint filters;
+- compatible cyclic-order counts;
+- perpendicular-bisector polynomial equations and selected equal-distance
+  equations;
+- rational-span certificates, Groebner certificates, duplicate/collinearity
+  certificates, and strict-interior branch checks.
+
+Diagnostic or provenance-only fields:
+
+- archive ID mappings, unless the optional archive JSON is supplied;
+- long compatible-order lists, except as replay data for the counts;
+- explanatory notes and historical reconstruction text;
+- any numerical search output, which is not part of this `n=8` exact packet.
+
+## Independent Review Checklist
+
+- Check that the source-of-truth docs still say no general proof and no
+  counterexample are claimed.
+- Check that the packet's scope is only selected-witness `n=8` finite-case
+  review, with `n <= 8` kept repo-local and machine-checked pending
+  independent review.
+- Verify the two-circle cap, witness-pair cap, and `n=8` indegree regularity
+  derivation independently.
+- Audit whether fixing row `0` to witnesses `{1,2,3,4}` is only a relabeling
+  symmetry break.
+- Reproduce the 15 canonical incidence classes from
+  `scripts/enumerate_n8_incidence.py`.
+- Recheck the survivor JSON without relying on the incidence generator.
+- Recheck class `12` cyclic-order noncrossing and the compatible-order counts.
+- Recheck the ten `y_2` rational-span certificates over exact rational
+  arithmetic.
+- Recheck classes `3`, `4`, `5`, and especially `14`, where Groebner machinery
+  is required.
+- Confirm that all exact obstruction steps avoid floating-point equality and
+  numerical optimization.
+- Confirm that no `n=9`, `n=10`, fixed-pattern, or all-order fixed-pattern
+  result is promoted by this packet.
+- Record any failed or partial review outcome in an issue or PR with command,
+  environment, artifact path, and exact gap.
+
+## Known Weak Points
+
+- `scripts/independent_check_n8_artifacts.py` treats checked-in artifacts as
+  input data and cross-checks them; it does not independently regenerate the
+  full incidence enumeration.
+- `scripts/independent_n8_obstruction_recheck.py` is SymPy-free but covers
+  only class `12` plus the ten `y_2` rational-span kills. It intentionally
+  does not cover Groebner-dependent classes `3`, `4`, `5`, and `14`.
+- Class `14` is the most delicate survivor: it uses the full
+  perpendicular-bisector plus equal-distance system and a strict-interior
+  conclusion from four algebraic branches.
+- The aggregate `n=8` exclusion is a computer-assisted repo-local artifact,
+  not a standalone public proof certificate.
+- Literature coverage must still be rechecked before any public theorem-style
+  statement about Erdos Problem #97.
+
+## Relation To Source-Of-Truth Docs
+
+This packet supports the existing source-of-truth wording in `STATE.md`,
+`RESULTS.md`, `docs/claims.md`, and `metadata/erdos97.yaml`. It does not
+supersede those files and should be updated if they change.
+
+The packet refines the audit route already described in `docs/reviewer-guide.md`
+and `docs/review-priorities.md`. It is narrower than the proof-note draft
+`papers/small-counterexamples-erdos97.md` and `docs/n8-geometric-proof.md`,
+which pursue a human-readable geometric small-case route.
+
+The relevant boundary-atlas categories are `INCIDENCE_OVERLAP_BOUNDARY`,
+`CYCLIC_ORDER_FORBIDDEN`, `COLLISION_BOUNDARY`,
+`COLLINEAR_WITNESS_BOUNDARY`, and `NONSTRICT_CONVEX_BOUNDARY`.
+
+## Status-Update Rules
+
+- A successful review of this packet may justify updating review notes or
+  adding a dated review entry, but it does not by itself update the
+  official/global status.
+- Do not update `metadata/erdos97.yaml` unless the source-of-truth strongest
+  result, review status, official-status check date, or artifact inventory
+  actually changes.
+- Do not update `STATE.md`, `RESULTS.md`, or `docs/claims.md` to stronger
+  public theorem-style language unless an independent review explicitly
+  accepts the incidence completeness, exact survivor obstructions, claim
+  scope, and literature boundary.
+- A failed review should preserve the packet and record the precise gap, then
+  demote or qualify source-of-truth wording only if the gap affects the current
+  repo-local `n <= 8` machine-checked claim.
+- Any future promotion must keep separate: official/global status, repo-local
+  finite-case artifacts, review-pending `n=9` and `n=10` artifacts,
+  fixed-order obstructions, fixed-pattern all-order obstructions, and
+  numerical evidence.


### PR DESCRIPTION
## Summary

- Adds `papers/n8-reviewer-packet.md`, a claim-neutral reviewer packet for the repo-local machine-checked `n=8` selected-witness finite-case artifact.
- Adds the supporting claim-neutral infrastructure docs: `docs/glossary.md`, `docs/boundary-atlas.md`, and `docs/review-packet-template.md`.
- Adds `papers/README.md` so paper-style drafts and reviewer packets have a local index.
- Links the new reviewer packet and infrastructure docs from `docs/index.md`.

## Scope

This PR preserves the repository's non-overclaiming boundary: no general proof and no counterexample are claimed, the official/global status remains falsifiable/open, and the `n <= 8` result is described as repo-local, machine-checked, and pending independent review before public theorem-style claims.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/independent_check_n8_artifacts.py --check --json`
- `python scripts/enumerate_n8_incidence.py --summary`
- `python scripts/analyze_n8_exact_survivors.py --check --json`