### PR TITLE
[codex] Add bootstrap T12 forcing targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the bootstrap-core / vertex-circle overlay on the tight `n=9`
   non-ear-orderable rows, read
   [`docs/bootstrap-vertex-circle-overlay.md`](docs/bootstrap-vertex-circle-overlay.md).
+- For the follow-up T12 forcing-target ledger naming the missing row centers
+  and direct private-pair contacts, read
+  [`docs/bootstrap-t12-forcing-targets.md`](docs/bootstrap-t12-forcing-targets.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -151,6 +151,15 @@ diagnostic information only; see `docs/bootstrap-vertex-circle-overlay.md`,
 `scripts/check_bootstrap_vertex_circle_overlay.py`, and
 `data/certificates/bootstrap_vertex_circle_overlay.json`.
 
+The follow-up bootstrap/T12 forcing-target ledger records what the overlay
+would still need a bridge lemma to force. Source `81` needs equality-connector
+row centers `3` and `8` and has no direct private-pair hit; source `151` needs
+row centers `5,6,7,8` and has two direct private-pair hits. This is still an
+open proof-mining target, not a proof that the missing rows are forced; see
+`docs/bootstrap-t12-forcing-targets.md`,
+`scripts/check_bootstrap_t12_forcing_targets.py`, and
+`data/certificates/bootstrap_t12_forcing_targets.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -60,6 +60,12 @@ Both rows join by selected-row signature to the same `T12/F16` strict-cycle
 template, but neither strict-cycle core is contained in the bootstrap core. See
 `docs/bootstrap-vertex-circle-overlay.md`.
 
+A follow-up T12 forcing-target ledger spells out the next bridge gap in that
+overlay: source `81` still needs equality-connector rows `3` and `8` and has no
+direct private-pair hit, while source `151` needs row centers `5,6,7,8` and has
+only two direct private-pair hits. This is target bookkeeping only; it is not a
+proof that those rows are forced. See `docs/bootstrap-t12-forcing-targets.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_forcing_targets.json
+++ b/data/certificates/bootstrap_t12_forcing_targets.json
@@ -1,0 +1,672 @@
+{
+  "claim_scope": "Second-pass diagnostic on the two tight n=9 bootstrap-core rows that land on the review-pending T12/F16 vertex-circle strict-cycle template; records row-center and private-pair forcing targets only, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.",
+  "interpretation_warnings": [
+    "This is a proof-mining target ledger, not a proof of the bridge.",
+    "The input overlay is fixed selected-row data, not full geometric rich-class data.",
+    "Direct private-pair hits are diagnostic contacts, not Euclidean realizability evidence.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_forcing_targets.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_forcing_targets.py"
+  },
+  "records": [
+    {
+      "bootstrap_core": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "capacity_margin": 8,
+      "classification_assignment_id": "A082",
+      "cycle_length": 3,
+      "cycle_outside_labels": [
+        3,
+        7,
+        8
+      ],
+      "cycle_outside_labels_in_private_halos": [
+        3,
+        7,
+        8
+      ],
+      "cycle_row_centers": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "diagnosis": {
+        "core_only_target_status": "BLOCKED_BY_ROW_GAPS",
+        "private_pair_only_target_status": "NO_DIRECT_HITS",
+        "recommended_next_target": "Prove a row-center or equality-connector forcing condition that supplies the missing T12/F16 local rows from the bootstrap-core/private-halo geometry."
+      },
+      "equality_connector_rows_subset_of_bootstrap_core": false,
+      "family_id": "F16",
+      "outside": [
+        3,
+        5,
+        6,
+        7,
+        8
+      ],
+      "private_halo_labels": [
+        3,
+        5,
+        6,
+        7,
+        8
+      ],
+      "private_pair_hit_count": 0,
+      "private_pair_hit_pairs": [],
+      "private_pair_hits": [],
+      "private_pair_records": [
+        {
+          "core_vertex": 0,
+          "pair": [
+            3,
+            6
+          ]
+        },
+        {
+          "core_vertex": 0,
+          "pair": [
+            3,
+            7
+          ]
+        },
+        {
+          "core_vertex": 4,
+          "pair": [
+            5,
+            7
+          ]
+        },
+        {
+          "core_vertex": 2,
+          "pair": [
+            5,
+            8
+          ]
+        },
+        {
+          "core_vertex": 0,
+          "pair": [
+            6,
+            7
+          ]
+        },
+        {
+          "core_vertex": 1,
+          "pair": [
+            7,
+            8
+          ]
+        }
+      ],
+      "row_gap_centers": [
+        3,
+        8
+      ],
+      "row_gap_count": 2,
+      "row_gap_role_counts": {
+        "equality_connector_row": 2
+      },
+      "row_gaps": [
+        {
+          "center": 3,
+          "roles": [
+            "equality_connector_row"
+          ],
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "center": 8,
+          "roles": [
+            "equality_connector_row"
+          ],
+          "witnesses": [
+            0,
+            2,
+            5,
+            6
+          ]
+        }
+      ],
+      "source_record_id": 81,
+      "strict_edge_rows_subset_of_bootstrap_core": true,
+      "template_id": "T12",
+      "unique_cycle_pair_location_counts": {
+        "core_core": 2,
+        "core_outside": 5
+      },
+      "unique_cycle_pairs": [
+        {
+          "location": "core_outside",
+          "pair": [
+            0,
+            3
+          ],
+          "roles": [
+            "connector_end_pair",
+            "connector_path_next_pair",
+            "strict_outer_pair"
+          ],
+          "rows": [
+            3
+          ],
+          "steps": [
+            0,
+            2
+          ]
+        },
+        {
+          "location": "core_outside",
+          "pair": [
+            0,
+            8
+          ],
+          "roles": [
+            "connector_start_pair",
+            "strict_inner_pair"
+          ],
+          "rows": [],
+          "steps": [
+            0
+          ]
+        },
+        {
+          "location": "core_outside",
+          "pair": [
+            2,
+            8
+          ],
+          "roles": [
+            "connector_end_pair",
+            "connector_path_next_pair",
+            "strict_outer_pair"
+          ],
+          "rows": [
+            8
+          ],
+          "steps": [
+            0,
+            1
+          ]
+        },
+        {
+          "location": "core_core",
+          "pair": [
+            2,
+            4
+          ],
+          "roles": [
+            "connector_start_pair",
+            "strict_inner_pair"
+          ],
+          "rows": [],
+          "steps": [
+            1
+          ]
+        },
+        {
+          "location": "core_outside",
+          "pair": [
+            1,
+            7
+          ],
+          "roles": [
+            "connector_end_pair",
+            "connector_path_next_pair",
+            "strict_outer_pair"
+          ],
+          "rows": [
+            1
+          ],
+          "steps": [
+            1,
+            2
+          ]
+        },
+        {
+          "location": "core_core",
+          "pair": [
+            1,
+            4
+          ],
+          "roles": [
+            "connector_path_next_pair"
+          ],
+          "rows": [
+            4
+          ],
+          "steps": [
+            1
+          ]
+        },
+        {
+          "location": "core_outside",
+          "pair": [
+            1,
+            3
+          ],
+          "roles": [
+            "connector_start_pair",
+            "strict_inner_pair"
+          ],
+          "rows": [],
+          "steps": [
+            2
+          ]
+        }
+      ]
+    },
+    {
+      "bootstrap_core": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "capacity_margin": 6,
+      "classification_assignment_id": "A152",
+      "cycle_length": 3,
+      "cycle_outside_labels": [
+        5,
+        6,
+        7,
+        8
+      ],
+      "cycle_outside_labels_in_private_halos": [
+        5,
+        6,
+        7,
+        8
+      ],
+      "cycle_row_centers": [
+        0,
+        1,
+        5,
+        6,
+        7,
+        8
+      ],
+      "diagnosis": {
+        "core_only_target_status": "BLOCKED_BY_ROW_GAPS",
+        "private_pair_only_target_status": "PARTIAL_DIRECT_HITS_ONLY",
+        "recommended_next_target": "Prove a row-center or equality-connector forcing condition that supplies the missing T12/F16 local rows from the bootstrap-core/private-halo geometry."
+      },
+      "equality_connector_rows_subset_of_bootstrap_core": false,
+      "family_id": "F16",
+      "outside": [
+        3,
+        5,
+        6,
+        7,
+        8
+      ],
+      "private_halo_labels": [
+        3,
+        5,
+        6,
+        7,
+        8
+      ],
+      "private_pair_hit_count": 2,
+      "private_pair_hit_pairs": [
+        [
+          5,
+          8
+        ],
+        [
+          6,
+          8
+        ]
+      ],
+      "private_pair_hits": [
+        {
+          "location": "outside_outside",
+          "pair": [
+            5,
+            8
+          ],
+          "private_core_vertices": [
+            2
+          ]
+        },
+        {
+          "location": "outside_outside",
+          "pair": [
+            6,
+            8
+          ],
+          "private_core_vertices": [
+            0
+          ]
+        }
+      ],
+      "private_pair_records": [
+        {
+          "core_vertex": 0,
+          "pair": [
+            3,
+            6
+          ]
+        },
+        {
+          "core_vertex": 4,
+          "pair": [
+            3,
+            6
+          ]
+        },
+        {
+          "core_vertex": 1,
+          "pair": [
+            3,
+            7
+          ]
+        },
+        {
+          "core_vertex": 4,
+          "pair": [
+            3,
+            7
+          ]
+        },
+        {
+          "core_vertex": 0,
+          "pair": [
+            3,
+            8
+          ]
+        },
+        {
+          "core_vertex": 2,
+          "pair": [
+            5,
+            8
+          ]
+        },
+        {
+          "core_vertex": 4,
+          "pair": [
+            6,
+            7
+          ]
+        },
+        {
+          "core_vertex": 0,
+          "pair": [
+            6,
+            8
+          ]
+        }
+      ],
+      "row_gap_centers": [
+        5,
+        6,
+        7,
+        8
+      ],
+      "row_gap_count": 4,
+      "row_gap_role_counts": {
+        "equality_connector_row": 3,
+        "strict_edge_row": 2
+      },
+      "row_gaps": [
+        {
+          "center": 5,
+          "roles": [
+            "equality_connector_row"
+          ],
+          "witnesses": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "roles": [
+            "equality_connector_row"
+          ],
+          "witnesses": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "center": 7,
+          "roles": [
+            "strict_edge_row"
+          ],
+          "witnesses": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "center": 8,
+          "roles": [
+            "strict_edge_row",
+            "equality_connector_row"
+          ],
+          "witnesses": [
+            1,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "source_record_id": 151,
+      "strict_edge_rows_subset_of_bootstrap_core": false,
+      "template_id": "T12",
+      "unique_cycle_pair_location_counts": {
+        "core_core": 1,
+        "core_outside": 3,
+        "outside_outside": 3
+      },
+      "unique_cycle_pairs": [
+        {
+          "location": "core_outside",
+          "pair": [
+            0,
+            6
+          ],
+          "roles": [
+            "connector_end_pair",
+            "connector_path_next_pair",
+            "strict_outer_pair"
+          ],
+          "rows": [
+            6
+          ],
+          "steps": [
+            0,
+            2
+          ]
+        },
+        {
+          "location": "core_core",
+          "pair": [
+            0,
+            1
+          ],
+          "roles": [
+            "connector_start_pair",
+            "strict_inner_pair"
+          ],
+          "rows": [],
+          "steps": [
+            0
+          ]
+        },
+        {
+          "location": "core_outside",
+          "pair": [
+            1,
+            7
+          ],
+          "roles": [
+            "connector_end_pair",
+            "connector_path_next_pair",
+            "strict_outer_pair"
+          ],
+          "rows": [
+            1
+          ],
+          "steps": [
+            0,
+            1
+          ]
+        },
+        {
+          "location": "outside_outside",
+          "pair": [
+            5,
+            7
+          ],
+          "roles": [
+            "connector_start_pair",
+            "strict_inner_pair"
+          ],
+          "rows": [],
+          "steps": [
+            1
+          ]
+        },
+        {
+          "location": "core_outside",
+          "pair": [
+            2,
+            8
+          ],
+          "roles": [
+            "connector_end_pair",
+            "connector_path_next_pair",
+            "strict_outer_pair"
+          ],
+          "rows": [
+            8
+          ],
+          "steps": [
+            1,
+            2
+          ]
+        },
+        {
+          "location": "outside_outside",
+          "pair": [
+            5,
+            8
+          ],
+          "roles": [
+            "connector_path_next_pair"
+          ],
+          "rows": [
+            5
+          ],
+          "steps": [
+            1
+          ]
+        },
+        {
+          "location": "outside_outside",
+          "pair": [
+            6,
+            8
+          ],
+          "roles": [
+            "connector_start_pair",
+            "strict_inner_pair"
+          ],
+          "rows": [],
+          "steps": [
+            2
+          ]
+        }
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_forcing_targets.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+      "role": "source overlay joining tight bootstrap rows to T12/F16",
+      "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+      "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_FORCING_TARGET_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_records_have_direct_private_pair_hits": false,
+    "all_records_have_row_gaps": true,
+    "bootstrap_core": [
+      0,
+      1,
+      2,
+      4
+    ],
+    "capacity_margins_by_source_id": {
+      "151": 6,
+      "81": 8
+    },
+    "classification_assignment_ids": [
+      "A082",
+      "A152"
+    ],
+    "family_counts": {
+      "F16": 2
+    },
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "primary_next_target": "bootstrap core [0,1,2,4] plus tight private-halo geometry should force the missing T12/F16 row centers or equivalent equality connectors",
+    "private_pair_hit_counts_by_source_id": {
+      "151": 2,
+      "81": 0
+    },
+    "row_gap_centers_by_source_id": {
+      "151": [
+        5,
+        6,
+        7,
+        8
+      ],
+      "81": [
+        3,
+        8
+      ]
+    },
+    "row_gap_counts_by_source_id": {
+      "151": 4,
+      "81": 2
+    },
+    "source_record_ids": [
+      81,
+      151
+    ],
+    "target_count": 2,
+    "template_counts": {
+      "T12": 2
+    },
+    "zero_private_pair_hit_source_ids": [
+      81
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-forcing-targets.md
+++ b/docs/bootstrap-t12-forcing-targets.md
@@ -1,0 +1,91 @@
+# Bootstrap T12 Forcing Targets
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note is a second-pass diagnostic on
+[`bootstrap-vertex-circle-overlay.md`](bootstrap-vertex-circle-overlay.md). The
+checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_forcing_targets.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_forcing_targets.json`.
+
+## Scope
+
+The input records are still fixed selected-row diagnostics. They are not full
+rich-class data for a hypothetical polygon, they do not certify Euclidean
+realizability, and they do not promote the review-pending `n=9`
+vertex-circle checker. The purpose is narrower: name exactly what a future
+bridge lemma would need to force after the two tight non-ear bootstrap rows
+both land on the `T12/F16` strict-cycle template.
+
+The artifact records:
+
+- which `T12/F16` row centers are outside the bootstrap core `[0,1,2,4]`;
+- whether those outside rows are strict-edge rows or equality-connector rows;
+- where the strict-cycle quotient pairs sit relative to the bootstrap core;
+- which strict-cycle pairs are direct private-pair hits in the bootstrap
+  private-halo ledger.
+
+## Results
+
+Both tight rows still need row centers beyond the bootstrap core.
+
+| Bridge source id | Classification id | Capacity margin | Missing T12 row centers | Row-gap roles | Direct private-pair hits |
+|---:|---|---:|---|---|---|
+| `81` | `A082` | `8` | `[3,8]` | two equality-connector rows | none |
+| `151` | `A152` | `6` | `[5,6,7,8]` | two strict-edge rows and three equality-connector rows | `[5,8]`, `[6,8]` |
+
+For source `81`, every strict-edge row is already in the bootstrap core, but
+the equality connector uses row centers `3` and `8`. Its unique T12 cycle pairs
+have location counts:
+
+```text
+core_core: 2
+core_outside: 5
+outside_outside: 0
+```
+
+None of those unique cycle pairs is a direct private-pair hit.
+
+For source `151`, the strict cycle itself uses strict-edge rows outside the
+bootstrap core. Its unique T12 cycle pairs have location counts:
+
+```text
+core_core: 1
+core_outside: 3
+outside_outside: 3
+```
+
+Only two outside-outside pairs, `[5,8]` and `[6,8]`, are direct private-pair
+hits.
+
+## Reading
+
+This refines the next conjectural bridge target from the overlay note:
+
+```text
+bootstrap core [0,1,2,4] + tight private-halo geometry
+  -> force the missing T12/F16 row centers or equivalent equality connectors
+```
+
+The negative controls are as useful as the positive contact:
+
+- a core-only contradiction is blocked, because both records require rows
+  outside `[0,1,2,4]`;
+- a private-pair-only contradiction is also blocked, because source `81` has
+  no direct private-pair hit and source `151` has only partial direct hits.
+
+So the promising route is not simply to spend the existing capacity ledger
+harder. A future bridge needs an extra metric/order ingredient that turns
+private halos, row-center placement, or equality-connector availability into
+the missing `T12/F16` local rows.

--- a/docs/bootstrap-vertex-circle-overlay.md
+++ b/docs/bootstrap-vertex-circle-overlay.md
@@ -76,3 +76,9 @@ bootstrap core [0,1,2,4] + small private-halo margin
 That is still a conjectural bridge target. The current overlay only records the
 finite artifact join and the row-center mismatch that any future lemma must
 handle.
+
+The follow-up ledger in
+[`bootstrap-t12-forcing-targets.md`](bootstrap-t12-forcing-targets.md) breaks
+this target into concrete row-center gaps and direct private-pair contacts. It
+keeps the same status: proof-mining scaffolding only, not a proof that the
+missing rows are forced.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -450,6 +450,12 @@ template by selected-row signature, but their local strict-cycle row cores are
 not bootstrap-core-only. This is proof-mining scaffolding, not a proof of
 `n=9`, not a proof of the bridge, and not a global status update.
 
+The follow-up ledger in `docs/bootstrap-t12-forcing-targets.md` records the
+next T12 target more explicitly: both tight rows need T12/F16 row centers
+outside the bootstrap core, and the direct private-pair contacts are absent for
+source `81` and partial for source `151`. This remains an open target ledger,
+not a theorem that the missing rows are forced.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -32,6 +32,9 @@ Use this queue when no more specific issue is selected.
    The current singleton-rich stuck/frontier motifs all survive the weighted
    ledger, while the two tight `n=9` non-ear rows both land on the `T12/F16`
    strict-cycle template without yielding a bootstrap-core-only contradiction.
+   The follow-up `docs/bootstrap-t12-forcing-targets.md` refines this into a
+   row-center forcing target: source `81` has no direct private-pair hit, and
+   source `151` has only partial direct private-pair hits.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,6 +139,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-vertex-circle-overlay.md`](bootstrap-vertex-circle-overlay.md):
   checked overlay joining the two tight `n=9` non-ear bootstrap rows to the
   review-pending vertex-circle strict-cycle chain.
+- [`bootstrap-t12-forcing-targets.md`](bootstrap-t12-forcing-targets.md):
+  follow-up target ledger naming the missing `T12/F16` row centers and direct
+  private-pair contacts for the two tight bootstrap rows.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -317,6 +317,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-vertex-circle-overlay.md`, showing that the two tight
   non-ear-orderable `n=9` rows both join to the `T12/F16` strict-cycle template
   but not by a bootstrap-core-only contradiction.
+- bootstrap/T12 forcing-target evidence, as recorded in
+  `docs/bootstrap-t12-forcing-targets.md`, showing that source `81` has no
+  direct private-pair hit and source `151` has only partial direct hits, so the
+  next useful condition should force missing row centers or equality connectors
+  rather than rely on private pairs alone.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -153,6 +153,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_vertex_circle_overlay.json"
       verifier: "scripts/check_bootstrap_vertex_circle_overlay.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; both tight non-ear n=9 rows land on the T12/F16 strict-cycle template by selected-row signature, but this is not a proof of n=9, not a bridge proof, and not a counterexample"
+    - pattern: "bootstrap_t12_forcing_targets"
+      status: "row-center and private-pair forcing-target ledger for the two tight n=9 bootstrap/T12 overlay rows"
+      artifact: "data/certificates/bootstrap_t12_forcing_targets.json"
+      verifier: "scripts/check_bootstrap_t12_forcing_targets.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; records missing T12/F16 row centers and direct private-pair contacts, but does not prove that the missing rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1866,6 +1866,57 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_forcing_targets
+    path: data/certificates/bootstrap_t12_forcing_targets.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_forcing_targets.py
+    command: python scripts/check_bootstrap_t12_forcing_targets.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_forcing_targets.py
+    check_command: python scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Second-pass T12/F16 forcing-target ledger for the two tight n=9 bootstrap-core rows; not a proof that the missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_forcing_targets.v1
+      status: BOOTSTRAP_T12_FORCING_TARGET_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_count: 2
+      summary.source_record_ids:
+        - 81
+        - 151
+      summary.classification_assignment_ids:
+        - A082
+        - A152
+      summary.template_counts.T12: 2
+      summary.family_counts.F16: 2
+      summary.bootstrap_core:
+        - 0
+        - 1
+        - 2
+        - 4
+      summary.capacity_margins_by_source_id.81: 8
+      summary.capacity_margins_by_source_id.151: 6
+      summary.row_gap_counts_by_source_id.81: 2
+      summary.row_gap_counts_by_source_id.151: 4
+      summary.private_pair_hit_counts_by_source_id.81: 0
+      summary.private_pair_hit_counts_by_source_id.151: 2
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_forcing_targets.py
+      provenance.command: python scripts/check_bootstrap_t12_forcing_targets.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - direct private-pair hits force T12/F16
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_t12_forcing_targets.py
+++ b/scripts/check_bootstrap_t12_forcing_targets.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 forcing-target diagnostic artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_forcing_targets import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_forcing_targets_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 forcing targets")
+    print(f"targets: {summary['target_count']}")
+    print(f"source record ids: {summary['source_record_ids']}")
+    print(f"classification assignment ids: {summary['classification_assignment_ids']}")
+    print(f"templates: {summary['template_counts']}")
+    print(f"row gaps: {summary['row_gap_centers_by_source_id']}")
+    print(f"private-pair hits: {summary['private_pair_hit_counts_by_source_id']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned target counts")
+    args = parser.parse_args()
+
+    generated = build_t12_forcing_targets_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated T12 targets")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 forcing-target artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 forcing-target expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_forcing_targets.py
+++ b/src/erdos97/bootstrap_t12_forcing_targets.py
@@ -1,0 +1,419 @@
+"""T12 forcing-target diagnostic for tight bootstrap-core rows.
+
+This module is proof-mining bookkeeping only.  It refines the
+bootstrap-core / vertex-circle overlay by recording exactly which T12/F16
+strict-cycle rows and pair contacts are not already supplied by the bootstrap
+core or by direct private-pair hits.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_vertex_circle_overlay import build_overlay_payload
+
+
+SCHEMA = "erdos97.bootstrap_t12_forcing_targets.v1"
+STATUS = "BOOTSTRAP_T12_FORCING_TARGET_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Second-pass diagnostic on the two tight n=9 bootstrap-core rows that "
+    "land on the review-pending T12/F16 vertex-circle strict-cycle template; "
+    "records row-center and private-pair forcing targets only, not a proof of "
+    "n=9, not a proof of the bridge, not a counterexample, and not a global "
+    "status update."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / "bootstrap_t12_forcing_targets.json"
+
+TARGET_TEMPLATE_ID = "T12"
+TARGET_FAMILY_ID = "F16"
+EXPECTED_BOOTSTRAP_CORE = [0, 1, 2, 4]
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _pair(values: Sequence[Any]) -> tuple[int, int]:
+    a, b = int(values[0]), int(values[1])
+    if a == b:
+        raise ValueError("pair endpoints must be distinct")
+    return tuple(sorted((a, b)))
+
+
+def _pair_json(values: Sequence[Any]) -> list[int]:
+    return list(_pair(values))
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _unique_cycle_pairs(
+    cycle_pair_entries: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    """Return first-seen unique cycle pairs with all recorded roles attached."""
+
+    first_seen: dict[tuple[int, int], dict[str, object]] = {}
+    roles_by_pair: defaultdict[tuple[int, int], list[str]] = defaultdict(list)
+    rows_by_pair: defaultdict[tuple[int, int], set[int]] = defaultdict(set)
+    steps_by_pair: defaultdict[tuple[int, int], set[int]] = defaultdict(set)
+
+    for entry in cycle_pair_entries:
+        pair = _pair(entry["pair"])
+        location = str(entry["location"])
+        role = str(entry["role"])
+        if pair not in first_seen:
+            first_seen[pair] = {
+                "pair": list(pair),
+                "location": location,
+            }
+        roles_by_pair[pair].append(role)
+        if "row" in entry:
+            rows_by_pair[pair].add(int(entry["row"]))
+        if "step_index" in entry:
+            steps_by_pair[pair].add(int(entry["step_index"]))
+
+    out = []
+    for pair, record in first_seen.items():
+        enriched = dict(record)
+        enriched["roles"] = sorted(set(roles_by_pair[pair]))
+        enriched["rows"] = sorted(rows_by_pair[pair])
+        enriched["steps"] = sorted(steps_by_pair[pair])
+        out.append(enriched)
+    return out
+
+
+def _private_pair_records(
+    deletion_closures: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    out = []
+    for closure in deletion_closures:
+        core_vertex = int(closure["core_vertex"])
+        for pair in closure["private_pairs"]:
+            out.append({"pair": _pair_json(pair), "core_vertex": core_vertex})
+    return sorted(out, key=lambda item: (item["pair"], item["core_vertex"]))
+
+
+def _private_halo_labels(
+    deletion_closures: Sequence[Mapping[str, Any]],
+) -> list[int]:
+    labels: set[int] = set()
+    for closure in deletion_closures:
+        labels.update(_int_list(closure["private_halo"]))
+    return sorted(labels)
+
+
+def _cycle_outside_labels(
+    unique_cycle_pairs: Sequence[Mapping[str, object]],
+    bootstrap_core: set[int],
+) -> list[int]:
+    labels: set[int] = set()
+    for pair_record in unique_cycle_pairs:
+        for label in _int_list(pair_record["pair"]):
+            if label not in bootstrap_core:
+                labels.add(label)
+    return sorted(labels)
+
+
+def _private_pair_hits(
+    unique_cycle_pairs: Sequence[Mapping[str, object]],
+    private_pairs: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    private_core_vertices: defaultdict[tuple[int, int], set[int]] = defaultdict(set)
+    for record in private_pairs:
+        private_core_vertices[_pair(record["pair"])].add(int(record["core_vertex"]))
+
+    hits = []
+    for pair_record in unique_cycle_pairs:
+        pair = _pair(pair_record["pair"])
+        core_vertices = sorted(private_core_vertices.get(pair, set()))
+        if core_vertices:
+            hits.append(
+                {
+                    "pair": list(pair),
+                    "location": str(pair_record["location"]),
+                    "private_core_vertices": core_vertices,
+                }
+            )
+    return hits
+
+
+def _row_gap_records(
+    vertex_circle: Mapping[str, Any],
+    bootstrap_core: set[int],
+) -> list[dict[str, object]]:
+    strict_rows = set(_int_list(vertex_circle["strict_edge_rows"]))
+    connector_rows = set(_int_list(vertex_circle["equality_connector_rows"]))
+    local_rows = {
+        int(row["center"]): _int_list(row["witnesses"])
+        for row in vertex_circle["local_core_rows"]
+    }
+    gap_rows = sorted(set(_int_list(vertex_circle["cycle_row_centers"])) - bootstrap_core)
+    out = []
+    for center in gap_rows:
+        roles = []
+        if center in strict_rows:
+            roles.append("strict_edge_row")
+        if center in connector_rows:
+            roles.append("equality_connector_row")
+        out.append(
+            {
+                "center": center,
+                "roles": roles,
+                "witnesses": local_rows[center],
+            }
+        )
+    return out
+
+
+def _target_record(overlay_record: Mapping[str, Any]) -> dict[str, object]:
+    source_id = int(overlay_record["source_record_id"])
+    bootstrap_core = _int_list(overlay_record["bootstrap_core"])
+    bootstrap_core_set = set(bootstrap_core)
+    vertex_circle = overlay_record["vertex_circle"]
+    if vertex_circle["template_id"] != TARGET_TEMPLATE_ID:
+        raise AssertionError(f"source {source_id} is not a T12 record")
+    if vertex_circle["family_id"] != TARGET_FAMILY_ID:
+        raise AssertionError(f"source {source_id} is not an F16 record")
+
+    unique_pairs = _unique_cycle_pairs(vertex_circle["cycle_pair_entries"])
+    private_pairs = _private_pair_records(overlay_record["deletion_closures"])
+    private_hits = _private_pair_hits(unique_pairs, private_pairs)
+    row_gaps = _row_gap_records(vertex_circle, bootstrap_core_set)
+    row_gap_centers = [int(record["center"]) for record in row_gaps]
+    row_gap_role_counts = Counter(
+        role for record in row_gaps for role in record["roles"]
+    )
+    unique_pair_location_counts = Counter(
+        str(record["location"]) for record in unique_pairs
+    )
+    private_labels = _private_halo_labels(overlay_record["deletion_closures"])
+    cycle_outside = _cycle_outside_labels(unique_pairs, bootstrap_core_set)
+
+    return {
+        "source_record_id": source_id,
+        "classification_assignment_id": overlay_record["classification_assignment_id"],
+        "template_id": TARGET_TEMPLATE_ID,
+        "family_id": TARGET_FAMILY_ID,
+        "cycle_length": int(vertex_circle["cycle_length"]),
+        "bootstrap_core": bootstrap_core,
+        "capacity_margin": int(overlay_record["bootstrap_capacity"]["capacity_margin"]),
+        "outside": _int_list(overlay_record["bootstrap_capacity"]["outside"]),
+        "cycle_row_centers": _int_list(vertex_circle["cycle_row_centers"]),
+        "row_gap_centers": row_gap_centers,
+        "row_gap_count": len(row_gap_centers),
+        "row_gap_role_counts": _json_counter(row_gap_role_counts),
+        "row_gaps": row_gaps,
+        "strict_edge_rows_subset_of_bootstrap_core": bool(
+            vertex_circle["strict_edge_rows_subset_of_bootstrap_core"]
+        ),
+        "equality_connector_rows_subset_of_bootstrap_core": bool(
+            vertex_circle["equality_connector_rows_subset_of_bootstrap_core"]
+        ),
+        "unique_cycle_pairs": unique_pairs,
+        "unique_cycle_pair_location_counts": _json_counter(unique_pair_location_counts),
+        "cycle_outside_labels": cycle_outside,
+        "private_halo_labels": private_labels,
+        "cycle_outside_labels_in_private_halos": sorted(
+            set(cycle_outside) & set(private_labels)
+        ),
+        "private_pair_hits": private_hits,
+        "private_pair_hit_count": len(private_hits),
+        "private_pair_hit_pairs": [hit["pair"] for hit in private_hits],
+        "private_pair_records": private_pairs,
+        "diagnosis": {
+            "core_only_target_status": "BLOCKED_BY_ROW_GAPS",
+            "private_pair_only_target_status": (
+                "NO_DIRECT_HITS"
+                if not private_hits
+                else "PARTIAL_DIRECT_HITS_ONLY"
+            ),
+            "recommended_next_target": (
+                "Prove a row-center or equality-connector forcing condition "
+                "that supplies the missing T12/F16 local rows from the "
+                "bootstrap-core/private-halo geometry."
+            ),
+        },
+    }
+
+
+def build_t12_forcing_targets_payload() -> dict[str, object]:
+    """Return the deterministic T12 forcing-target diagnostic payload."""
+
+    overlay = build_overlay_payload()
+    records = [
+        _target_record(record)
+        for record in overlay["records"]
+        if record["vertex_circle"]["template_id"] == TARGET_TEMPLATE_ID
+        and record["vertex_circle"]["family_id"] == TARGET_FAMILY_ID
+    ]
+    records.sort(key=lambda record: int(record["source_record_id"]))
+    if any(record["bootstrap_core"] != EXPECTED_BOOTSTRAP_CORE for record in records):
+        raise AssertionError("T12 forcing-target records no longer share the expected bootstrap core")
+
+    template_counts = Counter(str(record["template_id"]) for record in records)
+    family_counts = Counter(str(record["family_id"]) for record in records)
+    row_gap_counts = {
+        str(record["source_record_id"]): int(record["row_gap_count"])
+        for record in records
+    }
+    private_hit_counts = {
+        str(record["source_record_id"]): int(record["private_pair_hit_count"])
+        for record in records
+    }
+    zero_private_hit_sources = [
+        int(record["source_record_id"])
+        for record in records
+        if int(record["private_pair_hit_count"]) == 0
+    ]
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This is a proof-mining target ledger, not a proof of the bridge.",
+            "The input overlay is fixed selected-row data, not full geometric rich-class data.",
+            "Direct private-pair hits are diagnostic contacts, not Euclidean realizability evidence.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "summary": {
+            "target_count": len(records),
+            "source_record_ids": [int(record["source_record_id"]) for record in records],
+            "classification_assignment_ids": [
+                str(record["classification_assignment_id"]) for record in records
+            ],
+            "template_counts": _json_counter(template_counts),
+            "family_counts": _json_counter(family_counts),
+            "bootstrap_core": EXPECTED_BOOTSTRAP_CORE,
+            "capacity_margins_by_source_id": {
+                str(record["source_record_id"]): int(record["capacity_margin"])
+                for record in records
+            },
+            "row_gap_counts_by_source_id": row_gap_counts,
+            "row_gap_centers_by_source_id": {
+                str(record["source_record_id"]): record["row_gap_centers"]
+                for record in records
+            },
+            "private_pair_hit_counts_by_source_id": private_hit_counts,
+            "zero_private_pair_hit_source_ids": zero_private_hit_sources,
+            "all_records_have_row_gaps": all(
+                int(record["row_gap_count"]) > 0 for record in records
+            ),
+            "all_records_have_direct_private_pair_hits": all(
+                int(record["private_pair_hit_count"]) > 0 for record in records
+            ),
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "primary_next_target": (
+                "bootstrap core [0,1,2,4] plus tight private-halo geometry "
+                "should force the missing T12/F16 row centers or equivalent "
+                "equality connectors"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+                "role": "source overlay joining tight bootstrap rows to T12/F16",
+                "schema": overlay.get("schema"),
+                "status": overlay.get("status"),
+                "trust": overlay.get("trust"),
+            }
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_forcing_targets.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_forcing_targets.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the T12 forcing-target diagnostic."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 forcing-target schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 forcing-target status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_count": 2,
+        "source_record_ids": [81, 151],
+        "classification_assignment_ids": ["A082", "A152"],
+        "template_counts": {"T12": 2},
+        "family_counts": {"F16": 2},
+        "bootstrap_core": [0, 1, 2, 4],
+        "capacity_margins_by_source_id": {"81": 8, "151": 6},
+        "row_gap_counts_by_source_id": {"81": 2, "151": 4},
+        "row_gap_centers_by_source_id": {"81": [3, 8], "151": [5, 6, 7, 8]},
+        "private_pair_hit_counts_by_source_id": {"81": 0, "151": 2},
+        "zero_private_pair_hit_source_ids": [81],
+        "all_records_have_row_gaps": True,
+        "all_records_have_direct_private_pair_hits": False,
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    expected_records = {
+        81: {
+            "row_gap_centers": [3, 8],
+            "row_gap_role_counts": {"equality_connector_row": 2},
+            "unique_cycle_pair_location_counts": {"core_core": 2, "core_outside": 5},
+            "cycle_outside_labels": [3, 7, 8],
+            "cycle_outside_labels_in_private_halos": [3, 7, 8],
+            "private_pair_hit_pairs": [],
+        },
+        151: {
+            "row_gap_centers": [5, 6, 7, 8],
+            "row_gap_role_counts": {
+                "equality_connector_row": 3,
+                "strict_edge_row": 2,
+            },
+            "unique_cycle_pair_location_counts": {
+                "core_core": 1,
+                "core_outside": 3,
+                "outside_outside": 3,
+            },
+            "cycle_outside_labels": [5, 6, 7, 8],
+            "cycle_outside_labels_in_private_halos": [5, 6, 7, 8],
+            "private_pair_hit_pairs": [[5, 8], [6, 8]],
+        },
+    }
+    by_source = {int(record["source_record_id"]): record for record in records}
+    if set(by_source) != set(expected_records):
+        raise AssertionError("unexpected source-record ids")
+    for source_id, expected in expected_records.items():
+        record = by_source[source_id]
+        for key, value in expected.items():
+            if record.get(key) != value:
+                raise AssertionError(f"{source_id} {key} is {record.get(key)!r}, expected {value!r}")
+        if record["template_id"] != TARGET_TEMPLATE_ID or record["family_id"] != TARGET_FAMILY_ID:
+            raise AssertionError(f"{source_id} template/family changed")

--- a/tests/test_bootstrap_t12_forcing_targets.py
+++ b/tests/test_bootstrap_t12_forcing_targets.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_t12_forcing_targets import (
+    assert_expected_payload,
+    build_t12_forcing_targets_payload,
+)
+
+
+def test_bootstrap_t12_forcing_targets_expected_payload() -> None:
+    payload = build_t12_forcing_targets_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["source_record_ids"] == [81, 151]
+    assert summary["template_counts"] == {"T12": 2}
+    assert summary["row_gap_counts_by_source_id"] == {"81": 2, "151": 4}
+    assert summary["forcing_target_status"] == "OPEN_TARGET_NOT_PROVED"
+
+
+def test_bootstrap_t12_forcing_targets_private_pair_gap() -> None:
+    payload = build_t12_forcing_targets_payload()
+    by_source = {record["source_record_id"]: record for record in payload["records"]}
+
+    assert by_source[81]["private_pair_hit_pairs"] == []
+    assert by_source[81]["diagnosis"]["private_pair_only_target_status"] == "NO_DIRECT_HITS"
+    assert by_source[151]["private_pair_hit_pairs"] == [[5, 8], [6, 8]]
+    assert (
+        by_source[151]["diagnosis"]["private_pair_only_target_status"]
+        == "PARTIAL_DIRECT_HITS_ONLY"
+    )
+
+
+def test_bootstrap_t12_forcing_targets_row_center_gaps() -> None:
+    payload = build_t12_forcing_targets_payload()
+    by_source = {record["source_record_id"]: record for record in payload["records"]}
+
+    assert by_source[81]["row_gap_centers"] == [3, 8]
+    assert by_source[81]["row_gap_role_counts"] == {"equality_connector_row": 2}
+    assert by_source[151]["row_gap_centers"] == [5, 6, 7, 8]
+    assert by_source[151]["row_gap_role_counts"] == {
+        "equality_connector_row": 3,
+        "strict_edge_row": 2,
+    }
+
+
+def test_bootstrap_t12_forcing_targets_expected_payload_rejects_drift() -> None:
+    payload = build_t12_forcing_targets_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["row_gap_counts_by_source_id"] = {"81": 0, "151": 0}
+
+    with pytest.raises(AssertionError, match="row_gap_counts_by_source_id"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a checked bootstrap/T12 forcing-target diagnostic derived from the existing bootstrap/vertex-circle overlay
- record the missing T12/F16 row centers, row-gap roles, cycle-pair locations, and direct private-pair hits for source records 81 and 151
- document the result as proof-mining target bookkeeping only, with no n=9, bridge, counterexample, or global-status promotion

## Validation

- `python scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected`
- `python scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check origin/main`
- `python -m ruff check .`
- `python -m pytest -q` (`606 passed, 278 deselected`)
- GitHub Actions `tests` passed on Python 3.10, 3.11, and 3.12; artifact-review skipped by workflow rules

## Review notes

This is a derived diagnostic artifact. It deliberately records `OPEN_TARGET_NOT_PROVED` and keeps the source overlay and review-pending n=9 chain in their existing trust lane.