### PR TITLE
[codex] Add endpoint-control Kalmanson survivor certificate

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -186,6 +186,25 @@ obstruction for the abstract C29 Sidon selected-witness pattern, and it is not
 a proof of Erdos #97. Check it with
 `python scripts/check_kalmanson_certificate.py data/certificates/c29_sidon_fixed_order_kalmanson_165_unsat.json --summary-json`.
 
+### Fixed-order Kalmanson/Farkas obstruction for the endpoint-control survivor
+
+Status: `EXACT_OBSTRUCTION` for one fixed selected-witness extension and one
+fixed cyclic order only.
+
+For the endpoint-control survivor recorded in
+`docs/minimal-fragile-cover-bridge.md`, in the natural cyclic order on labels
+`0,...,10`, the checked certificate in
+`scripts/check_endpoint_control_survivor_kalmanson_certificate.py` gives a
+positive integer combination of 22 strict Kalmanson distance inequalities
+whose total coefficient vector is exactly zero after quotienting by the
+selected-distance equalities. The weight sum is 89, and summing the strict
+inequalities gives `0 > 0`.
+
+This rejects only that fixed full selected-row extension and natural cyclic
+order. It is not an all-extension endpoint-control proof, not a Euclidean
+realizability theorem for the abstract fragile rows, and not a proof of
+Erdos #97.
+
 ## Lemmas
 
 ### Circle-intersection cap

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,7 +102,8 @@ put detailed reconciliation in the canonical synthesis.
   by itself.
 - [`minimal-fragile-cover-bridge.md`](minimal-fragile-cover-bridge.md):
   partial bridge theorem showing that every minimal counterexample admits a
-  fragile-cover witness system; also records why this is not sufficient.
+  fragile-cover witness system; also records why this is not sufficient,
+  including endpoint-control survivor row-circle and Kalmanson audits.
 - [`block6-fragile-vertex-circle-extension-audit.md`](block6-fragile-vertex-circle-extension-audit.md):
   bounded audit showing that the two-block block-6 fragile-cover obstruction
   closes once full selected-row extension is combined with vertex-circle

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -223,6 +223,23 @@ is only algebraic feasibility for the quotient equations. It does not impose
 triangle inequalities, Kalmanson inequalities, global metric consistency,
 Euclidean realizability, or critical-radius ordering.
 
+A stronger fixed-order Kalmanson quotient-cone layer does reject the same
+endpoint-control survivor in the natural cyclic order:
+
+```bash
+python scripts/check_endpoint_control_survivor_kalmanson_certificate.py --assert-expected --json
+```
+
+The certificate is a positive integer combination of `22` strict Kalmanson
+inequalities, with weight sum `89`, whose coefficient vector reduces to zero
+across the same `25` selected-distance quotient classes. Summing those strict
+inequalities gives `0 > 0`, so this fixed survivor/order is impossible. This
+does not contradict the quotient-Ptolemy feasibility result above: Ptolemy
+equalities alone are feasible, while Kalmanson order inequalities are not.
+The obstruction is still local and fixed-order only. It does not show that
+every full-row extension of the endpoint-control fragile rows has such a
+certificate, and it does not prove endpoint control.
+
 ### Bounded block-6 row-Ptolemy audit
 
 The following bounded exact audit tests this gate on the two-block fragile

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,177 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 676 - Endpoint-Control Kalmanson Quotient-Cone Obstruction
+
+### Mathematical Subquestion
+
+Cycle 675 showed that the fixed endpoint-control survivor admits a positive
+quotient-level row-Ptolemy assignment. The next exact question was:
+
+```text
+Does the natural-order Kalmanson quotient cone reject the same fixed
+endpoint-control survivor?
+```
+
+This tests the next metric-order layer after row-Ptolemy feasibility, still
+with scope fixed to the Cycle 674 survivor and natural cyclic order.
+
+### Definitions and Assumptions
+
+Use the same full selected-row extension on labels `0,...,10`:
+
+```text
+0  -> {1,3,5,6}
+1  -> {0,2,7,9}
+2  -> {1,3,4,10}
+3  -> {2,4,5,7}
+4  -> {1,6,7,8}
+5  -> {0,2,3,6}
+6  -> {0,4,8,10}
+7  -> {1,2,4,9}
+8  -> {3,7,9,10}
+9  -> {2,5,8,10}
+10 -> {0,1,8,9}
+```
+
+Quotient ordinary pair-distance variables by the selected-distance equalities
+from these rows, giving `25` quotient classes. In the natural cyclic order,
+each ordered quadruple `a<b<c<d` supplies two strict Kalmanson inequalities:
+
+```text
+d(a,c)+d(b,d) > d(a,b)+d(c,d)
+d(a,c)+d(b,d) > d(a,d)+d(b,c).
+```
+
+A Kalmanson quotient-cone certificate is a positive integer combination of
+such strict inequalities whose coefficient vector becomes zero after the
+selected-distance quotient. Summing then gives the contradiction `0 > 0`.
+
+### Result Status
+
+Exact obstruction for a fixed survivor/order:
+**Endpoint-Control Kalmanson Quotient-Cone Obstruction**.
+
+### Argument Or Obstruction
+
+The certificate in
+`scripts/check_endpoint_control_survivor_kalmanson_certificate.py` lists `22`
+strict Kalmanson inequalities with positive integer weights. The weight sum is
+`89`, the maximum weight is `11`, and the combined vector is the zero vector
+across all `25` quotient classes.
+
+The support is:
+
+```text
+10*K1(0,1,2,6) + 3*K1(0,2,4,8) + 7*K1(0,2,5,7)
++ K2(0,2,6,9) + 2*K2(0,2,8,10) + 4*K2(0,4,7,8)
++ 3*K1(0,4,7,9) + 3*K2(0,4,9,10) + 7*K2(0,5,6,7)
++ 2*K2(0,5,8,9) + 11*K2(1,2,3,6) + K2(1,2,8,9)
++ 6*K1(1,3,4,9) + 2*K1(1,3,5,8) + 3*K1(1,3,7,10)
++ K2(1,5,6,8) + 2*K1(1,5,7,9) + 3*K2(1,5,9,10)
++ 3*K2(3,4,7,10) + 6*K2(3,6,8,9) + 6*K2(4,6,9,10)
++ 3*K2(5,7,8,10).
+```
+
+The generic quotient-cone checker verifies the selected-distance quotient,
+recomputes every Kalmanson row vector, applies the weights, and confirms:
+
+```text
+strict rows: 22
+distance classes: 25
+weight sum: 89
+max weight: 11
+zero sum verified: true
+combined nonzero coefficient count: 0
+```
+
+Therefore this fixed full selected-row extension and natural cyclic order are
+impossible in a strictly convex realization satisfying Kalmanson inequalities.
+
+### Exact Scope
+
+This is an exact obstruction for the fixed Cycle 674 survivor and natural
+cyclic order only. It is not an all-extension obstruction for the
+endpoint-control fragile rows, not an endpoint-control proof, not a Euclidean
+realization theorem, not a counterexample to Erdos Problem #97, and not a
+proof of Erdos Problem #97. It also does not contradict Cycle 675: the
+row-Ptolemy quotient equations are feasible, but the stronger natural-order
+Kalmanson inequalities are not.
+
+### Files Changed
+
+- `docs/claims.md`
+- `docs/index.md`
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_endpoint_control_survivor_kalmanson_certificate.py`
+- `tests/test_endpoint_control_survivor_kalmanson_certificate.py`
+
+### Effect On The Attack
+
+The endpoint-control benchmark now separates three layers:
+product-cancellation is too weak, quotient-level row-Ptolemy feasibility is
+still too weak, but natural-order Kalmanson quotient-cone constraints kill
+this fixed survivor. This suggests the endpoint-control route should look for
+an all-extension or order-forced Kalmanson/metric-order argument, not for a
+row-circle-only argument.
+
+### Next Lead
+
+Test whether every full selected-row extension of the Cycle 673 fixed fragile
+rows either has a row-Ptolemy product-cancellation certificate or a
+natural-order Kalmanson quotient-cone certificate. If not, record the next
+survivor as a sharper endpoint-control benchmark.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-676`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-676`.
+- The branch was started from `origin/main` at commit
+  `c8a5ee994704eddf4bbce38275efa311473f2692`, after PR #415 merged Cycle
+  675.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- Parallel read-only agents were used: one reviewed Kalmanson/Farkas search
+  tooling, and one checked docs/workflow placement.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_endpoint_control_survivor_kalmanson_certificate.py
+  --assert-expected --json`: passed. It verified `22` strict Kalmanson rows,
+  `25` distance classes, weight sum `89`, max weight `11`, and exact zero
+  quotient sum.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q
+  tests/test_endpoint_control_survivor_kalmanson_certificate.py`: passed, `3`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff format
+  scripts/check_endpoint_control_survivor_kalmanson_certificate.py
+  tests/test_endpoint_control_survivor_kalmanson_certificate.py`: passed; `2`
+  files reformatted.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check
+  scripts/check_endpoint_control_survivor_kalmanson_certificate.py
+  tests/test_endpoint_control_survivor_kalmanson_certificate.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `602 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 675 - Endpoint-Control Quotient-Ptolemy Feasible Survivor
 
 ### Mathematical Subquestion

--- a/scripts/check_endpoint_control_survivor_kalmanson_certificate.py
+++ b/scripts/check_endpoint_control_survivor_kalmanson_certificate.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Check a Kalmanson quotient-cone certificate for the endpoint-control survivor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quotient_cone import check_quotient_cone_certificate  # noqa: E402
+
+
+SURVIVOR_ROWS: list[list[int]] = [
+    [1, 3, 5, 6],
+    [0, 2, 7, 9],
+    [1, 3, 4, 10],
+    [2, 4, 5, 7],
+    [1, 6, 7, 8],
+    [0, 2, 3, 6],
+    [0, 4, 8, 10],
+    [1, 2, 4, 9],
+    [3, 7, 9, 10],
+    [2, 5, 8, 10],
+    [0, 1, 8, 9],
+]
+
+STRICT_ROWS: list[dict[str, object]] = [
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [0, 1, 2, 6],
+        "weight": 10,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [0, 2, 4, 8],
+        "weight": 3,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [0, 2, 5, 7],
+        "weight": 7,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [0, 2, 6, 9],
+        "weight": 1,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [0, 2, 8, 10],
+        "weight": 2,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [0, 4, 7, 8],
+        "weight": 4,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [0, 4, 7, 9],
+        "weight": 3,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [0, 4, 9, 10],
+        "weight": 3,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [0, 5, 6, 7],
+        "weight": 7,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [0, 5, 8, 9],
+        "weight": 2,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [1, 2, 3, 6],
+        "weight": 11,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [1, 2, 8, 9],
+        "weight": 1,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [1, 3, 4, 9],
+        "weight": 6,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [1, 3, 5, 8],
+        "weight": 2,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [1, 3, 7, 10],
+        "weight": 3,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [1, 5, 6, 8],
+        "weight": 1,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K1_diag_gt_sides",
+        "quad": [1, 5, 7, 9],
+        "weight": 2,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [1, 5, 9, 10],
+        "weight": 3,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [3, 4, 7, 10],
+        "weight": 3,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [3, 6, 8, 9],
+        "weight": 6,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [4, 6, 9, 10],
+        "weight": 6,
+    },
+    {
+        "source": "kalmanson",
+        "kind": "K2_diag_gt_other",
+        "quad": [5, 7, 8, 10],
+        "weight": 3,
+    },
+]
+
+CERTIFICATE: dict[str, object] = {
+    "type": "endpoint_control_survivor_kalmanson_quotient_cone_certificate",
+    "schema": "erdos97.endpoint_control_survivor_kalmanson_quotient_cone_certificate.v1",
+    "status": "EXACT_OBSTRUCTION_FOR_FIXED_SURVIVOR_AND_FIXED_CYCLIC_ORDER",
+    "claim_strength": (
+        "Exact obstruction for the fixed Cycle 674 endpoint-control survivor "
+        "and natural cyclic order only."
+    ),
+    "pattern": {
+        "name": "endpoint_control_survivor_cycle_674",
+        "n": 11,
+        "selected_rows": SURVIVOR_ROWS,
+    },
+    "cyclic_order": list(range(11)),
+    "strict_rows": STRICT_ROWS,
+    "num_inequalities": 22,
+    "weight_sum": 89,
+}
+
+
+def audit() -> dict[str, object]:
+    result = check_quotient_cone_certificate(CERTIFICATE)
+    return {
+        "type": CERTIFICATE["type"],
+        "schema": CERTIFICATE["schema"],
+        "status": result.status,
+        "claim_strength": result.claim_strength,
+        "pattern": result.pattern,
+        "n": result.n,
+        "cyclic_order": CERTIFICATE["cyclic_order"],
+        "strict_rows": result.strict_rows,
+        "distance_classes": result.distance_classes,
+        "weight_sum": result.weight_sum,
+        "max_weight": result.max_weight,
+        "zero_sum_verified": result.zero_sum_verified,
+        "nonpositive_sum_verified": result.nonpositive_sum_verified,
+        "combined_nonzero_coefficient_count": result.combined_nonzero_coefficient_count,
+        "coefficient_positive_count": result.coefficient_positive_count,
+        "coefficient_negative_count": result.coefficient_negative_count,
+        "coefficient_zero_count": result.coefficient_zero_count,
+        "certificate": CERTIFICATE,
+        "interpretation": (
+            "The listed positive integer combination of strict Kalmanson "
+            "inequalities reduces to the zero vector after selected-distance "
+            "quotienting. Summing the strict inequalities gives 0 > 0 for this "
+            "fixed survivor/order."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit()
+    if args.assert_expected:
+        if payload["strict_rows"] != 22:
+            raise AssertionError("unexpected strict-row count")
+        if payload["distance_classes"] != 25:
+            raise AssertionError("unexpected distance-class count")
+        if payload["weight_sum"] != 89:
+            raise AssertionError("unexpected weight sum")
+        if payload["max_weight"] != 11:
+            raise AssertionError("unexpected max weight")
+        if not payload["zero_sum_verified"]:
+            raise AssertionError("expected zero-sum certificate")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("endpoint-control survivor Kalmanson quotient-cone certificate")
+        print(f"strict rows: {payload['strict_rows']}")
+        print(f"distance classes: {payload['distance_classes']}")
+        print(f"weight sum: {payload['weight_sum']}")
+        print(f"max weight: {payload['max_weight']}")
+        print(f"zero sum verified: {payload['zero_sum_verified']}")
+        if args.assert_expected:
+            print("OK: expected Kalmanson certificate verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_endpoint_control_survivor_kalmanson_certificate.py
+++ b/tests/test_endpoint_control_survivor_kalmanson_certificate.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.quotient_cone import check_quotient_cone_certificate
+from scripts.check_endpoint_control_survivor_kalmanson_certificate import (
+    CERTIFICATE,
+    audit,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_endpoint_control_survivor_kalmanson_certificate_replays() -> None:
+    result = check_quotient_cone_certificate(CERTIFICATE)
+
+    assert (
+        result.status == "EXACT_OBSTRUCTION_FOR_FIXED_SURVIVOR_AND_FIXED_CYCLIC_ORDER"
+    )
+    assert result.strict_rows == 22
+    assert result.distance_classes == 25
+    assert result.weight_sum == 89
+    assert result.max_weight == 11
+    assert result.zero_sum_verified is True
+    assert result.combined_nonzero_coefficient_count == 0
+
+
+def test_endpoint_control_survivor_kalmanson_audit_summary() -> None:
+    payload = audit()
+
+    assert payload["strict_rows"] == 22
+    assert payload["distance_classes"] == 25
+    assert payload["weight_sum"] == 89
+    assert payload["max_weight"] == 11
+    assert payload["zero_sum_verified"] is True
+    assert payload["combined_nonzero_coefficient_count"] == 0
+
+
+def test_endpoint_control_survivor_kalmanson_certificate_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_endpoint_control_survivor_kalmanson_certificate.py",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "strict rows: 22" in result.stdout
+    assert "distance classes: 25" in result.stdout
+    assert "weight sum: 89" in result.stdout
+    assert "zero sum verified: True" in result.stdout
+    assert "OK: expected Kalmanson certificate verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

Records Cycle 676 for the endpoint-control fragile-cover route. The fixed Cycle 674 endpoint-control survivor, which passed quotient-level row-Ptolemy feasibility in Cycle 675, is rejected in the natural cyclic order by an exact Kalmanson quotient-cone certificate.

The certificate is a positive integer combination of 22 strict Kalmanson inequalities with weight sum 89. After selected-distance quotienting, the combined vector is exactly zero across 25 distance classes, so summing the strict inequalities gives `0 > 0`.

This rejects only this fixed full selected-row extension and natural cyclic order. It is not an all-extension endpoint-control proof, not a Euclidean realization theorem for the abstract fragile rows, not a proof of Erdos Problem #97, and not a counterexample.

## Files changed

- `scripts/check_endpoint_control_survivor_kalmanson_certificate.py`: exact replay checker for the fixed survivor/order Kalmanson certificate.
- `tests/test_endpoint_control_survivor_kalmanson_certificate.py`: focused checker and CLI tests.
- `docs/minimal-fragile-cover-bridge.md`: records the Kalmanson layer after the quotient-Ptolemy feasibility layer.
- `docs/claims.md`: adds a narrowly scoped fixed-order obstruction entry.
- `docs/index.md`: updates the bridge note summary.
- `reports/codex_goal_erdos97_log.md`: adds the dated Cycle 676 research-log entry.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_endpoint_control_survivor_kalmanson_certificate.py --assert-expected --json`: passed
  - strict Kalmanson rows: 22
  - distance classes: 25
  - weight sum: 89
  - max weight: 11
  - zero-sum quotient vector: true
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q tests/test_endpoint_control_survivor_kalmanson_certificate.py`: passed, `3 passed`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`: passed
- `git diff --check`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`: passed, `602 passed, 278 deselected`

## Remaining limitations

- This is fixed-survivor and fixed-order only.
- It does not prove every full selected-row extension of the endpoint-control fragile rows is obstructed.
- It does not prove endpoint control or Erdos Problem #97.
- The overarching proof/counterexample goal remains open.