### PR TITLE
[codex] record two-row quotient-cycle nondegeneracy

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -541,6 +541,30 @@ counterexamples contain such a core, does not prove `n=9`, and does not prove
 Erdos Problem #97. The focused `T10/F12` packet below is one checked instance
 of this schema.
 
+### Two-row nondegeneracy for two-edge quotient cycles
+
+Status: `LEMMA` for the two-edge vertex-circle schema.
+
+In the two-edge schema above, suppose the only selected-distance equalities
+available are those from the two rows producing the two strict
+vertex-circle inequalities. If the four strict-edge endpoint pairs are
+pairwise distinct, and neither strict edge is already a quotient self-edge,
+then the cross-wired equalities cannot both hold.
+
+The reason is purely combinatorial. The two rows generate only two star
+equivalence classes of pair distances, one for pairs from the first center to
+its four witnesses and one for pairs from the second center to its four
+witnesses, possibly merged along a common center-witness pair. For the two
+cross-wires to hold nontrivially, both strict pairs of the first row must lie
+in the second row's star, and both strict pairs of the second row must lie in
+the first row's star. Then each strict edge is already a self-edge, contrary
+to the nondegeneracy assumption.
+
+Thus a genuine two-edge quotient cycle needs an additional connector row or a
+longer selected-distance path, unless it has already collapsed to a simpler
+self-edge obstruction. This is a local structural fact only; it does not force
+such connector rows to exist in arbitrary counterexamples.
+
 ### Vertex-circle T01/F09 self-edge local lemma candidate
 
 Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.

--- a/docs/n9-vertex-circle-strict-cycle-criterion.md
+++ b/docs/n9-vertex-circle-strict-cycle-criterion.md
@@ -113,6 +113,42 @@ cross-wired schema gives
 D_06 > D_16 > D_06.
 ```
 
+### Why connector rows are needed
+
+A nondegenerate two-edge schema cannot be forced by the two strict rows alone.
+Here nondegenerate means that the four strict-edge endpoint pairs
+
+```text
+{a,c}, {a,b}, {f,h}, {g,h}
+```
+
+are pairwise distinct, and neither strict edge is already a quotient self-edge
+using only the two selected rows centered at `r` and `s`.
+
+Indeed, the two selected rows generate at most two star equivalence classes:
+
+```text
+A = {{r,x} : x in {a,b,c,d}},
+B = {{s,y} : y in {e,f,g,h}},
+```
+
+possibly merged if they share a pair. The row-`r` strict pairs `{a,c}` and
+`{a,b}` do not lie in `A`, and the row-`s` strict pairs `{f,h}` and `{g,h}` do
+not lie in `B`.
+
+For a nontrivial cross-wire `{a,b} ~ {f,h}` to hold, `{a,b}` must lie in `B`,
+`{f,h}` must lie in `A`, and the two stars must be merged. Similarly, the
+other cross-wire `{g,h} ~ {a,c}` forces `{a,c}` to lie in `B` and `{g,h}` to
+lie in `A`. But then both row-`r` strict pairs lie in `B`, so
+`{a,c} ~ {a,b}` and the first strict edge is already a self-edge; likewise
+both row-`s` strict pairs lie in `A`, so the second strict edge is also a
+self-edge. This contradicts nondegeneracy.
+
+Thus a genuine two-edge quotient cycle needs either an additional connector
+row, a longer selected-distance path, or it has already collapsed to a simpler
+self-edge obstruction. The `T10/F12` instance uses rows `0` and `6` as the
+connector rows beyond the two strict rows centered at `8` and `3`.
+
 ## Current Packet Audit
 
 The checked source artifact is

--- a/reports/codex_goal_erdos97_log.md
+++ b/reports/codex_goal_erdos97_log.md
@@ -22947,6 +22947,160 @@ witnesses admit the analogous quotient-cancellation classification.
 The overarching proof/counterexample goal remains open. No general proof and
 no exact counterexample are claimed.
 
+## 2026-05-10 - Cycle 682 - Two-Row Nondegeneracy for Two-Edge Quotient Cycles
+
+### Mathematical Subquestion
+
+Can the two-edge vertex-circle quotient-cycle schema from Cycle 681 be forced
+by only the two rows that supply the two strict vertex-circle inequalities?
+
+This asks whether the next search target should be a two-row pattern or whether
+additional connector rows are structurally necessary for a genuine two-edge
+cycle.
+
+### Definitions and Assumptions
+
+Use the Cycle 681 notation. A first selected row is centered at `r` and has
+witness order
+
+```text
+a,b,c,d,
+```
+
+giving the strict edge
+
+```text
+D_ac > D_ab.
+```
+
+A second selected row is centered at `s` and has witness order
+
+```text
+e,f,g,h,
+```
+
+giving the strict edge
+
+```text
+D_fh > D_gh.
+```
+
+The only selected-distance equalities allowed in this subquestion are those
+from these two selected rows. Call the schema nondegenerate when the four
+endpoint pairs `{a,c}`, `{a,b}`, `{f,h}`, and `{g,h}` are pairwise distinct and
+neither strict edge is already a quotient self-edge under the two-row
+selected-distance quotient.
+
+### Result Status
+
+Proved local obstruction to an overstrong search target:
+**Two-Row Nondegeneracy Lemma**.
+
+### Argument Or Obstruction
+
+The two selected rows generate at most two star equivalence classes of ordinary
+pair distances:
+
+```text
+A = {{r,x} : x in {a,b,c,d}},
+B = {{s,y} : y in {e,f,g,h}},
+```
+
+possibly merged if a pair belongs to both stars. The row-`r` strict pairs
+`{a,c}` and `{a,b}` do not contain `r`, so they are not in `A`; they can be
+identified by the two-row quotient only by lying in `B`. Similarly, the row-`s`
+strict pairs `{f,h}` and `{g,h}` can be identified only by lying in `A`.
+
+For the cross-wire `{a,b} ~ {f,h}` to hold nontrivially, `{a,b}` must lie in
+`B`, `{f,h}` must lie in `A`, and the two stars must be connected. For the
+other cross-wire `{g,h} ~ {a,c}` to hold nontrivially, `{a,c}` must lie in `B`
+and `{g,h}` must lie in `A`.
+
+But then both row-`r` strict pairs `{a,c}` and `{a,b}` lie in `B`, so
+`{a,c} ~ {a,b}` and the first strict inequality is already a self-edge. Also
+both row-`s` strict pairs `{f,h}` and `{g,h}` lie in `A`, so the second strict
+inequality is already a self-edge. This contradicts nondegeneracy.
+
+Therefore a genuine two-edge quotient cycle cannot be supplied by only the two
+strict rows. It needs an additional connector row or a longer
+selected-distance path, unless the contradiction has already collapsed to a
+simpler self-edge.
+
+### Exact Scope
+
+This is a local quotient-combinatorial lemma about the two-edge schema. It does
+not say that arbitrary counterexamples contain the schema, does not prove
+`n=9`, does not promote any review-pending finite-case checker, does not prove
+Erdos Problem #97, and does not produce a counterexample.
+
+A one-off finite sanity check over small label sets confirmed the distinction:
+two-row cross-wires exist only in degenerate cases with an immediate self-edge
+or a repeated strict pair; no nondegenerate four-pair instance occurred through
+ten labels. The proof above is the actual evidence, not the finite check.
+
+### Files Changed
+
+- `docs/claims.md`
+- `docs/n9-vertex-circle-strict-cycle-criterion.md`
+- `reports/codex_goal_erdos97_log.md`
+
+### Effect On The Attack
+
+This rules out a tempting but too-small target. The next structural search
+should not look for a two-row source of the Cycle 681 schema; it should look
+for forced connector rows or short selected-distance paths. The `T10/F12`
+packet fits this: the strict rows are centered at `8` and `3`, while rows `0`
+and `6` provide the connector equalities.
+
+### Next Lead
+
+Classify the shortest nondegenerate connector patterns for the two-edge schema:
+one cross-wire can be an identity or one-row path, but a genuine four-pair
+two-cycle needs connector structure beyond the two strict rows. The useful
+next lemma would identify when a two-overlap or shared-center configuration
+forces such a connector row.
+
+### Traceability
+
+- Research cycle worktree:
+  `/private/tmp/erdos97-cycle-682`.
+- Branch during the cycle:
+  `codex/erdos97-cycle-682`.
+- The branch was started from `origin/main` at commit
+  `a35bc59cbf8e21476707d4653eccb4fd3148b6e2`, after PR #427 merged Cycle
+  681.
+- The primary checkout `/Users/openclaw/Desktop/code/erdos97` was already
+  dirty and was left unchanged during this cycle.
+- `origin` is connected to `https://github.com/davidiach/erdos97.git`.
+
+### Validation
+
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check
+  --assert-expected --json`: passed. It verified the `T10` focused packet
+  with `18` assignments, core size `4`, cycle length `2`, and no validation
+  errors.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check
+  --assert-expected --json`: passed. It verified `3` strict-cycle templates
+  covering `26` assignments.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_text_clean.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_status_consistency.py`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python
+  scripts/check_artifact_provenance.py`: passed.
+- `git diff --check`: passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`:
+  passed.
+- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q`:
+  passed, `617 passed, 278 deselected`.
+
+### Goal Status
+
+The overarching proof/counterexample goal remains open. No general proof and
+no exact counterexample are claimed.
+
 ## 2026-05-10 - Cycle 681 - Two-Edge Vertex-Circle Quotient-Cycle Schema
 
 ### Mathematical Subquestion


### PR DESCRIPTION
## Mathematical scope

This PR records Cycle 682. It proves a local nondegeneracy fact for the two-edge vertex-circle quotient-cycle schema: if only the two strict rows supply selected-distance equalities, then a nondegenerate cross-wired two-edge cycle cannot occur. Any two-row cross-wire either collapses to an immediate self-edge or repeats a strict pair; a genuine four-pair two-cycle needs an additional connector row or longer selected-distance path.

This is a local quotient-combinatorial lemma. It does not prove `n=9`, does not promote any review-pending finite-case checker, does not prove Erdos Problem #97, and does not produce a counterexample.

## Files changed

- `docs/n9-vertex-circle-strict-cycle-criterion.md`
- `docs/claims.md`
- `reports/codex_goal_erdos97_log.md`

## Validation run

- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m ruff check .`
- `/Users/openclaw/Desktop/code/erdos97/.venv/bin/python -m pytest -q` (`617 passed, 278 deselected`)

## Remaining limitations

- This only rules out the overstrong two-row source for a nondegenerate two-edge quotient cycle.
- It does not force connector rows to exist in arbitrary counterexamples.
- The next useful target is classifying shortest connector patterns beyond the two strict rows.
- The global proof/counterexample goal remains open.