### PR TITLE
[codex] Add block6 row-Ptolemy extension audit

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -124,6 +124,42 @@ fragile rows and all row-circle constraints. Thus a bridge proof using this
 gate must either check all relevant extensions or prove that every extension
 falls to a row-circle certificate.
 
+### Bounded block-6 row-Ptolemy audit
+
+The following bounded exact audit tests this gate on the two-block fragile
+negative control:
+
+```bash
+python scripts/check_block6_row_ptolemy_extensions.py --blocks 2 --max-extensions 3 --assert-survivor --json
+```
+
+In the deterministic full-extension order used by the checker, the first two
+full selected-row extensions are rejected by row-Ptolemy
+product-cancellation. The third extension has no row-Ptolemy
+product-cancellation certificate. Its selected rows are:
+
+```text
+0  -> {1,2,3,4}
+1  -> {3,6,9,11}
+2  -> {1,3,5,10}
+3  -> {0,2,4,5}
+4  -> {0,3,8,11}
+5  -> {0,1,6,7}
+6  -> {7,8,9,10}
+7  -> {1,5,6,8}
+8  -> {0,5,7,9}
+9  -> {6,8,10,11}
+10 -> {2,5,9,11}
+11 -> {0,4,6,10}
+```
+
+This is a counterexample to the overstrong subclaim that row-Ptolemy
+product-cancellation alone kills every full selected-row extension of the
+two-block block-6 fragile rows. It is not a counterexample to Erdos #97 and is
+not a Euclidean realization certificate. It only says that this particular
+row-circle gate must be strengthened, or applied through an all-extension
+certificate, before it can close the fragile-cover bridge.
+
 ## What This Does Not Prove
 
 The bridge is necessary, not sufficient. The checked block-6 family passes the

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,154 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 668 - Block-6 Row-Ptolemy Survivor
+
+### Mathematical Subquestion
+
+Cycle 667 isolated the row-circle full-extension gate. The narrow test for
+this cycle was:
+
+```text
+Does row-Ptolemy product-cancellation kill every deterministic full
+selected-row extension of the two-block block-6 fragile negative control, or
+is there an exact survivor extension?
+```
+
+### Definitions and Assumptions
+
+Use the two-block `block6_family` fragile rows. A full selected-row extension
+assigns one four-element selected row to every center, preserves the fixed
+fragile rows, and satisfies the pair/crossing incidence constraints used by
+the full-extension diagnostic.
+
+A row-Ptolemy product-cancellation certificate is the exact local obstruction
+from `docs/row-ptolemy-product-filter.md`: selected-distance quotienting in
+one selected row makes Ptolemy's row-circle identity force a positive chord
+product to be zero.
+
+The audit is bounded by the deterministic extension order and the requested
+`--max-extensions`/`--max-nodes` limits.
+
+### Result Status
+
+Exact bounded obstruction to an overstrong subclaim:
+**Block-6 Row-Ptolemy Survivor**.
+
+### Argument Or Obstruction
+
+The new bounded checker enumerates deterministic full selected-row extensions
+of the two-block fragile rows under the pair/crossing constraints and tests
+each extension for row-Ptolemy product-cancellation certificates.
+
+With `--blocks 2 --max-extensions 3 --assert-survivor`, it examines three
+extensions before finding a survivor. The first two extensions are killed by
+one row-Ptolemy product-cancellation certificate each. In both cases the first
+certificate is at row `6`, has witness order `[7,8,9,10]`, uses variant
+`cancel_d01_d23_via_d02_eq_d23_and_d13_eq_d01`, and forces zero product
+`d03*d12`.
+
+The third full extension has zero row-Ptolemy product-cancellation
+certificates:
+
+```text
+0  -> {1,2,3,4}
+1  -> {3,6,9,11}
+2  -> {1,3,5,10}
+3  -> {0,2,4,5}
+4  -> {0,3,8,11}
+5  -> {0,1,6,7}
+6  -> {7,8,9,10}
+7  -> {1,5,6,8}
+8  -> {0,5,7,9}
+9  -> {6,8,10,11}
+10 -> {2,5,9,11}
+11 -> {0,4,6,10}
+```
+
+Therefore row-Ptolemy product-cancellation alone cannot prove that every full
+selected-row extension of the two-block block-6 fragile rows is impossible.
+This refutes only that overstrong bridge subclaim.
+
+### Exact Scope
+
+The conclusion is exact inside the bounded deterministic audit:
+
+- `blocks = 2`;
+- `max_extensions = 3`;
+- `max_nodes = 100000`;
+- the checker reports `extensions_examined = 3`,
+  `extensions_killed_by_row_ptolemy_product_cancellation = 2`,
+  `survivor_found = true`, `nodes_visited = 47`, and
+  `hit_node_limit = false`.
+
+The survivor is not a Euclidean realization, not an algebraic row-circle
+solution, not a counterexample to Erdos #97, and not evidence that stronger
+row-circle certificates fail. It only blocks the product-cancellation-only
+all-extension route.
+
+### Files Changed
+
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_block6_row_ptolemy_extensions.py`
+- `tests/test_block6_row_ptolemy_extensions.py`
+
+### Effect On The Attack
+
+Cycle 667's row-circle gate remains a necessary condition, but the simplest
+product-cancellation filter is too weak to close the two-block fragile
+negative control by itself. The bridge route now needs either stronger
+row-circle algebra, a complete all-extension certificate for a stronger
+certificate family, or a different minimal-counterexample reduction.
+
+### Next Lead
+
+Promote the survivor extension into the next exact row-circle algebra target:
+construct the selected-distance quotient classes for that extension, write the
+row-Ptolemy equations that remain after quotienting, and test whether the
+resulting positive system has an exact contradiction or a symbolic positive
+solution. If it survives, the route should shift away from local
+product-cancellation and toward higher-row compatibility.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-668`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-668`.
+- The branch was started from `origin/main` at commit
+  `18e3de94f7484489dbaa043f970f14b824dd1746`, after PR #405 merged Cycle
+  667.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_row_ptolemy_extensions.py --blocks 2 --max-extensions
+  3 --assert-survivor --json`: passed; the audit reports three examined
+  extensions, two product-cancellation kills, one survivor, `47` visited
+  nodes, and no node-limit hit.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_row_ptolemy_extensions.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `588 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 667 - Row-circle Full-extension Gate
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_row_ptolemy_extensions.py
+++ b/scripts/check_block6_row_ptolemy_extensions.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Bounded row-Ptolemy audit for block-6 fragile full extensions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from itertools import combinations
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.fragile_hypergraph import _selected_pair_ok, block6_family  # noqa: E402
+from erdos97.incidence_filters import (  # noqa: E402
+    row_ptolemy_product_cancellation_certificates,
+)
+
+
+def _full_extensions(
+    n: int,
+    fixed_rows: dict[int, list[int]],
+    order: Sequence[int],
+    max_nodes: int,
+    state: dict[str, int | bool],
+):
+    candidates: dict[int, list[tuple[int, ...]]] = {}
+    for center in range(n):
+        if center in fixed_rows:
+            candidates[center] = [tuple(fixed_rows[center])]
+        else:
+            labels = [label for label in range(n) if label != center]
+            candidates[center] = [tuple(row) for row in combinations(labels, 4)]
+
+    assigned: dict[int, tuple[int, ...]] = {}
+    nodes = 0
+    hit_limit = False
+
+    def candidate_ok(center: int, row: Sequence[int]) -> bool:
+        return all(
+            _selected_pair_ok(center, row, other, other_row, order)
+            for other, other_row in assigned.items()
+        )
+
+    def choose_center() -> tuple[int | None, list[tuple[int, ...]]]:
+        best_center: int | None = None
+        best_rows: list[tuple[int, ...]] = []
+        for center in range(n):
+            if center in assigned:
+                continue
+            viable = [row for row in candidates[center] if candidate_ok(center, row)]
+            if best_center is None or len(viable) < len(best_rows):
+                best_center = center
+                best_rows = viable
+            if not viable:
+                break
+        return best_center, best_rows
+
+    def search():
+        nonlocal nodes, hit_limit
+        state["nodes_visited"] = nodes
+        state["hit_node_limit"] = hit_limit
+        if len(assigned) == n:
+            yield {center: list(row) for center, row in sorted(assigned.items())}
+            return
+        if nodes >= max_nodes:
+            hit_limit = True
+            state["hit_node_limit"] = hit_limit
+            return
+        center, viable = choose_center()
+        if center is None:
+            yield {center: list(row) for center, row in sorted(assigned.items())}
+            return
+        for row in viable:
+            nodes += 1
+            state["nodes_visited"] = nodes
+            assigned[center] = row
+            yield from search()
+            del assigned[center]
+            if hit_limit:
+                return
+
+    yield from search()
+    state["nodes_visited"] = nodes
+    state["hit_node_limit"] = hit_limit
+
+
+def _rows_as_sequence(rows: dict[int, list[int]]) -> list[list[int]]:
+    return [rows[center] for center in range(len(rows))]
+
+
+def audit(blocks: int, max_extensions: int, max_nodes: int) -> dict[str, object]:
+    n, fixed_rows = block6_family(blocks)
+    order = list(range(n))
+    records = []
+    killed = 0
+    survivor = None
+
+    state: dict[str, int | bool] = {"nodes_visited": 0, "hit_node_limit": False}
+    generator = _full_extensions(n, fixed_rows, order, max_nodes, state)
+    for index, rows in enumerate(generator, start=1):
+        certs = row_ptolemy_product_cancellation_certificates(
+            _rows_as_sequence(rows),
+            order,
+        )
+        record = {
+            "extension_index": index,
+            "row_ptolemy_product_cancellation_count": len(certs),
+            "status": "killed_by_row_ptolemy_product_cancellation"
+            if certs
+            else "survives_row_ptolemy_product_cancellation",
+            "rows": {str(center): row for center, row in sorted(rows.items())},
+        }
+        if certs:
+            killed += 1
+            first = certs[0]
+            record["first_certificate"] = {
+                "row": first["row"],
+                "witness_order": first["witness_order"],
+                "variant": first["variant"],
+                "zero_product": first["zero_product"],
+            }
+        elif survivor is None:
+            survivor = record
+        records.append(record)
+        if survivor is not None or len(records) >= max_extensions:
+            break
+
+    return {
+        "type": "block6_row_ptolemy_full_extension_audit",
+        "schema": "erdos97.block6_row_ptolemy_full_extension_audit.v1",
+        "blocks": blocks,
+        "n": n,
+        "fixed_rows": {str(center): row for center, row in sorted(fixed_rows.items())},
+        "cyclic_order": order,
+        "max_extensions": max_extensions,
+        "max_nodes": max_nodes,
+        "extensions_examined": len(records),
+        "extensions_killed_by_row_ptolemy_product_cancellation": killed,
+        "survivor_found": survivor is not None,
+        "survivor": survivor,
+        "records": records,
+        "nodes_visited": state["nodes_visited"],
+        "hit_node_limit": state["hit_node_limit"],
+        "interpretation": (
+            "Bounded exact audit only. A survivor is an obstruction to the "
+            "claim that row-Ptolemy product-cancellation kills every full "
+            "selected-row extension of the fixed block-6 fragile rows."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--blocks", type=int, default=2)
+    parser.add_argument("--max-extensions", type=int, default=3)
+    parser.add_argument("--max-nodes", type=int, default=100_000)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-survivor", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit(args.blocks, args.max_extensions, args.max_nodes)
+    if args.assert_survivor and not payload["survivor_found"]:
+        raise AssertionError("expected a row-Ptolemy survivor extension")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("block6 row-Ptolemy full-extension audit")
+        print(f"blocks: {payload['blocks']}")
+        print(f"extensions examined: {payload['extensions_examined']}")
+        print(
+            "killed by product-cancellation: "
+            f"{payload['extensions_killed_by_row_ptolemy_product_cancellation']}"
+        )
+        print(f"survivor found: {payload['survivor_found']}")
+        if args.assert_survivor:
+            print("OK: survivor expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block6_row_ptolemy_extensions.py
+++ b/tests/test_block6_row_ptolemy_extensions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_block6_row_ptolemy_extensions import audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_two_block_audit_finds_product_cancellation_survivor() -> None:
+    payload = audit(blocks=2, max_extensions=3, max_nodes=100_000)
+
+    assert payload["extensions_examined"] == 3
+    assert payload["extensions_killed_by_row_ptolemy_product_cancellation"] == 2
+    assert payload["survivor_found"] is True
+    assert payload["hit_node_limit"] is False
+
+    survivor = payload["survivor"]
+    assert isinstance(survivor, dict)
+    assert survivor["extension_index"] == 3
+    assert survivor["row_ptolemy_product_cancellation_count"] == 0
+    assert survivor["rows"]["0"] == [1, 2, 3, 4]
+    assert survivor["rows"]["3"] == [0, 2, 4, 5]
+    assert survivor["rows"]["6"] == [7, 8, 9, 10]
+    assert survivor["rows"]["9"] == [6, 8, 10, 11]
+
+
+def test_block6_row_ptolemy_cli_assert_survivor() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_row_ptolemy_extensions.py",
+            "--blocks",
+            "2",
+            "--max-extensions",
+            "3",
+            "--assert-survivor",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "survivor found: True" in result.stdout
+    assert "OK: survivor expectation verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

Cycle 668 tests the row-circle gate from Cycle 667 on the two-block block-6 fragile negative control.

The new bounded exact audit enumerates deterministic full selected-row extensions under the existing pair/crossing constraints and checks each for row-Ptolemy product-cancellation certificates. In the first three extensions, the first two are killed by product-cancellation and the third survives with zero such certificates.

Named result: **Block-6 Row-Ptolemy Survivor**.

## Files changed

- `scripts/check_block6_row_ptolemy_extensions.py`
- `tests/test_block6_row_ptolemy_extensions.py`
- `docs/minimal-fragile-cover-bridge.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_row_ptolemy_extensions.py --blocks 2 --max-extensions 3 --assert-survivor --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_row_ptolemy_extensions.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `588 passed, 278 deselected`

## Remaining limitations

- This is a bounded deterministic audit: `blocks = 2`, `max_extensions = 3`, `max_nodes = 100000`.
- The survivor is not a Euclidean realization, not an algebraic row-circle solution, not a counterexample to Erdos #97, and not evidence that stronger row-circle certificates fail.
- The global proof/counterexample goal remains open.