### PR TITLE
[codex] Add endpoint-control quotient-Ptolemy survivor

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -200,6 +200,29 @@ endpoint-control benchmark. This survivor is not a Euclidean realization
 certificate; it only shows that a proof using this row-circle gate needs a
 stronger metric layer or an all-extension certificate.
 
+The same endpoint-control survivor also passes the quotient-level
+row-Ptolemy feasibility test:
+
+```bash
+python scripts/check_endpoint_control_survivor_ptolemy_feasibility.py --assert-expected --json
+```
+
+The checker quotients ordinary pair distances by the selected-distance
+equalities of the survivor, obtains `25` distance classes, and verifies an
+explicit positive rational assignment satisfying all `11` row-Ptolemy
+identities. For example, class values include
+
+```text
+x0=1, x2=1/2, x4=3, x6=2, x14=19/4, x15=11/4.
+```
+
+This rules out a stronger but still quotient-level subclaim: selected-distance
+quotienting plus the row-circle Ptolemy equalities alone do not force a
+positivity contradiction for the endpoint-control survivor. The certificate
+is only algebraic feasibility for the quotient equations. It does not impose
+triangle inequalities, Kalmanson inequalities, global metric consistency,
+Euclidean realizability, or critical-radius ordering.
+
 ### Bounded block-6 row-Ptolemy audit
 
 The following bounded exact audit tests this gate on the two-block fragile

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,178 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 675 - Endpoint-Control Quotient-Ptolemy Feasible Survivor
+
+### Mathematical Subquestion
+
+Cycle 674 found a full selected-row extension of the endpoint-control
+negative-control fragile rows with no row-Ptolemy product-cancellation
+certificate. The next exact question was:
+
+```text
+Does selected-distance quotienting plus the row-circle Ptolemy equalities
+already force a positivity contradiction for that fixed survivor/order?
+```
+
+This tests the next metric layer after product-cancellation while keeping the
+scope fixed to the Cycle 674 survivor in the natural cyclic order.
+
+### Definitions and Assumptions
+
+Use the Cycle 674 endpoint-control survivor on labels `0,...,10`:
+
+```text
+0  -> {1,3,5,6}
+1  -> {0,2,7,9}
+2  -> {1,3,4,10}
+3  -> {2,4,5,7}
+4  -> {1,6,7,8}
+5  -> {0,2,3,6}
+6  -> {0,4,8,10}
+7  -> {1,2,4,9}
+8  -> {3,7,9,10}
+9  -> {2,5,8,10}
+10 -> {0,1,8,9}
+```
+
+Let `x_k` denote the ordinary pair-distance quotient classes obtained by
+identifying the four center-to-witness distances in each selected row. For
+each row, write its witnesses in the natural cyclic order around the center.
+The row-circle Ptolemy identity is
+
+```text
+d02*d13 = d01*d23 + d03*d12.
+```
+
+The subquestion asks whether there exists a positive rational value for every
+quotient class satisfying all `11` such equations.
+
+### Result Status
+
+Positive feasibility certificate:
+**Endpoint-Control Quotient-Ptolemy Feasible Survivor**.
+
+### Argument Or Obstruction
+
+The exact checker
+`scripts/check_endpoint_control_survivor_ptolemy_feasibility.py` quotients
+the ordinary pair distances by the selected-distance equalities of the fixed
+survivor. It obtains `25` quotient classes and verifies the following
+positive rational assignment:
+
+```text
+x0=1, x1=1, x2=1/2, x3=1, x4=3,
+x5=1, x6=2, x7=3/4, x8=1, x9=1/4,
+x10=1, x11=2, x12=3, x13=1, x14=19/4,
+x15=11/4, x16=1/2, x17=1, x18=1, x19=1/2,
+x20=1, x21=1, x22=1/2, x23=1, x24=1.
+```
+
+For each of the `11` selected rows, substituting these class values into
+`d02*d13 = d01*d23 + d03*d12` gives an exact equality over `Fraction`s. For
+example, row `0` has witness order `[1,3,5,6]` and classes
+
+```text
+d01=x7, d02=x8, d03=x9, d12=x0, d13=x13, d23=x0,
+```
+
+so the identity reads
+
+```text
+1 * 1 = (3/4) * 1 + (1/4) * 1.
+```
+
+Row `6` has witness order `[8,10,0,4]` and classes
+
+```text
+d01=x6, d02=x4, d03=x0, d12=x6, d13=x18, d23=x2,
+```
+
+so the identity reads
+
+```text
+3 * 1 = 2 * (1/2) + 1 * 2.
+```
+
+Thus selected-distance quotienting plus row-circle Ptolemy equalities alone
+do not reject the fixed endpoint-control survivor.
+
+### Exact Scope
+
+This is an exact positive rational feasibility certificate for the fixed
+Cycle 674 survivor and natural cyclic order only. It is not a Euclidean
+realization certificate, not a metric certificate, not a counterexample to
+Erdos Problem #97, and not a counterexample to the full Endpoint Control
+Auxiliary Claim. It does not impose triangle inequalities, Kalmanson
+inequalities, global metric consistency, Euclidean realizability, or
+critical-radius ordering.
+
+### Files Changed
+
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_endpoint_control_survivor_ptolemy_feasibility.py`
+- `tests/test_endpoint_control_survivor_ptolemy_feasibility.py`
+
+### Effect On The Attack
+
+The endpoint-control benchmark now survives two row-circle layers:
+product-cancellation and quotient-level row-Ptolemy feasibility. This shows
+that the row-circle Ptolemy equations alone are still too weak for the
+endpoint-control bridge. The next layer must use order/metric inequalities or
+minimality information not present in the quotient equations.
+
+### Next Lead
+
+Apply a Kalmanson quotient-cone search to the same fixed survivor in the
+natural cyclic order. A zero-sum Kalmanson/Farkas certificate would reject the
+fixed survivor/order exactly, while a miss would push the benchmark toward
+triangle/global-metric or critical-radius constraints.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-675`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-675`.
+- The branch was started from `origin/main` at commit
+  `d0aa2ffd9780cc716615738f2a6b60a004e8517a`, after PR #413 merged Cycle
+  674.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- Parallel read-only agents were used: one checked docs/workflow placement,
+  and one suggested the adjacent exact Ptolemy-log obstruction route.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_endpoint_control_survivor_ptolemy_feasibility.py
+  --assert-expected --json`: passed. It verified `25` distance classes, `11`
+  row-Ptolemy equations, and a positive rational assignment.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q
+  tests/test_endpoint_control_survivor_ptolemy_feasibility.py`: passed, `2`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check
+  scripts/check_endpoint_control_survivor_ptolemy_feasibility.py
+  tests/test_endpoint_control_survivor_ptolemy_feasibility.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `595 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 674 - Endpoint-Control Product-Cancellation Survivor
 
 ### Mathematical Subquestion

--- a/scripts/check_endpoint_control_survivor_ptolemy_feasibility.py
+++ b/scripts/check_endpoint_control_survivor_ptolemy_feasibility.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Check quotient-level row-Ptolemy feasibility for the endpoint-control survivor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import pair, selected_distance_quotient  # noqa: E402
+
+
+SURVIVOR_ROWS: list[list[int]] = [
+    [1, 3, 5, 6],
+    [0, 2, 7, 9],
+    [1, 3, 4, 10],
+    [2, 4, 5, 7],
+    [1, 6, 7, 8],
+    [0, 2, 3, 6],
+    [0, 4, 8, 10],
+    [1, 2, 4, 9],
+    [3, 7, 9, 10],
+    [2, 5, 8, 10],
+    [0, 1, 8, 9],
+]
+
+EXPECTED_CLASS_COUNT = 25
+
+POSITIVE_CLASS_VALUES: dict[int, Fraction] = {
+    0: Fraction(1),
+    1: Fraction(1),
+    2: Fraction(1, 2),
+    3: Fraction(1),
+    4: Fraction(3),
+    5: Fraction(1),
+    6: Fraction(2),
+    7: Fraction(3, 4),
+    8: Fraction(1),
+    9: Fraction(1, 4),
+    10: Fraction(1),
+    11: Fraction(2),
+    12: Fraction(3),
+    13: Fraction(1),
+    14: Fraction(19, 4),
+    15: Fraction(11, 4),
+    16: Fraction(1, 2),
+    17: Fraction(1),
+    18: Fraction(1),
+    19: Fraction(1, 2),
+    20: Fraction(1),
+    21: Fraction(1),
+    22: Fraction(1, 2),
+    23: Fraction(1),
+    24: Fraction(1),
+}
+
+
+def _fraction_json(value: Fraction) -> str:
+    if value.denominator == 1:
+        return str(value.numerator)
+    return f"{value.numerator}/{value.denominator}"
+
+
+def _witness_order(center: int, row: list[int], order: list[int]) -> list[int]:
+    positions = {label: idx for idx, label in enumerate(order)}
+    return sorted(row, key=lambda label: (positions[label] - positions[center]) % len(order))
+
+
+def audit() -> dict[str, object]:
+    order = list(range(len(SURVIVOR_ROWS)))
+    quotient = selected_distance_quotient(SURVIVOR_ROWS)
+    if quotient.class_count != EXPECTED_CLASS_COUNT:
+        raise AssertionError(
+            f"expected {EXPECTED_CLASS_COUNT} quotient classes, got {quotient.class_count}"
+        )
+    if sorted(POSITIVE_CLASS_VALUES) != list(range(quotient.class_count)):
+        raise AssertionError("positive assignment does not cover every quotient class")
+    if any(value <= 0 for value in POSITIVE_CLASS_VALUES.values()):
+        raise AssertionError("positive assignment contains a nonpositive value")
+
+    records = []
+    for center, row in enumerate(SURVIVOR_ROWS):
+        witnesses = _witness_order(center, row, order)
+        w0, w1, w2, w3 = witnesses
+        pairs = {
+            "d01": pair(w0, w1),
+            "d02": pair(w0, w2),
+            "d03": pair(w0, w3),
+            "d12": pair(w1, w2),
+            "d13": pair(w1, w3),
+            "d23": pair(w2, w3),
+        }
+        classes = {name: quotient.pair_class[item] for name, item in pairs.items()}
+        values = {name: POSITIVE_CLASS_VALUES[classes[name]] for name in pairs}
+        lhs = values["d02"] * values["d13"]
+        rhs_terms = (
+            values["d01"] * values["d23"],
+            values["d03"] * values["d12"],
+        )
+        rhs = rhs_terms[0] + rhs_terms[1]
+        if lhs != rhs:
+            raise AssertionError(f"row {center} violates row-Ptolemy")
+        records.append(
+            {
+                "row": center,
+                "witness_order": witnesses,
+                "classes": {name: int(classes[name]) for name in sorted(classes)},
+                "class_values": {
+                    name: _fraction_json(values[name]) for name in sorted(values)
+                },
+                "ptolemy_lhs": _fraction_json(lhs),
+                "ptolemy_rhs_terms": [_fraction_json(term) for term in rhs_terms],
+                "ptolemy_rhs": _fraction_json(rhs),
+                "ptolemy_verified": True,
+            }
+        )
+
+    return {
+        "type": "endpoint_control_survivor_quotient_ptolemy_feasibility",
+        "schema": "erdos97.endpoint_control_survivor_quotient_ptolemy_feasibility.v1",
+        "cyclic_order": order,
+        "rows": {str(center): row for center, row in enumerate(SURVIVOR_ROWS)},
+        "distance_class_count": quotient.class_count,
+        "distance_class_values": {
+            str(class_idx): _fraction_json(value)
+            for class_idx, value in sorted(POSITIVE_CLASS_VALUES.items())
+        },
+        "positive_assignment": True,
+        "row_ptolemy_equations_verified": len(records),
+        "records": records,
+        "interpretation": (
+            "Exact positive rational feasibility for the selected-distance quotient "
+            "and row-Ptolemy equations of the Cycle 674 endpoint-control survivor. "
+            "This is not a metric realization certificate and not a counterexample."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit()
+    if args.assert_expected:
+        if payload["distance_class_count"] != EXPECTED_CLASS_COUNT:
+            raise AssertionError("unexpected distance class count")
+        if payload["row_ptolemy_equations_verified"] != len(SURVIVOR_ROWS):
+            raise AssertionError("unexpected row-Ptolemy verification count")
+        if not payload["positive_assignment"]:
+            raise AssertionError("expected positive assignment")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("endpoint-control survivor quotient-Ptolemy feasibility")
+        print(f"distance classes: {payload['distance_class_count']}")
+        print(
+            "row-Ptolemy equations verified: "
+            f"{payload['row_ptolemy_equations_verified']}"
+        )
+        print(f"positive assignment: {payload['positive_assignment']}")
+        if args.assert_expected:
+            print("OK: expected feasibility certificate verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_endpoint_control_survivor_ptolemy_feasibility.py
+++ b/tests/test_endpoint_control_survivor_ptolemy_feasibility.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_endpoint_control_survivor_ptolemy_feasibility import audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_endpoint_control_survivor_has_positive_quotient_ptolemy_assignment() -> None:
+    payload = audit()
+
+    assert payload["distance_class_count"] == 25
+    assert payload["positive_assignment"] is True
+    assert payload["row_ptolemy_equations_verified"] == 11
+
+    values = payload["distance_class_values"]
+    assert values["0"] == "1"
+    assert values["2"] == "1/2"
+    assert values["4"] == "3"
+    assert values["6"] == "2"
+    assert values["14"] == "19/4"
+    assert values["15"] == "11/4"
+
+    rows = payload["records"]
+    assert rows[0]["classes"] == {
+        "d01": 7,
+        "d02": 8,
+        "d03": 9,
+        "d12": 0,
+        "d13": 13,
+        "d23": 0,
+    }
+    assert rows[0]["ptolemy_lhs"] == "1"
+    assert rows[0]["ptolemy_rhs"] == "1"
+    assert rows[6]["classes"] == {
+        "d01": 6,
+        "d02": 4,
+        "d03": 0,
+        "d12": 6,
+        "d13": 18,
+        "d23": 2,
+    }
+    assert rows[6]["ptolemy_lhs"] == "3"
+    assert rows[6]["ptolemy_rhs"] == "3"
+
+
+def test_endpoint_control_survivor_ptolemy_feasibility_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_endpoint_control_survivor_ptolemy_feasibility.py",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "distance classes: 25" in result.stdout
+    assert "row-Ptolemy equations verified: 11" in result.stdout
+    assert "OK: expected feasibility certificate verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

Records Cycle 675 for the endpoint-control fragile-cover route. The fixed Cycle 674 endpoint-control survivor has an exact positive rational assignment satisfying all quotient-level row-Ptolemy identities after selected-distance quotienting.

This rules out only the stronger but still local subclaim that selected-distance quotienting plus row-circle Ptolemy equalities alone force a positivity contradiction for this fixed survivor/order. It is not a Euclidean realization certificate, not a metric certificate, not a counterexample to Erdos Problem #97, and not a counterexample to the full Endpoint Control Auxiliary Claim.

## Files changed

- `scripts/check_endpoint_control_survivor_ptolemy_feasibility.py`: exact checker for the positive rational quotient-Ptolemy assignment.
- `tests/test_endpoint_control_survivor_ptolemy_feasibility.py`: focused checker and CLI tests.
- `docs/minimal-fragile-cover-bridge.md`: records the endpoint-control quotient-Ptolemy feasibility result.
- `reports/codex_goal_erdos97_log.md`: adds the dated Cycle 675 research-log entry.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_endpoint_control_survivor_ptolemy_feasibility.py --assert-expected --json`: passed
  - distance classes: 25
  - row-Ptolemy equations verified: 11
  - positive rational assignment: true
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q tests/test_endpoint_control_survivor_ptolemy_feasibility.py`: passed, `2 passed`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`: passed
- `git diff --check`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`: passed, `595 passed, 278 deselected`

## Remaining limitations

- The certificate only checks quotient-level row-Ptolemy equations for the fixed Cycle 674 survivor and natural cyclic order.
- It does not impose triangle inequalities, Kalmanson inequalities, global metric consistency, Euclidean realizability, or critical-radius ordering.
- The overarching proof/counterexample goal remains open.