### PR TITLE
[codex] Add bootstrap T12 closure-exposed packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the row-pressure refinement classifying those missing T12 row centers
   by core deficit, deletion-closure exposure, and private-halo support, read
   [`docs/bootstrap-t12-row-pressure.md`](docs/bootstrap-t12-row-pressure.md).
+- For the closure-exposed subpacket isolating the two activation-ready T12
+  row-pressure rows, read
+  [`docs/bootstrap-t12-closure-exposed.md`](docs/bootstrap-t12-closure-exposed.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -168,6 +168,14 @@ diagnostic bookkeeping only; see `docs/bootstrap-t12-row-pressure.md`,
 `scripts/check_bootstrap_t12_row_pressure.py`, and
 `data/certificates/bootstrap_t12_row_pressure.json`.
 
+The closure-exposed subpacket isolates the two deletion-closure-exposed rows
+from that ledger. Rows `81:3` and `151:7` share core witnesses `[0,1,4]` and
+are exposed by the deletion closure for core vertex `2`; only `81:3` has its
+full selected row contained in the closure. This is a smaller proof-mining
+target only; see `docs/bootstrap-t12-closure-exposed.md`,
+`scripts/check_bootstrap_t12_closure_exposed.py`, and
+`data/certificates/bootstrap_t12_closure_exposed.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -72,6 +72,13 @@ their row centers stay private, and one needs an outside pair with partial
 private-pair ledger support. This is still only a diagnostic for the next
 bridge lemma. See `docs/bootstrap-t12-row-pressure.md`.
 
+A closure-exposed subpacket isolates the two easiest row-pressure gaps:
+`81:3` and `151:7` are activation-ready in the deletion closure for core
+vertex `2`. Source `81` has the full selected row in that closure, while
+source `151` has only the row center and three core witnesses. This is
+proof-mining bookkeeping only, not a proof that either row is forced. See
+`docs/bootstrap-t12-closure-exposed.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_closure_exposed.json
+++ b/data/certificates/bootstrap_t12_closure_exposed.json
@@ -1,0 +1,197 @@
+{
+  "claim_scope": "Closure-exposed-row packet for the two tight n=9 bootstrap/T12 records; isolates the missing T12/F16 row centers that are already activation-ready inside a deletion closure. This does not prove that the missing rows are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates fixed selected-row deletion-closure exposures; it does not prove the rows are forced.",
+    "A closure exposure is a local activation-ready bookkeeping state, not a Euclidean rich-class certificate.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_closure_exposed.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_closure_exposed.py"
+  },
+  "records": [
+    {
+      "activation_ready_in_closure": true,
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "classification_assignment_id": "A082",
+      "closure_exposure_mode": "CENTER_AND_FULL_ROW_IN_CLOSURE",
+      "closure_labels": [
+        0,
+        1,
+        3,
+        4,
+        6
+      ],
+      "closure_size": 5,
+      "core_witness_count_in_closure": 3,
+      "core_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "deletion_seed": [
+        0,
+        1,
+        4
+      ],
+      "exposed_core_vertex": 2,
+      "full_row_contained_in_exposure_closure": true,
+      "outside_witnesses": [
+        6
+      ],
+      "outside_witnesses_in_closure": [
+        6
+      ],
+      "outside_witnesses_private": [],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "private_witnesses": [],
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 3,
+      "row_center_in_closure": true,
+      "source_record_id": 81,
+      "witness_count_in_closure": 4,
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "witnesses_in_closure": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "activation_ready_in_closure": true,
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "classification_assignment_id": "A152",
+      "closure_exposure_mode": "CENTER_AND_CORE_WITNESSES_IN_CLOSURE",
+      "closure_labels": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "closure_size": 4,
+      "core_witness_count_in_closure": 3,
+      "core_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "deletion_seed": [
+        0,
+        1,
+        4
+      ],
+      "exposed_core_vertex": 2,
+      "full_row_contained_in_exposure_closure": false,
+      "outside_witnesses": [
+        6
+      ],
+      "outside_witnesses_in_closure": [],
+      "outside_witnesses_private": [
+        6
+      ],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "private_witnesses": [
+        6
+      ],
+      "roles": [
+        "strict_edge_row"
+      ],
+      "row_center": 7,
+      "row_center_in_closure": true,
+      "source_record_id": 151,
+      "witness_count_in_closure": 3,
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "witnesses_in_closure": [
+        0,
+        1,
+        4
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_closure_exposed.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_row_pressure.json",
+      "role": "source row-pressure records and deletion-closure exposures",
+      "schema": "erdos97.bootstrap_t12_row_pressure.v1",
+      "status": "BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_CLOSURE_EXPOSED_DIAGNOSTIC_ONLY",
+  "summary": {
+    "activation_ready_count": 2,
+    "closure_exposed_row_record_count": 2,
+    "core_witness_only_rows_by_source_id": {
+      "151": [
+        7
+      ]
+    },
+    "core_witness_signatures": [
+      [
+        0,
+        1,
+        4
+      ]
+    ],
+    "exposed_core_vertices_by_source_id": {
+      "151": [
+        2
+      ],
+      "81": [
+        2
+      ]
+    },
+    "exposure_mode_counts": {
+      "CENTER_AND_CORE_WITNESSES_IN_CLOSURE": 1,
+      "CENTER_AND_FULL_ROW_IN_CLOSURE": 1
+    },
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "full_row_contained_count": 1,
+    "full_row_contained_rows_by_source_id": {
+      "81": [
+        3
+      ]
+    },
+    "next_bridge_question": "Can a future bridge turn deletion-closure activation readiness into a genuine rich-class row-forcing lemma?",
+    "role_counts": {
+      "equality_connector_row": 1,
+      "strict_edge_row": 1
+    },
+    "row_center_in_closure_count": 2,
+    "row_centers_by_source_id": {
+      "151": [
+        7
+      ],
+      "81": [
+        3
+      ]
+    },
+    "source_record_ids": [
+      81,
+      151
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-closure-exposed.md
+++ b/docs/bootstrap-t12-closure-exposed.md
@@ -1,0 +1,75 @@
+# Bootstrap T12 Closure-Exposed Rows
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the easiest subcase of the
+[`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md) ledger: missing
+`T12/F16` rows whose row center and at least three selected witnesses are
+already visible inside a deletion closure.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_closure_exposed.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_closure_exposed.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_closure_exposed.json`.
+
+## Scope
+
+The input is fixed selected-row bookkeeping from the row-pressure diagnostic.
+A closure-exposed row is not a Euclidean certificate and does not prove that a
+real rich-class/minimal-counterexample geometry must contain that selected
+row. It only records a local activation-ready state inside the existing
+deletion-closure ledger.
+
+The artifact records, for each isolated row:
+
+- the source assignment and missing row center;
+- the deletion closure exposing the row center;
+- the three bootstrap-core witnesses already in that closure;
+- whether the full selected row is contained in the same closure or whether
+  only the row center plus three core witnesses are present.
+
+## Results
+
+Exactly two row-pressure gaps are closure-exposed.
+
+| Source row | Role | Exposing deletion core | Closure mode |
+|---|---|---:|---|
+| `81:3` | equality connector | `2` | center and full selected row in closure |
+| `151:7` | strict edge | `2` | center and three core witnesses in closure |
+
+Both rows use the same core witness signature:
+
+```text
+[0,1,4]
+```
+
+For source `81`, the deletion closure for core vertex `2` is
+`[0,1,3,4,6]`. It contains row center `3` and the whole selected row
+`{0,1,4,6}`.
+
+For source `151`, the deletion closure for core vertex `2` is `[0,1,4,7]`.
+It contains row center `7` and three witnesses `[0,1,4]`; the outside witness
+`6` remains private.
+
+## Reading
+
+This packet narrows one small target for a future bridge lemma:
+
+```text
+Can deletion-closure activation readiness force an actual rich-class row, or
+is it only an artifact of the fixed selected-row overlay?
+```
+
+The packet does not answer that question. It simply separates the two
+closure-exposed rows from the harder one-outside-label and outside-pair cases
+so future proof attempts can state their hypotheses more sharply.

--- a/docs/bootstrap-t12-row-pressure.md
+++ b/docs/bootstrap-t12-row-pressure.md
@@ -57,6 +57,12 @@ The rows `81:3` and `151:7` each have three core witnesses and are already
 visible in the deletion closure for core vertex `2`. These are not the hard
 part of the row-center bridge.
 
+The focused closure-exposed packet
+[`bootstrap-t12-closure-exposed.md`](bootstrap-t12-closure-exposed.md) records
+this subcase separately. It distinguishes `81:3`, whose full selected row is
+inside the exposing deletion closure, from `151:7`, whose row center and three
+core witnesses are present while the outside witness remains private.
+
 The rows `81:8`, `151:5`, and `151:8` each have two core witnesses. They need
 one outside label to become activation-ready from the bootstrap core, while
 their row centers remain private across all deletion closures.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -483,6 +483,12 @@ one-outside-label rows, and one outside-pair row. This is a diagnostic
 decomposition of the open target, not a theorem that any of those rows are
 forced by genuine geometry.
 
+The closure-exposed packet in `docs/bootstrap-t12-closure-exposed.md` isolates
+the two deletion-closure-exposed rows, `81:3` and `151:7`. Both are
+activation-ready in the deletion closure for core vertex `2`, but only `81:3`
+has its full selected row contained in that closure. This remains fixed-row
+proof-mining bookkeeping; it is not a rich-class row-forcing theorem.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -37,7 +37,9 @@ Use this queue when no more specific issue is selected.
    source `151` has only partial direct private-pair hits.
    The row-pressure refinement in `docs/bootstrap-t12-row-pressure.md` splits
    the missing rows into deletion-closure-exposed, one-outside-label, and
-   outside-pair cases for the next bridge attempt.
+   outside-pair cases for the next bridge attempt. The closure-exposed
+   subpacket in `docs/bootstrap-t12-closure-exposed.md` isolates the two
+   activation-ready deletion-closure rows as the smallest next lemma target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.
+- [`bootstrap-t12-closure-exposed.md`](bootstrap-t12-closure-exposed.md):
+  focused packet isolating the two deletion-closure-exposed T12 row-pressure
+  gaps.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -326,6 +326,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-t12-row-pressure.md`, splitting the six missing row centers
   into deletion-closure-exposed rows, one-outside-label rows, and one
   outside-pair row with partial private-pair support.
+- bootstrap/T12 closure-exposed evidence, as recorded in
+  `docs/bootstrap-t12-closure-exposed.md`, isolating the two activation-ready
+  deletion-closure rows before attacking the one-outside-label and outside-pair
+  cases.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -163,6 +163,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_row_pressure.json"
       verifier: "scripts/check_bootstrap_t12_row_pressure.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; classifies missing row centers by bootstrap-core deficit, deletion-closure exposure, and private-halo support, but does not prove that the missing rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_closure_exposed"
+      status: "closure-exposed subpacket for the two activation-ready T12 row-pressure gaps"
+      artifact: "data/certificates/bootstrap_t12_closure_exposed.json"
+      verifier: "scripts/check_bootstrap_t12_closure_exposed.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates the deletion-closure-exposed rows 81:3 and 151:7, but does not prove that the missing rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1969,6 +1969,54 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_closure_exposed
+    path: data/certificates/bootstrap_t12_closure_exposed.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_closure_exposed.py
+    command: python scripts/check_bootstrap_t12_closure_exposed.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_closure_exposed.py
+    check_command: python scripts/check_bootstrap_t12_closure_exposed.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Closure-exposed-row packet for the two tight n=9 bootstrap/T12 records; not a proof that the missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_closure_exposed.v1
+      status: BOOTSTRAP_T12_CLOSURE_EXPOSED_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 81
+        - 151
+      summary.closure_exposed_row_record_count: 2
+      summary.row_centers_by_source_id.81:
+        - 3
+      summary.row_centers_by_source_id.151:
+        - 7
+      summary.exposed_core_vertices_by_source_id.81:
+        - 2
+      summary.exposed_core_vertices_by_source_id.151:
+        - 2
+      summary.exposure_mode_counts.CENTER_AND_CORE_WITNESSES_IN_CLOSURE: 1
+      summary.exposure_mode_counts.CENTER_AND_FULL_ROW_IN_CLOSURE: 1
+      summary.full_row_contained_count: 1
+      summary.activation_ready_count: 2
+      summary.row_center_in_closure_count: 2
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_closure_exposed.py
+      provenance.command: python scripts/check_bootstrap_t12_closure_exposed.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - closure exposure proves the missing rows are forced
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_t12_closure_exposed.py
+++ b/scripts/check_bootstrap_t12_closure_exposed.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 closure-exposed row packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_closure_exposed import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_closure_exposed_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 closure-exposed rows")
+    print(f"records: {summary['closure_exposed_row_record_count']}")
+    print(f"row centers: {summary['row_centers_by_source_id']}")
+    print(f"exposure modes: {summary['exposure_mode_counts']}")
+    print(f"full-row contained: {summary['full_row_contained_rows_by_source_id']}")
+    print(f"core-witness only: {summary['core_witness_only_rows_by_source_id']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned closure-exposed counts")
+    args = parser.parse_args()
+
+    generated = build_t12_closure_exposed_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated closure-exposed packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 closure-exposed artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 closure-exposed expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_closure_exposed.py
+++ b/src/erdos97/bootstrap_t12_closure_exposed.py
@@ -1,0 +1,313 @@
+"""Closure-exposed row packet for the bootstrap/T12 target.
+
+This module isolates the easiest row-pressure subcase: missing T12/F16 rows
+whose row center and three selected witnesses are already visible in a deletion
+closure.  It is proof-mining bookkeeping only and does not prove that any
+missing row is geometrically forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from erdos97.bootstrap_t12_row_pressure import build_t12_row_pressure_payload
+
+
+SCHEMA = "erdos97.bootstrap_t12_closure_exposed.v1"
+STATUS = "BOOTSTRAP_T12_CLOSURE_EXPOSED_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Closure-exposed-row packet for the two tight n=9 bootstrap/T12 records; "
+    "isolates the missing T12/F16 row centers that are already activation-ready "
+    "inside a deletion closure. This does not prove that the missing rows are "
+    "forced, does not prove n=9, does not prove the bridge, and does not claim "
+    "a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / "bootstrap_t12_closure_exposed.json"
+
+PRESSURE_CLASS = "ALREADY_PRESENT_IN_A_DELETION_CLOSURE"
+FULL_ROW_MODE = "CENTER_AND_FULL_ROW_IN_CLOSURE"
+CORE_WITNESS_MODE = "CENTER_AND_CORE_WITNESSES_IN_CLOSURE"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _closure_exposure_mode(*, full_row_contained: bool) -> str:
+    if full_row_contained:
+        return FULL_ROW_MODE
+    return CORE_WITNESS_MODE
+
+
+def _exposure_record(
+    *,
+    row_record: Mapping[str, Any],
+    exposure: Mapping[str, Any],
+) -> dict[str, object]:
+    witnesses = set(_int_list(row_record["witnesses"]))
+    core_witnesses = set(_int_list(row_record["bootstrap_core_witnesses"]))
+    outside_witnesses = set(_int_list(row_record["outside_witnesses"]))
+    closure_labels = set(_int_list(exposure["closure_labels"]))
+
+    witnesses_in_closure = sorted(witnesses & closure_labels)
+    full_row_contained = witnesses <= closure_labels
+    mode = _closure_exposure_mode(full_row_contained=full_row_contained)
+
+    return {
+        "source_record_id": int(row_record["source_record_id"]),
+        "classification_assignment_id": str(row_record["classification_assignment_id"]),
+        "row_center": int(row_record["row_center"]),
+        "roles": [str(role) for role in row_record["roles"]],
+        "witnesses": sorted(witnesses),
+        "bootstrap_core_witnesses": sorted(core_witnesses),
+        "outside_witnesses": sorted(outside_witnesses),
+        "pressure_class": str(row_record["pressure_class"]),
+        "exposed_core_vertex": int(exposure["core_vertex"]),
+        "deletion_seed": _int_list(exposure["deletion_seed"]),
+        "closure_labels": sorted(closure_labels),
+        "closure_size": int(exposure["closure_size"]),
+        "row_center_in_closure": bool(exposure["row_center_in_closure"]),
+        "witnesses_in_closure": witnesses_in_closure,
+        "witness_count_in_closure": len(witnesses_in_closure),
+        "core_witnesses_in_closure": sorted(core_witnesses & closure_labels),
+        "core_witness_count_in_closure": len(core_witnesses & closure_labels),
+        "outside_witnesses_in_closure": sorted(outside_witnesses & closure_labels),
+        "outside_witnesses_private": sorted(outside_witnesses - closure_labels),
+        "private_witnesses": _int_list(exposure["private_witnesses"]),
+        "activation_ready_in_closure": bool(exposure["activation_ready_in_closure"]),
+        "full_row_contained_in_exposure_closure": full_row_contained,
+        "closure_exposure_mode": mode,
+    }
+
+
+def _closure_exposed_records(row_pressure: Mapping[str, Any]) -> list[dict[str, object]]:
+    row_records = row_pressure.get("row_records")
+    if not isinstance(row_records, list):
+        raise AssertionError("row-pressure payload row_records must be a list")
+
+    records = []
+    for row_record in row_records:
+        if row_record["pressure_class"] != PRESSURE_CLASS:
+            continue
+        exposures = [
+            exposure
+            for exposure in row_record["deletion_closure_exposures"]
+            if bool(exposure["row_exposed_in_closure"])
+        ]
+        if not exposures:
+            raise AssertionError("closure-exposed row has no exposed deletion closure")
+        for exposure in exposures:
+            records.append(_exposure_record(row_record=row_record, exposure=exposure))
+
+    records.sort(
+        key=lambda record: (
+            int(record["source_record_id"]),
+            int(record["row_center"]),
+            int(record["exposed_core_vertex"]),
+        )
+    )
+    return records
+
+
+def build_t12_closure_exposed_payload() -> dict[str, object]:
+    """Return the deterministic closure-exposed bootstrap/T12 packet."""
+
+    row_pressure = build_t12_row_pressure_payload()
+    records = _closure_exposed_records(row_pressure)
+
+    exposure_mode_counts = Counter(str(record["closure_exposure_mode"]) for record in records)
+    role_counts = Counter(role for record in records for role in record["roles"])
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    exposed_core_vertices_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    full_row_rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    core_only_rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    for record in records:
+        source_id = int(record["source_record_id"])
+        row_center = int(record["row_center"])
+        rows_by_source[source_id].append(row_center)
+        exposed_core_vertices_by_source[source_id].append(int(record["exposed_core_vertex"]))
+        if record["full_row_contained_in_exposure_closure"]:
+            full_row_rows_by_source[source_id].append(row_center)
+        else:
+            core_only_rows_by_source[source_id].append(row_center)
+
+    core_witness_signatures = sorted(
+        {tuple(_int_list(record["core_witnesses_in_closure"])) for record in records}
+    )
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates fixed selected-row deletion-closure exposures; it does not prove the rows are forced.",
+            "A closure exposure is a local activation-ready bookkeeping state, not a Euclidean rich-class certificate.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted(rows_by_source),
+            "closure_exposed_row_record_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "exposed_core_vertices_by_source_id": {
+                str(source_id): centers
+                for source_id, centers in sorted(exposed_core_vertices_by_source.items())
+            },
+            "exposure_mode_counts": _json_counter(exposure_mode_counts),
+            "full_row_contained_count": sum(
+                1 for record in records if record["full_row_contained_in_exposure_closure"]
+            ),
+            "activation_ready_count": sum(
+                1 for record in records if record["activation_ready_in_closure"]
+            ),
+            "row_center_in_closure_count": sum(
+                1 for record in records if record["row_center_in_closure"]
+            ),
+            "core_witness_signatures": [list(signature) for signature in core_witness_signatures],
+            "role_counts": _json_counter(role_counts),
+            "full_row_contained_rows_by_source_id": {
+                str(source_id): centers
+                for source_id, centers in sorted(full_row_rows_by_source.items())
+            },
+            "core_witness_only_rows_by_source_id": {
+                str(source_id): centers
+                for source_id, centers in sorted(core_only_rows_by_source.items())
+            },
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can a future bridge turn deletion-closure activation readiness "
+                "into a genuine rich-class row-forcing lemma?"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_row_pressure.json",
+                "role": "source row-pressure records and deletion-closure exposures",
+                "schema": row_pressure.get("schema"),
+                "status": row_pressure.get("status"),
+                "trust": row_pressure.get("trust"),
+            }
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_closure_exposed.py",
+            "command": "python scripts/check_bootstrap_t12_closure_exposed.py --write --assert-expected",
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the closure-exposed packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 closure-exposed schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 closure-exposed status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [81, 151],
+        "closure_exposed_row_record_count": 2,
+        "row_centers_by_source_id": {"81": [3], "151": [7]},
+        "exposed_core_vertices_by_source_id": {"81": [2], "151": [2]},
+        "exposure_mode_counts": {
+            CORE_WITNESS_MODE: 1,
+            FULL_ROW_MODE: 1,
+        },
+        "full_row_contained_count": 1,
+        "activation_ready_count": 2,
+        "row_center_in_closure_count": 2,
+        "core_witness_signatures": [[0, 1, 4]],
+        "role_counts": {"equality_connector_row": 1, "strict_edge_row": 1},
+        "full_row_contained_rows_by_source_id": {"81": [3]},
+        "core_witness_only_rows_by_source_id": {"151": [7]},
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    expected_records = {
+        (81, 3): {
+            "classification_assignment_id": "A082",
+            "roles": ["equality_connector_row"],
+            "witnesses": [0, 1, 4, 6],
+            "bootstrap_core_witnesses": [0, 1, 4],
+            "outside_witnesses": [6],
+            "exposed_core_vertex": 2,
+            "deletion_seed": [0, 1, 4],
+            "closure_labels": [0, 1, 3, 4, 6],
+            "closure_size": 5,
+            "witnesses_in_closure": [0, 1, 4, 6],
+            "outside_witnesses_in_closure": [6],
+            "outside_witnesses_private": [],
+            "full_row_contained_in_exposure_closure": True,
+            "closure_exposure_mode": FULL_ROW_MODE,
+        },
+        (151, 7): {
+            "classification_assignment_id": "A152",
+            "roles": ["strict_edge_row"],
+            "witnesses": [0, 1, 4, 6],
+            "bootstrap_core_witnesses": [0, 1, 4],
+            "outside_witnesses": [6],
+            "exposed_core_vertex": 2,
+            "deletion_seed": [0, 1, 4],
+            "closure_labels": [0, 1, 4, 7],
+            "closure_size": 4,
+            "witnesses_in_closure": [0, 1, 4],
+            "outside_witnesses_in_closure": [],
+            "outside_witnesses_private": [6],
+            "full_row_contained_in_exposure_closure": False,
+            "closure_exposure_mode": CORE_WITNESS_MODE,
+        },
+    }
+    by_key = {
+        (int(record["source_record_id"]), int(record["row_center"])): record
+        for record in records
+    }
+    if set(by_key) != set(expected_records):
+        raise AssertionError("unexpected closure-exposed record keys")
+    for key, expected in expected_records.items():
+        record = by_key[key]
+        for field, expected_value in expected.items():
+            if record.get(field) != expected_value:
+                raise AssertionError(
+                    f"closure-exposed {key} {field} is {record.get(field)!r}, "
+                    f"expected {expected_value!r}"
+                )
+        if record.get("pressure_class") != PRESSURE_CLASS:
+            raise AssertionError(f"closure-exposed {key} pressure class changed")
+        if not record.get("row_center_in_closure"):
+            raise AssertionError(f"closure-exposed {key} row center not in closure")
+        if not record.get("activation_ready_in_closure"):
+            raise AssertionError(f"closure-exposed {key} not activation-ready")
+        if record.get("core_witnesses_in_closure") != [0, 1, 4]:
+            raise AssertionError(f"closure-exposed {key} core witnesses changed")

--- a/tests/test_bootstrap_t12_closure_exposed.py
+++ b/tests/test_bootstrap_t12_closure_exposed.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_t12_closure_exposed import (
+    CORE_WITNESS_MODE,
+    FULL_ROW_MODE,
+    assert_expected_payload,
+    build_t12_closure_exposed_payload,
+)
+
+
+def test_bootstrap_t12_closure_exposed_expected_payload() -> None:
+    payload = build_t12_closure_exposed_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["closure_exposed_row_record_count"] == 2
+    assert summary["forcing_target_status"] == "OPEN_TARGET_NOT_PROVED"
+
+
+def test_bootstrap_t12_closure_exposed_isolates_expected_rows() -> None:
+    payload = build_t12_closure_exposed_payload()
+    by_key = {
+        (record["source_record_id"], record["row_center"]): record
+        for record in payload["records"]
+    }
+
+    assert set(by_key) == {(81, 3), (151, 7)}
+    assert by_key[(81, 3)]["exposed_core_vertex"] == 2
+    assert by_key[(151, 7)]["exposed_core_vertex"] == 2
+    assert by_key[(81, 3)]["core_witnesses_in_closure"] == [0, 1, 4]
+    assert by_key[(151, 7)]["core_witnesses_in_closure"] == [0, 1, 4]
+
+
+def test_bootstrap_t12_closure_exposed_modes() -> None:
+    payload = build_t12_closure_exposed_payload()
+    by_key = {
+        (record["source_record_id"], record["row_center"]): record
+        for record in payload["records"]
+    }
+
+    assert by_key[(81, 3)]["closure_exposure_mode"] == FULL_ROW_MODE
+    assert by_key[(81, 3)]["full_row_contained_in_exposure_closure"]
+    assert by_key[(81, 3)]["outside_witnesses_in_closure"] == [6]
+    assert by_key[(81, 3)]["outside_witnesses_private"] == []
+
+    assert by_key[(151, 7)]["closure_exposure_mode"] == CORE_WITNESS_MODE
+    assert not by_key[(151, 7)]["full_row_contained_in_exposure_closure"]
+    assert by_key[(151, 7)]["outside_witnesses_in_closure"] == []
+    assert by_key[(151, 7)]["outside_witnesses_private"] == [6]
+
+
+def test_bootstrap_t12_closure_exposed_expected_payload_rejects_drift() -> None:
+    payload = build_t12_closure_exposed_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["closure_exposed_row_record_count"] = 3
+
+    with pytest.raises(AssertionError, match="closure_exposed_row_record_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- Add a generator-backed closure-exposed T12 packet for the two row-pressure gaps `81:3` and `151:7`.
- Record the generated JSON artifact, focused checker, pytest coverage, and documentation/status/manifest links.
- Keep the scope explicitly diagnostic: no forced-row theorem, no n=9 promotion, no bridge proof, and no counterexample claim.

## Validation

- `python scripts/check_bootstrap_t12_closure_exposed.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_t12_closure_exposed.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --cached --check`
- `python -m ruff check .`
- `python -m pytest -q`