### PR TITLE
[codex] Add bootstrap T12 row-pressure diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the follow-up T12 forcing-target ledger naming the missing row centers
   and direct private-pair contacts, read
   [`docs/bootstrap-t12-forcing-targets.md`](docs/bootstrap-t12-forcing-targets.md).
+- For the row-pressure refinement classifying those missing T12 row centers
+  by core deficit, deletion-closure exposure, and private-halo support, read
+  [`docs/bootstrap-t12-row-pressure.md`](docs/bootstrap-t12-row-pressure.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -160,6 +160,14 @@ open proof-mining target, not a proof that the missing rows are forced; see
 `scripts/check_bootstrap_t12_forcing_targets.py`, and
 `data/certificates/bootstrap_t12_forcing_targets.json`.
 
+The row-pressure refinement splits those six missing row centers by the kind
+of bridge ingredient they would need: two are already exposed in a deletion
+closure, three need one outside label while the row center remains private,
+and one needs an outside pair with two private-pair ledger hits. This is still
+diagnostic bookkeeping only; see `docs/bootstrap-t12-row-pressure.md`,
+`scripts/check_bootstrap_t12_row_pressure.py`, and
+`data/certificates/bootstrap_t12_row_pressure.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -66,6 +66,12 @@ direct private-pair hit, while source `151` needs row centers `5,6,7,8` and has
 only two direct private-pair hits. This is target bookkeeping only; it is not a
 proof that those rows are forced. See `docs/bootstrap-t12-forcing-targets.md`.
 
+A row-pressure refinement classifies those six missing T12 row centers: two
+are already exposed in a deletion closure, three need one outside label while
+their row centers stay private, and one needs an outside pair with partial
+private-pair ledger support. This is still only a diagnostic for the next
+bridge lemma. See `docs/bootstrap-t12-row-pressure.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_row_pressure.json
+++ b/data/certificates/bootstrap_t12_row_pressure.json
@@ -1,0 +1,1164 @@
+{
+  "claim_scope": "Row-pressure diagnostic for the two tight n=9 bootstrap/T12 records; classifies missing T12/F16 row centers by bootstrap-core witness count, deletion-closure exposure, and private-halo support only. This does not prove that the missing rows are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This classifies fixed selected-row gaps; it does not prove the row centers are forced.",
+    "Private-halo containment and ledger private-pair hits are bookkeeping contacts, not Euclidean certificates.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_row_pressure.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_row_pressure.py"
+  },
+  "row_records": [
+    {
+      "activation_deficit_from_bootstrap_core": 0,
+      "bootstrap_core_witness_count": 3,
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "classification_assignment_id": "A082",
+      "deletion_closure_exposures": [
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            1,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            1,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": true,
+          "closure_labels": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "closure_size": 5,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_witnesses": [],
+          "row_center_in_closure": true,
+          "row_exposed_in_closure": true,
+          "witness_count_in_closure": 4,
+          "witnesses_in_closure": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            2
+          ],
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            1
+          ]
+        }
+      ],
+      "exposed_deletion_core_vertices": [
+        2
+      ],
+      "ledger_private_pair_support_hit_count": 0,
+      "ledger_private_pair_support_hits": [],
+      "max_witness_count_in_deletion_closure": 4,
+      "outside_support_kind": "core_sufficient",
+      "outside_support_subsets": [],
+      "outside_witnesses": [
+        6
+      ],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 3,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": false,
+      "source_record_id": 81,
+      "support_hits": [],
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witness_count": 2,
+      "bootstrap_core_witnesses": [
+        0,
+        2
+      ],
+      "classification_assignment_id": "A082",
+      "deletion_closure_exposures": [
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            1,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            5,
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 1,
+          "witnesses_in_closure": [
+            2
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            5,
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            2
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "closure_size": 5,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_witnesses": [
+            5
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            6
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            2
+          ],
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_witnesses": [
+            5,
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            2
+          ]
+        }
+      ],
+      "exposed_deletion_core_vertices": [],
+      "ledger_private_pair_support_hit_count": 0,
+      "ledger_private_pair_support_hits": [],
+      "max_witness_count_in_deletion_closure": 2,
+      "outside_support_kind": "outside_1_set",
+      "outside_support_subsets": [
+        [
+          5
+        ],
+        [
+          6
+        ]
+      ],
+      "outside_witnesses": [
+        5,
+        6
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 81,
+      "support_hits": [
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            5
+          ]
+        },
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 3,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "support": [
+            6
+          ]
+        }
+      ],
+      "witnesses": [
+        0,
+        2,
+        5,
+        6
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witness_count": 2,
+      "bootstrap_core_witnesses": [
+        2,
+        4
+      ],
+      "classification_assignment_id": "A152",
+      "deletion_closure_exposures": [
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            1,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            7,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            2,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            7,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            2,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "closure_size": 4,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_witnesses": [
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            4,
+            7
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            2
+          ],
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_witnesses": [
+            7,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 1,
+          "witnesses_in_closure": [
+            2
+          ]
+        }
+      ],
+      "exposed_deletion_core_vertices": [],
+      "ledger_private_pair_support_hit_count": 0,
+      "ledger_private_pair_support_hits": [],
+      "max_witness_count_in_deletion_closure": 2,
+      "outside_support_kind": "outside_1_set",
+      "outside_support_subsets": [
+        [
+          7
+        ],
+        [
+          8
+        ]
+      ],
+      "outside_witnesses": [
+        7,
+        8
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 5,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "support_hits": [
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 3,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "support": [
+            7
+          ]
+        },
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            8
+          ]
+        }
+      ],
+      "witnesses": [
+        2,
+        4,
+        7,
+        8
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 2,
+      "bootstrap_core_witness_count": 1,
+      "bootstrap_core_witnesses": [
+        0
+      ],
+      "classification_assignment_id": "A152",
+      "deletion_closure_exposures": [
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            1,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            3,
+            5,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 0,
+          "witnesses_in_closure": []
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            3,
+            5,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 1,
+          "witnesses_in_closure": [
+            0
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "closure_size": 4,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_witnesses": [
+            3,
+            5,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 1,
+          "witnesses_in_closure": [
+            0
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            2
+          ],
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_witnesses": [
+            3,
+            5,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 1,
+          "witnesses_in_closure": [
+            0
+          ]
+        }
+      ],
+      "exposed_deletion_core_vertices": [],
+      "ledger_private_pair_support_hit_count": 2,
+      "ledger_private_pair_support_hits": [
+        {
+          "ledger_private_pair_core_vertices": [
+            0
+          ],
+          "ledger_private_pair_hit": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            3,
+            8
+          ]
+        },
+        {
+          "ledger_private_pair_core_vertices": [
+            2
+          ],
+          "ledger_private_pair_hit": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            5,
+            8
+          ]
+        }
+      ],
+      "max_witness_count_in_deletion_closure": 1,
+      "outside_support_kind": "outside_2_set",
+      "outside_support_subsets": [
+        [
+          3,
+          5
+        ],
+        [
+          3,
+          8
+        ],
+        [
+          5,
+          8
+        ]
+      ],
+      "outside_witnesses": [
+        3,
+        5,
+        8
+      ],
+      "pressure_class": "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 6,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "support_hits": [
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            3,
+            5
+          ]
+        },
+        {
+          "ledger_private_pair_core_vertices": [
+            0
+          ],
+          "ledger_private_pair_hit": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            3,
+            8
+          ]
+        },
+        {
+          "ledger_private_pair_core_vertices": [
+            2
+          ],
+          "ledger_private_pair_hit": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            5,
+            8
+          ]
+        }
+      ],
+      "witnesses": [
+        0,
+        3,
+        5,
+        8
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 0,
+      "bootstrap_core_witness_count": 3,
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "classification_assignment_id": "A152",
+      "deletion_closure_exposures": [
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            1,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            1,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": true,
+          "closure_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "closure_size": 4,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": true,
+          "row_exposed_in_closure": true,
+          "witness_count_in_closure": 3,
+          "witnesses_in_closure": [
+            0,
+            1,
+            4
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            2
+          ],
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_witnesses": [
+            6
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            0,
+            1
+          ]
+        }
+      ],
+      "exposed_deletion_core_vertices": [
+        2
+      ],
+      "ledger_private_pair_support_hit_count": 0,
+      "ledger_private_pair_support_hits": [],
+      "max_witness_count_in_deletion_closure": 3,
+      "outside_support_kind": "core_sufficient",
+      "outside_support_subsets": [],
+      "outside_witnesses": [
+        6
+      ],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "roles": [
+        "strict_edge_row"
+      ],
+      "row_center": 7,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": false,
+      "source_record_id": 151,
+      "support_hits": [],
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witness_count": 2,
+      "bootstrap_core_witnesses": [
+        1,
+        2
+      ],
+      "classification_assignment_id": "A152",
+      "deletion_closure_exposures": [
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            1,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 0,
+          "deletion_seed": [
+            1,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            5,
+            7
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            1,
+            2
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            2,
+            4
+          ],
+          "closure_size": 3,
+          "core_vertex": 1,
+          "deletion_seed": [
+            0,
+            2,
+            4
+          ],
+          "private_witnesses": [
+            5,
+            7
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 1,
+          "witnesses_in_closure": [
+            2
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "closure_size": 4,
+          "core_vertex": 2,
+          "deletion_seed": [
+            0,
+            1,
+            4
+          ],
+          "private_witnesses": [
+            5
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            1,
+            7
+          ]
+        },
+        {
+          "activation_ready_in_closure": false,
+          "closure_labels": [
+            0,
+            1,
+            2
+          ],
+          "closure_size": 3,
+          "core_vertex": 4,
+          "deletion_seed": [
+            0,
+            1,
+            2
+          ],
+          "private_witnesses": [
+            5,
+            7
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "witness_count_in_closure": 2,
+          "witnesses_in_closure": [
+            1,
+            2
+          ]
+        }
+      ],
+      "exposed_deletion_core_vertices": [],
+      "ledger_private_pair_support_hit_count": 0,
+      "ledger_private_pair_support_hits": [],
+      "max_witness_count_in_deletion_closure": 2,
+      "outside_support_kind": "outside_1_set",
+      "outside_support_subsets": [
+        [
+          5
+        ],
+        [
+          7
+        ]
+      ],
+      "outside_witnesses": [
+        5,
+        7
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "roles": [
+        "strict_edge_row",
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "support_hits": [
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support": [
+            5
+          ]
+        },
+        {
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "private_halo_containment_count": 3,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "support": [
+            7
+          ]
+        }
+      ],
+      "witnesses": [
+        1,
+        2,
+        5,
+        7
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_row_pressure.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_forcing_targets.json",
+      "role": "missing T12/F16 row centers and direct cycle-pair contacts",
+      "schema": "erdos97.bootstrap_t12_forcing_targets.v1",
+      "status": "BOOTSTRAP_T12_FORCING_TARGET_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+      "role": "bootstrap deletion closures and source overlay records",
+      "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+      "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "activation_deficit_counts": {
+      "0": 2,
+      "1": 3,
+      "2": 1
+    },
+    "deletion_closure_exposed_row_count": 2,
+    "exposed_rows_by_source_id": {
+      "151": [
+        7
+      ],
+      "81": [
+        3
+      ]
+    },
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "ledger_private_pair_support_row_count": 1,
+    "ledger_private_pair_support_rows_by_source_id": {
+      "151": [
+        6
+      ]
+    },
+    "next_bridge_question": "Can closure-exposed rows, one-outside-label rows, and the single outside-pair row be forced from genuine rich-class geometry rather than fixed selected-row bookkeeping?",
+    "outside_support_kind_counts": {
+      "core_sufficient": 2,
+      "outside_1_set": 3,
+      "outside_2_set": 1
+    },
+    "pressure_class_counts": {
+      "ALREADY_PRESENT_IN_A_DELETION_CLOSURE": 2,
+      "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 3,
+      "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER": 1
+    },
+    "private_center_rows_by_source_id": {
+      "151": [
+        5,
+        6,
+        8
+      ],
+      "81": [
+        8
+      ]
+    },
+    "row_center_private_in_all_deletions_count": 4,
+    "row_gap_centers_by_source_id": {
+      "151": [
+        5,
+        6,
+        7,
+        8
+      ],
+      "81": [
+        3,
+        8
+      ]
+    },
+    "row_gap_record_count": 6,
+    "target_source_ids": [
+      81,
+      151
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-forcing-targets.md
+++ b/docs/bootstrap-t12-forcing-targets.md
@@ -89,3 +89,9 @@ So the promising route is not simply to spend the existing capacity ledger
 harder. A future bridge needs an extra metric/order ingredient that turns
 private halos, row-center placement, or equality-connector availability into
 the missing `T12/F16` local rows.
+
+The row-pressure refinement in
+[`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md) decomposes
+those missing row centers into deletion-closure-exposed rows,
+one-outside-label rows, and one outside-pair row with partial private-pair
+ledger support.

--- a/docs/bootstrap-t12-row-pressure.md
+++ b/docs/bootstrap-t12-row-pressure.md
@@ -1,0 +1,84 @@
+# Bootstrap T12 Row Pressure
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note refines
+[`bootstrap-t12-forcing-targets.md`](bootstrap-t12-forcing-targets.md) by
+classifying each missing `T12/F16` row center against the bootstrap core,
+deletion closures, and private halos. The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_row_pressure.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_row_pressure.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_row_pressure.json`.
+
+## Scope
+
+The input is still fixed selected-row bookkeeping. A row-pressure class is not
+a Euclidean certificate and does not prove that a missing row is forced in a
+real minimal counterexample. The diagnostic only records which kind of bridge
+ingredient would be needed for each missing `T12/F16` row.
+
+The artifact records, for each missing row center:
+
+- how many selected witnesses already lie in the bootstrap core `[0,1,2,4]`;
+- the outside-label deficit needed to activate the row from that core;
+- whether the row center is already exposed in a deletion closure;
+- whether the row center stays private in every deletion closure;
+- whether an outside-pair deficit has direct private-pair ledger support.
+
+## Results
+
+The six missing row centers split into three pressure classes.
+
+| Pressure class | Count | Rows |
+|---|---:|---|
+| Already present in a deletion closure | `2` | `81:3`, `151:7` |
+| Needs one outside label and a private center | `3` | `81:8`, `151:5`, `151:8` |
+| Needs an outside pair and a private center | `1` | `151:6` |
+
+Equivalently, the bootstrap-core activation deficits are:
+
+```text
+deficit 0: 2 rows
+deficit 1: 3 rows
+deficit 2: 1 row
+```
+
+The rows `81:3` and `151:7` each have three core witnesses and are already
+visible in the deletion closure for core vertex `2`. These are not the hard
+part of the row-center bridge.
+
+The rows `81:8`, `151:5`, and `151:8` each have two core witnesses. They need
+one outside label to become activation-ready from the bootstrap core, while
+their row centers remain private across all deletion closures.
+
+The row `151:6` has only one core witness. It needs an outside pair, and two
+of its possible outside pairs, `[3,8]` and `[5,8]`, hit the existing
+private-pair ledger.
+
+## Reading
+
+This narrows the next proof-mining question:
+
+```text
+Can closure-exposed rows, one-outside-label rows, and the single outside-pair
+row be forced from genuine rich-class geometry, rather than from fixed
+selected-row bookkeeping?
+```
+
+The answer is not supplied here. The ledger says only that a future bridge
+lemma probably needs more than the current weighted private-pair count:
+
+- two rows are deletion-closure bookkeeping rows;
+- three rows are single-outside-label problems, so pair capacity alone does
+  not see them directly;
+- one row is a genuine outside-pair problem with partial private-pair support.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -456,6 +456,12 @@ outside the bootstrap core, and the direct private-pair contacts are absent for
 source `81` and partial for source `151`. This remains an open target ledger,
 not a theorem that the missing rows are forced.
 
+The row-pressure refinement in `docs/bootstrap-t12-row-pressure.md` classifies
+the six missing row centers into two deletion-closure-exposed rows, three
+one-outside-label rows, and one outside-pair row. This is a diagnostic
+decomposition of the open target, not a theorem that any of those rows are
+forced by genuine geometry.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -35,6 +35,9 @@ Use this queue when no more specific issue is selected.
    The follow-up `docs/bootstrap-t12-forcing-targets.md` refines this into a
    row-center forcing target: source `81` has no direct private-pair hit, and
    source `151` has only partial direct private-pair hits.
+   The row-pressure refinement in `docs/bootstrap-t12-row-pressure.md` splits
+   the missing rows into deletion-closure-exposed, one-outside-label, and
+   outside-pair cases for the next bridge attempt.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-forcing-targets.md`](bootstrap-t12-forcing-targets.md):
   follow-up target ledger naming the missing `T12/F16` row centers and direct
   private-pair contacts for the two tight bootstrap rows.
+- [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
+  row-pressure refinement classifying those missing T12 row centers by core
+  deficit, deletion-closure exposure, and private-halo support.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -322,6 +322,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   direct private-pair hit and source `151` has only partial direct hits, so the
   next useful condition should force missing row centers or equality connectors
   rather than rely on private pairs alone.
+- bootstrap/T12 row-pressure evidence, as recorded in
+  `docs/bootstrap-t12-row-pressure.md`, splitting the six missing row centers
+  into deletion-closure-exposed rows, one-outside-label rows, and one
+  outside-pair row with partial private-pair support.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -158,6 +158,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_forcing_targets.json"
       verifier: "scripts/check_bootstrap_t12_forcing_targets.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; records missing T12/F16 row centers and direct private-pair contacts, but does not prove that the missing rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_row_pressure"
+      status: "row-pressure classification for the missing T12/F16 row centers in the two tight n=9 bootstrap/T12 records"
+      artifact: "data/certificates/bootstrap_t12_row_pressure.json"
+      verifier: "scripts/check_bootstrap_t12_row_pressure.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; classifies missing row centers by bootstrap-core deficit, deletion-closure exposure, and private-halo support, but does not prove that the missing rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1917,6 +1917,58 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_row_pressure
+    path: data/certificates/bootstrap_t12_row_pressure.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_row_pressure.py
+    command: python scripts/check_bootstrap_t12_row_pressure.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_row_pressure.py
+    check_command: python scripts/check_bootstrap_t12_row_pressure.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Row-pressure diagnostic for the two tight n=9 bootstrap/T12 records; not a proof that the missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_row_pressure.v1
+      status: BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_source_ids:
+        - 81
+        - 151
+      summary.row_gap_record_count: 6
+      summary.row_gap_centers_by_source_id.81:
+        - 3
+        - 8
+      summary.row_gap_centers_by_source_id.151:
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.pressure_class_counts.ALREADY_PRESENT_IN_A_DELETION_CLOSURE: 2
+      summary.pressure_class_counts.NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER: 3
+      summary.pressure_class_counts.NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER: 1
+      summary.activation_deficit_counts.0: 2
+      summary.activation_deficit_counts.1: 3
+      summary.activation_deficit_counts.2: 1
+      summary.deletion_closure_exposed_row_count: 2
+      summary.row_center_private_in_all_deletions_count: 4
+      summary.ledger_private_pair_support_row_count: 1
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_row_pressure.py
+      provenance.command: python scripts/check_bootstrap_t12_row_pressure.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - row-pressure classes prove the missing rows are forced
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_t12_row_pressure.py
+++ b/scripts/check_bootstrap_t12_row_pressure.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 row-pressure diagnostic artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_row_pressure import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_row_pressure_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 row pressure")
+    print(f"row gaps: {summary['row_gap_record_count']}")
+    print(f"row centers: {summary['row_gap_centers_by_source_id']}")
+    print(f"pressure classes: {summary['pressure_class_counts']}")
+    print(f"activation deficits: {summary['activation_deficit_counts']}")
+    print(f"closure-exposed rows: {summary['exposed_rows_by_source_id']}")
+    print(f"private-center rows: {summary['private_center_rows_by_source_id']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned row-pressure counts")
+    args = parser.parse_args()
+
+    generated = build_t12_row_pressure_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated row pressure")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 row-pressure artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 row-pressure expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_row_pressure.py
+++ b/src/erdos97/bootstrap_t12_row_pressure.py
@@ -1,0 +1,442 @@
+"""Row-pressure diagnostic for the bootstrap/T12 forcing target.
+
+This module refines the T12 forcing-target ledger by asking how each missing
+T12/F16 row center sits relative to the bootstrap core, deletion closures, and
+private halos.  It is proof-mining bookkeeping only: it does not prove that
+any missing row is forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_forcing_targets import build_t12_forcing_targets_payload
+from erdos97.bootstrap_vertex_circle_overlay import build_overlay_payload
+
+
+SCHEMA = "erdos97.bootstrap_t12_row_pressure.v1"
+STATUS = "BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Row-pressure diagnostic for the two tight n=9 bootstrap/T12 records; "
+    "classifies missing T12/F16 row centers by bootstrap-core witness count, "
+    "deletion-closure exposure, and private-halo support only. This does not "
+    "prove that the missing rows are forced, does not prove n=9, does not "
+    "prove the bridge, and does not claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / "bootstrap_t12_row_pressure.json"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _pair(values: Sequence[Any]) -> tuple[int, int]:
+    a, b = int(values[0]), int(values[1])
+    if a == b:
+        raise ValueError("pair endpoints must be distinct")
+    return tuple(sorted((a, b)))
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _closure_labels(n: int, core_vertex: int, private_halo: Iterable[Any]) -> list[int]:
+    return sorted(set(range(n)) - {int(core_vertex)} - set(_int_list(private_halo)))
+
+
+def _private_pair_index(
+    private_pair_records: Sequence[Mapping[str, Any]],
+) -> dict[tuple[int, int], list[int]]:
+    index: defaultdict[tuple[int, int], set[int]] = defaultdict(set)
+    for record in private_pair_records:
+        index[_pair(record["pair"])].add(int(record["core_vertex"]))
+    return {pair: sorted(core_vertices) for pair, core_vertices in sorted(index.items())}
+
+
+def _outside_support_subsets(outside_witnesses: Sequence[int], deficit: int) -> list[list[int]]:
+    if deficit <= 0:
+        return []
+    return [list(combo) for combo in combinations(sorted(outside_witnesses), deficit)]
+
+
+def _support_hits(
+    *,
+    support_subsets: Sequence[Sequence[int]],
+    deletion_closures: Sequence[Mapping[str, Any]],
+    private_pair_records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    pair_index = _private_pair_index(private_pair_records)
+    out = []
+    for support in support_subsets:
+        support_set = set(_int_list(support))
+        halo_core_vertices = [
+            int(closure["core_vertex"])
+            for closure in deletion_closures
+            if support_set <= set(_int_list(closure["private_halo"]))
+        ]
+        ledger_core_vertices: list[int] = []
+        if len(support_set) == 2:
+            ledger_core_vertices = pair_index.get(_pair(sorted(support_set)), [])
+        out.append(
+            {
+                "support": sorted(support_set),
+                "private_halo_core_vertices": sorted(halo_core_vertices),
+                "private_halo_containment_count": len(halo_core_vertices),
+                "ledger_private_pair_core_vertices": ledger_core_vertices,
+                "ledger_private_pair_hit": bool(ledger_core_vertices),
+            }
+        )
+    return out
+
+
+def _deletion_closure_exposures(
+    *,
+    n: int,
+    row_center: int,
+    witnesses: Sequence[int],
+    deletion_closures: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    witness_set = set(witnesses)
+    out = []
+    for closure in deletion_closures:
+        closure_labels = _closure_labels(n, int(closure["core_vertex"]), closure["private_halo"])
+        closure_set = set(closure_labels)
+        witnesses_in_closure = sorted(witness_set & closure_set)
+        private_witnesses = sorted(witness_set & set(_int_list(closure["private_halo"])))
+        center_in_closure = row_center in closure_set
+        witness_count = len(witnesses_in_closure)
+        out.append(
+            {
+                "core_vertex": int(closure["core_vertex"]),
+                "deletion_seed": _int_list(closure["deletion_seed"]),
+                "closure_labels": closure_labels,
+                "closure_size": int(closure["closure_size"]),
+                "row_center_in_closure": center_in_closure,
+                "witnesses_in_closure": witnesses_in_closure,
+                "witness_count_in_closure": witness_count,
+                "private_witnesses": private_witnesses,
+                "activation_ready_in_closure": witness_count >= 3,
+                "row_exposed_in_closure": center_in_closure and witness_count >= 3,
+            }
+        )
+    return out
+
+
+def _pressure_class(
+    *,
+    exposed_deletion_core_vertices: Sequence[int],
+    activation_deficit_from_core: int,
+) -> str:
+    if exposed_deletion_core_vertices:
+        return "ALREADY_PRESENT_IN_A_DELETION_CLOSURE"
+    if activation_deficit_from_core <= 0:
+        return "CORE_SUFFICIENT_BUT_ROW_CENTER_PRIVATE"
+    if activation_deficit_from_core == 1:
+        return "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER"
+    if activation_deficit_from_core == 2:
+        return "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER"
+    return "NEEDS_OUTSIDE_TRIPLE_AND_PRIVATE_CENTER"
+
+
+def _row_pressure_record(
+    *,
+    target_record: Mapping[str, Any],
+    gap: Mapping[str, Any],
+    overlay_record: Mapping[str, Any],
+) -> dict[str, object]:
+    source_id = int(target_record["source_record_id"])
+    n = int(overlay_record["n"])
+    row_center = int(gap["center"])
+    witnesses = _int_list(gap["witnesses"])
+    bootstrap_core = set(_int_list(target_record["bootstrap_core"]))
+    outside = set(_int_list(target_record["outside"]))
+    core_witnesses = sorted(set(witnesses) & bootstrap_core)
+    outside_witnesses = sorted(set(witnesses) & outside)
+    activation_deficit = max(0, 3 - len(core_witnesses))
+    support_subsets = _outside_support_subsets(outside_witnesses, activation_deficit)
+    deletion_closures = overlay_record["deletion_closures"]
+    exposures = _deletion_closure_exposures(
+        n=n,
+        row_center=row_center,
+        witnesses=witnesses,
+        deletion_closures=deletion_closures,
+    )
+    exposed_core_vertices = [
+        int(exposure["core_vertex"])
+        for exposure in exposures
+        if exposure["row_exposed_in_closure"]
+    ]
+    support_hits = _support_hits(
+        support_subsets=support_subsets,
+        deletion_closures=deletion_closures,
+        private_pair_records=target_record["private_pair_records"],
+    )
+    ledger_private_pair_hits = [
+        hit for hit in support_hits if bool(hit["ledger_private_pair_hit"])
+    ]
+    center_private_core_vertices = [
+        int(closure["core_vertex"])
+        for closure in deletion_closures
+        if row_center in set(_int_list(closure["private_halo"]))
+    ]
+    pressure_class = _pressure_class(
+        exposed_deletion_core_vertices=exposed_core_vertices,
+        activation_deficit_from_core=activation_deficit,
+    )
+    return {
+        "source_record_id": source_id,
+        "classification_assignment_id": target_record["classification_assignment_id"],
+        "row_center": row_center,
+        "roles": gap["roles"],
+        "witnesses": witnesses,
+        "bootstrap_core_witnesses": core_witnesses,
+        "outside_witnesses": outside_witnesses,
+        "bootstrap_core_witness_count": len(core_witnesses),
+        "activation_deficit_from_bootstrap_core": activation_deficit,
+        "outside_support_subsets": support_subsets,
+        "outside_support_kind": (
+            "core_sufficient"
+            if activation_deficit == 0
+            else f"outside_{activation_deficit}_set"
+        ),
+        "support_hits": support_hits,
+        "ledger_private_pair_support_hits": ledger_private_pair_hits,
+        "ledger_private_pair_support_hit_count": len(ledger_private_pair_hits),
+        "deletion_closure_exposures": exposures,
+        "exposed_deletion_core_vertices": exposed_core_vertices,
+        "max_witness_count_in_deletion_closure": max(
+            int(exposure["witness_count_in_closure"]) for exposure in exposures
+        ),
+        "row_center_private_core_vertices": sorted(center_private_core_vertices),
+        "row_center_private_in_all_deletion_closures": len(center_private_core_vertices)
+        == len(deletion_closures),
+        "pressure_class": pressure_class,
+    }
+
+
+def build_t12_row_pressure_payload() -> dict[str, object]:
+    """Return the deterministic bootstrap/T12 row-pressure payload."""
+
+    targets = build_t12_forcing_targets_payload()
+    overlay = build_overlay_payload()
+    overlay_by_source = {
+        int(record["source_record_id"]): record for record in overlay["records"]
+    }
+
+    row_records = []
+    for target_record in targets["records"]:
+        source_id = int(target_record["source_record_id"])
+        overlay_record = overlay_by_source[source_id]
+        for gap in target_record["row_gaps"]:
+            row_records.append(
+                _row_pressure_record(
+                    target_record=target_record,
+                    gap=gap,
+                    overlay_record=overlay_record,
+                )
+            )
+    row_records.sort(key=lambda record: (int(record["source_record_id"]), int(record["row_center"])))
+
+    pressure_counts = Counter(str(record["pressure_class"]) for record in row_records)
+    deficit_counts = Counter(
+        int(record["activation_deficit_from_bootstrap_core"]) for record in row_records
+    )
+    support_kind_counts = Counter(str(record["outside_support_kind"]) for record in row_records)
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    exposed_rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    private_center_rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    ledger_pair_support_rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    for record in row_records:
+        source_id = int(record["source_record_id"])
+        row_center = int(record["row_center"])
+        rows_by_source[source_id].append(row_center)
+        if record["exposed_deletion_core_vertices"]:
+            exposed_rows_by_source[source_id].append(row_center)
+        if record["row_center_private_in_all_deletion_closures"]:
+            private_center_rows_by_source[source_id].append(row_center)
+        if record["ledger_private_pair_support_hits"]:
+            ledger_pair_support_rows_by_source[source_id].append(row_center)
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This classifies fixed selected-row gaps; it does not prove the row centers are forced.",
+            "Private-halo containment and ledger private-pair hits are bookkeeping contacts, not Euclidean certificates.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_source_ids": [int(record["source_record_id"]) for record in targets["records"]],
+            "row_gap_record_count": len(row_records),
+            "row_gap_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "pressure_class_counts": _json_counter(pressure_counts),
+            "activation_deficit_counts": _json_counter(deficit_counts),
+            "outside_support_kind_counts": _json_counter(support_kind_counts),
+            "deletion_closure_exposed_row_count": sum(
+                1 for record in row_records if record["exposed_deletion_core_vertices"]
+            ),
+            "row_center_private_in_all_deletions_count": sum(
+                1 for record in row_records if record["row_center_private_in_all_deletion_closures"]
+            ),
+            "ledger_private_pair_support_row_count": sum(
+                1 for record in row_records if record["ledger_private_pair_support_hits"]
+            ),
+            "exposed_rows_by_source_id": {
+                str(source_id): centers
+                for source_id, centers in sorted(exposed_rows_by_source.items())
+            },
+            "private_center_rows_by_source_id": {
+                str(source_id): centers
+                for source_id, centers in sorted(private_center_rows_by_source.items())
+            },
+            "ledger_private_pair_support_rows_by_source_id": {
+                str(source_id): centers
+                for source_id, centers in sorted(ledger_pair_support_rows_by_source.items())
+            },
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can closure-exposed rows, one-outside-label rows, and the "
+                "single outside-pair row be forced from genuine rich-class "
+                "geometry rather than fixed selected-row bookkeeping?"
+            ),
+        },
+        "row_records": row_records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_forcing_targets.json",
+                "role": "missing T12/F16 row centers and direct cycle-pair contacts",
+                "schema": targets.get("schema"),
+                "status": targets.get("status"),
+                "trust": targets.get("trust"),
+            },
+            {
+                "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+                "role": "bootstrap deletion closures and source overlay records",
+                "schema": overlay.get("schema"),
+                "status": overlay.get("status"),
+                "trust": overlay.get("trust"),
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_row_pressure.py",
+            "command": "python scripts/check_bootstrap_t12_row_pressure.py --write --assert-expected",
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the row-pressure diagnostic."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 row-pressure schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 row-pressure status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_source_ids": [81, 151],
+        "row_gap_record_count": 6,
+        "row_gap_centers_by_source_id": {"81": [3, 8], "151": [5, 6, 7, 8]},
+        "pressure_class_counts": {
+            "ALREADY_PRESENT_IN_A_DELETION_CLOSURE": 2,
+            "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 3,
+            "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER": 1,
+        },
+        "activation_deficit_counts": {"0": 2, "1": 3, "2": 1},
+        "outside_support_kind_counts": {
+            "core_sufficient": 2,
+            "outside_1_set": 3,
+            "outside_2_set": 1,
+        },
+        "deletion_closure_exposed_row_count": 2,
+        "row_center_private_in_all_deletions_count": 4,
+        "ledger_private_pair_support_row_count": 1,
+        "exposed_rows_by_source_id": {"81": [3], "151": [7]},
+        "private_center_rows_by_source_id": {"81": [8], "151": [5, 6, 8]},
+        "ledger_private_pair_support_rows_by_source_id": {"151": [6]},
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("row_records")
+    if not isinstance(records, list):
+        raise AssertionError("row_records must be a list")
+    expected_records = {
+        (81, 3): {
+            "bootstrap_core_witnesses": [0, 1, 4],
+            "activation_deficit_from_bootstrap_core": 0,
+            "exposed_deletion_core_vertices": [2],
+            "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+        },
+        (81, 8): {
+            "bootstrap_core_witnesses": [0, 2],
+            "outside_support_subsets": [[5], [6]],
+            "activation_deficit_from_bootstrap_core": 1,
+            "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+        },
+        (151, 5): {
+            "bootstrap_core_witnesses": [2, 4],
+            "outside_support_subsets": [[7], [8]],
+            "activation_deficit_from_bootstrap_core": 1,
+            "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+        },
+        (151, 6): {
+            "bootstrap_core_witnesses": [0],
+            "outside_support_subsets": [[3, 5], [3, 8], [5, 8]],
+            "activation_deficit_from_bootstrap_core": 2,
+            "ledger_private_pair_support_hit_count": 2,
+            "pressure_class": "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER",
+        },
+        (151, 7): {
+            "bootstrap_core_witnesses": [0, 1, 4],
+            "activation_deficit_from_bootstrap_core": 0,
+            "exposed_deletion_core_vertices": [2],
+            "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+        },
+        (151, 8): {
+            "bootstrap_core_witnesses": [1, 2],
+            "outside_support_subsets": [[5], [7]],
+            "activation_deficit_from_bootstrap_core": 1,
+            "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+        },
+    }
+    by_key = {
+        (int(record["source_record_id"]), int(record["row_center"])): record
+        for record in records
+    }
+    if set(by_key) != set(expected_records):
+        raise AssertionError("unexpected row-pressure record keys")
+    for key, expected in expected_records.items():
+        record = by_key[key]
+        for field, expected_value in expected.items():
+            if record.get(field) != expected_value:
+                raise AssertionError(
+                    f"row-pressure {key} {field} is {record.get(field)!r}, expected {expected_value!r}"
+                )

--- a/tests/test_bootstrap_t12_row_pressure.py
+++ b/tests/test_bootstrap_t12_row_pressure.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_t12_row_pressure import (
+    assert_expected_payload,
+    build_t12_row_pressure_payload,
+)
+
+
+def test_bootstrap_t12_row_pressure_expected_payload() -> None:
+    payload = build_t12_row_pressure_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["row_gap_record_count"] == 6
+    assert summary["activation_deficit_counts"] == {"0": 2, "1": 3, "2": 1}
+    assert summary["forcing_target_status"] == "OPEN_TARGET_NOT_PROVED"
+
+
+def test_bootstrap_t12_row_pressure_classifies_rows() -> None:
+    payload = build_t12_row_pressure_payload()
+    by_key = {
+        (record["source_record_id"], record["row_center"]): record
+        for record in payload["row_records"]
+    }
+
+    assert by_key[(81, 3)]["pressure_class"] == "ALREADY_PRESENT_IN_A_DELETION_CLOSURE"
+    assert by_key[(151, 7)]["pressure_class"] == "ALREADY_PRESENT_IN_A_DELETION_CLOSURE"
+    assert by_key[(151, 6)]["pressure_class"] == "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER"
+    assert by_key[(151, 6)]["ledger_private_pair_support_hit_count"] == 2
+
+
+def test_bootstrap_t12_row_pressure_private_center_rows() -> None:
+    payload = build_t12_row_pressure_payload()
+    by_key = {
+        (record["source_record_id"], record["row_center"]): record
+        for record in payload["row_records"]
+    }
+
+    assert by_key[(81, 8)]["row_center_private_in_all_deletion_closures"]
+    assert by_key[(151, 5)]["row_center_private_in_all_deletion_closures"]
+    assert by_key[(151, 6)]["row_center_private_in_all_deletion_closures"]
+    assert by_key[(151, 8)]["row_center_private_in_all_deletion_closures"]
+    assert not by_key[(81, 3)]["row_center_private_in_all_deletion_closures"]
+    assert not by_key[(151, 7)]["row_center_private_in_all_deletion_closures"]
+
+
+def test_bootstrap_t12_row_pressure_expected_payload_rejects_drift() -> None:
+    payload = build_t12_row_pressure_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["pressure_class_counts"] = {"NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER": 6}
+
+    with pytest.raises(AssertionError, match="pressure_class_counts"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a checked bootstrap/T12 row-pressure diagnostic derived from the T12 forcing-target and overlay artifacts
- classify the six missing T12/F16 row centers by bootstrap-core activation deficit, deletion-closure exposure, private-center status, and private-pair ledger support
- document the result as proof-mining target bookkeeping only, with no n=9, bridge, counterexample, or global-status promotion

## Key diagnostic split

- 2 rows are already exposed in a deletion closure (`81:3`, `151:7`)
- 3 rows need one outside label while the row center remains private (`81:8`, `151:5`, `151:8`)
- 1 row needs an outside pair and has partial private-pair ledger support (`151:6`)

## Validation

- `python scripts/check_bootstrap_t12_row_pressure.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_t12_row_pressure.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check origin/main`
- `python -m ruff check .`
- `python -m pytest -q` (`610 passed, 278 deselected`)
- GitHub Actions `tests` passed on Python 3.10, 3.11, and 3.12; artifact-review skipped by workflow rules

## Review notes

This remains a derived fixed-row diagnostic. It records `OPEN_TARGET_NOT_PROVED` and does not claim that any missing row center is forced by genuine geometry.