### PR TITLE
[codex] add endpoint-control spine-pocket Kalmanson closure

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -205,6 +205,27 @@ order. It is not an all-extension endpoint-control proof, not a Euclidean
 realizability theorem for the abstract fragile rows, and not a proof of
 Erdos #97.
 
+### Crossing-compatible Kalmanson/Farkas obstruction for the endpoint-control survivor
+
+Status: `EXACT_OBSTRUCTION` for one fixed selected-witness extension across
+its five crossing-compatible cyclic orders only.
+
+For the same endpoint-control survivor, the crossing-only frontier checker in
+`scripts/check_endpoint_control_survivor_spine_pocket_orders.py` proves that
+the necessary two-overlap crossing constraints leave exactly five normalized
+cyclic orders. The checker
+`scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py` then
+replays a positive integer Kalmanson quotient-cone certificate for each of the
+five orders. The strict-row counts are `[23, 12, 16, 10, 12]`, the weight sums
+are `[541, 51, 79, 27, 38]`, and each combined coefficient vector reduces
+exactly to zero across `25` selected-distance quotient classes.
+
+Check it with
+`python scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py --assert-expected --json`.
+This closes the fixed survivor at the crossing-compatible Kalmanson level. It
+does not rule out other full selected-row extensions of the same fragile rows,
+does not prove endpoint control, and is not a proof of Erdos #97.
+
 ## Lemmas
 
 ### Circle-intersection cap

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -259,6 +259,26 @@ This is not an obstruction by itself. It only says that any realization of
 this fixed full-row survivor must lie in one of those five crossing-compatible
 cyclic orders before any Kalmanson or metric-order certificate is applied.
 
+The five crossing-compatible orders are all rejected by an exact Kalmanson
+quotient-cone replay:
+
+```bash
+python scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py --assert-expected --json
+```
+
+For the five orders above, the checker verifies positive integer combinations
+of strict Kalmanson inequalities with strict-row counts
+`[23, 12, 16, 10, 12]`, weight sums `[541, 51, 79, 27, 38]`, and maximum
+weights `[73, 11, 15, 6, 10]`. In each order, the combined coefficient vector
+reduces exactly to zero across the survivor's `25` selected-distance quotient
+classes. Therefore this fixed full-row survivor is impossible in every cyclic
+order satisfying its necessary two-overlap crossing constraints.
+
+This still has the same fixed-survivor quantifier. It is not an obstruction
+for every full-row extension of the endpoint-control fragile rows, not an
+endpoint-control proof, not a Euclidean non-realizability theorem for the
+abstract fragile rows, and not a proof of Erdos #97.
+
 ### Bounded block-6 row-Ptolemy audit
 
 The following bounded exact audit tests this gate on the two-block fragile

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,159 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 680 - Endpoint-Control Spine-Pocket Kalmanson Closure
+
+### Mathematical Subquestion
+
+Do all five crossing-compatible spine-pocket cyclic orders for the fixed
+Cycle 674 endpoint-control survivor admit exact Kalmanson quotient-cone
+certificates?
+
+This asks only about the fixed full selected-row survivor from Cycle 674. It
+does not quantify over all full-row extensions of the endpoint-control fragile
+rows.
+
+### Definitions and Assumptions
+
+Use the fixed selected-row survivor on labels `0,...,10`:
+
+```text
+0  -> {1,3,5,6}
+1  -> {0,2,7,9}
+2  -> {1,3,4,10}
+3  -> {2,4,5,7}
+4  -> {1,6,7,8}
+5  -> {0,2,3,6}
+6  -> {0,4,8,10}
+7  -> {1,2,4,9}
+8  -> {3,7,9,10}
+9  -> {2,5,8,10}
+10 -> {0,1,8,9}
+```
+
+Use the five normalized cyclic orders found in Cycle 679 by enforcing every
+two-overlap crossing constraint for this survivor. A Kalmanson quotient-cone
+certificate is a positive integer linear combination of strict Kalmanson
+distance inequalities whose coefficient vector becomes exactly zero after
+quotienting by the selected-distance equalities of the survivor. Summing such
+a certificate gives `0 > 0`.
+
+### Result Status
+
+Exact obstruction for a fixed survivor across its crossing-compatible cyclic
+orders:
+**Endpoint-Control Spine-Pocket Kalmanson Closure**.
+
+### Argument Or Obstruction
+
+The checker
+`scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py` imports
+the Cycle 679 crossing-order frontier and replays one certificate for each of
+the five orders. Each certificate is verified by
+`check_quotient_cone_certificate`, so the replay checks the selected-distance
+quotient classes, strict Kalmanson rows, positive integer weights, and exact
+zero-sum condition.
+
+The verified certificate summary is:
+
+```text
+order  cyclic order                    strict rows  weight sum  max weight
+0      0,1,2,3,4,5,6,7,8,9,10          23           541         73
+1      0,1,2,3,4,5,7,6,8,9,10          12           51          11
+2      0,1,2,3,4,7,5,6,8,9,10          16           79          15
+3      0,1,2,3,5,4,6,7,8,9,10          10           27          6
+4      0,1,2,3,5,4,7,6,8,9,10          12           38          10
+```
+
+All five certificates have `25` distance classes, exact zero-sum `true`, and
+combined nonzero coefficient count `0`. Thus the fixed Cycle 674 full
+selected-row survivor is impossible in every cyclic order satisfying its
+necessary two-overlap crossing constraints.
+
+### Exact Scope
+
+This is an exact finite obstruction for one fixed full selected-row extension
+only. It uses the five-order crossing frontier from Cycle 679, so it covers all
+cyclic orders satisfying the necessary crossing constraints for that fixed
+survivor. It does not prove that every extension of the endpoint-control
+fragile rows falls to a Kalmanson certificate, does not prove endpoint control,
+does not give a Euclidean realization theorem, does not produce a
+counterexample, and does not prove Erdos Problem #97.
+
+### Files Changed
+
+- `docs/claims.md`
+- `docs/minimal-fragile-cover-bridge.md`
+- `reports/codex_goal_erdos97_log.md`
+- `scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py`
+- `tests/test_endpoint_control_survivor_spine_pocket_kalmanson.py`
+
+### Effect On The Attack
+
+The fixed endpoint-control survivor is now closed at the crossing-compatible
+Kalmanson level. This is genuine progress on the benchmark: after row-Ptolemy
+product-cancellation failed and quotient-Ptolemy feasibility survived, the
+metric-order layer rejects every crossing-compatible cyclic order for this
+particular full selected-row extension.
+
+The endpoint-control bridge remains open because a minimal counterexample
+would only require some full selected-row extension of the fragile rows, not
+this one extension. The next proof route must either extend the closure to all
+full selected-row extensions of the endpoint-control fragile rows, or extract a
+structural lemma explaining why any such extension reduces to a similar
+Kalmanson quotient-cone contradiction.
+
+### Next Lead
+
+Try to lift this from one full selected-row survivor to the endpoint-control
+fragile rows themselves. A useful intermediate target is a reusable template
+for the five certificates: identify common quotient classes or row families
+that are forced by the fragile rows plus crossing constraints, rather than by
+the arbitrary non-fragile row choices.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-680`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-680`.
+- The branch was started from `origin/main` at commit
+  `79e07bd37eba1a690fe792222ce365b8fbf59b3d`, after PR #421 merged Cycle
+  679.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- Multiple parallel agents were used read-only for narrow review and scope
+  checks; no agent edited files.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py
+  --assert-expected --json`: passed. It verified `5` crossing-compatible
+  orders, `5` obstructed orders, strict-row counts `[23, 12, 16, 10, 12]`,
+  weight sums `[541, 51, 79, 27, 38]`, and exact zero-sum certificates across
+  `25` selected-distance quotient classes.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q
+  tests/test_endpoint_control_survivor_spine_pocket_kalmanson.py`: passed,
+  `3` passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `617 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 679 - Endpoint-Control Spine-Pocket Crossing Frontier
 
 ### Mathematical Subquestion

--- a/scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py
+++ b/scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Replay Kalmanson certificates for the endpoint survivor spine-pocket orders."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from erdos97.quotient_cone import check_quotient_cone_certificate  # noqa: E402
+from scripts.check_endpoint_control_survivor_spine_pocket_orders import (  # noqa: E402
+    EXPECTED_ORDERS,
+    SURVIVOR_ROWS,
+    assert_expected as assert_spine_pocket_expected,
+    audit as spine_pocket_audit,
+)
+
+
+def row(kind: str, quad: list[int], weight: int) -> dict[str, object]:
+    """Return one weighted Kalmanson strict-row item."""
+    return {
+        "source": "kalmanson",
+        "kind": kind,
+        "quad": quad,
+        "weight": weight,
+    }
+
+
+K1 = "K1_diag_gt_sides"
+K2 = "K2_diag_gt_other"
+
+STRICT_ROWS_BY_ORDER: list[list[dict[str, object]]] = [
+    [
+        row(K2, [0, 1, 2, 4], 20),
+        row(K2, [0, 1, 6, 8], 55),
+        row(K2, [0, 2, 4, 9], 10),
+        row(K1, [0, 2, 7, 9], 20),
+        row(K2, [0, 2, 8, 10], 55),
+        row(K1, [0, 3, 4, 10], 10),
+        row(K2, [0, 3, 6, 10], 4),
+        row(K2, [0, 4, 9, 10], 10),
+        row(K2, [0, 5, 6, 7], 26),
+        row(K1, [0, 5, 7, 10], 6),
+        row(K2, [1, 2, 3, 5], 18),
+        row(K2, [1, 2, 5, 6], 18),
+        row(K1, [1, 3, 7, 9], 18),
+        row(K2, [1, 4, 7, 8], 55),
+        row(K2, [1, 5, 6, 9], 73),
+        row(K1, [2, 6, 8, 9], 18),
+        row(K2, [2, 7, 8, 9], 37),
+        row(K1, [3, 4, 6, 9], 4),
+        row(K2, [3, 5, 8, 9], 32),
+        row(K2, [3, 6, 9, 10], 14),
+        row(K2, [4, 5, 7, 8], 26),
+        row(K1, [4, 7, 9, 10], 6),
+        row(K2, [5, 6, 8, 10], 6),
+    ],
+    [
+        row(K1, [0, 1, 3, 9], 11),
+        row(K1, [0, 1, 9, 10], 2),
+        row(K2, [0, 2, 6, 9], 2),
+        row(K2, [1, 2, 3, 5], 5),
+        row(K1, [1, 3, 4, 10], 5),
+        row(K2, [1, 3, 5, 10], 5),
+        row(K2, [2, 3, 6, 8], 2),
+        row(K2, [2, 4, 8, 10], 2),
+        row(K1, [3, 4, 9, 10], 3),
+        row(K1, [3, 5, 6, 8], 2),
+        row(K2, [3, 5, 8, 9], 2),
+        row(K2, [3, 8, 9, 10], 10),
+    ],
+    [
+        row(K1, [0, 1, 2, 5], 4),
+        row(K1, [0, 2, 4, 7], 4),
+        row(K2, [0, 2, 6, 8], 4),
+        row(K1, [0, 3, 9, 10], 1),
+        row(K1, [0, 4, 6, 9], 4),
+        row(K2, [0, 4, 8, 9], 4),
+        row(K2, [0, 6, 9, 10], 3),
+        row(K2, [1, 2, 4, 6], 4),
+        row(K1, [1, 2, 4, 10], 9),
+        row(K1, [1, 5, 6, 9], 4),
+        row(K2, [2, 4, 7, 8], 15),
+        row(K2, [2, 4, 9, 10], 9),
+        row(K2, [2, 6, 8, 9], 11),
+        row(K2, [3, 4, 8, 9], 1),
+        row(K2, [3, 7, 9, 10], 1),
+        row(K2, [7, 6, 8, 10], 1),
+    ],
+    [
+        row(K2, [0, 1, 2, 4], 3),
+        row(K2, [0, 1, 4, 7], 2),
+        row(K1, [0, 1, 8, 10], 6),
+        row(K1, [0, 2, 5, 10], 3),
+        row(K2, [0, 3, 5, 8], 6),
+        row(K1, [0, 5, 4, 7], 1),
+        row(K2, [0, 5, 7, 9], 1),
+        row(K1, [0, 6, 7, 9], 1),
+        row(K2, [0, 6, 9, 10], 1),
+        row(K2, [1, 5, 9, 10], 3),
+    ],
+    [
+        row(K2, [0, 1, 2, 4], 3),
+        row(K1, [0, 1, 4, 9], 2),
+        row(K1, [0, 1, 8, 10], 10),
+        row(K1, [0, 2, 5, 10], 3),
+        row(K2, [0, 2, 9, 10], 1),
+        row(K2, [0, 3, 5, 8], 10),
+        row(K2, [0, 3, 4, 9], 1),
+        row(K2, [1, 5, 9, 10], 4),
+        row(K2, [3, 4, 6, 9], 1),
+        row(K1, [3, 6, 8, 9], 1),
+        row(K2, [5, 4, 6, 10], 1),
+        row(K2, [4, 6, 9, 10], 1),
+    ],
+]
+
+EXPECTED_STRICT_ROWS = [23, 12, 16, 10, 12]
+EXPECTED_WEIGHT_SUMS = [541, 51, 79, 27, 38]
+EXPECTED_MAX_WEIGHTS = [73, 11, 15, 6, 10]
+
+
+def certificate_for_order(index: int) -> dict[str, object]:
+    """Return the stored certificate for one crossing-compatible order."""
+    strict_rows = STRICT_ROWS_BY_ORDER[index]
+    return {
+        "type": "endpoint_control_survivor_spine_pocket_kalmanson_certificate",
+        "schema": "erdos97.endpoint_control_survivor_spine_pocket_kalmanson.v1",
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_SURVIVOR_AND_CYCLIC_ORDER",
+        "claim_strength": (
+            "Exact Kalmanson obstruction for the fixed Cycle 674 "
+            "endpoint-control survivor and this fixed cyclic order only."
+        ),
+        "pattern": {
+            "name": "endpoint_control_survivor_cycle_674",
+            "n": len(SURVIVOR_ROWS),
+            "selected_rows": SURVIVOR_ROWS,
+        },
+        "cyclic_order": EXPECTED_ORDERS[index],
+        "order_index": index,
+        "strict_rows": strict_rows,
+        "num_inequalities": len(strict_rows),
+        "weight_sum": sum(int(item["weight"]) for item in strict_rows),
+    }
+
+
+def audit() -> dict[str, object]:
+    """Replay the crossing frontier and every stored Kalmanson certificate."""
+    frontier = spine_pocket_audit()
+    assert_spine_pocket_expected(frontier)
+    certificates = [
+        certificate_for_order(index) for index in range(len(EXPECTED_ORDERS))
+    ]
+    checks = [check_quotient_cone_certificate(cert) for cert in certificates]
+    order_summaries = []
+    for index, (cert, check) in enumerate(zip(certificates, checks, strict=True)):
+        order_summaries.append(
+            {
+                "order_index": index,
+                "cyclic_order": cert["cyclic_order"],
+                "strict_rows": check.strict_rows,
+                "distance_classes": check.distance_classes,
+                "weight_sum": check.weight_sum,
+                "max_weight": check.max_weight,
+                "zero_sum_verified": check.zero_sum_verified,
+                "nonpositive_sum_verified": check.nonpositive_sum_verified,
+                "combined_nonzero_coefficient_count": (
+                    check.combined_nonzero_coefficient_count
+                ),
+            }
+        )
+    return {
+        "type": "endpoint_control_survivor_spine_pocket_kalmanson_audit",
+        "schema": "erdos97.endpoint_control_survivor_spine_pocket_kalmanson.v1",
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_SURVIVOR_AND_CROSSING_ORDERS",
+        "claim_strength": (
+            "Exact obstruction for the fixed Cycle 674 endpoint-control survivor "
+            "across the five crossing-compatible cyclic orders. This is not an "
+            "all-extension endpoint-control proof and not an Erdos97 proof."
+        ),
+        "pattern": {
+            "name": "endpoint_control_survivor_cycle_674",
+            "n": len(SURVIVOR_ROWS),
+            "selected_rows": SURVIVOR_ROWS,
+        },
+        "crossing_frontier": {
+            "constraint_count": frontier["constraint_count"],
+            "order_count": frontier["order_count"],
+            "nodes_visited": frontier["nodes_visited"],
+            "orders": frontier["orders"],
+        },
+        "order_summaries": order_summaries,
+        "obstructed_order_count": sum(
+            1 for summary in order_summaries if summary["zero_sum_verified"]
+        ),
+        "certificates": certificates,
+        "interpretation": (
+            "The crossing-only frontier has five cyclic orders, and each order "
+            "has an exact positive integer Kalmanson quotient-cone certificate. "
+            "Therefore this fixed full selected-row extension is obstructed in "
+            "every cyclic order satisfying the necessary two-overlap crossing "
+            "constraints."
+        ),
+    }
+
+
+def assert_expected(payload: dict[str, object]) -> None:
+    if payload["crossing_frontier"]["order_count"] != 5:  # type: ignore[index]
+        raise AssertionError("unexpected crossing-order count")
+    if payload["obstructed_order_count"] != 5:
+        raise AssertionError("not all crossing-compatible orders are obstructed")
+    summaries = payload["order_summaries"]
+    if not isinstance(summaries, list):
+        raise AssertionError("order summaries must be a list")
+    strict_rows = [summary["strict_rows"] for summary in summaries]
+    weight_sums = [summary["weight_sum"] for summary in summaries]
+    max_weights = [summary["max_weight"] for summary in summaries]
+    if strict_rows != EXPECTED_STRICT_ROWS:
+        raise AssertionError("unexpected strict-row counts")
+    if weight_sums != EXPECTED_WEIGHT_SUMS:
+        raise AssertionError("unexpected weight sums")
+    if max_weights != EXPECTED_MAX_WEIGHTS:
+        raise AssertionError("unexpected max weights")
+    if not all(summary["zero_sum_verified"] for summary in summaries):
+        raise AssertionError("expected every certificate to be zero-sum")
+    if not all(
+        summary["combined_nonzero_coefficient_count"] == 0 for summary in summaries
+    ):
+        raise AssertionError("expected every combined coefficient vector to vanish")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit()
+    if args.assert_expected:
+        assert_expected(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("endpoint-control survivor spine-pocket Kalmanson audit")
+        print(
+            f"crossing-compatible orders: {payload['crossing_frontier']['order_count']}"
+        )
+        print(f"obstructed orders: {payload['obstructed_order_count']}")
+        for summary in payload["order_summaries"]:  # type: ignore[assignment]
+            print(
+                f"order {summary['order_index']}: "
+                f"rows={summary['strict_rows']} "
+                f"weight_sum={summary['weight_sum']} "
+                f"zero_sum={summary['zero_sum_verified']}"
+            )
+        if args.assert_expected:
+            print("OK: expected spine-pocket Kalmanson certificates verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_endpoint_control_survivor_spine_pocket_kalmanson.py
+++ b/tests/test_endpoint_control_survivor_spine_pocket_kalmanson.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.quotient_cone import check_quotient_cone_certificate
+from scripts.check_endpoint_control_survivor_spine_pocket_kalmanson import (
+    EXPECTED_MAX_WEIGHTS,
+    EXPECTED_STRICT_ROWS,
+    EXPECTED_WEIGHT_SUMS,
+    assert_expected,
+    audit,
+    certificate_for_order,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_endpoint_control_survivor_spine_pocket_each_certificate_replays() -> None:
+    for index in range(5):
+        result = check_quotient_cone_certificate(certificate_for_order(index))
+
+        assert result.strict_rows == EXPECTED_STRICT_ROWS[index]
+        assert result.weight_sum == EXPECTED_WEIGHT_SUMS[index]
+        assert result.max_weight == EXPECTED_MAX_WEIGHTS[index]
+        assert result.distance_classes == 25
+        assert result.zero_sum_verified is True
+        assert result.combined_nonzero_coefficient_count == 0
+
+
+def test_endpoint_control_survivor_spine_pocket_kalmanson_audit() -> None:
+    payload = audit()
+
+    assert payload["crossing_frontier"]["order_count"] == 5
+    assert payload["obstructed_order_count"] == 5
+    assert [
+        summary["strict_rows"] for summary in payload["order_summaries"]
+    ] == EXPECTED_STRICT_ROWS
+    assert [
+        summary["weight_sum"] for summary in payload["order_summaries"]
+    ] == EXPECTED_WEIGHT_SUMS
+    assert_expected(payload)
+
+
+def test_endpoint_control_survivor_spine_pocket_kalmanson_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "crossing-compatible orders: 5" in result.stdout
+    assert "obstructed orders: 5" in result.stdout
+    assert "order 0: rows=23 weight_sum=541 zero_sum=True" in result.stdout
+    assert "OK: expected spine-pocket Kalmanson certificates verified" in result.stdout


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 680. It adds an exact Kalmanson quotient-cone replay for the fixed Cycle 674 endpoint-control full selected-row survivor across the five crossing-compatible cyclic orders isolated in Cycle 679.

The result is narrow: the fixed survivor is obstructed in every cyclic order satisfying its necessary two-overlap crossing constraints. This is not an all-extension endpoint-control proof, not a Euclidean non-realizability theorem for the abstract fragile rows, and not a proof or counterexample for Erdos Problem #97.

This replaces draft PR #423, which was closed only because the connector failed to mark it ready for review.

## Files changed

- `scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py`
- `tests/test_endpoint_control_survivor_spine_pocket_kalmanson.py`
- `docs/minimal-fragile-cover-bridge.md`
- `docs/claims.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_endpoint_control_survivor_spine_pocket_kalmanson.py --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q tests/test_endpoint_control_survivor_spine_pocket_kalmanson.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`617 passed, 278 deselected`)
- GitHub Actions `tests` workflow on `c8bec6b1e3d4ee8ad26efa2dc90f9f836bb81569`: Python 3.10, 3.11, and 3.12 passed; artifact-review skipped.

## Remaining limitations

- The checker covers one fixed full selected-row extension only.
- It relies on the Cycle 679 crossing-order frontier for that same fixed survivor.
- The endpoint-control bridge remains open because other full-row extensions of the fragile rows are not ruled out here.
- The global Erdos97 proof/counterexample goal remains open.