### PR TITLE
[codex] Add endpoint-control spine-pocket order checker

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -240,6 +240,25 @@ The obstruction is still local and fixed-order only. It does not show that
 every full-row extension of the endpoint-control fragile rows has such a
 certificate, and it does not prove endpoint control.
 
+The same fixed survivor has a small crossing-only cyclic-order frontier:
+
+```bash
+python scripts/check_endpoint_control_survivor_spine_pocket_orders.py --assert-expected --json
+```
+
+The checker recomputes the `17` two-overlap crossing constraints for this
+survivor and enumerates all cyclic orders satisfying them, modulo rotation and
+reversal. It visits `38` search nodes and finds exactly five normalized
+orders, all with spine form
+
+```text
+0,1,2,3, [4,5,6,7 pocket], 8,9,10.
+```
+
+This is not an obstruction by itself. It only says that any realization of
+this fixed full-row survivor must lie in one of those five crossing-compatible
+cyclic orders before any Kalmanson or metric-order certificate is applied.
+
 ### Bounded block-6 row-Ptolemy audit
 
 The following bounded exact audit tests this gate on the two-block fragile

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,179 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 679 - Endpoint-Control Spine-Pocket Crossing Frontier
+
+### Mathematical Subquestion
+
+Cycle 676 killed the fixed endpoint-control survivor in the natural cyclic
+order by a Kalmanson quotient-cone certificate. A parallel side investigation
+in Cycle 678 suggested that the same survivor has only five cyclic orders
+compatible with the necessary two-overlap crossing constraints. This cycle
+asked:
+
+```text
+Can the crossing-only spine-pocket order frontier for the fixed endpoint-
+control survivor be replayed by a small exact checker?
+```
+
+This is a finite fixed-survivor benchmark, not an all-extension endpoint-
+control argument.
+
+### Definitions and Assumptions
+
+Use the fixed Cycle 674 full selected-row extension on labels `0,...,10`:
+
+```text
+0  -> {1,3,5,6}
+1  -> {0,2,7,9}
+2  -> {1,3,4,10}
+3  -> {2,4,5,7}
+4  -> {1,6,7,8}
+5  -> {0,2,3,6}
+6  -> {0,4,8,10}
+7  -> {1,2,4,9}
+8  -> {3,7,9,10}
+9  -> {2,5,8,10}
+10 -> {0,1,8,9}
+```
+
+For two rows `i,j` with `|S_i cap S_j|=2`, define
+
+```text
+phi({i,j}) = S_i cap S_j.
+```
+
+The necessary two-overlap crossing condition for a strictly convex selected-
+witness realization is that the source chord `{i,j}` crosses the witness
+chord `phi({i,j})` in the cyclic order.
+
+### Result Status
+
+Exact fixed-survivor crossing-only frontier:
+**Endpoint-Control Spine-Pocket Crossing Frontier**.
+
+### Argument Or Obstruction
+
+The checker
+`scripts/check_endpoint_control_survivor_spine_pocket_orders.py` recomputes
+the fixed survivor's `phi_map` using the shared incidence utilities. It finds
+exactly these `17` two-overlap crossing constraints:
+
+```text
+(0,2)->(1,3), (0,4)->(1,6), (0,5)->(3,6),
+(1,3)->(2,7), (1,5)->(0,2), (1,7)->(2,9),
+(1,8)->(7,9), (1,10)->(0,9), (2,6)->(4,10),
+(2,7)->(1,4), (2,8)->(3,10), (3,7)->(2,4),
+(3,9)->(2,5), (4,10)->(1,8), (6,9)->(8,10),
+(6,10)->(0,8), (7,10)->(1,9).
+```
+
+It then performs a normalized cyclic-order insertion search. The first
+crossing constraint fixes the initial four labels up to rotation and reversal
+as either `[0,1,2,3]` or `[0,3,2,1]`. At each step the search inserts the
+unplaced label touching the most nearly completed constraints, and it prunes
+only when a completed crossing constraint fails. The checker visits `38`
+nodes and finds exactly five normalized orders:
+
+```text
+0,1,2,3,4,5,6,7,8,9,10
+0,1,2,3,4,5,7,6,8,9,10
+0,1,2,3,4,7,5,6,8,9,10
+0,1,2,3,5,4,6,7,8,9,10
+0,1,2,3,5,4,7,6,8,9,10
+```
+
+Thus every cyclic order compatible with these crossing constraints has the
+spine-pocket form
+
+```text
+0,1,2,3, [pocket on {4,5,6,7}], 8,9,10,
+```
+
+with forced pocket relations `4<6`, `4<7`, and `5<6`.
+
+### Exact Scope
+
+This is exact only for the fixed Cycle 674 endpoint-control survivor and only
+for the necessary crossing-bisector constraints arising from two-overlap row
+pairs. It is not a metric realization certificate, not a Kalmanson obstruction
+for all five orders, not an all-extension endpoint-control proof, not a
+counterexample, and not a proof of Erdos Problem #97.
+
+It does strengthen the fixed-survivor route: the next metric-order check can
+target five crossing-compatible orders instead of an unstructured cyclic-order
+space.
+
+### Files Changed
+
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_endpoint_control_survivor_spine_pocket_orders.py`
+- `tests/test_endpoint_control_survivor_spine_pocket_orders.py`
+
+### Effect On The Attack
+
+The endpoint-control survivor now has four exact layers:
+
+1. Row-Ptolemy product-cancellation does not kill it.
+2. Quotient-level row-Ptolemy equations are feasible.
+3. Natural-order Kalmanson quotient-cone constraints kill it.
+4. Crossing constraints reduce the remaining fixed-survivor cyclic-order
+   frontier to five spine-pocket orders.
+
+The immediate finite route is to replay or find Kalmanson quotient-cone
+certificates for the other four spine-pocket orders. If all five are killed,
+the fixed survivor is ruled out across every cyclic order satisfying the
+two-overlap crossing constraints, still without proving endpoint control.
+
+### Next Lead
+
+Add a five-order Kalmanson quotient-cone certificate checker for this fixed
+survivor. The natural-order certificate from Cycle 676 already covers the
+first order. The side investigation reported candidate small certificates for
+the remaining three nontrivial pocket orders, while one pocket order may reuse
+the natural-order certificate after relabeling or reversal.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-679`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-679`.
+- The branch was started from `origin/main` at commit
+  `423bff94e25cbb08dbd978e7c23dec7945d04f55`, after PR #420 merged Cycle
+  678.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_endpoint_control_survivor_spine_pocket_orders.py
+  --assert-expected --json`: passed. It verified `17` crossing constraints,
+  `5` normalized crossing-compatible orders, `38` search nodes, and exact
+  match to the expected spine-pocket frontier.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q
+  tests/test_endpoint_control_survivor_spine_pocket_orders.py`: passed, `4`
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `614 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 678 - Four-Hit Rolle Normal-Incidence Lemma
 
 ### Mathematical Subquestion

--- a/scripts/check_endpoint_control_survivor_spine_pocket_orders.py
+++ b/scripts/check_endpoint_control_survivor_spine_pocket_orders.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Replay the crossing-only spine-pocket orders for the endpoint survivor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.incidence_filters import Chord, chords_cross_in_order, phi_map  # noqa: E402
+from erdos97.sparse_frontier import normalize_cyclic_order  # noqa: E402
+
+Constraint = tuple[Chord, Chord]
+
+SURVIVOR_ROWS: list[list[int]] = [
+    [1, 3, 5, 6],
+    [0, 2, 7, 9],
+    [1, 3, 4, 10],
+    [2, 4, 5, 7],
+    [1, 6, 7, 8],
+    [0, 2, 3, 6],
+    [0, 4, 8, 10],
+    [1, 2, 4, 9],
+    [3, 7, 9, 10],
+    [2, 5, 8, 10],
+    [0, 1, 8, 9],
+]
+
+EXPECTED_CONSTRAINTS: list[Constraint] = [
+    ((0, 2), (1, 3)),
+    ((0, 4), (1, 6)),
+    ((0, 5), (3, 6)),
+    ((1, 3), (2, 7)),
+    ((1, 5), (0, 2)),
+    ((1, 7), (2, 9)),
+    ((1, 8), (7, 9)),
+    ((1, 10), (0, 9)),
+    ((2, 6), (4, 10)),
+    ((2, 7), (1, 4)),
+    ((2, 8), (3, 10)),
+    ((3, 7), (2, 4)),
+    ((3, 9), (2, 5)),
+    ((4, 10), (1, 8)),
+    ((6, 9), (8, 10)),
+    ((6, 10), (0, 8)),
+    ((7, 10), (1, 9)),
+]
+
+EXPECTED_ORDERS: list[list[int]] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    [0, 1, 2, 3, 4, 5, 7, 6, 8, 9, 10],
+    [0, 1, 2, 3, 4, 7, 5, 6, 8, 9, 10],
+    [0, 1, 2, 3, 5, 4, 6, 7, 8, 9, 10],
+    [0, 1, 2, 3, 5, 4, 7, 6, 8, 9, 10],
+]
+
+
+def _json_chord(chord: Chord) -> list[int]:
+    return [int(chord[0]), int(chord[1])]
+
+
+def _json_constraint(constraint: Constraint) -> dict[str, list[int]]:
+    return {
+        "source": _json_chord(constraint[0]),
+        "target": _json_chord(constraint[1]),
+    }
+
+
+def crossing_constraints() -> list[Constraint]:
+    """Return the fixed survivor's two-overlap crossing constraints."""
+    return sorted(phi_map(SURVIVOR_ROWS).items())
+
+
+def enumerate_crossing_orders() -> tuple[list[list[int]], int]:
+    """Return all normalized crossing-compatible orders and search-node count."""
+    constraints = crossing_constraints()
+    n = len(SURVIVOR_ROWS)
+    labels = set(range(n))
+    constraint_label_sets = [
+        set(source) | set(target) for source, target in constraints
+    ]
+    label_to_constraints: dict[int, list[int]] = {label: [] for label in labels}
+    for idx, constraint_labels in enumerate(constraint_label_sets):
+        for label in constraint_labels:
+            label_to_constraints[label].append(idx)
+
+    nodes_visited = 0
+    orders: set[tuple[int, ...]] = set()
+
+    def completed_failure(
+        order: Sequence[int],
+        placed: set[int],
+        affected_labels: set[int] | None = None,
+    ) -> bool:
+        if affected_labels is None:
+            candidate_idxs = range(len(constraints))
+        else:
+            idxs: set[int] = set()
+            for label in affected_labels:
+                idxs.update(label_to_constraints[label])
+            candidate_idxs = sorted(idxs)
+        for idx in candidate_idxs:
+            if constraint_label_sets[idx] <= placed:
+                source, target = constraints[idx]
+                if not chords_cross_in_order(source, target, order):
+                    return True
+        return False
+
+    def choose_label(placed: set[int]) -> int:
+        def score(label: int) -> tuple[int, int, int, int, int]:
+            touches = [
+                len(constraint_label_sets[idx] & placed)
+                for idx in label_to_constraints[label]
+            ]
+            return (
+                sum(count == 3 for count in touches),
+                sum(count == 2 for count in touches),
+                sum(count == 1 for count in touches),
+                len(label_to_constraints[label]),
+                -label,
+            )
+
+        return max(labels - placed, key=score)
+
+    def search(order: list[int], placed: set[int]) -> None:
+        nonlocal nodes_visited
+        nodes_visited += 1
+        if len(placed) == n:
+            if not completed_failure(order, placed):
+                orders.add(tuple(normalize_cyclic_order(order)))
+            return
+
+        label = choose_label(placed)
+        for position in range(1, len(order) + 1):
+            candidate_order = order[:position] + [label] + order[position:]
+            candidate_placed = placed | {label}
+            if not completed_failure(candidate_order, candidate_placed, {label}):
+                search(candidate_order, candidate_placed)
+
+    for initial_order in ([0, 1, 2, 3], [0, 3, 2, 1]):
+        search(list(initial_order), set(initial_order))
+
+    return [list(order) for order in sorted(orders)], nodes_visited
+
+
+def audit() -> dict[str, object]:
+    constraints = crossing_constraints()
+    orders, nodes_visited = enumerate_crossing_orders()
+    return {
+        "type": "endpoint_control_survivor_spine_pocket_order_audit",
+        "schema": "erdos97.endpoint_control_survivor_spine_pocket_order_audit.v1",
+        "status": "EXACT_CROSSING_ONLY_FRONTIER_FOR_FIXED_SURVIVOR",
+        "claim_strength": (
+            "Exact crossing-only cyclic-order frontier for the fixed Cycle 674 "
+            "endpoint-control survivor; not an obstruction, endpoint-control "
+            "proof, or Erdos97 proof."
+        ),
+        "pattern": {
+            "name": "endpoint_control_survivor_cycle_674",
+            "n": len(SURVIVOR_ROWS),
+            "selected_rows": SURVIVOR_ROWS,
+        },
+        "constraints": [_json_constraint(constraint) for constraint in constraints],
+        "constraint_count": len(constraints),
+        "orders": orders,
+        "order_count": len(orders),
+        "nodes_visited": nodes_visited,
+        "expected_constraints_match": constraints == EXPECTED_CONSTRAINTS,
+        "expected_orders_match": orders == EXPECTED_ORDERS,
+        "spine_pocket_summary": {
+            "left_spine": [0, 1, 2, 3],
+            "pocket": [4, 5, 6, 7],
+            "right_spine": [8, 9, 10],
+            "forced_pocket_relations": [[4, 6], [4, 7], [5, 6]],
+        },
+        "next_metric_gate": (
+            "Replay a Kalmanson quotient-cone certificate for each of the five "
+            "crossing-compatible orders."
+        ),
+    }
+
+
+def assert_expected(payload: dict[str, object]) -> None:
+    if payload["constraint_count"] != 17:
+        raise AssertionError("unexpected crossing-constraint count")
+    if payload["order_count"] != 5:
+        raise AssertionError("unexpected crossing-compatible order count")
+    if payload["nodes_visited"] != 38:
+        raise AssertionError("unexpected search-node count")
+    if payload["expected_constraints_match"] is not True:
+        raise AssertionError("unexpected crossing constraints")
+    if payload["expected_orders_match"] is not True:
+        raise AssertionError("unexpected crossing-compatible orders")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit()
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("endpoint-control survivor spine-pocket crossing-order audit")
+        print(f"crossing constraints: {payload['constraint_count']}")
+        print(f"crossing-compatible orders: {payload['order_count']}")
+        print(f"nodes visited: {payload['nodes_visited']}")
+        print(f"expected constraints match: {payload['expected_constraints_match']}")
+        print(f"expected orders match: {payload['expected_orders_match']}")
+        if args.assert_expected:
+            print("OK: expected spine-pocket frontier verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_endpoint_control_survivor_spine_pocket_orders.py
+++ b/tests/test_endpoint_control_survivor_spine_pocket_orders.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_endpoint_control_survivor_spine_pocket_orders import (
+    EXPECTED_CONSTRAINTS,
+    EXPECTED_ORDERS,
+    assert_expected,
+    audit,
+    crossing_constraints,
+    enumerate_crossing_orders,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_endpoint_control_survivor_spine_pocket_constraints() -> None:
+    assert crossing_constraints() == EXPECTED_CONSTRAINTS
+
+
+def test_endpoint_control_survivor_spine_pocket_orders() -> None:
+    orders, nodes_visited = enumerate_crossing_orders()
+
+    assert orders == EXPECTED_ORDERS
+    assert nodes_visited > 0
+
+
+def test_endpoint_control_survivor_spine_pocket_audit() -> None:
+    payload = audit()
+
+    assert payload["constraint_count"] == 17
+    assert payload["order_count"] == 5
+    assert payload["nodes_visited"] == 38
+    assert payload["expected_constraints_match"] is True
+    assert payload["expected_orders_match"] is True
+    assert_expected(payload)
+
+
+def test_endpoint_control_survivor_spine_pocket_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_endpoint_control_survivor_spine_pocket_orders.py",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "crossing constraints: 17" in result.stdout
+    assert "crossing-compatible orders: 5" in result.stdout
+    assert "nodes visited: 38" in result.stdout
+    assert "OK: expected spine-pocket frontier verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

Records Cycle 679 for the fixed endpoint-control survivor. The new checker recomputes the 17 two-overlap crossing constraints for the fixed Cycle 674 survivor and enumerates all cyclic orders satisfying those constraints modulo rotation and reversal.

It finds exactly five normalized crossing-compatible orders, all with spine-pocket form `0,1,2,3,[4,5,6,7 pocket],8,9,10`, after visiting 38 search nodes.

This is a crossing-only frontier for one fixed full selected-row extension. It is not a metric realization certificate, not a Kalmanson obstruction for all five orders, not an endpoint-control proof, not a proof of Erdos Problem #97, and not a counterexample.

## Files changed

- `scripts/check_endpoint_control_survivor_spine_pocket_orders.py`: exact crossing-only replay checker for the fixed survivor.
- `tests/test_endpoint_control_survivor_spine_pocket_orders.py`: focused checker and CLI tests.
- `docs/minimal-fragile-cover-bridge.md`: records the crossing-only frontier next to the existing endpoint-control survivor layers.
- `reports/codex_goal_erdos97_log.md`: adds the dated Cycle 679 research-log entry.

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_endpoint_control_survivor_spine_pocket_orders.py --assert-expected --json`: passed
  - crossing constraints: 17
  - normalized orders: 5
  - search nodes: 38
  - expected frontier match: true
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q tests/test_endpoint_control_survivor_spine_pocket_orders.py`: passed, `4 passed`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`: passed
- `git diff --check`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`: passed
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`: passed, `614 passed, 278 deselected`

## Remaining limitations

- Fixed survivor only.
- Crossing constraints only; no metric or Kalmanson obstruction is claimed for all five orders.
- Does not prove endpoint control or Erdos Problem #97.
- The next metric gate is a five-order Kalmanson quotient-cone certificate replay.