### PR TITLE
[codex] Add block6 survivor Kalmanson certificate

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -181,6 +181,21 @@ contradiction for the survivor. The certificate is only algebraic feasibility
 for the quotient equations. It does not impose triangle inequalities,
 Kalmanson inequalities, global metric consistency, or Euclidean realizability.
 
+A stronger metric-order layer does reject the same fixed survivor in the
+natural cyclic order:
+
+```bash
+python scripts/check_block6_survivor_kalmanson_certificate.py --assert-expected --json
+```
+
+The certificate is a positive integer combination of `31` strict Kalmanson
+inequalities, with weight sum `4294`, whose coefficient vector reduces to
+zero across the same `33` selected-distance quotient classes. Summing those
+strict inequalities gives `0 > 0`, so this fixed survivor/order is impossible.
+This is still a local obstruction only: it does not show that every
+full-row extension of the two-block fragile rows has such a certificate, and
+it does not rule out minimal counterexamples.
+
 ## What This Does Not Prove
 
 The bridge is necessary, not sufficient. The checked block-6 family passes the

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,139 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 670 - Survivor Kalmanson Certificate
+
+### Mathematical Subquestion
+
+Cycle 669 showed that the Cycle 668 survivor is feasible for the
+selected-distance quotient plus row-Ptolemy equations alone. The next exact
+metric-order question was:
+
+```text
+Does the natural-order Kalmanson quotient cone already obstruct that fixed
+survivor extension?
+```
+
+### Definitions and Assumptions
+
+Use the same two-block block-6 survivor rows and the natural cyclic order
+`[0,1,2,3,4,5,6,7,8,9,10,11]`. The selected-distance quotient has `33`
+ordinary pair-distance classes.
+
+For four vertices `a,b,c,d` in cyclic order, use the strict Kalmanson
+inequalities:
+
+```text
+K1: d(a,c)+d(b,d) > d(a,b)+d(c,d),
+K2: d(a,c)+d(b,d) > d(a,d)+d(b,c).
+```
+
+A Kalmanson quotient-cone certificate is a positive integer combination of
+such strict rows whose coefficient vector is coordinatewise nonpositive after
+selected-distance quotienting. In the stronger zero-sum case, the reduced
+coefficient vector is exactly zero, so summing the strict inequalities gives
+`0 > 0`.
+
+### Result Status
+
+Exact fixed-survivor obstruction:
+**Survivor Kalmanson Certificate**.
+
+### Argument Or Obstruction
+
+The new checker `scripts/check_block6_survivor_kalmanson_certificate.py`
+stores and verifies a `31`-row positive integer Kalmanson certificate for the
+fixed survivor and natural cyclic order. The generic quotient-cone checker
+confirms:
+
+```text
+strict rows: 31
+distance classes: 33
+weight sum: 4294
+max weight: 402
+combined nonzero coefficient count: 0
+zero sum verified: true
+```
+
+Thus the weighted sum of strict Kalmanson inequalities reduces to the zero
+linear form after selected-distance quotienting. Since each Kalmanson row is
+strictly positive in any strictly convex realization with that cyclic order,
+the sum would be strictly positive; the quotiented coefficient vector says the
+same sum is exactly zero. This gives an exact contradiction for this fixed
+survivor/order.
+
+### Exact Scope
+
+The result is exact for the fixed two-block block-6 survivor extension from
+Cycle 668 and the natural cyclic order only. It is not an all-extension audit
+for the two-block fragile rows, not an all-order obstruction for the survivor
+rows, not a proof that the block-6 fragile cover is impossible, not a
+counterexample, and not a proof of Erdos #97.
+
+### Files Changed
+
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_block6_survivor_kalmanson_certificate.py`
+- `tests/test_block6_survivor_kalmanson_certificate.py`
+
+### Effect On The Attack
+
+This salvages a useful bridge direction after the product-cancellation and
+raw Ptolemy feasibility failures. The survivor is not metric-order feasible
+in the natural order once Kalmanson inequalities are included. However, the
+main bridge gap remains the quantifier over full selected-row extensions and
+cyclic orders: a minimal counterexample only needs one compatible extension
+surviving all necessary geometric constraints.
+
+### Next Lead
+
+Run a bounded all-extension Kalmanson audit for the two-block fragile negative
+control: enumerate deterministic full selected-row extensions under
+pair/crossing constraints, and for each extension search or replay a
+Kalmanson quotient-cone certificate. The key question is whether the first
+surviving extension was a one-off or whether every early extension falls to a
+metric-order certificate.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-670`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-670`.
+- The branch was started from `origin/main` at commit
+  `46bb7e0e64e9b68e2dd77337dffa24e250dd3bcd`, after PR #408 merged Cycle
+  669.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_block6_survivor_kalmanson_certificate.py --assert-expected
+  --json`: passed; the checker verifies a `31`-row zero-sum Kalmanson
+  quotient-cone certificate with weight sum `4294` over `33` quotient classes.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest
+  tests/test_block6_survivor_kalmanson_certificate.py -q`: passed,
+  `3 passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `593 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 669 - Quotient-Ptolemy Feasible Survivor
 
 ### Mathematical Subquestion

--- a/scripts/check_block6_survivor_kalmanson_certificate.py
+++ b/scripts/check_block6_survivor_kalmanson_certificate.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Check a Kalmanson quotient-cone certificate for the block-6 survivor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import check_quotient_cone_certificate  # noqa: E402
+
+
+SURVIVOR_ROWS: list[list[int]] = [
+    [1, 2, 3, 4],
+    [3, 6, 9, 11],
+    [1, 3, 5, 10],
+    [0, 2, 4, 5],
+    [0, 3, 8, 11],
+    [0, 1, 6, 7],
+    [7, 8, 9, 10],
+    [1, 5, 6, 8],
+    [0, 5, 7, 9],
+    [6, 8, 10, 11],
+    [2, 5, 9, 11],
+    [0, 4, 6, 10],
+]
+
+STRICT_ROWS: list[dict[str, object]] = [
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 1, 3, 9], "weight": 402},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 1, 7, 10], "weight": 100},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 2, 3, 11], "weight": 146},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 2, 5, 9], "weight": 105},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [0, 2, 6, 10], "weight": 5},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 4, 6, 7], "weight": 96},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [0, 4, 7, 9], "weight": 48},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 6, 7, 8], "weight": 101},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 7, 8, 10], "weight": 249},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [0, 7, 9, 11], "weight": 48},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 8, 10, 11], "weight": 5},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [1, 2, 7, 10], "weight": 246},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [1, 3, 4, 9], "weight": 284},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [1, 3, 10, 11], "weight": 146},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [1, 4, 5, 11], "weight": 256},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [1, 4, 6, 8], "weight": 28},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [1, 4, 8, 11], "weight": 28},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [2, 3, 4, 10], "weight": 264},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [2, 3, 7, 11], "weight": 97},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [2, 4, 5, 6], "weight": 264},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [2, 4, 6, 9], "weight": 236},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [2, 6, 7, 10], "weight": 149},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [2, 6, 8, 11], "weight": 82},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [2, 7, 8, 11], "weight": 49},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [2, 8, 9, 10], "weight": 131},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [3, 5, 6, 11], "weight": 97},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [3, 6, 7, 11], "weight": 97},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [3, 8, 9, 10], "weight": 118},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [4, 5, 10, 11], "weight": 264},
+    {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [4, 7, 8, 9], "weight": 48},
+    {"source": "kalmanson", "kind": "K2_diag_gt_other", "quad": [5, 8, 9, 11], "weight": 105},
+]
+
+CERTIFICATE: dict[str, object] = {
+    "type": "block6_survivor_kalmanson_quotient_cone_certificate",
+    "schema": "erdos97.block6_survivor_kalmanson_quotient_cone_certificate.v1",
+    "status": "EXACT_OBSTRUCTION_FOR_FIXED_SURVIVOR_AND_FIXED_CYCLIC_ORDER",
+    "claim_strength": (
+        "Exact obstruction for the fixed two-block block-6 survivor extension "
+        "and natural cyclic order only."
+    ),
+    "pattern": {
+        "name": "block6_two_block_survivor_extension_3",
+        "n": 12,
+        "selected_rows": SURVIVOR_ROWS,
+    },
+    "cyclic_order": list(range(12)),
+    "strict_rows": STRICT_ROWS,
+    "num_inequalities": 31,
+    "weight_sum": 4294,
+}
+
+
+def audit() -> dict[str, object]:
+    result = check_quotient_cone_certificate(CERTIFICATE)
+    return {
+        "type": CERTIFICATE["type"],
+        "schema": CERTIFICATE["schema"],
+        "status": result.status,
+        "claim_strength": result.claim_strength,
+        "pattern": result.pattern,
+        "n": result.n,
+        "cyclic_order": CERTIFICATE["cyclic_order"],
+        "strict_rows": result.strict_rows,
+        "distance_classes": result.distance_classes,
+        "weight_sum": result.weight_sum,
+        "max_weight": result.max_weight,
+        "zero_sum_verified": result.zero_sum_verified,
+        "nonpositive_sum_verified": result.nonpositive_sum_verified,
+        "combined_nonzero_coefficient_count": result.combined_nonzero_coefficient_count,
+        "coefficient_positive_count": result.coefficient_positive_count,
+        "coefficient_negative_count": result.coefficient_negative_count,
+        "coefficient_zero_count": result.coefficient_zero_count,
+        "certificate": CERTIFICATE,
+        "interpretation": (
+            "The listed positive integer combination of strict Kalmanson "
+            "inequalities reduces to the zero vector after selected-distance "
+            "quotienting. Summing the strict inequalities gives 0 > 0 for this "
+            "fixed survivor/order."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit()
+    if args.assert_expected:
+        if payload["strict_rows"] != 31:
+            raise AssertionError("unexpected strict-row count")
+        if payload["distance_classes"] != 33:
+            raise AssertionError("unexpected distance-class count")
+        if payload["weight_sum"] != 4294:
+            raise AssertionError("unexpected weight sum")
+        if payload["max_weight"] != 402:
+            raise AssertionError("unexpected max weight")
+        if not payload["zero_sum_verified"]:
+            raise AssertionError("expected zero-sum certificate")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("block6 survivor Kalmanson quotient-cone certificate")
+        print(f"strict rows: {payload['strict_rows']}")
+        print(f"distance classes: {payload['distance_classes']}")
+        print(f"weight sum: {payload['weight_sum']}")
+        print(f"max weight: {payload['max_weight']}")
+        print(f"zero sum verified: {payload['zero_sum_verified']}")
+        if args.assert_expected:
+            print("OK: expected Kalmanson certificate verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_block6_survivor_kalmanson_certificate.py
+++ b/tests/test_block6_survivor_kalmanson_certificate.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.quotient_cone import check_quotient_cone_certificate
+from scripts.check_block6_survivor_kalmanson_certificate import CERTIFICATE, audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_block6_survivor_kalmanson_certificate_replays() -> None:
+    result = check_quotient_cone_certificate(CERTIFICATE)
+
+    assert result.pattern == "block6_two_block_survivor_extension_3"
+    assert result.strict_rows == 31
+    assert result.distance_classes == 33
+    assert result.weight_sum == 4294
+    assert result.max_weight == 402
+    assert result.zero_sum_verified is True
+    assert result.nonpositive_sum_verified is True
+    assert result.combined_nonzero_coefficient_count == 0
+
+
+def test_block6_survivor_kalmanson_audit_summary() -> None:
+    payload = audit()
+
+    assert payload["status"] == "EXACT_OBSTRUCTION_FOR_FIXED_SURVIVOR_AND_FIXED_CYCLIC_ORDER"
+    assert payload["strict_rows"] == 31
+    assert payload["distance_classes"] == 33
+    assert payload["weight_sum"] == 4294
+    assert payload["zero_sum_verified"] is True
+    assert payload["certificate"]["num_inequalities"] == 31
+
+
+def test_block6_survivor_kalmanson_certificate_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_survivor_kalmanson_certificate.py",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "strict rows: 31" in result.stdout
+    assert "distance classes: 33" in result.stdout
+    assert "OK: expected Kalmanson certificate verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

Cycle 670 tests the Cycle 668/669 block-6 survivor against natural-order Kalmanson quotient-cone inequalities.

The new checker stores and verifies a 31-row positive integer Kalmanson certificate. The weighted coefficient vector reduces to zero across the survivor's 33 selected-distance quotient classes, so summing the strict inequalities gives `0 > 0` for this fixed survivor/order.

Named result: **Survivor Kalmanson Certificate**.

## Files changed

- `scripts/check_block6_survivor_kalmanson_certificate.py`
- `tests/test_block6_survivor_kalmanson_certificate.py`
- `docs/minimal-fragile-cover-bridge.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_block6_survivor_kalmanson_certificate.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest tests/test_block6_survivor_kalmanson_certificate.py -q`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` -> `593 passed, 278 deselected`

## Remaining limitations

- This is exact only for the fixed two-block block-6 survivor extension and natural cyclic order.
- It is not an all-extension audit for the two-block fragile rows and not an all-order obstruction for the survivor rows.
- This is not a proof that the block-6 fragile cover is impossible, not a counterexample, and not a proof of Erdos #97.