### PR TITLE
[codex] Add bootstrap vertex-circle overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the bootstrap-core rank/capacity crosswalk on current fixed-row
   frontier motifs, read
   [`docs/bootstrap-core-crosswalk.md`](docs/bootstrap-core-crosswalk.md).
+- For the bootstrap-core / vertex-circle overlay on the tight `n=9`
+  non-ear-orderable rows, read
+  [`docs/bootstrap-vertex-circle-overlay.md`](docs/bootstrap-vertex-circle-overlay.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -142,6 +142,15 @@ realizability; see `docs/bootstrap-core-crosswalk.md`,
 `scripts/check_bootstrap_core_crosswalk.py`, and
 `data/certificates/bootstrap_core_crosswalk.json`.
 
+The companion bootstrap / vertex-circle overlay joins the two tight
+non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
+certificate chain by selected-row signature. Both land on the same `T12/F16`
+strict-cycle template, with capacity margins `8` and `6`, but the strict-cycle
+local row cores are not contained in the bootstrap core. This is proof-mining
+diagnostic information only; see `docs/bootstrap-vertex-circle-overlay.md`,
+`scripts/check_bootstrap_vertex_circle_overlay.py`, and
+`data/certificates/bootstrap_vertex_circle_overlay.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -54,6 +54,12 @@ current fixed-row frontier motifs and records that the audited singleton-rich
 cases have rank greater than 3 but still pass the weighted capacity check; see
 `docs/bootstrap-core-crosswalk.md`.
 
+A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
+`n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
+Both rows join by selected-row signature to the same `T12/F16` strict-cycle
+template, but neither strict-cycle core is contained in the bootstrap core. See
+`docs/bootstrap-vertex-circle-overlay.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_vertex_circle_overlay.json
+++ b/data/certificates/bootstrap_vertex_circle_overlay.json
@@ -1,0 +1,1552 @@
+{
+  "claim_scope": "Overlay of the two non-ear-orderable n=9 bootstrap-core frontier assignments with the review-pending vertex-circle strict-cycle chain; not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.",
+  "interpretation_warnings": [
+    "This overlay joins existing review-pending diagnostics; it is not an independent n=9 proof.",
+    "The bridge-frontier source indices and vertex-circle assignment ids are joined by selected-row signature.",
+    "The strict-cycle rows are local selected-row cores, not full rich-class data.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_vertex_circle_overlay.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_vertex_circle_overlay.py"
+  },
+  "records": [
+    {
+      "assignment_join_method": "selected_row_signature",
+      "bootstrap_capacity": {
+        "capacity_margin": 8,
+        "cyclic_capacity_sum": 14,
+        "outside": [
+          3,
+          5,
+          6,
+          7,
+          8
+        ],
+        "outside_run_lengths": [
+          1,
+          4
+        ],
+        "private_pair_count": 6
+      },
+      "bootstrap_core": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "bootstrap_minimum_rank": 4,
+      "circulant_offsets": [
+        1,
+        3,
+        6,
+        7
+      ],
+      "classification_assignment_id": "A082",
+      "crosswalk_case_id": "n9_vertex_circle_assignment_81:natural",
+      "deletion_closures": [
+        {
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            7,
+            8
+          ],
+          "private_halo_size": 5,
+          "private_pair_count": 3,
+          "private_pairs": [
+            [
+              3,
+              6
+            ],
+            [
+              3,
+              7
+            ],
+            [
+              6,
+              7
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                3,
+                6,
+                7
+              ],
+              "private_pair_count": 3,
+              "rich_class_index": 0
+            }
+          ]
+        },
+        {
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            7,
+            8
+          ],
+          "private_halo_size": 5,
+          "private_pair_count": 1,
+          "private_pairs": [
+            [
+              7,
+              8
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                7,
+                8
+              ],
+              "private_pair_count": 1,
+              "rich_class_index": 0
+            }
+          ]
+        },
+        {
+          "closure_size": 5,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_halo": [
+            5,
+            7,
+            8
+          ],
+          "private_halo_size": 3,
+          "private_pair_count": 1,
+          "private_pairs": [
+            [
+              5,
+              8
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                5,
+                8
+              ],
+              "private_pair_count": 1,
+              "rich_class_index": 0
+            }
+          ]
+        },
+        {
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            7,
+            8
+          ],
+          "private_halo_size": 5,
+          "private_pair_count": 1,
+          "private_pairs": [
+            [
+              5,
+              7
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                5,
+                7
+              ],
+              "private_pair_count": 1,
+              "rich_class_index": 0
+            }
+          ]
+        }
+      ],
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          3,
+          4,
+          6
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          4
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "interpretation": "The selected-row stuck/bootstrap core and the vertex-circle strict cycle coexist in this fixed assignment, but the strict cycle is not a bootstrap-core-only contradiction.",
+      "n": 9,
+      "selected_rows": [
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "source_assignment_index": 81,
+      "source_record_id": 81,
+      "target_id": "n9-assignment-81",
+      "template_packet_summary": {
+        "assignment_count": 2,
+        "cycle_length": 3,
+        "cycle_span_counts": [
+          {
+            "count": 3,
+            "inner_span": 1,
+            "outer_span": 3
+          }
+        ],
+        "families": [
+          "F16"
+        ],
+        "family_count": 1,
+        "status": "strict_cycle",
+        "template_id": "T12"
+      },
+      "vertex_circle": {
+        "assignment_id": "A082",
+        "connector_path_lengths": [
+          1,
+          2,
+          1
+        ],
+        "core_size": 6,
+        "cycle_length": 3,
+        "cycle_pair_entries": [
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              3
+            ],
+            "role": "strict_outer_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              8
+            ],
+            "role": "strict_inner_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              8
+            ],
+            "role": "connector_start_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              2,
+              8
+            ],
+            "role": "connector_end_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              2,
+              8
+            ],
+            "path_index": 0,
+            "role": "connector_path_next_pair",
+            "row": 8,
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              2,
+              8
+            ],
+            "role": "strict_outer_pair",
+            "step_index": 1
+          },
+          {
+            "location": "core_core",
+            "pair": [
+              2,
+              4
+            ],
+            "role": "strict_inner_pair",
+            "step_index": 1
+          },
+          {
+            "location": "core_core",
+            "pair": [
+              2,
+              4
+            ],
+            "role": "connector_start_pair",
+            "step_index": 1
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              7
+            ],
+            "role": "connector_end_pair",
+            "step_index": 1
+          },
+          {
+            "location": "core_core",
+            "pair": [
+              1,
+              4
+            ],
+            "path_index": 0,
+            "role": "connector_path_next_pair",
+            "row": 4,
+            "step_index": 1
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              7
+            ],
+            "path_index": 1,
+            "role": "connector_path_next_pair",
+            "row": 1,
+            "step_index": 1
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              7
+            ],
+            "role": "strict_outer_pair",
+            "step_index": 2
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              3
+            ],
+            "role": "strict_inner_pair",
+            "step_index": 2
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              3
+            ],
+            "role": "connector_start_pair",
+            "step_index": 2
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              3
+            ],
+            "role": "connector_end_pair",
+            "step_index": 2
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              3
+            ],
+            "path_index": 0,
+            "role": "connector_path_next_pair",
+            "row": 3,
+            "step_index": 2
+          }
+        ],
+        "cycle_pair_location_counts": {
+          "core_core": 3,
+          "core_outside": 13
+        },
+        "cycle_row_centers": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          8
+        ],
+        "cycle_row_centers_in_bootstrap_core": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "cycle_row_centers_outside_bootstrap_core": [
+          3,
+          8
+        ],
+        "cycle_rows_subset_of_bootstrap_core": false,
+        "cycle_steps": [
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                2,
+                8
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    2,
+                    8
+                  ],
+                  "row": 8
+                }
+              ],
+              "start_pair": [
+                0,
+                8
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                0,
+                2
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                8
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                0,
+                3
+              ],
+              "outer_span": 3,
+              "row": 2,
+              "witness_order": [
+                3,
+                5,
+                8,
+                0
+              ]
+            }
+          },
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                1,
+                7
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 4
+                },
+                {
+                  "next_pair": [
+                    1,
+                    7
+                  ],
+                  "row": 1
+                }
+              ],
+              "start_pair": [
+                2,
+                4
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                1,
+                2
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                2,
+                4
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                2,
+                8
+              ],
+              "outer_span": 3,
+              "row": 1,
+              "witness_order": [
+                2,
+                4,
+                7,
+                8
+              ]
+            }
+          },
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                0,
+                3
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 3
+                }
+              ],
+              "start_pair": [
+                1,
+                3
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                1,
+                3
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                1,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                1,
+                7
+              ],
+              "outer_span": 3,
+              "row": 0,
+              "witness_order": [
+                1,
+                3,
+                6,
+                7
+              ]
+            }
+          }
+        ],
+        "equality_connector_rows": [
+          8,
+          4,
+          1,
+          3
+        ],
+        "equality_connector_rows_outside_bootstrap_core": [
+          3,
+          8
+        ],
+        "equality_connector_rows_subset_of_bootstrap_core": false,
+        "family_id": "F16",
+        "local_core_rows": [
+          {
+            "center": 0,
+            "witnesses": [
+              1,
+              3,
+              6,
+              7
+            ]
+          },
+          {
+            "center": 1,
+            "witnesses": [
+              2,
+              4,
+              7,
+              8
+            ]
+          },
+          {
+            "center": 2,
+            "witnesses": [
+              0,
+              3,
+              5,
+              8
+            ]
+          },
+          {
+            "center": 3,
+            "witnesses": [
+              0,
+              1,
+              4,
+              6
+            ]
+          },
+          {
+            "center": 4,
+            "witnesses": [
+              1,
+              2,
+              5,
+              7
+            ]
+          },
+          {
+            "center": 8,
+            "witnesses": [
+              0,
+              2,
+              5,
+              6
+            ]
+          }
+        ],
+        "span_signature": "3:1,3:1,3:1",
+        "status": "strict_cycle",
+        "strict_edge_count": 54,
+        "strict_edge_rows": [
+          2,
+          1,
+          0
+        ],
+        "strict_edge_rows_outside_bootstrap_core": [],
+        "strict_edge_rows_subset_of_bootstrap_core": true,
+        "template_id": "T12",
+        "unique_cycle_pair_location_counts": {
+          "core_core": 2,
+          "core_outside": 5
+        }
+      }
+    },
+    {
+      "assignment_join_method": "selected_row_signature",
+      "bootstrap_capacity": {
+        "capacity_margin": 6,
+        "cyclic_capacity_sum": 14,
+        "outside": [
+          3,
+          5,
+          6,
+          7,
+          8
+        ],
+        "outside_run_lengths": [
+          1,
+          4
+        ],
+        "private_pair_count": 8
+      },
+      "bootstrap_core": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "bootstrap_minimum_rank": 4,
+      "circulant_offsets": [
+        2,
+        3,
+        6,
+        8
+      ],
+      "classification_assignment_id": "A152",
+      "crosswalk_case_id": "n9_vertex_circle_assignment_151:natural",
+      "deletion_closures": [
+        {
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            7,
+            8
+          ],
+          "private_halo_size": 5,
+          "private_pair_count": 3,
+          "private_pairs": [
+            [
+              3,
+              6
+            ],
+            [
+              3,
+              8
+            ],
+            [
+              6,
+              8
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                3,
+                6,
+                8
+              ],
+              "private_pair_count": 3,
+              "rich_class_index": 0
+            }
+          ]
+        },
+        {
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            7,
+            8
+          ],
+          "private_halo_size": 5,
+          "private_pair_count": 1,
+          "private_pairs": [
+            [
+              3,
+              7
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                3,
+                7
+              ],
+              "private_pair_count": 1,
+              "rich_class_index": 0
+            }
+          ]
+        },
+        {
+          "closure_size": 4,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            8
+          ],
+          "private_halo_size": 4,
+          "private_pair_count": 1,
+          "private_pairs": [
+            [
+              5,
+              8
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                5,
+                8
+              ],
+              "private_pair_count": 1,
+              "rich_class_index": 0
+            }
+          ]
+        },
+        {
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_halo": [
+            3,
+            5,
+            6,
+            7,
+            8
+          ],
+          "private_halo_size": 5,
+          "private_pair_count": 3,
+          "private_pairs": [
+            [
+              3,
+              6
+            ],
+            [
+              3,
+              7
+            ],
+            [
+              6,
+              7
+            ]
+          ],
+          "private_witnesses_by_rich_class": [
+            {
+              "private_halo_witnesses": [
+                3,
+                6,
+                7
+              ],
+              "private_pair_count": 3,
+              "rich_class_index": 0
+            }
+          ]
+        }
+      ],
+      "ear_order": {
+        "exists": false,
+        "largest_closure": [
+          0,
+          1,
+          4,
+          6,
+          7
+        ],
+        "largest_closure_seed": [
+          0,
+          1,
+          6
+        ],
+        "largest_closure_size": 5,
+        "order": null,
+        "seed": null
+      },
+      "interpretation": "The selected-row stuck/bootstrap core and the vertex-circle strict cycle coexist in this fixed assignment, but the strict cycle is not a bootstrap-core-only contradiction.",
+      "n": 9,
+      "selected_rows": [
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_assignment_index": 151,
+      "source_record_id": 151,
+      "target_id": "n9-assignment-151",
+      "template_packet_summary": {
+        "assignment_count": 2,
+        "cycle_length": 3,
+        "cycle_span_counts": [
+          {
+            "count": 3,
+            "inner_span": 1,
+            "outer_span": 3
+          }
+        ],
+        "families": [
+          "F16"
+        ],
+        "family_count": 1,
+        "status": "strict_cycle",
+        "template_id": "T12"
+      },
+      "vertex_circle": {
+        "assignment_id": "A152",
+        "connector_path_lengths": [
+          1,
+          2,
+          1
+        ],
+        "core_size": 6,
+        "cycle_length": 3,
+        "cycle_pair_entries": [
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              6
+            ],
+            "role": "strict_outer_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_core",
+            "pair": [
+              0,
+              1
+            ],
+            "role": "strict_inner_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_core",
+            "pair": [
+              0,
+              1
+            ],
+            "role": "connector_start_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              7
+            ],
+            "role": "connector_end_pair",
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              7
+            ],
+            "path_index": 0,
+            "role": "connector_path_next_pair",
+            "row": 1,
+            "step_index": 0
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              1,
+              7
+            ],
+            "role": "strict_outer_pair",
+            "step_index": 1
+          },
+          {
+            "location": "outside_outside",
+            "pair": [
+              5,
+              7
+            ],
+            "role": "strict_inner_pair",
+            "step_index": 1
+          },
+          {
+            "location": "outside_outside",
+            "pair": [
+              5,
+              7
+            ],
+            "role": "connector_start_pair",
+            "step_index": 1
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              2,
+              8
+            ],
+            "role": "connector_end_pair",
+            "step_index": 1
+          },
+          {
+            "location": "outside_outside",
+            "pair": [
+              5,
+              8
+            ],
+            "path_index": 0,
+            "role": "connector_path_next_pair",
+            "row": 5,
+            "step_index": 1
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              2,
+              8
+            ],
+            "path_index": 1,
+            "role": "connector_path_next_pair",
+            "row": 8,
+            "step_index": 1
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              2,
+              8
+            ],
+            "role": "strict_outer_pair",
+            "step_index": 2
+          },
+          {
+            "location": "outside_outside",
+            "pair": [
+              6,
+              8
+            ],
+            "role": "strict_inner_pair",
+            "step_index": 2
+          },
+          {
+            "location": "outside_outside",
+            "pair": [
+              6,
+              8
+            ],
+            "role": "connector_start_pair",
+            "step_index": 2
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              6
+            ],
+            "role": "connector_end_pair",
+            "step_index": 2
+          },
+          {
+            "location": "core_outside",
+            "pair": [
+              0,
+              6
+            ],
+            "path_index": 0,
+            "role": "connector_path_next_pair",
+            "row": 6,
+            "step_index": 2
+          }
+        ],
+        "cycle_pair_location_counts": {
+          "core_core": 2,
+          "core_outside": 9,
+          "outside_outside": 5
+        },
+        "cycle_row_centers": [
+          0,
+          1,
+          5,
+          6,
+          7,
+          8
+        ],
+        "cycle_row_centers_in_bootstrap_core": [
+          0,
+          1
+        ],
+        "cycle_row_centers_outside_bootstrap_core": [
+          5,
+          6,
+          7,
+          8
+        ],
+        "cycle_rows_subset_of_bootstrap_core": false,
+        "cycle_steps": [
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                1,
+                7
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    1,
+                    7
+                  ],
+                  "row": 1
+                }
+              ],
+              "start_pair": [
+                0,
+                1
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                0,
+                1
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                0,
+                6
+              ],
+              "outer_span": 3,
+              "row": 7,
+              "witness_order": [
+                0,
+                1,
+                4,
+                6
+              ]
+            }
+          },
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                2,
+                8
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 5
+                },
+                {
+                  "next_pair": [
+                    2,
+                    8
+                  ],
+                  "row": 8
+                }
+              ],
+              "start_pair": [
+                5,
+                7
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                1,
+                8
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                5,
+                7
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                1,
+                7
+              ],
+              "outer_span": 3,
+              "row": 8,
+              "witness_order": [
+                1,
+                2,
+                5,
+                7
+              ]
+            }
+          },
+          {
+            "equality_to_next_outer_pair": {
+              "end_pair": [
+                0,
+                6
+              ],
+              "path": [
+                {
+                  "next_pair": [
+                    0,
+                    6
+                  ],
+                  "row": 6
+                }
+              ],
+              "start_pair": [
+                6,
+                8
+              ]
+            },
+            "strict_inequality": {
+              "inner_class": [
+                0,
+                2
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                6,
+                8
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                1,
+                8
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                2,
+                8
+              ],
+              "outer_span": 3,
+              "row": 0,
+              "witness_order": [
+                2,
+                3,
+                6,
+                8
+              ]
+            }
+          }
+        ],
+        "equality_connector_rows": [
+          1,
+          5,
+          8,
+          6
+        ],
+        "equality_connector_rows_outside_bootstrap_core": [
+          5,
+          6,
+          8
+        ],
+        "equality_connector_rows_subset_of_bootstrap_core": false,
+        "family_id": "F16",
+        "local_core_rows": [
+          {
+            "center": 0,
+            "witnesses": [
+              2,
+              3,
+              6,
+              8
+            ]
+          },
+          {
+            "center": 1,
+            "witnesses": [
+              0,
+              3,
+              4,
+              7
+            ]
+          },
+          {
+            "center": 5,
+            "witnesses": [
+              2,
+              4,
+              7,
+              8
+            ]
+          },
+          {
+            "center": 6,
+            "witnesses": [
+              0,
+              3,
+              5,
+              8
+            ]
+          },
+          {
+            "center": 7,
+            "witnesses": [
+              0,
+              1,
+              4,
+              6
+            ]
+          },
+          {
+            "center": 8,
+            "witnesses": [
+              1,
+              2,
+              5,
+              7
+            ]
+          }
+        ],
+        "span_signature": "3:1,3:1,3:1",
+        "status": "strict_cycle",
+        "strict_edge_count": 54,
+        "strict_edge_rows": [
+          7,
+          8,
+          0
+        ],
+        "strict_edge_rows_outside_bootstrap_core": [
+          7,
+          8
+        ],
+        "strict_edge_rows_subset_of_bootstrap_core": false,
+        "template_id": "T12",
+        "unique_cycle_pair_location_counts": {
+          "core_core": 1,
+          "core_outside": 3,
+          "outside_outside": 3
+        }
+      }
+    }
+  ],
+  "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_core_crosswalk.json",
+      "role": "singleton-rich bootstrap-core rank/capacity records",
+      "schema": "erdos97.bootstrap_core_crosswalk.v1",
+      "status": "BOOTSTRAP_CORE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bridge_lemma_frontier.json",
+      "role": "bridge proof-mining target ids and selected rows",
+      "schema": "erdos97.bridge_lemma_frontier.v1",
+      "status": "BRIDGE_LEMMA_FRONTIER_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+      "role": "selected-row signature to vertex-circle assignment/template classification",
+      "schema": "erdos97.n9_vertex_circle_frontier_motif_classification.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_path_join.json",
+      "role": "strict-cycle equality connectors and vertex-circle strict edges",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_path_join.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+      "role": "strict-cycle template packet summaries",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY",
+  "summary": {
+    "bootstrap_core": [
+      0,
+      1,
+      2,
+      4
+    ],
+    "bootstrap_minimum_rank_counts": {
+      "4": 2
+    },
+    "capacity_margins_by_source_id": {
+      "151": 6,
+      "81": 8
+    },
+    "classification_assignment_ids": [
+      "A082",
+      "A152"
+    ],
+    "cycle_length_counts": {
+      "3": 2
+    },
+    "cycle_rows_subset_of_bootstrap_core_count": 0,
+    "equality_connector_rows_subset_of_bootstrap_core_count": 0,
+    "family_counts": {
+      "F16": 2
+    },
+    "overlay_conclusion": "T12_STRICT_CYCLE_SHARED_BUT_NOT_BOOTSTRAP_CORE_ONLY",
+    "source_assignment_indices": [
+      81,
+      151
+    ],
+    "strict_edge_rows_subset_of_bootstrap_core_count": 1,
+    "target_count": 2,
+    "template_counts": {
+      "T12": 2
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-core-crosswalk.md
+++ b/docs/bootstrap-core-crosswalk.md
@@ -63,6 +63,12 @@ their capacity margins are `8` and `6`. The sparse circulant cases have much
 larger margins, so this private-pair ledger alone is too weak to explain their
 known exact Kalmanson/Farkas obstructions.
 
+A follow-up overlay joins these two tight `n=9` rows to the review-pending
+vertex-circle strict-cycle certificate chain; see
+`docs/bootstrap-vertex-circle-overlay.md`. Both rows land on the `T12/F16`
+strict-cycle template by selected-row signature, but the strict-cycle local
+row cores are not contained in the bootstrap core.
+
 ## Reading
 
 The useful negative conclusion is narrow:

--- a/docs/bootstrap-vertex-circle-overlay.md
+++ b/docs/bootstrap-vertex-circle-overlay.md
@@ -1,0 +1,78 @@
+# Bootstrap / Vertex-circle Overlay
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note overlays the two tight non-ear-orderable `n=9` rows from
+`docs/bootstrap-core-crosswalk.md` with the review-pending vertex-circle
+strict-cycle certificate chain. The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_vertex_circle_overlay.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_vertex_circle_overlay.json`.
+
+## Scope
+
+The input bootstrap records are singleton-rich fixed selected-row diagnostics.
+They are not full geometric rich-class data, and passing the capacity ledger is
+not a Euclidean realization certificate.
+
+The vertex-circle side is also review-pending. The overlay does not reprove the
+exhaustive `n=9` checker, and it does not promote any finite-case status. It
+only joins existing artifacts by selected-row signature:
+
+- `data/certificates/bootstrap_core_crosswalk.json`;
+- `data/certificates/bridge_lemma_frontier.json`;
+- `data/certificates/n9_vertex_circle_frontier_motif_classification.json`;
+- `data/certificates/n9_vertex_circle_strict_cycle_path_join.json`;
+- `data/certificates/n9_vertex_circle_strict_cycle_template_packet.json`.
+
+The signature join matters: bridge-frontier source indices `81` and `151`
+correspond to vertex-circle classification assignment ids `A082` and `A152`,
+respectively.
+
+## Results
+
+Both tight non-ear assignments share the same strict-cycle template bucket:
+`T12/F16`, cycle length `3`.
+
+| Bridge source id | Classification id | Offsets | Bootstrap core | Margin | Template | Local cycle rows | Rows outside bootstrap core |
+|---:|---|---|---|---:|---|---|---|
+| `81` | `A082` | `[1,3,6,7]` | `[0,1,2,4]` | `8` | `T12/F16` | `[0,1,2,3,4,8]` | `[3,8]` |
+| `151` | `A152` | `[2,3,6,8]` | `[0,1,2,4]` | `6` | `T12/F16` | `[0,1,5,6,7,8]` | `[5,6,7,8]` |
+
+The overlay conclusion is deliberately narrow:
+
+```text
+T12 strict-cycle shared by the two tight non-ear cases,
+but not a bootstrap-core-only contradiction.
+```
+
+For source id `81`, all three strict-edge rows lie in the bootstrap core, but
+the equality connectors still need rows outside the core. For source id `151`,
+even the strict-edge rows are not contained in the bootstrap core. Thus the
+current data does not support a private-halo-only or core-only contradiction
+lemma.
+
+## Reading
+
+The useful bridge signal is that the two tight cases are not two unrelated
+vertex-circle phenomena. They are both relabelings of the `T12/F16` strict
+cycle. A plausible next proof-mining task is therefore:
+
+```text
+bootstrap core [0,1,2,4] + small private-halo margin
+  -> force a T12-like six-row strict-cycle core
+```
+
+That is still a conjectural bridge target. The current overlay only records the
+finite artifact join and the row-center mismatch that any future lemma must
+handle.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -424,6 +424,13 @@ that the audited cases have rank greater than 3 but still pass weighted
 capacity, so it is negative diagnostic information about the strength of the
 ledger, not a new obstruction theorem.
 
+The companion overlay in `docs/bootstrap-vertex-circle-overlay.md` joins the
+two tight `n=9` non-ear-orderable crosswalk rows to the review-pending
+vertex-circle strict-cycle chain. Both rows land on the `T12/F16` strict-cycle
+template by selected-row signature, but their local strict-cycle row cores are
+not bootstrap-core-only. This is proof-mining scaffolding, not a proof of
+`n=9`, not a proof of the bridge, and not a global status update.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -26,10 +26,12 @@ Use this queue when no more specific issue is selected.
    current quotient-replay helper.
 3. Strengthen the minimal fragile-cover bridge with one geometric necessary
    condition and test it against the block-6 negative controls.
-4. Use the bootstrap-core crosswalk in
-   `docs/bootstrap-core-crosswalk.md` to design a sharper condition that
-   reduces private-halo capacity slack or adds private-pair demand; the current
-   singleton-rich stuck/frontier motifs all survive the weighted ledger.
+4. Use the bootstrap-core crosswalk and the bootstrap / vertex-circle overlay
+   in `docs/bootstrap-core-crosswalk.md` and
+   `docs/bootstrap-vertex-circle-overlay.md` to design a sharper condition.
+   The current singleton-rich stuck/frontier motifs all survive the weighted
+   ledger, while the two tight `n=9` non-ear rows both land on the `T12/F16`
+   strict-cycle template without yielding a bootstrap-core-only contradiction.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked
   singleton-rich bootstrap-core rank/capacity crosswalk for current fixed-row
   frontier motifs.
+- [`bootstrap-vertex-circle-overlay.md`](bootstrap-vertex-circle-overlay.md):
+  checked overlay joining the two tight `n=9` non-ear bootstrap rows to the
+  review-pending vertex-circle strict-cycle chain.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -313,6 +313,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   sparse/frontier motifs have rank greater than 3 but retain positive weighted
   capacity margin; any useful next condition should reduce that slack or add
   additional private-pair demand.
+- bootstrap / vertex-circle overlay evidence, as recorded in
+  `docs/bootstrap-vertex-circle-overlay.md`, showing that the two tight
+  non-ear-orderable `n=9` rows both join to the `T12/F16` strict-cycle template
+  but not by a bootstrap-core-only contradiction.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -148,6 +148,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_core_crosswalk.json"
       verifier: "scripts/check_bootstrap_core_crosswalk.py"
       claim_scope: "fixed selected-row bridge diagnostic only; all audited cases have rank greater than 3 and survive weighted private-halo capacity; not a proof or counterexample"
+    - pattern: "bootstrap_vertex_circle_overlay"
+      status: "overlay of the two tight n=9 bootstrap-core rows with the review-pending vertex-circle strict-cycle chain"
+      artifact: "data/certificates/bootstrap_vertex_circle_overlay.json"
+      verifier: "scripts/check_bootstrap_vertex_circle_overlay.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; both tight non-ear n=9 rows land on the T12/F16 strict-cycle template by selected-row signature, but this is not a proof of n=9, not a bridge proof, and not a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1824,6 +1824,48 @@ artifacts:
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
 
+  - id: bootstrap_vertex_circle_overlay
+    path: data/certificates/bootstrap_vertex_circle_overlay.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_vertex_circle_overlay.py
+    command: python scripts/check_bootstrap_vertex_circle_overlay.py --write --assert-expected
+    checker: scripts/check_bootstrap_vertex_circle_overlay.py
+    check_command: python scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Overlay of the two non-ear-orderable n=9 bootstrap-core frontier assignments with the review-pending vertex-circle strict-cycle chain; not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_vertex_circle_overlay.v1
+      status: BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_count: 2
+      summary.source_assignment_indices:
+        - 81
+        - 151
+      summary.classification_assignment_ids:
+        - A082
+        - A152
+      summary.template_counts.T12: 2
+      summary.family_counts.F16: 2
+      summary.cycle_length_counts.3: 2
+      summary.bootstrap_minimum_rank_counts.4: 2
+      summary.capacity_margins_by_source_id.81: 8
+      summary.capacity_margins_by_source_id.151: 6
+      summary.overlay_conclusion: T12_STRICT_CYCLE_SHARED_BUT_NOT_BOOTSTRAP_CORE_ONLY
+      provenance.generator: scripts/check_bootstrap_vertex_circle_overlay.py
+      provenance.command: python scripts/check_bootstrap_vertex_circle_overlay.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_vertex_circle_overlay.py
+++ b/scripts/check_bootstrap_vertex_circle_overlay.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Check the bootstrap-core / vertex-circle overlay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_vertex_circle_overlay import (  # noqa: E402
+    assert_expected_payload,
+    build_overlay_payload,
+)
+
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "bootstrap_vertex_circle_overlay.json"
+
+
+def load_artifact(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("bootstrap/vertex-circle overlay artifact must be a JSON object")
+    return payload
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / vertex-circle overlay")
+    print(f"targets: {summary['target_count']}")
+    print(f"source assignment indices: {summary['source_assignment_indices']}")
+    print(f"classification assignment ids: {summary['classification_assignment_ids']}")
+    print(f"templates: {summary['template_counts']}")
+    print(f"cycle lengths: {summary['cycle_length_counts']}")
+    print(f"capacity margins: {summary['capacity_margins_by_source_id']}")
+    print(f"conclusion: {summary['overlay_conclusion']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned overlay counts")
+    args = parser.parse_args()
+
+    generated = build_overlay_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated overlay")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/vertex-circle overlay matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/vertex-circle overlay expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_vertex_circle_overlay.py
+++ b/src/erdos97/bootstrap_vertex_circle_overlay.py
@@ -1,0 +1,654 @@
+"""Bootstrap-core / vertex-circle overlay for tight n=9 bridge targets.
+
+This module joins the singleton-rich bootstrap-core crosswalk to the
+review-pending n=9 vertex-circle strict-cycle certificate chain.  It is
+diagnostic bookkeeping only: it does not prove Erdos Problem #97, does not
+promote the n=9 checker, and does not claim a counterexample.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SCHEMA = "erdos97.bootstrap_vertex_circle_overlay.v1"
+STATUS = "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Overlay of the two non-ear-orderable n=9 bootstrap-core frontier "
+    "assignments with the review-pending vertex-circle strict-cycle chain; "
+    "not a proof of n=9, not a proof of the bridge, not a counterexample, "
+    "and not a global status update."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+BOOTSTRAP_CROSSWALK_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bootstrap_core_crosswalk.json"
+)
+BRIDGE_FRONTIER_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bridge_lemma_frontier.json"
+)
+FRONTIER_CLASSIFICATION_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "n9_vertex_circle_frontier_motif_classification.json"
+)
+STRICT_CYCLE_PATH_JOIN_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_path_join.json"
+)
+STRICT_CYCLE_TEMPLATE_PACKET_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
+)
+
+TARGET_SOURCE_RECORD_IDS = (81, 151)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _pair(values: Sequence[Any]) -> tuple[int, int]:
+    a, b = int(values[0]), int(values[1])
+    if a == b:
+        raise ValueError("pair endpoints must be distinct")
+    return tuple(sorted((a, b)))
+
+
+def _pair_json(values: Sequence[Any]) -> list[int]:
+    return list(_pair(values))
+
+
+def _pair_location(values: Sequence[Any], core: set[int]) -> str:
+    hits = sum(1 for value in _pair(values) if value in core)
+    if hits == 2:
+        return "core_core"
+    if hits == 1:
+        return "core_outside"
+    return "outside_outside"
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _row_signature(rows: Sequence[Sequence[Any]]) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(sorted(int(label) for label in row)) for row in rows)
+
+
+def _witness_rows_from_compact_rows(
+    compact_rows: Sequence[Sequence[Any]],
+) -> list[list[int]]:
+    rows: list[list[int] | None] = [None] * len(compact_rows)
+    for raw_row in compact_rows:
+        row = _int_list(raw_row)
+        if len(row) != 5:
+            raise ValueError("compact selected rows must have center plus four witnesses")
+        center = row[0]
+        if center < 0 or center >= len(compact_rows):
+            raise ValueError(f"compact row has out-of-range center {center}")
+        if rows[center] is not None:
+            raise ValueError(f"duplicate compact row for center {center}")
+        rows[center] = sorted(row[1:])
+    if any(row is None for row in rows):
+        raise ValueError("compact selected rows are missing at least one center")
+    return [row for row in rows if row is not None]
+
+
+def _local_core_rows(compact_rows: Sequence[Sequence[Any]]) -> list[dict[str, object]]:
+    out = []
+    for raw_row in compact_rows:
+        row = _int_list(raw_row)
+        out.append({"center": row[0], "witnesses": sorted(row[1:])})
+    return sorted(out, key=lambda item: int(item["center"]))
+
+
+def _source_payloads() -> dict[str, dict[str, Any]]:
+    return {
+        "bootstrap_crosswalk": _load_json(BOOTSTRAP_CROSSWALK_ARTIFACT),
+        "bridge_frontier": _load_json(BRIDGE_FRONTIER_ARTIFACT),
+        "frontier_classification": _load_json(FRONTIER_CLASSIFICATION_ARTIFACT),
+        "strict_cycle_path_join": _load_json(STRICT_CYCLE_PATH_JOIN_ARTIFACT),
+        "strict_cycle_template_packet": _load_json(STRICT_CYCLE_TEMPLATE_PACKET_ARTIFACT),
+    }
+
+
+def _target_bridge_records(bridge_payload: Mapping[str, Any]) -> dict[int, dict[str, Any]]:
+    targets = bridge_payload.get("proof_mining_targets")
+    if not isinstance(targets, list):
+        raise ValueError("bridge frontier artifact must contain proof_mining_targets")
+    by_id: dict[int, dict[str, Any]] = {}
+    for target in targets:
+        if not isinstance(target, dict) or int(target.get("n", -1)) != 9:
+            continue
+        source_record_id = target.get("source_record_id")
+        if not isinstance(source_record_id, int):
+            continue
+        if source_record_id in TARGET_SOURCE_RECORD_IDS:
+            by_id[source_record_id] = target
+    missing = [record_id for record_id in TARGET_SOURCE_RECORD_IDS if record_id not in by_id]
+    if missing:
+        raise AssertionError(f"missing bridge-frontier target records {missing}")
+    return by_id
+
+
+def _crosswalk_records(crosswalk_payload: Mapping[str, Any]) -> dict[int, dict[str, Any]]:
+    records = crosswalk_payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("bootstrap crosswalk artifact must contain records")
+    out: dict[int, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        source_record_id = record.get("source_record_id")
+        if isinstance(source_record_id, int) and source_record_id in TARGET_SOURCE_RECORD_IDS:
+            out[source_record_id] = record
+    missing = [record_id for record_id in TARGET_SOURCE_RECORD_IDS if record_id not in out]
+    if missing:
+        raise AssertionError(f"missing bootstrap-crosswalk records {missing}")
+    return out
+
+
+def _classification_by_signature(
+    classification_payload: Mapping[str, Any],
+) -> dict[tuple[tuple[int, ...], ...], dict[str, Any]]:
+    assignments = classification_payload.get("assignments")
+    if not isinstance(assignments, list):
+        raise ValueError("classification artifact must contain assignments")
+    out: dict[tuple[tuple[int, ...], ...], dict[str, Any]] = {}
+    for assignment in assignments:
+        if not isinstance(assignment, dict):
+            continue
+        selected_rows = assignment.get("selected_rows")
+        if not isinstance(selected_rows, list):
+            continue
+        signature = _row_signature(_witness_rows_from_compact_rows(selected_rows))
+        if signature in out:
+            raise AssertionError("duplicate selected-row signature in classification artifact")
+        out[signature] = assignment
+    return out
+
+
+def _strict_cycle_records_by_assignment_id(
+    path_join_payload: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    records = path_join_payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("strict-cycle path join must contain records")
+    out: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        if record.get("status") != "strict_cycle":
+            continue
+        assignment_id = str(record["assignment_id"])
+        if assignment_id in out:
+            raise AssertionError(f"duplicate strict-cycle assignment id {assignment_id}")
+        out[assignment_id] = record
+    return out
+
+
+def _deletion_closure_summaries(
+    bootstrap_record: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    audit = bootstrap_record["bootstrap_core_audit"]
+    if not isinstance(audit, dict):
+        raise AssertionError("bootstrap_core_audit must be a mapping")
+    deletion_closures = audit["deletion_closures"]
+    if not isinstance(deletion_closures, list):
+        raise AssertionError("bootstrap deletion closures must be a list")
+
+    summaries = []
+    for deletion in deletion_closures:
+        if not isinstance(deletion, dict):
+            raise AssertionError("deletion closure must be a mapping")
+        rich_slices = deletion.get("rich_class_private_slices")
+        if not isinstance(rich_slices, list):
+            raise AssertionError("deletion closure must contain rich slices")
+        private_pairs: list[list[int]] = []
+        private_witnesses_by_class = []
+        for rich_slice in rich_slices:
+            if not isinstance(rich_slice, dict):
+                raise AssertionError("rich slice must be a mapping")
+            private_witnesses = sorted(_int_list(rich_slice["private_halo_witnesses"]))
+            private_pairs.extend(
+                [list(pair) for pair in combinations(private_witnesses, 2)]
+            )
+            private_witnesses_by_class.append(
+                {
+                    "rich_class_index": int(rich_slice["rich_class_index"]),
+                    "private_halo_witnesses": private_witnesses,
+                    "private_pair_count": int(rich_slice["private_pair_count"]),
+                }
+            )
+        summaries.append(
+            {
+                "core_vertex": int(deletion["core_vertex"]),
+                "deletion_seed": _int_list(deletion["deletion_seed"]),
+                "closure_size": int(deletion["closure_size"]),
+                "private_halo": _int_list(deletion["private_halo"]),
+                "private_halo_size": int(deletion["private_halo_size"]),
+                "private_pair_count": int(deletion["private_pair_count"]),
+                "private_pairs": sorted(private_pairs),
+                "private_witnesses_by_rich_class": private_witnesses_by_class,
+            }
+        )
+    return summaries
+
+
+def _cycle_pair_entries(
+    strict_cycle_record: Mapping[str, Any],
+    bootstrap_core: Sequence[int],
+) -> list[dict[str, object]]:
+    core = set(int(label) for label in bootstrap_core)
+    entries: list[dict[str, object]] = []
+    steps = strict_cycle_record["cycle_steps"]
+    if not isinstance(steps, list):
+        raise AssertionError("strict-cycle record must contain cycle_steps")
+
+    for step_index, step in enumerate(steps):
+        edge = step["strict_inequality"]
+        equality = step["equality_to_next_outer_pair"]
+        for role, pair_values in (
+            ("strict_outer_pair", edge["outer_pair"]),
+            ("strict_inner_pair", edge["inner_pair"]),
+            ("connector_start_pair", equality["start_pair"]),
+            ("connector_end_pair", equality["end_pair"]),
+        ):
+            entries.append(
+                {
+                    "step_index": step_index,
+                    "role": role,
+                    "pair": _pair_json(pair_values),
+                    "location": _pair_location(pair_values, core),
+                }
+            )
+        path = equality["path"]
+        if not isinstance(path, list):
+            raise AssertionError("equality connector path must be a list")
+        for path_index, link in enumerate(path):
+            entries.append(
+                {
+                    "step_index": step_index,
+                    "path_index": path_index,
+                    "role": "connector_path_next_pair",
+                    "row": int(link["row"]),
+                    "pair": _pair_json(link["next_pair"]),
+                    "location": _pair_location(link["next_pair"], core),
+                }
+            )
+    return entries
+
+
+def _cycle_overlay(
+    strict_cycle_record: Mapping[str, Any],
+    bootstrap_core: Sequence[int],
+) -> dict[str, object]:
+    core_set = {int(label) for label in bootstrap_core}
+    steps = strict_cycle_record["cycle_steps"]
+    if not isinstance(steps, list):
+        raise AssertionError("strict-cycle record must contain cycle_steps")
+
+    local_core_rows = _local_core_rows(strict_cycle_record["core_selected_rows"])
+    local_core_centers = sorted(int(row["center"]) for row in local_core_rows)
+    strict_edge_rows = [
+        int(step["strict_inequality"]["row"])
+        for step in steps
+    ]
+    connector_rows = [
+        int(link["row"])
+        for step in steps
+        for link in step["equality_to_next_outer_pair"]["path"]
+    ]
+    cycle_row_centers = sorted(set(strict_edge_rows) | set(connector_rows))
+    if cycle_row_centers != local_core_centers:
+        raise AssertionError("cycle rows and compact local-core rows diverge")
+
+    pair_entries = _cycle_pair_entries(strict_cycle_record, bootstrap_core)
+    pair_location_counts = Counter(str(entry["location"]) for entry in pair_entries)
+    unique_pair_locations = {
+        tuple(entry["pair"]): str(entry["location"])
+        for entry in pair_entries
+    }
+    unique_pair_location_counts = Counter(unique_pair_locations.values())
+
+    row_centers_in_core = sorted(set(cycle_row_centers) & core_set)
+    row_centers_outside_core = sorted(set(cycle_row_centers) - core_set)
+    strict_edge_rows_outside_core = sorted(set(strict_edge_rows) - core_set)
+    connector_rows_outside_core = sorted(set(connector_rows) - core_set)
+
+    return {
+        "assignment_id": strict_cycle_record["assignment_id"],
+        "status": strict_cycle_record["status"],
+        "template_id": strict_cycle_record["template_id"],
+        "family_id": strict_cycle_record["family_id"],
+        "cycle_length": int(strict_cycle_record["cycle_length"]),
+        "core_size": int(strict_cycle_record["core_size"]),
+        "strict_edge_count": int(strict_cycle_record["strict_edge_count"]),
+        "connector_path_lengths": _int_list(strict_cycle_record["connector_path_lengths"]),
+        "span_signature": strict_cycle_record["span_signature"],
+        "local_core_rows": local_core_rows,
+        "strict_edge_rows": strict_edge_rows,
+        "equality_connector_rows": connector_rows,
+        "cycle_row_centers": cycle_row_centers,
+        "cycle_row_centers_in_bootstrap_core": row_centers_in_core,
+        "cycle_row_centers_outside_bootstrap_core": row_centers_outside_core,
+        "strict_edge_rows_outside_bootstrap_core": strict_edge_rows_outside_core,
+        "equality_connector_rows_outside_bootstrap_core": connector_rows_outside_core,
+        "cycle_rows_subset_of_bootstrap_core": not row_centers_outside_core,
+        "strict_edge_rows_subset_of_bootstrap_core": not strict_edge_rows_outside_core,
+        "equality_connector_rows_subset_of_bootstrap_core": not connector_rows_outside_core,
+        "cycle_pair_location_counts": _json_counter(pair_location_counts),
+        "unique_cycle_pair_location_counts": _json_counter(unique_pair_location_counts),
+        "cycle_pair_entries": pair_entries,
+        "cycle_steps": strict_cycle_record["cycle_steps"],
+    }
+
+
+def _template_summary(template_packet_payload: Mapping[str, Any], template_id: str) -> dict[str, Any]:
+    templates = template_packet_payload.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("strict-cycle template packet must contain templates")
+    matches = [
+        template
+        for template in templates
+        if isinstance(template, dict) and str(template.get("template_id")) == template_id
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one template summary for {template_id}")
+    template = matches[0]
+    return {
+        "template_id": template["template_id"],
+        "status": template["status"],
+        "family_count": template["family_count"],
+        "assignment_count": template["assignment_count"],
+        "cycle_length": template["cycle_length"],
+        "cycle_span_counts": template["cycle_span_counts"],
+        "families": template["families"],
+    }
+
+
+def _overlay_record(
+    *,
+    source_record_id: int,
+    bridge_record: Mapping[str, Any],
+    bootstrap_record: Mapping[str, Any],
+    classification_record: Mapping[str, Any],
+    strict_cycle_record: Mapping[str, Any],
+    template_packet_payload: Mapping[str, Any],
+) -> dict[str, object]:
+    audit = bootstrap_record["bootstrap_core_audit"]
+    if not isinstance(audit, dict):
+        raise AssertionError("bootstrap audit must be a mapping")
+    bootstrap_core = _int_list(audit["core"])
+    cycle = _cycle_overlay(strict_cycle_record, bootstrap_core)
+    return {
+        "target_id": bridge_record["target_id"],
+        "source_record_id": source_record_id,
+        "source_assignment_index": source_record_id,
+        "classification_assignment_id": classification_record["assignment_id"],
+        "assignment_join_method": "selected_row_signature",
+        "crosswalk_case_id": bootstrap_record["case_id"],
+        "n": int(bridge_record["n"]),
+        "selected_rows": bridge_record["selected_rows"],
+        "circulant_offsets": bridge_record.get("circulant_offsets"),
+        "ear_order": bridge_record["ear_order"],
+        "bootstrap_core": bootstrap_core,
+        "bootstrap_minimum_rank": int(bootstrap_record["minimum_generator"]["minimum_rank"]),
+        "bootstrap_capacity": {
+            "private_pair_count": int(audit["private_pair_count"]),
+            "cyclic_capacity_sum": int(audit["cyclic_capacity_sum"]),
+            "capacity_margin": int(audit["capacity_margin"]),
+            "outside": _int_list(audit["outside"]),
+            "outside_run_lengths": _int_list(audit["outside_run_lengths"]),
+        },
+        "deletion_closures": _deletion_closure_summaries(bootstrap_record),
+        "vertex_circle": cycle,
+        "template_packet_summary": _template_summary(
+            template_packet_payload,
+            str(cycle["template_id"]),
+        ),
+        "interpretation": (
+            "The selected-row stuck/bootstrap core and the vertex-circle "
+            "strict cycle coexist in this fixed assignment, but the strict "
+            "cycle is not a bootstrap-core-only contradiction."
+        ),
+    }
+
+
+def build_overlay_payload() -> dict[str, object]:
+    """Return the deterministic bootstrap/vertex-circle overlay payload."""
+
+    sources = _source_payloads()
+    bridge_records = _target_bridge_records(sources["bridge_frontier"])
+    crosswalk_records = _crosswalk_records(sources["bootstrap_crosswalk"])
+    classification_by_signature = _classification_by_signature(
+        sources["frontier_classification"]
+    )
+    strict_records_by_id = _strict_cycle_records_by_assignment_id(
+        sources["strict_cycle_path_join"]
+    )
+
+    records = []
+    for source_record_id in TARGET_SOURCE_RECORD_IDS:
+        bridge_record = bridge_records[source_record_id]
+        selected_rows = bridge_record["selected_rows"]
+        if not isinstance(selected_rows, list):
+            raise AssertionError("bridge selected rows must be a list")
+        signature = _row_signature(selected_rows)
+        classification_record = classification_by_signature.get(signature)
+        if classification_record is None:
+            raise AssertionError(
+                f"no vertex-circle classification row matches target {source_record_id}"
+            )
+        strict_cycle_record = strict_records_by_id.get(
+            str(classification_record["assignment_id"])
+        )
+        if strict_cycle_record is None:
+            raise AssertionError(
+                "no strict-cycle path-join row matches classification "
+                f"{classification_record['assignment_id']}"
+            )
+        records.append(
+            _overlay_record(
+                source_record_id=source_record_id,
+                bridge_record=bridge_record,
+                bootstrap_record=crosswalk_records[source_record_id],
+                classification_record=classification_record,
+                strict_cycle_record=strict_cycle_record,
+                template_packet_payload=sources["strict_cycle_template_packet"],
+            )
+        )
+
+    template_counts = Counter(str(record["vertex_circle"]["template_id"]) for record in records)
+    family_counts = Counter(str(record["vertex_circle"]["family_id"]) for record in records)
+    cycle_length_counts = Counter(
+        int(record["vertex_circle"]["cycle_length"]) for record in records
+    )
+    rank_counts = Counter(int(record["bootstrap_minimum_rank"]) for record in records)
+    strict_edge_subset_count = sum(
+        1
+        for record in records
+        if record["vertex_circle"]["strict_edge_rows_subset_of_bootstrap_core"]
+    )
+    connector_subset_count = sum(
+        1
+        for record in records
+        if record["vertex_circle"]["equality_connector_rows_subset_of_bootstrap_core"]
+    )
+    cycle_row_subset_count = sum(
+        1 for record in records if record["vertex_circle"]["cycle_rows_subset_of_bootstrap_core"]
+    )
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This overlay joins existing review-pending diagnostics; it is not an independent n=9 proof.",
+            "The bridge-frontier source indices and vertex-circle assignment ids are joined by selected-row signature.",
+            "The strict-cycle rows are local selected-row cores, not full rich-class data.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "summary": {
+            "target_count": len(records),
+            "source_assignment_indices": [int(record["source_record_id"]) for record in records],
+            "classification_assignment_ids": [
+                str(record["classification_assignment_id"]) for record in records
+            ],
+            "template_counts": _json_counter(template_counts),
+            "family_counts": _json_counter(family_counts),
+            "cycle_length_counts": _json_counter(cycle_length_counts),
+            "bootstrap_minimum_rank_counts": _json_counter(rank_counts),
+            "bootstrap_core": [0, 1, 2, 4],
+            "capacity_margins_by_source_id": {
+                str(record["source_record_id"]): int(
+                    record["bootstrap_capacity"]["capacity_margin"]
+                )
+                for record in records
+            },
+            "cycle_rows_subset_of_bootstrap_core_count": cycle_row_subset_count,
+            "strict_edge_rows_subset_of_bootstrap_core_count": strict_edge_subset_count,
+            "equality_connector_rows_subset_of_bootstrap_core_count": connector_subset_count,
+            "overlay_conclusion": "T12_STRICT_CYCLE_SHARED_BUT_NOT_BOOTSTRAP_CORE_ONLY",
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_core_crosswalk.json",
+                "role": "singleton-rich bootstrap-core rank/capacity records",
+                "schema": sources["bootstrap_crosswalk"].get("schema"),
+                "status": sources["bootstrap_crosswalk"].get("status"),
+                "trust": sources["bootstrap_crosswalk"].get("trust"),
+            },
+            {
+                "path": "data/certificates/bridge_lemma_frontier.json",
+                "role": "bridge proof-mining target ids and selected rows",
+                "schema": sources["bridge_frontier"].get("schema"),
+                "status": sources["bridge_frontier"].get("status"),
+                "trust": sources["bridge_frontier"].get("trust"),
+            },
+            {
+                "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+                "role": "selected-row signature to vertex-circle assignment/template classification",
+                "schema": sources["frontier_classification"].get("schema"),
+                "status": sources["frontier_classification"].get("status"),
+                "trust": sources["frontier_classification"].get("trust"),
+            },
+            {
+                "path": "data/certificates/n9_vertex_circle_strict_cycle_path_join.json",
+                "role": "strict-cycle equality connectors and vertex-circle strict edges",
+                "schema": sources["strict_cycle_path_join"].get("schema"),
+                "status": sources["strict_cycle_path_join"].get("status"),
+                "trust": sources["strict_cycle_path_join"].get("trust"),
+            },
+            {
+                "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+                "role": "strict-cycle template packet summaries",
+                "schema": sources["strict_cycle_template_packet"].get("schema"),
+                "status": sources["strict_cycle_template_packet"].get("status"),
+                "trust": sources["strict_cycle_template_packet"].get("trust"),
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_vertex_circle_overlay.py",
+            "command": (
+                "python scripts/check_bootstrap_vertex_circle_overlay.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the overlay artifact."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/vertex-circle overlay schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/vertex-circle overlay status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_count": 2,
+        "source_assignment_indices": [81, 151],
+        "classification_assignment_ids": ["A082", "A152"],
+        "template_counts": {"T12": 2},
+        "family_counts": {"F16": 2},
+        "cycle_length_counts": {"3": 2},
+        "bootstrap_minimum_rank_counts": {"4": 2},
+        "bootstrap_core": [0, 1, 2, 4],
+        "capacity_margins_by_source_id": {"81": 8, "151": 6},
+        "cycle_rows_subset_of_bootstrap_core_count": 0,
+        "strict_edge_rows_subset_of_bootstrap_core_count": 1,
+        "equality_connector_rows_subset_of_bootstrap_core_count": 0,
+        "overlay_conclusion": "T12_STRICT_CYCLE_SHARED_BUT_NOT_BOOTSTRAP_CORE_ONLY",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    expected_records = {
+        81: {
+            "classification_assignment_id": "A082",
+            "capacity_margin": 8,
+            "cycle_row_centers": [0, 1, 2, 3, 4, 8],
+            "cycle_row_centers_in_bootstrap_core": [0, 1, 2, 4],
+            "cycle_row_centers_outside_bootstrap_core": [3, 8],
+            "strict_edge_rows_subset_of_bootstrap_core": True,
+            "equality_connector_rows_subset_of_bootstrap_core": False,
+            "unique_cycle_pair_location_counts": {"core_core": 2, "core_outside": 5},
+        },
+        151: {
+            "classification_assignment_id": "A152",
+            "capacity_margin": 6,
+            "cycle_row_centers": [0, 1, 5, 6, 7, 8],
+            "cycle_row_centers_in_bootstrap_core": [0, 1],
+            "cycle_row_centers_outside_bootstrap_core": [5, 6, 7, 8],
+            "strict_edge_rows_subset_of_bootstrap_core": False,
+            "equality_connector_rows_subset_of_bootstrap_core": False,
+            "unique_cycle_pair_location_counts": {
+                "core_core": 1,
+                "core_outside": 3,
+                "outside_outside": 3,
+            },
+        },
+    }
+    by_source_id = {int(record["source_record_id"]): record for record in records}
+    if set(by_source_id) != set(expected_records):
+        raise AssertionError("unexpected overlay source-record ids")
+    for source_id, expected in expected_records.items():
+        record = by_source_id[source_id]
+        vertex_circle = record["vertex_circle"]
+        if record["classification_assignment_id"] != expected["classification_assignment_id"]:
+            raise AssertionError(f"{source_id} classification assignment id changed")
+        if record["bootstrap_capacity"]["capacity_margin"] != expected["capacity_margin"]:
+            raise AssertionError(f"{source_id} bootstrap capacity margin changed")
+        for key in (
+            "cycle_row_centers",
+            "cycle_row_centers_in_bootstrap_core",
+            "cycle_row_centers_outside_bootstrap_core",
+            "strict_edge_rows_subset_of_bootstrap_core",
+            "equality_connector_rows_subset_of_bootstrap_core",
+            "unique_cycle_pair_location_counts",
+        ):
+            if vertex_circle[key] != expected[key]:
+                raise AssertionError(f"{source_id} vertex-circle {key} changed")
+        if vertex_circle["template_id"] != "T12" or vertex_circle["family_id"] != "F16":
+            raise AssertionError(f"{source_id} strict-cycle template/family changed")
+        if vertex_circle["cycle_length"] != 3:
+            raise AssertionError(f"{source_id} strict-cycle length changed")

--- a/tests/test_bootstrap_vertex_circle_overlay.py
+++ b/tests/test_bootstrap_vertex_circle_overlay.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_vertex_circle_overlay import (
+    assert_expected_payload,
+    build_overlay_payload,
+)
+
+
+def test_bootstrap_vertex_circle_overlay_expected_payload() -> None:
+    payload = build_overlay_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["source_assignment_indices"] == [81, 151]
+    assert summary["classification_assignment_ids"] == ["A082", "A152"]
+    assert summary["template_counts"] == {"T12": 2}
+    assert summary["cycle_rows_subset_of_bootstrap_core_count"] == 0
+
+
+def test_bootstrap_vertex_circle_overlay_signature_join() -> None:
+    payload = build_overlay_payload()
+    by_source = {record["source_record_id"]: record for record in payload["records"]}
+
+    assert by_source[81]["classification_assignment_id"] == "A082"
+    assert by_source[151]["classification_assignment_id"] == "A152"
+    assert all(
+        record["assignment_join_method"] == "selected_row_signature"
+        for record in by_source.values()
+    )
+
+
+def test_bootstrap_vertex_circle_overlay_rows_are_not_core_only() -> None:
+    payload = build_overlay_payload()
+
+    for record in payload["records"]:
+        vertex_circle = record["vertex_circle"]
+        assert vertex_circle["cycle_rows_subset_of_bootstrap_core"] is False
+        assert vertex_circle["equality_connector_rows_subset_of_bootstrap_core"] is False
+
+    by_source = {record["source_record_id"]: record for record in payload["records"]}
+    assert by_source[81]["vertex_circle"]["strict_edge_rows_subset_of_bootstrap_core"]
+    assert not by_source[151]["vertex_circle"]["strict_edge_rows_subset_of_bootstrap_core"]
+
+
+def test_bootstrap_vertex_circle_overlay_expected_payload_rejects_drift() -> None:
+    payload = build_overlay_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["classification_assignment_ids"] = ["A081", "A151"]
+
+    with pytest.raises(AssertionError, match="classification_assignment_ids"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

Adds a checked bootstrap-core / vertex-circle overlay for the two tight non-ear-orderable n=9 bridge-frontier rows.

- joins bridge-frontier source indices 81 and 151 to the vertex-circle strict-cycle chain by selected-row signature
- records that both rows land on the T12/F16 strict-cycle template, while neither strict-cycle local core is bootstrap-core-only
- adds a generated JSON artifact, checker, tests, and documentation/source-of-truth pointers

## Scope

This is review-pending proof-mining bookkeeping only. It does not prove n=9, does not prove the bridge, does not claim a counterexample, and does not update the official/global status.

## Validation

- `python scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_vertex_circle_overlay.py -q`
- `python scripts/check_bootstrap_core_crosswalk.py --check --assert-expected`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`597 passed, 278 deselected`)