### PR TITLE
[codex] Add block6 survivor quotient-Ptolemy check

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -160,6 +160,27 @@ not a Euclidean realization certificate. It only says that this particular
 row-circle gate must be strengthened, or applied through an all-extension
 certificate, before it can close the fragile-cover bridge.
 
+The survivor also passes a weaker quotient-level row-Ptolemy feasibility test:
+
+```bash
+python scripts/check_block6_survivor_ptolemy_feasibility.py --assert-expected --json
+```
+
+The checker quotients ordinary pair distances by the selected-distance
+equalities of the survivor, obtains `33` distance classes, and verifies an
+explicit positive rational assignment satisfying all `12` row-Ptolemy
+identities. For example, class values include
+
+```text
+x0=1, x5=3, x6=1/2, x9=1/2, x27=6, x32=3/2.
+```
+
+This rules out the next overstrong subclaim: selected-distance quotienting plus
+the row-circle Ptolemy equalities alone do not already force a positivity
+contradiction for the survivor. The certificate is only algebraic feasibility
+for the quotient equations. It does not impose triangle inequalities,
+Kalmanson inequalities, global metric consistency, or Euclidean realizability.
+
 ## What This Does Not Prove
 
 The bridge is necessary, not sufficient. The checked block-6 family passes the

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,159 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 669 - Quotient-Ptolemy Feasible Survivor
+
+### Mathematical Subquestion
+
+Cycle 668 found a full selected-row extension of the two-block block-6
+fragile negative control with zero row-Ptolemy product-cancellation
+certificates. The next narrow bridge question was:
+
+```text
+Do the selected-distance quotient equalities and all row-circle Ptolemy
+equations for that survivor already force a contradiction with positivity?
+```
+
+### Definitions and Assumptions
+
+Use the Cycle 668 survivor rows in the natural cyclic order:
+
+```text
+0  -> {1,2,3,4}
+1  -> {3,6,9,11}
+2  -> {1,3,5,10}
+3  -> {0,2,4,5}
+4  -> {0,3,8,11}
+5  -> {0,1,6,7}
+6  -> {7,8,9,10}
+7  -> {1,5,6,8}
+8  -> {0,5,7,9}
+9  -> {6,8,10,11}
+10 -> {2,5,9,11}
+11 -> {0,4,6,10}
+```
+
+Quotient ordinary pair-distance variables by the selected-distance equalities:
+for every center `i`, all four distances from `i` to its selected row are one
+quotient class. A quotient-level row-Ptolemy feasibility certificate is a
+positive rational value assigned to every quotient class such that every
+selected row satisfies
+
+```text
+d02*d13 = d01*d23 + d03*d12
+```
+
+in its cyclic witness order.
+
+### Result Status
+
+Exact positive feasibility certificate:
+**Quotient-Ptolemy Feasible Survivor**.
+
+### Argument Or Obstruction
+
+The new checker `scripts/check_block6_survivor_ptolemy_feasibility.py` builds
+the selected-distance quotient for the survivor. It obtains `33` ordinary
+distance classes and verifies the following positive rational assignment:
+
+```text
+x0=1, x1=4, x2=1, x3=1, x4=1, x5=3, x6=1/2, x7=2,
+x8=1, x9=1/2, x10=1, x11=1, x12=1, x13=1, x14=1, x15=1,
+x16=1, x17=1/2, x18=3, x19=4, x20=2, x21=1/2, x22=1,
+x23=1, x24=1, x25=1/2, x26=5, x27=6, x28=4, x29=1,
+x30=1, x31=1/2, x32=3/2.
+```
+
+All values are positive and all `12` row-Ptolemy equations verify exactly over
+the rationals. For instance row `0`, with witness order `[1,2,3,4]`, has
+
+```text
+d01=x0, d02=x5, d03=x6, d12=x0, d13=x9, d23=x0,
+```
+
+so the equation reads
+
+```text
+x5*x9 = x0*x0 + x6*x0,
+3*(1/2) = 1*1 + (1/2)*1.
+```
+
+Thus the quotient-level row-circle equations alone do not contradict
+positivity for the survivor. This is a counterexample only to the overstrong
+subclaim that quotienting plus row-Ptolemy identities already kills the
+survivor.
+
+### Exact Scope
+
+The certificate is exact for the fixed survivor rows above, the natural cyclic
+order, the selected-distance quotient computed by the repo's quotient helper,
+and the `12` row-Ptolemy equations. It does not impose triangle inequalities,
+Kalmanson inequalities, global metric consistency, coordinates, strict
+convexity determinants, or Euclidean realizability. It is not a counterexample
+to Erdos #97.
+
+### Files Changed
+
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_block6_survivor_ptolemy_feasibility.py`
+- `tests/test_block6_survivor_ptolemy_feasibility.py`
+
+### Effect On The Attack
+
+The fragile-cover row-circle route needs a stronger exact ingredient than
+local product-cancellation or raw quotient-level Ptolemy feasibility. The next
+reasonable additions are global metric inequalities such as Kalmanson rows,
+triangle inequalities, vertex-circle strict inequalities, or an exact
+Euclidean realization/real-root obstruction.
+
+### Next Lead
+
+Apply one stronger necessary metric layer to the same survivor. The most
+direct proof-facing test is a quotient-cone search for a positive linear
+combination of Kalmanson inequalities that reduces to a nonpositive vector
+after the survivor's selected-distance quotient. A second useful test is to
+replay vertex-circle strict inequalities on the survivor and look for a
+self-edge or strict cycle.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-669`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-669`.
+- The branch was started from `origin/main` at commit
+  `6dd045385e0758b506906f57968c5202d209d5e8`, after PR #407 merged Cycle
+  668.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_survivor_ptolemy_feasibility.py --assert-expected
+  --json`: passed; the audit reports `33` quotient classes, a positive
+  rational assignment, and `12` verified row-Ptolemy equations.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_survivor_ptolemy_feasibility.py -q`: passed, `2 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `590 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 668 - Block-6 Row-Ptolemy Survivor
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_survivor_ptolemy_feasibility.py
+++ b/scripts/check_block6_survivor_ptolemy_feasibility.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Check quotient-level row-Ptolemy feasibility for the block-6 survivor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import pair, selected_distance_quotient  # noqa: E402
+
+
+SURVIVOR_ROWS: list[list[int]] = [
+    [1, 2, 3, 4],
+    [3, 6, 9, 11],
+    [1, 3, 5, 10],
+    [0, 2, 4, 5],
+    [0, 3, 8, 11],
+    [0, 1, 6, 7],
+    [7, 8, 9, 10],
+    [1, 5, 6, 8],
+    [0, 5, 7, 9],
+    [6, 8, 10, 11],
+    [2, 5, 9, 11],
+    [0, 4, 6, 10],
+]
+
+EXPECTED_CLASS_COUNT = 33
+
+POSITIVE_CLASS_VALUES: dict[int, Fraction] = {
+    0: Fraction(1),
+    1: Fraction(4),
+    2: Fraction(1),
+    3: Fraction(1),
+    4: Fraction(1),
+    5: Fraction(3),
+    6: Fraction(1, 2),
+    7: Fraction(2),
+    8: Fraction(1),
+    9: Fraction(1, 2),
+    10: Fraction(1),
+    11: Fraction(1),
+    12: Fraction(1),
+    13: Fraction(1),
+    14: Fraction(1),
+    15: Fraction(1),
+    16: Fraction(1),
+    17: Fraction(1, 2),
+    18: Fraction(3),
+    19: Fraction(4),
+    20: Fraction(2),
+    21: Fraction(1, 2),
+    22: Fraction(1),
+    23: Fraction(1),
+    24: Fraction(1),
+    25: Fraction(1, 2),
+    26: Fraction(5),
+    27: Fraction(6),
+    28: Fraction(4),
+    29: Fraction(1),
+    30: Fraction(1),
+    31: Fraction(1, 2),
+    32: Fraction(3, 2),
+}
+
+
+def _fraction_json(value: Fraction) -> str:
+    if value.denominator == 1:
+        return str(value.numerator)
+    return f"{value.numerator}/{value.denominator}"
+
+
+def _witness_order(center: int, row: list[int], order: list[int]) -> list[int]:
+    positions = {label: idx for idx, label in enumerate(order)}
+    return sorted(row, key=lambda label: (positions[label] - positions[center]) % len(order))
+
+
+def audit() -> dict[str, object]:
+    order = list(range(len(SURVIVOR_ROWS)))
+    quotient = selected_distance_quotient(SURVIVOR_ROWS)
+    if quotient.class_count != EXPECTED_CLASS_COUNT:
+        raise AssertionError(
+            f"expected {EXPECTED_CLASS_COUNT} quotient classes, got {quotient.class_count}"
+        )
+    if sorted(POSITIVE_CLASS_VALUES) != list(range(quotient.class_count)):
+        raise AssertionError("positive assignment does not cover every quotient class")
+    if any(value <= 0 for value in POSITIVE_CLASS_VALUES.values()):
+        raise AssertionError("positive assignment contains a nonpositive value")
+
+    records = []
+    for center, row in enumerate(SURVIVOR_ROWS):
+        witnesses = _witness_order(center, row, order)
+        w0, w1, w2, w3 = witnesses
+        pairs = {
+            "d01": pair(w0, w1),
+            "d02": pair(w0, w2),
+            "d03": pair(w0, w3),
+            "d12": pair(w1, w2),
+            "d13": pair(w1, w3),
+            "d23": pair(w2, w3),
+        }
+        classes = {name: quotient.pair_class[item] for name, item in pairs.items()}
+        values = {name: POSITIVE_CLASS_VALUES[classes[name]] for name in pairs}
+        lhs = values["d02"] * values["d13"]
+        rhs_terms = (
+            values["d01"] * values["d23"],
+            values["d03"] * values["d12"],
+        )
+        rhs = rhs_terms[0] + rhs_terms[1]
+        if lhs != rhs:
+            raise AssertionError(f"row {center} violates row-Ptolemy")
+        records.append(
+            {
+                "row": center,
+                "witness_order": witnesses,
+                "classes": {name: int(classes[name]) for name in sorted(classes)},
+                "class_values": {
+                    name: _fraction_json(values[name]) for name in sorted(values)
+                },
+                "ptolemy_lhs": _fraction_json(lhs),
+                "ptolemy_rhs_terms": [_fraction_json(term) for term in rhs_terms],
+                "ptolemy_rhs": _fraction_json(rhs),
+                "ptolemy_verified": True,
+            }
+        )
+
+    return {
+        "type": "block6_survivor_quotient_ptolemy_feasibility",
+        "schema": "erdos97.block6_survivor_quotient_ptolemy_feasibility.v1",
+        "cyclic_order": order,
+        "rows": {str(center): row for center, row in enumerate(SURVIVOR_ROWS)},
+        "distance_class_count": quotient.class_count,
+        "distance_class_values": {
+            str(class_idx): _fraction_json(value)
+            for class_idx, value in sorted(POSITIVE_CLASS_VALUES.items())
+        },
+        "positive_assignment": True,
+        "row_ptolemy_equations_verified": len(records),
+        "records": records,
+        "interpretation": (
+            "Exact positive rational feasibility for the selected-distance quotient "
+            "and row-Ptolemy equations of the Cycle 668 survivor. This is not a "
+            "metric realization certificate and not a counterexample."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit()
+    if args.assert_expected:
+        if payload["distance_class_count"] != EXPECTED_CLASS_COUNT:
+            raise AssertionError("unexpected distance class count")
+        if payload["row_ptolemy_equations_verified"] != len(SURVIVOR_ROWS):
+            raise AssertionError("unexpected row-Ptolemy verification count")
+        if not payload["positive_assignment"]:
+            raise AssertionError("expected positive assignment")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("block6 survivor quotient-Ptolemy feasibility")
+        print(f"distance classes: {payload['distance_class_count']}")
+        print(
+            "row-Ptolemy equations verified: "
+            f"{payload['row_ptolemy_equations_verified']}"
+        )
+        print(f"positive assignment: {payload['positive_assignment']}")
+        if args.assert_expected:
+            print("OK: expected feasibility certificate verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block6_survivor_ptolemy_feasibility.py
+++ b/tests/test_block6_survivor_ptolemy_feasibility.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_block6_survivor_ptolemy_feasibility import audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_block6_survivor_has_positive_quotient_ptolemy_assignment() -> None:
+    payload = audit()
+
+    assert payload["distance_class_count"] == 33
+    assert payload["positive_assignment"] is True
+    assert payload["row_ptolemy_equations_verified"] == 12
+
+    values = payload["distance_class_values"]
+    assert values["0"] == "1"
+    assert values["5"] == "3"
+    assert values["9"] == "1/2"
+    assert values["27"] == "6"
+
+    rows = payload["records"]
+    assert rows[0]["classes"] == {
+        "d01": 0,
+        "d02": 5,
+        "d03": 6,
+        "d12": 0,
+        "d13": 9,
+        "d23": 0,
+    }
+    assert rows[0]["ptolemy_lhs"] == "3/2"
+    assert rows[0]["ptolemy_rhs"] == "3/2"
+
+
+def test_block6_survivor_ptolemy_feasibility_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_survivor_ptolemy_feasibility.py",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "distance classes: 33" in result.stdout
+    assert "row-Ptolemy equations verified: 12" in result.stdout
+    assert "OK: expected feasibility certificate verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

Cycle 669 tests the Cycle 668 block-6 survivor under a weaker quotient-level row-circle condition.

The new checker quotients ordinary pair distances by the survivor's selected-distance equalities and verifies an explicit positive rational assignment satisfying all 12 row-Ptolemy identities across 33 quotient classes.

Named result: **Quotient-Ptolemy Feasible Survivor**.

## Files changed

- `scripts/check_block6_survivor_ptolemy_feasibility.py`
- `tests/test_block6_survivor_ptolemy_feasibility.py`
- `docs/minimal-fragile-cover-bridge.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_survivor_ptolemy_feasibility.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_survivor_ptolemy_feasibility.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `590 passed, 278 deselected`

## Remaining limitations

- This is exact algebraic feasibility for the fixed survivor rows, selected-distance quotient, natural cyclic order, and row-Ptolemy equations only.
- It does not impose triangle inequalities, Kalmanson inequalities, global metric consistency, coordinates, strict convexity determinants, or Euclidean realizability.
- This is not a proof or counterexample for Erdos #97; the global goal remains open.