### PR TITLE
[codex] Add bootstrap T12 one-outside packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the closure-exposed subpacket isolating the two activation-ready T12
   row-pressure rows, read
   [`docs/bootstrap-t12-closure-exposed.md`](docs/bootstrap-t12-closure-exposed.md).
+- For the one-outside-label subpacket isolating the three singleton-support
+  T12 row-pressure rows, read
+  [`docs/bootstrap-t12-one-outside.md`](docs/bootstrap-t12-one-outside.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -176,6 +176,16 @@ target only; see `docs/bootstrap-t12-closure-exposed.md`,
 `scripts/check_bootstrap_t12_closure_exposed.py`, and
 `data/certificates/bootstrap_t12_closure_exposed.json`.
 
+The one-outside-label subpacket isolates the three singleton-support rows
+from the same ledger: `81:8`, `151:5`, and `151:8`. Each row has two
+bootstrap-core witnesses, two singleton outside supports, and a row center
+private in every deletion closure. In each row, exactly one support is private
+in all deletion halos and one is internal to the deletion closure for core
+vertex `2`. This is still diagnostic bookkeeping only; see
+`docs/bootstrap-t12-one-outside.md`,
+`scripts/check_bootstrap_t12_one_outside.py`, and
+`data/certificates/bootstrap_t12_one_outside.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -79,6 +79,14 @@ source `151` has only the row center and three core witnesses. This is
 proof-mining bookkeeping only, not a proof that either row is forced. See
 `docs/bootstrap-t12-closure-exposed.md`.
 
+A one-outside-label subpacket isolates the three singleton-support
+row-pressure gaps: `81:8`, `151:5`, and `151:8`. Each has two bootstrap-core
+witnesses and a row center private in every deletion closure; in each row, one
+singleton support is private in all deletion halos and one is already internal
+to the deletion closure for core vertex `2`. This remains diagnostic
+bookkeeping only, not a row-forcing theorem. See
+`docs/bootstrap-t12-one-outside.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_one_outside.json
+++ b/data/certificates/bootstrap_t12_one_outside.json
@@ -1,0 +1,337 @@
+{
+  "claim_scope": "One-outside-label packet for the two tight n=9 bootstrap/T12 records; isolates the missing T12/F16 row centers that need one outside label while the row center remains private in every deletion closure. This does not prove that the missing rows are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates fixed selected-row one-outside-label gaps; it does not prove the rows are forced.",
+    "A singleton outside support is activation bookkeeping, not a Euclidean rich-class certificate.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_one_outside.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_one_outside.py"
+  },
+  "records": [
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witnesses": [
+        0,
+        2
+      ],
+      "classification_assignment_id": "A082",
+      "ledger_private_pair_support_hit_count": 0,
+      "max_witness_count_in_deletion_closure": 2,
+      "outside_support_kind": "outside_1_set",
+      "outside_witnesses": [
+        5,
+        6
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 81,
+      "support_label_modes": {
+        "INTERNAL_TO_ONE_DELETION_CLOSURE": 1,
+        "PRIVATE_IN_ALL_DELETION_HALOS": 1
+      },
+      "support_option_count": 2,
+      "support_options": [
+        {
+          "activation_ready_with_support": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_support": [
+            0,
+            2,
+            5
+          ],
+          "closure_internal_core_vertices": [],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [],
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support_label": 5,
+          "support_label_mode": "PRIVATE_IN_ALL_DELETION_HALOS"
+        },
+        {
+          "activation_ready_with_support": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_support": [
+            0,
+            2,
+            6
+          ],
+          "closure_internal_core_vertices": [
+            2
+          ],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [
+            2
+          ],
+          "private_halo_containment_count": 3,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "support_label": 6,
+          "support_label_mode": "INTERNAL_TO_ONE_DELETION_CLOSURE"
+        }
+      ],
+      "witnesses": [
+        0,
+        2,
+        5,
+        6
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witnesses": [
+        2,
+        4
+      ],
+      "classification_assignment_id": "A152",
+      "ledger_private_pair_support_hit_count": 0,
+      "max_witness_count_in_deletion_closure": 2,
+      "outside_support_kind": "outside_1_set",
+      "outside_witnesses": [
+        7,
+        8
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 5,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "support_label_modes": {
+        "INTERNAL_TO_ONE_DELETION_CLOSURE": 1,
+        "PRIVATE_IN_ALL_DELETION_HALOS": 1
+      },
+      "support_option_count": 2,
+      "support_options": [
+        {
+          "activation_ready_with_support": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_support": [
+            2,
+            4,
+            7
+          ],
+          "closure_internal_core_vertices": [
+            2
+          ],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [
+            2
+          ],
+          "private_halo_containment_count": 3,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "support_label": 7,
+          "support_label_mode": "INTERNAL_TO_ONE_DELETION_CLOSURE"
+        },
+        {
+          "activation_ready_with_support": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_support": [
+            2,
+            4,
+            8
+          ],
+          "closure_internal_core_vertices": [],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [],
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support_label": 8,
+          "support_label_mode": "PRIVATE_IN_ALL_DELETION_HALOS"
+        }
+      ],
+      "witnesses": [
+        2,
+        4,
+        7,
+        8
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witnesses": [
+        1,
+        2
+      ],
+      "classification_assignment_id": "A152",
+      "ledger_private_pair_support_hit_count": 0,
+      "max_witness_count_in_deletion_closure": 2,
+      "outside_support_kind": "outside_1_set",
+      "outside_witnesses": [
+        5,
+        7
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "roles": [
+        "strict_edge_row",
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "support_label_modes": {
+        "INTERNAL_TO_ONE_DELETION_CLOSURE": 1,
+        "PRIVATE_IN_ALL_DELETION_HALOS": 1
+      },
+      "support_option_count": 2,
+      "support_options": [
+        {
+          "activation_ready_with_support": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_support": [
+            1,
+            2,
+            5
+          ],
+          "closure_internal_core_vertices": [],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [],
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support_label": 5,
+          "support_label_mode": "PRIVATE_IN_ALL_DELETION_HALOS"
+        },
+        {
+          "activation_ready_with_support": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_support": [
+            1,
+            2,
+            7
+          ],
+          "closure_internal_core_vertices": [
+            2
+          ],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [
+            2
+          ],
+          "private_halo_containment_count": 3,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "support_label": 7,
+          "support_label_mode": "INTERNAL_TO_ONE_DELETION_CLOSURE"
+        }
+      ],
+      "witnesses": [
+        1,
+        2,
+        5,
+        7
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_one_outside.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_row_pressure.json",
+      "role": "source row-pressure records and singleton outside-label supports",
+      "schema": "erdos97.bootstrap_t12_row_pressure.v1",
+      "status": "BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_ONE_OUTSIDE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "activation_deficit_counts": {
+      "1": 3
+    },
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "ledger_private_pair_support_hit_count": 0,
+    "multirow_support_labels": [
+      5,
+      7
+    ],
+    "next_bridge_question": "Can a future bridge force a private row center together with one of its singleton outside supports from genuine rich-class geometry?",
+    "one_outside_row_record_count": 3,
+    "private_halo_containment_count_distribution": {
+      "3": 3,
+      "4": 3
+    },
+    "role_counts": {
+      "equality_connector_row": 3,
+      "strict_edge_row": 1
+    },
+    "row_center_private_in_all_deletions_count": 3,
+    "row_centers_by_source_id": {
+      "151": [
+        5,
+        8
+      ],
+      "81": [
+        8
+      ]
+    },
+    "source_record_ids": [
+      81,
+      151
+    ],
+    "support_label_counts": {
+      "5": 2,
+      "6": 1,
+      "7": 2,
+      "8": 1
+    },
+    "support_label_mode_counts": {
+      "INTERNAL_TO_ONE_DELETION_CLOSURE": 3,
+      "PRIVATE_IN_ALL_DELETION_HALOS": 3
+    },
+    "support_option_count": 6
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-one-outside.md
+++ b/docs/bootstrap-t12-one-outside.md
@@ -1,0 +1,74 @@
+# Bootstrap T12 One-Outside-Label Rows
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the one-outside-label subcase of the
+[`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md) ledger:
+missing `T12/F16` rows with two bootstrap-core witnesses, one singleton
+outside-label support, and a row center that remains private in every deletion
+closure.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_one_outside.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_one_outside.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_one_outside.json`.
+
+## Scope
+
+The input is fixed selected-row bookkeeping from the row-pressure diagnostic.
+A singleton outside support is an activation record, not a Euclidean
+rich-class certificate. This packet does not prove that any missing row is
+forced in a real minimal counterexample.
+
+The artifact records, for each isolated row:
+
+- the source assignment and missing row center;
+- the two witnesses already in the bootstrap core `[0,1,2,4]`;
+- the singleton outside labels that make the row activation-ready;
+- whether each singleton support is private in every deletion halo or already
+  internal to one deletion closure;
+- whether the row center remains private in all deletion closures.
+
+## Results
+
+Exactly three row-pressure gaps need one outside label.
+
+| Source row | Role | Core witnesses | Singleton supports |
+|---|---|---|---|
+| `81:8` | equality connector | `[0,2]` | `5` private in all halos; `6` internal to core `2` closure |
+| `151:5` | equality connector | `[2,4]` | `7` internal to core `2` closure; `8` private in all halos |
+| `151:8` | strict edge, equality connector | `[1,2]` | `5` private in all halos; `7` internal to core `2` closure |
+
+Across the three rows, labels `5` and `7` each appear as singleton support in
+two rows; labels `6` and `8` appear once. Each row has one support private in
+all deletion halos and one support already internal to the deletion closure
+for core vertex `2`.
+
+All three row centers remain private in every deletion closure. None of the
+singleton supports has a direct private-pair ledger hit, which is expected:
+this is a one-label activation problem, so pair capacity does not see it
+directly.
+
+## Reading
+
+This packet narrows the next bridge question:
+
+```text
+Can genuine rich-class geometry force a private row center together with one
+of its singleton outside supports, or is this only fixed selected-row
+bookkeeping?
+```
+
+The packet does not answer that question. It separates the one-outside-label
+rows from the closure-exposed rows and the single outside-pair row so future
+bridge attempts can state exactly which hypothesis they need.

--- a/docs/bootstrap-t12-row-pressure.md
+++ b/docs/bootstrap-t12-row-pressure.md
@@ -67,6 +67,12 @@ The rows `81:8`, `151:5`, and `151:8` each have two core witnesses. They need
 one outside label to become activation-ready from the bootstrap core, while
 their row centers remain private across all deletion closures.
 
+The focused one-outside-label packet
+[`bootstrap-t12-one-outside.md`](bootstrap-t12-one-outside.md) records this
+subcase separately. It distinguishes, for each row, the singleton support that
+is private in all deletion halos from the singleton support that is already
+internal to the deletion closure for core vertex `2`.
+
 The row `151:6` has only one core witness. It needs an outside pair, and two
 of its possible outside pairs, `[3,8]` and `[5,8]`, hit the existing
 private-pair ledger.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -489,6 +489,14 @@ activation-ready in the deletion closure for core vertex `2`, but only `81:3`
 has its full selected row contained in that closure. This remains fixed-row
 proof-mining bookkeeping; it is not a rich-class row-forcing theorem.
 
+The one-outside-label packet in `docs/bootstrap-t12-one-outside.md` isolates
+the three singleton-support rows, `81:8`, `151:5`, and `151:8`. Each row has
+two bootstrap-core witnesses and a row center private in every deletion
+closure; in each row, one singleton support is private in all deletion halos
+and one is internal to the deletion closure for core vertex `2`. This is a
+diagnostic decomposition only, not a theorem that singleton supports or row
+centers are forced by Euclidean geometry.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -40,6 +40,9 @@ Use this queue when no more specific issue is selected.
    outside-pair cases for the next bridge attempt. The closure-exposed
    subpacket in `docs/bootstrap-t12-closure-exposed.md` isolates the two
    activation-ready deletion-closure rows as the smallest next lemma target.
+   The one-outside-label subpacket in `docs/bootstrap-t12-one-outside.md`
+   isolates the three singleton-support rows where a future bridge would need
+   to force one outside label without relying on private-pair capacity.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,6 +148,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-closure-exposed.md`](bootstrap-t12-closure-exposed.md):
   focused packet isolating the two deletion-closure-exposed T12 row-pressure
   gaps.
+- [`bootstrap-t12-one-outside.md`](bootstrap-t12-one-outside.md):
+  focused packet isolating the three singleton-support T12 row-pressure gaps.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -330,6 +330,9 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-t12-closure-exposed.md`, isolating the two activation-ready
   deletion-closure rows before attacking the one-outside-label and outside-pair
   cases.
+- bootstrap/T12 one-outside-label evidence, as recorded in
+  `docs/bootstrap-t12-one-outside.md`, isolating the three singleton-support
+  rows where pair-capacity arguments do not directly apply.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -168,6 +168,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_closure_exposed.json"
       verifier: "scripts/check_bootstrap_t12_closure_exposed.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; isolates the deletion-closure-exposed rows 81:3 and 151:7, but does not prove that the missing rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_one_outside"
+      status: "one-outside-label subpacket for the three singleton-support T12 row-pressure gaps"
+      artifact: "data/certificates/bootstrap_t12_one_outside.json"
+      verifier: "scripts/check_bootstrap_t12_one_outside.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates rows 81:8, 151:5, and 151:8 by singleton outside-label support, but does not prove missing rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2017,6 +2017,64 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_one_outside
+    path: data/certificates/bootstrap_t12_one_outside.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_one_outside.py
+    command: python scripts/check_bootstrap_t12_one_outside.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_one_outside.py
+    check_command: python scripts/check_bootstrap_t12_one_outside.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: One-outside-label packet for the two tight n=9 bootstrap/T12 records; not a proof that the missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_one_outside.v1
+      status: BOOTSTRAP_T12_ONE_OUTSIDE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 81
+        - 151
+      summary.one_outside_row_record_count: 3
+      summary.row_centers_by_source_id.81:
+        - 8
+      summary.row_centers_by_source_id.151:
+        - 5
+        - 8
+      summary.support_option_count: 6
+      summary.support_label_counts.5: 2
+      summary.support_label_counts.6: 1
+      summary.support_label_counts.7: 2
+      summary.support_label_counts.8: 1
+      summary.multirow_support_labels:
+        - 5
+        - 7
+      summary.support_label_mode_counts.INTERNAL_TO_ONE_DELETION_CLOSURE: 3
+      summary.support_label_mode_counts.PRIVATE_IN_ALL_DELETION_HALOS: 3
+      summary.private_halo_containment_count_distribution.3: 3
+      summary.private_halo_containment_count_distribution.4: 3
+      summary.row_center_private_in_all_deletions_count: 3
+      summary.ledger_private_pair_support_hit_count: 0
+      summary.role_counts.equality_connector_row: 3
+      summary.role_counts.strict_edge_row: 1
+      summary.activation_deficit_counts.1: 3
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_one_outside.py
+      provenance.command: python scripts/check_bootstrap_t12_one_outside.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - missing T12 row centers are forced
+      - one outside label proves missing rows are forced
+      - singleton support proves row-center forcing
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_t12_one_outside.py
+++ b/scripts/check_bootstrap_t12_one_outside.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 one-outside-label packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_one_outside import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_one_outside_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 one-outside-label rows")
+    print(f"records: {summary['one_outside_row_record_count']}")
+    print(f"row centers: {summary['row_centers_by_source_id']}")
+    print(f"support labels: {summary['support_label_counts']}")
+    print(f"support modes: {summary['support_label_mode_counts']}")
+    print(f"private-halo containment: {summary['private_halo_containment_count_distribution']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned one-outside counts")
+    args = parser.parse_args()
+
+    generated = build_t12_one_outside_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated one-outside packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 one-outside artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 one-outside expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_one_outside.py
+++ b/src/erdos97/bootstrap_t12_one_outside.py
@@ -1,0 +1,335 @@
+"""One-outside-label packet for the bootstrap/T12 target.
+
+This module isolates the row-pressure subcase where a missing T12/F16 row has
+two bootstrap-core witnesses and needs one outside label while its row center
+remains private in every deletion closure.  It is proof-mining bookkeeping only
+and does not prove that any missing row is geometrically forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from erdos97.bootstrap_t12_row_pressure import build_t12_row_pressure_payload
+
+
+SCHEMA = "erdos97.bootstrap_t12_one_outside.v1"
+STATUS = "BOOTSTRAP_T12_ONE_OUTSIDE_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "One-outside-label packet for the two tight n=9 bootstrap/T12 records; "
+    "isolates the missing T12/F16 row centers that need one outside label "
+    "while the row center remains private in every deletion closure. This "
+    "does not prove that the missing rows are forced, does not prove n=9, "
+    "does not prove the bridge, and does not claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / "bootstrap_t12_one_outside.json"
+
+PRESSURE_CLASS = "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER"
+PRIVATE_ALL_MODE = "PRIVATE_IN_ALL_DELETION_HALOS"
+CLOSURE_INTERNAL_MODE = "INTERNAL_TO_ONE_DELETION_CLOSURE"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _support_mode(missing_private_halo_core_vertices: list[int]) -> str:
+    if missing_private_halo_core_vertices:
+        return CLOSURE_INTERNAL_MODE
+    return PRIVATE_ALL_MODE
+
+
+def _support_option(
+    *,
+    row_record: Mapping[str, Any],
+    hit: Mapping[str, Any],
+) -> dict[str, object]:
+    support = _int_list(hit["support"])
+    if len(support) != 1:
+        raise AssertionError("one-outside-label packet received non-singleton support")
+    support_label = support[0]
+    core_witnesses = _int_list(row_record["bootstrap_core_witnesses"])
+    row_center_private_core_vertices = _int_list(row_record["row_center_private_core_vertices"])
+    private_halo_core_vertices = _int_list(hit["private_halo_core_vertices"])
+    missing_private_halo_core_vertices = sorted(
+        set(row_center_private_core_vertices) - set(private_halo_core_vertices)
+    )
+    closure_internal_core_vertices = [
+        int(exposure["core_vertex"])
+        for exposure in row_record["deletion_closure_exposures"]
+        if support_label in set(_int_list(exposure["closure_labels"]))
+    ]
+    mode = _support_mode(missing_private_halo_core_vertices)
+
+    return {
+        "support_label": support_label,
+        "activation_witnesses_from_core_plus_support": sorted(
+            set(core_witnesses) | {support_label}
+        ),
+        "activation_witness_count": len(set(core_witnesses) | {support_label}),
+        "activation_ready_with_support": len(set(core_witnesses) | {support_label}) >= 3,
+        "private_halo_core_vertices": private_halo_core_vertices,
+        "private_halo_containment_count": int(hit["private_halo_containment_count"]),
+        "missing_private_halo_core_vertices": missing_private_halo_core_vertices,
+        "closure_internal_core_vertices": sorted(closure_internal_core_vertices),
+        "support_label_mode": mode,
+        "ledger_private_pair_core_vertices": _int_list(hit["ledger_private_pair_core_vertices"]),
+        "ledger_private_pair_hit": bool(hit["ledger_private_pair_hit"]),
+    }
+
+
+def _one_outside_record(row_record: Mapping[str, Any]) -> dict[str, object]:
+    support_options = [
+        _support_option(row_record=row_record, hit=hit)
+        for hit in row_record["support_hits"]
+    ]
+    support_options.sort(key=lambda option: int(option["support_label"]))
+    support_mode_counts = Counter(str(option["support_label_mode"]) for option in support_options)
+
+    return {
+        "source_record_id": int(row_record["source_record_id"]),
+        "classification_assignment_id": str(row_record["classification_assignment_id"]),
+        "row_center": int(row_record["row_center"]),
+        "roles": [str(role) for role in row_record["roles"]],
+        "witnesses": _int_list(row_record["witnesses"]),
+        "bootstrap_core_witnesses": _int_list(row_record["bootstrap_core_witnesses"]),
+        "outside_witnesses": _int_list(row_record["outside_witnesses"]),
+        "activation_deficit_from_bootstrap_core": int(
+            row_record["activation_deficit_from_bootstrap_core"]
+        ),
+        "outside_support_kind": str(row_record["outside_support_kind"]),
+        "pressure_class": str(row_record["pressure_class"]),
+        "row_center_private_core_vertices": _int_list(row_record["row_center_private_core_vertices"]),
+        "row_center_private_in_all_deletion_closures": bool(
+            row_record["row_center_private_in_all_deletion_closures"]
+        ),
+        "max_witness_count_in_deletion_closure": int(
+            row_record["max_witness_count_in_deletion_closure"]
+        ),
+        "support_options": support_options,
+        "support_option_count": len(support_options),
+        "support_label_modes": _json_counter(support_mode_counts),
+        "ledger_private_pair_support_hit_count": int(
+            row_record["ledger_private_pair_support_hit_count"]
+        ),
+    }
+
+
+def _one_outside_records(row_pressure: Mapping[str, Any]) -> list[dict[str, object]]:
+    row_records = row_pressure.get("row_records")
+    if not isinstance(row_records, list):
+        raise AssertionError("row-pressure payload row_records must be a list")
+    records = [
+        _one_outside_record(row_record)
+        for row_record in row_records
+        if row_record["pressure_class"] == PRESSURE_CLASS
+    ]
+    records.sort(key=lambda record: (int(record["source_record_id"]), int(record["row_center"])))
+    return records
+
+
+def build_t12_one_outside_payload() -> dict[str, object]:
+    """Return the deterministic one-outside-label bootstrap/T12 packet."""
+
+    row_pressure = build_t12_row_pressure_payload()
+    records = _one_outside_records(row_pressure)
+
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    role_counts = Counter(role for record in records for role in record["roles"])
+    support_label_counts: Counter[int] = Counter()
+    support_mode_counts: Counter[str] = Counter()
+    containment_counts: Counter[int] = Counter()
+    for record in records:
+        source_id = int(record["source_record_id"])
+        row_center = int(record["row_center"])
+        rows_by_source[source_id].append(row_center)
+        for option in record["support_options"]:
+            support_label_counts[int(option["support_label"])] += 1
+            support_mode = str(option["support_label_mode"])
+            support_mode_counts[support_mode] += 1
+            containment_counts[int(option["private_halo_containment_count"])] += 1
+
+    multirow_support_labels = [
+        label for label, count in sorted(support_label_counts.items()) if count > 1
+    ]
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates fixed selected-row one-outside-label gaps; it does not prove the rows are forced.",
+            "A singleton outside support is activation bookkeeping, not a Euclidean rich-class certificate.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted(rows_by_source),
+            "one_outside_row_record_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "support_option_count": sum(int(record["support_option_count"]) for record in records),
+            "support_label_counts": _json_counter(support_label_counts),
+            "multirow_support_labels": multirow_support_labels,
+            "support_label_mode_counts": _json_counter(support_mode_counts),
+            "private_halo_containment_count_distribution": _json_counter(containment_counts),
+            "row_center_private_in_all_deletions_count": sum(
+                1 for record in records if record["row_center_private_in_all_deletion_closures"]
+            ),
+            "ledger_private_pair_support_hit_count": sum(
+                int(record["ledger_private_pair_support_hit_count"]) for record in records
+            ),
+            "role_counts": _json_counter(role_counts),
+            "activation_deficit_counts": {"1": len(records)},
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can a future bridge force a private row center together with "
+                "one of its singleton outside supports from genuine rich-class "
+                "geometry?"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_row_pressure.json",
+                "role": "source row-pressure records and singleton outside-label supports",
+                "schema": row_pressure.get("schema"),
+                "status": row_pressure.get("status"),
+                "trust": row_pressure.get("trust"),
+            }
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_one_outside.py",
+            "command": "python scripts/check_bootstrap_t12_one_outside.py --write --assert-expected",
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the one-outside-label packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 one-outside schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 one-outside status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [81, 151],
+        "one_outside_row_record_count": 3,
+        "row_centers_by_source_id": {"81": [8], "151": [5, 8]},
+        "support_option_count": 6,
+        "support_label_counts": {"5": 2, "6": 1, "7": 2, "8": 1},
+        "multirow_support_labels": [5, 7],
+        "support_label_mode_counts": {
+            CLOSURE_INTERNAL_MODE: 3,
+            PRIVATE_ALL_MODE: 3,
+        },
+        "private_halo_containment_count_distribution": {"3": 3, "4": 3},
+        "row_center_private_in_all_deletions_count": 3,
+        "ledger_private_pair_support_hit_count": 0,
+        "role_counts": {"equality_connector_row": 3, "strict_edge_row": 1},
+        "activation_deficit_counts": {"1": 3},
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    expected_records = {
+        (81, 8): {
+            "classification_assignment_id": "A082",
+            "roles": ["equality_connector_row"],
+            "witnesses": [0, 2, 5, 6],
+            "bootstrap_core_witnesses": [0, 2],
+            "outside_witnesses": [5, 6],
+            "support_labels": [5, 6],
+            "support_modes": [PRIVATE_ALL_MODE, CLOSURE_INTERNAL_MODE],
+        },
+        (151, 5): {
+            "classification_assignment_id": "A152",
+            "roles": ["equality_connector_row"],
+            "witnesses": [2, 4, 7, 8],
+            "bootstrap_core_witnesses": [2, 4],
+            "outside_witnesses": [7, 8],
+            "support_labels": [7, 8],
+            "support_modes": [CLOSURE_INTERNAL_MODE, PRIVATE_ALL_MODE],
+        },
+        (151, 8): {
+            "classification_assignment_id": "A152",
+            "roles": ["strict_edge_row", "equality_connector_row"],
+            "witnesses": [1, 2, 5, 7],
+            "bootstrap_core_witnesses": [1, 2],
+            "outside_witnesses": [5, 7],
+            "support_labels": [5, 7],
+            "support_modes": [PRIVATE_ALL_MODE, CLOSURE_INTERNAL_MODE],
+        },
+    }
+    by_key = {
+        (int(record["source_record_id"]), int(record["row_center"])): record
+        for record in records
+    }
+    if set(by_key) != set(expected_records):
+        raise AssertionError("unexpected one-outside record keys")
+    for key, expected in expected_records.items():
+        record = by_key[key]
+        for field in (
+            "classification_assignment_id",
+            "roles",
+            "witnesses",
+            "bootstrap_core_witnesses",
+            "outside_witnesses",
+        ):
+            if record.get(field) != expected[field]:
+                raise AssertionError(
+                    f"one-outside {key} {field} is {record.get(field)!r}, "
+                    f"expected {expected[field]!r}"
+                )
+        if record.get("pressure_class") != PRESSURE_CLASS:
+            raise AssertionError(f"one-outside {key} pressure class changed")
+        if record.get("activation_deficit_from_bootstrap_core") != 1:
+            raise AssertionError(f"one-outside {key} activation deficit changed")
+        if not record.get("row_center_private_in_all_deletion_closures"):
+            raise AssertionError(f"one-outside {key} row center is no longer private")
+
+        support_options = record.get("support_options")
+        if not isinstance(support_options, list):
+            raise AssertionError(f"one-outside {key} support_options must be a list")
+        labels = [int(option["support_label"]) for option in support_options]
+        modes = [str(option["support_label_mode"]) for option in support_options]
+        if labels != expected["support_labels"]:
+            raise AssertionError(f"one-outside {key} support labels changed")
+        if modes != expected["support_modes"]:
+            raise AssertionError(f"one-outside {key} support modes changed")
+        for option in support_options:
+            if not option["activation_ready_with_support"]:
+                raise AssertionError(f"one-outside {key} support is not activation-ready")
+            if option["ledger_private_pair_hit"]:
+                raise AssertionError(f"one-outside {key} unexpectedly has pair-ledger hit")

--- a/tests/test_bootstrap_t12_one_outside.py
+++ b/tests/test_bootstrap_t12_one_outside.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_t12_one_outside import (
+    CLOSURE_INTERNAL_MODE,
+    PRIVATE_ALL_MODE,
+    assert_expected_payload,
+    build_t12_one_outside_payload,
+)
+
+
+def test_bootstrap_t12_one_outside_expected_payload() -> None:
+    payload = build_t12_one_outside_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["one_outside_row_record_count"] == 3
+    assert summary["support_option_count"] == 6
+    assert summary["forcing_target_status"] == "OPEN_TARGET_NOT_PROVED"
+
+
+def test_bootstrap_t12_one_outside_isolates_expected_rows() -> None:
+    payload = build_t12_one_outside_payload()
+    by_key = {
+        (record["source_record_id"], record["row_center"]): record
+        for record in payload["records"]
+    }
+
+    assert set(by_key) == {(81, 8), (151, 5), (151, 8)}
+    assert by_key[(81, 8)]["bootstrap_core_witnesses"] == [0, 2]
+    assert by_key[(151, 5)]["bootstrap_core_witnesses"] == [2, 4]
+    assert by_key[(151, 8)]["bootstrap_core_witnesses"] == [1, 2]
+    assert all(record["row_center_private_in_all_deletion_closures"] for record in by_key.values())
+
+
+def test_bootstrap_t12_one_outside_support_modes() -> None:
+    payload = build_t12_one_outside_payload()
+    by_key = {
+        (record["source_record_id"], record["row_center"]): record
+        for record in payload["records"]
+    }
+
+    expected = {
+        (81, 8): [(5, PRIVATE_ALL_MODE), (6, CLOSURE_INTERNAL_MODE)],
+        (151, 5): [(7, CLOSURE_INTERNAL_MODE), (8, PRIVATE_ALL_MODE)],
+        (151, 8): [(5, PRIVATE_ALL_MODE), (7, CLOSURE_INTERNAL_MODE)],
+    }
+    for key, expected_options in expected.items():
+        actual = [
+            (option["support_label"], option["support_label_mode"])
+            for option in by_key[key]["support_options"]
+        ]
+        assert actual == expected_options
+
+
+def test_bootstrap_t12_one_outside_support_activation_and_ledger() -> None:
+    payload = build_t12_one_outside_payload()
+    for record in payload["records"]:
+        for option in record["support_options"]:
+            assert option["activation_ready_with_support"]
+            assert option["activation_witness_count"] == 3
+            assert not option["ledger_private_pair_hit"]
+
+
+def test_bootstrap_t12_one_outside_expected_payload_rejects_drift() -> None:
+    payload = build_t12_one_outside_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["support_label_counts"] = {"5": 6}
+
+    with pytest.raises(AssertionError, match="support_label_counts"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- Add a generated bootstrap/T12 one-outside-label diagnostic packet for rows `81:8`, `151:5`, and `151:8`.
- Add a checker, module, tests, and JSON certificate for the singleton-support split.
- Wire the packet into README, STATE, RESULTS, claims, review priorities, backlog, index, and provenance metadata with explicit non-overclaiming language.

## Validation

- `python scripts/check_bootstrap_t12_one_outside.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_t12_one_outside.py -q`
- `python -m ruff check src\erdos97\bootstrap_t12_one_outside.py scripts\check_bootstrap_t12_one_outside.py tests\test_bootstrap_t12_one_outside.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`