### PR TITLE
[codex] record two-edge vertex-circle quotient-cycle schema

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -503,6 +503,44 @@ For witnesses on a circle centered at that vertex, chord length is
 This supports endpoint and short-base reductions, but those reductions still
 need their global bridge claims.[^digest]
 
+### Two-edge vertex-circle quotient-cycle schema
+
+Status: `LEMMA` for any fixed local row core satisfying the stated hypotheses.
+
+Suppose two selected rows have four distinct witnesses each, in angular orders
+
+```text
+a,b,c,d
+e,f,g,h
+```
+
+around their respective centers. Vertex-circle chord monotonicity gives
+
+```text
+D_ac > D_ab,
+D_fh > D_gh.
+```
+
+If selected-distance equality paths identify the inner pair of each strict
+edge with the outer pair of the other,
+
+```text
+D_ab = D_fh,
+D_gh = D_ac,
+```
+
+then no strictly convex selected-witness realization can satisfy that local
+core, because
+
+```text
+D_ac > D_ab = D_fh > D_gh = D_ac.
+```
+
+This is only a local obstruction schema. It does not say that arbitrary
+counterexamples contain such a core, does not prove `n=9`, and does not prove
+Erdos Problem #97. The focused `T10/F12` packet below is one checked instance
+of this schema.
+
 ### Vertex-circle T01/F09 self-edge local lemma candidate
 
 Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.

--- a/docs/n9-vertex-circle-strict-cycle-criterion.md
+++ b/docs/n9-vertex-circle-strict-cycle-criterion.md
@@ -54,6 +54,65 @@ which is impossible for real distances.
 Equivalently, after quotienting ordinary pair distances by the selected-row
 equalities, the local row core has a directed strict cycle.
 
+## Two-edge Cross-wired Schema
+
+The smallest strict-cycle case has two vertex-circle rows. It is useful to
+state it without the packet labels.
+
+Suppose a selected row centered at `r` has four distinct witnesses in angular
+order
+
+```text
+a, b, c, d
+```
+
+and another selected row centered at `s` has four distinct witnesses in angular
+order
+
+```text
+e, f, g, h
+```
+
+The vertex-circle nesting lemma gives the two proper span inequalities
+
+```text
+D_ac > D_ab,
+D_fh > D_gh.
+```
+
+If selected-distance paths identify the inner pair of each strict edge with
+the outer pair of the other strict edge,
+
+```text
+D_ab = D_fh,
+D_gh = D_ac,
+```
+
+then the local core is unrealizable. Indeed,
+
+```text
+D_ac > D_ab = D_fh > D_gh = D_ac,
+```
+
+which is a strict two-cycle among real distance values.
+
+This schema is not a new completeness result. It is the `k=2` instance of the
+strict-cycle criterion with a concrete span-nesting certificate for each
+strict edge. It is useful because it separates the reusable proof object from
+the specific `T10/F12` labels: any selected-row core, in any larger polygon,
+that supplies the two nested chord inequalities and the two cross-wired
+selected-distance paths is impossible.
+
+The `T10/F12` focused packet is exactly one instance. The row centered at `8`
+has witness order `[0,3,6,7]`, giving `D_06 > D_03`; the row centered at `3`
+has witness order `[4,6,0,1]`, giving `D_16 > D_01`. Rows `3` and `6`
+identify `D_03 = D_36 = D_16`, and row `0` identifies `D_01 = D_06`, so the
+cross-wired schema gives
+
+```text
+D_06 > D_16 > D_06.
+```
+
 ## Current Packet Audit
 
 The checked source artifact is

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,184 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 681 - Two-Edge Vertex-Circle Quotient-Cycle Schema
+
+### Mathematical Subquestion
+
+Can the `T10/F12` vertex-circle strict-cycle packet be separated from its
+specific `n=9` labels and restated as a label-free local obstruction schema?
+
+This is a different route from the endpoint-control fixed-survivor work in
+Cycle 680. It tries to turn a finite local pattern into a reusable
+incidence/order lemma.
+
+### Definitions and Assumptions
+
+Work in any strictly convex polygon with selected witness rows. For an
+unordered pair `{u,v}`, write `D_uv` for its ordinary distance value; the same
+argument applies to squared distances because all distances are positive.
+
+Use the vertex-circle nesting lemma: if one selected row sees four witnesses
+in angular order `a,b,c,d`, then the chord interval for `{a,c}` properly
+contains the chord interval for `{a,b}`, so
+
+```text
+D_ac > D_ab.
+```
+
+Similarly, if another selected row sees witnesses in angular order `e,f,g,h`,
+then
+
+```text
+D_fh > D_gh.
+```
+
+A selected-distance path is a chain of equalities between pair distances,
+where each step is forced by one selected row.
+
+### Result Status
+
+Proved local lemma:
+**Two-Edge Vertex-Circle Quotient-Cycle Schema**.
+
+### Argument Or Obstruction
+
+Assume the two nested vertex-circle inequalities above and assume the local
+selected rows also force cross-wired equality paths
+
+```text
+D_ab = D_fh,
+D_gh = D_ac.
+```
+
+Then combining the inequalities and equalities gives
+
+```text
+D_ac > D_ab = D_fh > D_gh = D_ac,
+```
+
+which is impossible for real distance values. Equivalently, after
+selected-distance quotienting, the strict quotient graph has a directed
+two-cycle.
+
+The existing `T10/F12` packet is an exact instance of the schema:
+
+```text
+8-row order: [0,3,6,7] gives D_06 > D_03.
+3-row order: [4,6,0,1] gives D_16 > D_01.
+rows 3 and 6 identify D_03 = D_36 = D_16.
+row 0 identifies D_01 = D_06.
+```
+
+Thus the abstract schema specializes to
+
+```text
+D_06 > D_16 > D_06.
+```
+
+### Exact Scope
+
+This is a local exact obstruction under explicitly stated selected-row,
+cyclic-order, and selected-distance-path hypotheses. It does not prove that
+every `n=9` frontier assignment contains such a schema, does not promote the
+review-pending `n=9` exhaustive checker, does not prove Erdos Problem #97, and
+does not produce a counterexample.
+
+### Files Changed
+
+- `docs/claims.md`
+- `docs/n9-vertex-circle-strict-cycle-criterion.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+The cycle removes one layer of packet-specific notation from the smallest
+vertex-circle strict-cycle obstruction. The next bridge question is no longer
+"does T10 occur in the stored `n=9` packet?" but "do arbitrary
+selected-witness systems force a two-edge cross-wired nested-chord schema, or
+a finite descent region of the same type?"
+
+This is modest progress: it gives a reusable target for future structural
+arguments, but it does not itself supply the missing reduction from arbitrary
+counterexamples to such a target.
+
+### Parallel Fragile-Cover Reconnaissance
+
+A read-only fragile-cover pass tested a different possible bridge ingredient:
+short-gap radius propagation. For any full selected row, some consecutive
+angular witness gap is less than `pi/3`; if the short pair is `{a,b}` and
+`b in S_a`, then `r_a < r_i`, while if `a in S_b`, then `r_b < r_i`. A strict
+radius cycle is impossible.
+
+This gives a genuine geometric necessary condition for each fixed full
+selected-row extension and cyclic order. It did not reject the documented
+endpoint-control displayed extension, the endpoint-control Ptolemy survivor,
+the block-6 scripted survivor, or the first generated two-block block-6 full
+extension in natural order. Thus it is not currently a useful standalone
+fragile-cover obstruction. The remaining hard quantifier would be: every
+admissible full extension and cyclic order of a fragile candidate must be
+radius-cycle obstructed.
+
+### Next Lead
+
+Search for natural hypotheses that force the schema without naming `n=9`
+template labels. The most promising candidates are selected-distance paths of
+length at most two between nested witness chords, or a local row-intersection
+configuration that cross-wires two span-2-over-span-1 vertex-circle
+inequalities.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-681`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-681`.
+- The branch was started from `origin/main` at commit
+  `9cf18d3157e77095ecf1a912db2f95b50866df5c`, after PR #424 merged Cycle
+  680.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+- Multiple parallel agents were used read-only for fragile-cover and
+  vertex-circle reconnaissance; no agent edited files.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check
+  --assert-expected --json`: passed. It verified the `T10` focused packet
+  with `18` assignments, core size `4`, cycle length `2`, and no validation
+  errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check
+  --assert-expected --json`: passed. It verified `3` strict-cycle templates
+  covering `26` assignments.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_template_lemma_catalog.py --check
+  --assert-expected --json`: passed. It verified `12` template records
+  covering `184` assignments in the review-pending packet catalog.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check
+  --assert-expected --json`: passed. It replayed the stored local packet
+  contradictions without using the quotient-replay helper and reported
+  `validation_status: passed`.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `617 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 680 - Endpoint-Control Spine-Pocket Kalmanson Closure
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 681. It extracts a label-free local obstruction schema from the `T10/F12` vertex-circle strict-cycle packet: two selected rows give nested vertex-circle inequalities, and selected-distance paths cross-wire each inner pair to the other outer pair, forcing a strict two-cycle.

This is a local lemma for fixed row cores satisfying the stated hypotheses. It does not prove `n=9`, does not promote the review-pending exhaustive checker, does not prove Erdos Problem #97, and does not produce a counterexample.

## Files changed

- `docs/n9-vertex-circle-strict-cycle-criterion.md`
- `docs/claims.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`617 passed, 278 deselected`)

## Remaining limitations

- The schema applies only after the two nested vertex-circle strict edges and the two selected-distance equality paths are established.
- It does not show arbitrary counterexamples contain such a core.
- The `n=9` packet coverage remains review-pending diagnostic material only.
- The global proof/counterexample goal remains open.