### PR TITLE
[codex] Add bootstrap T12 outside-pair packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the one-outside-label subpacket isolating the three singleton-support
   T12 row-pressure rows, read
   [`docs/bootstrap-t12-one-outside.md`](docs/bootstrap-t12-one-outside.md).
+- For the outside-pair subpacket isolating the remaining pair-supported T12
+  row-pressure row, read
+  [`docs/bootstrap-t12-outside-pair.md`](docs/bootstrap-t12-outside-pair.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -186,6 +186,16 @@ vertex `2`. This is still diagnostic bookkeeping only; see
 `scripts/check_bootstrap_t12_one_outside.py`, and
 `data/certificates/bootstrap_t12_one_outside.json`.
 
+The outside-pair subpacket isolates the last row-pressure row, `151:6`. This
+equality-connector row has one bootstrap-core witness, three activation-ready
+outside-pair supports, and row center `6` private in every deletion closure.
+All three support pairs are private in every deletion halo; two supports,
+`[3,8]` and `[5,8]`, also hit the private-pair ledger, while `[3,5]` is
+private-halo-only. This is still diagnostic bookkeeping only; see
+`docs/bootstrap-t12-outside-pair.md`,
+`scripts/check_bootstrap_t12_outside_pair.py`, and
+`data/certificates/bootstrap_t12_outside_pair.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -87,6 +87,13 @@ to the deletion closure for core vertex `2`. This remains diagnostic
 bookkeeping only, not a row-forcing theorem. See
 `docs/bootstrap-t12-one-outside.md`.
 
+An outside-pair subpacket isolates the remaining row-pressure gap, `151:6`.
+It has one bootstrap-core witness, row center `6` private in every deletion
+closure, and three outside-pair supports. All three supports are private in
+every deletion halo; `[3,8]` and `[5,8]` also hit the private-pair ledger,
+while `[3,5]` is private-halo-only. This is still diagnostic bookkeeping only,
+not a row-forcing theorem. See `docs/bootstrap-t12-outside-pair.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_outside_pair.json
+++ b/data/certificates/bootstrap_t12_outside_pair.json
@@ -1,0 +1,216 @@
+{
+  "claim_scope": "Outside-pair packet for the two tight n=9 bootstrap/T12 records; isolates the single missing T12/F16 row center that needs an outside pair while the row center remains private in every deletion closure. This does not prove that the missing row is forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates a fixed selected-row outside-pair gap; it does not prove the row is forced.",
+    "Private-pair ledger hits are bookkeeping contacts, not Euclidean rich-class certificates.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_outside_pair.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_outside_pair.py"
+  },
+  "records": [
+    {
+      "activation_deficit_from_bootstrap_core": 2,
+      "bootstrap_core_witnesses": [
+        0
+      ],
+      "classification_assignment_id": "A152",
+      "ledger_private_pair_support_hit_count": 2,
+      "max_witness_count_in_deletion_closure": 1,
+      "outside_support_kind": "outside_2_set",
+      "outside_witnesses": [
+        3,
+        5,
+        8
+      ],
+      "pressure_class": "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER",
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 6,
+      "row_center_private_core_vertices": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "support_pair_modes": {
+        "LEDGER_PRIVATE_PAIR_HIT": 2,
+        "PRIVATE_HALO_ONLY": 1
+      },
+      "support_pair_option_count": 3,
+      "support_pair_options": [
+        {
+          "activation_ready_with_pair": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_pair": [
+            0,
+            3,
+            5
+          ],
+          "ledger_private_pair_core_vertices": [],
+          "ledger_private_pair_hit": false,
+          "missing_private_halo_core_vertices": [],
+          "pair_private_in_all_deletion_halos": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support_pair": [
+            3,
+            5
+          ],
+          "support_pair_key": "3-5",
+          "support_pair_mode": "PRIVATE_HALO_ONLY"
+        },
+        {
+          "activation_ready_with_pair": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_pair": [
+            0,
+            3,
+            8
+          ],
+          "ledger_private_pair_core_vertices": [
+            0
+          ],
+          "ledger_private_pair_hit": true,
+          "missing_private_halo_core_vertices": [],
+          "pair_private_in_all_deletion_halos": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support_pair": [
+            3,
+            8
+          ],
+          "support_pair_key": "3-8",
+          "support_pair_mode": "LEDGER_PRIVATE_PAIR_HIT"
+        },
+        {
+          "activation_ready_with_pair": true,
+          "activation_witness_count": 3,
+          "activation_witnesses_from_core_plus_pair": [
+            0,
+            5,
+            8
+          ],
+          "ledger_private_pair_core_vertices": [
+            2
+          ],
+          "ledger_private_pair_hit": true,
+          "missing_private_halo_core_vertices": [],
+          "pair_private_in_all_deletion_halos": true,
+          "private_halo_containment_count": 4,
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "support_pair": [
+            5,
+            8
+          ],
+          "support_pair_key": "5-8",
+          "support_pair_mode": "LEDGER_PRIVATE_PAIR_HIT"
+        }
+      ],
+      "witness_counts_by_deletion_core": {
+        "0": 0,
+        "1": 1,
+        "2": 1,
+        "4": 1
+      },
+      "witnesses": [
+        0,
+        3,
+        5,
+        8
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_outside_pair.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_row_pressure.json",
+      "role": "source row-pressure records and outside-pair supports",
+      "schema": "erdos97.bootstrap_t12_row_pressure.v1",
+      "status": "BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_OUTSIDE_PAIR_DIAGNOSTIC_ONLY",
+  "summary": {
+    "activation_deficit_counts": {
+      "2": 1
+    },
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "ledger_hit_support_pairs": [
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "ledger_miss_support_pairs": [
+      [
+        3,
+        5
+      ]
+    ],
+    "ledger_private_pair_core_vertices": [
+      0,
+      2
+    ],
+    "ledger_private_pair_support_hit_count": 2,
+    "ledger_private_pair_support_miss_count": 1,
+    "next_bridge_question": "Can a future bridge force an equality-connector row from one bootstrap-core witness plus an outside pair with partial private-pair ledger support?",
+    "outside_pair_row_record_count": 1,
+    "private_halo_containment_count_distribution": {
+      "4": 3
+    },
+    "role_counts": {
+      "equality_connector_row": 1
+    },
+    "row_center_private_in_all_deletions_count": 1,
+    "row_centers_by_source_id": {
+      "151": [
+        6
+      ]
+    },
+    "source_record_ids": [
+      151
+    ],
+    "support_label_counts": {
+      "3": 2,
+      "5": 2,
+      "8": 2
+    },
+    "support_pair_counts": {
+      "3-5": 1,
+      "3-8": 1,
+      "5-8": 1
+    },
+    "support_pair_mode_counts": {
+      "LEDGER_PRIVATE_PAIR_HIT": 2,
+      "PRIVATE_HALO_ONLY": 1
+    },
+    "support_pair_option_count": 3,
+    "support_pairs_private_in_all_deletion_halos_count": 3
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-outside-pair.md
+++ b/docs/bootstrap-t12-outside-pair.md
@@ -1,0 +1,72 @@
+# Bootstrap T12 Outside-Pair Row
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the outside-pair subcase of the
+[`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md) ledger: the
+single missing `T12/F16` row with one bootstrap-core witness, two needed
+outside labels, and a row center that remains private in every deletion
+closure.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_outside_pair.py --check --assert-expected
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_outside_pair.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_outside_pair.json`.
+
+## Scope
+
+The input is fixed selected-row bookkeeping from the row-pressure diagnostic.
+An outside-pair support is an activation record, not a Euclidean rich-class
+certificate. A private-pair ledger hit is a useful contact with the
+bootstrap-core capacity ledger, but it does not prove that the row is forced
+in a real minimal counterexample.
+
+The artifact records:
+
+- the source assignment and missing row center;
+- the one witness already in the bootstrap core `[0,1,2,4]`;
+- the three outside-pair supports that make the row activation-ready;
+- which supports hit the private-pair ledger;
+- whether each support pair is private in every deletion halo;
+- whether the row center remains private in all deletion closures.
+
+## Results
+
+Exactly one row-pressure gap needs an outside pair.
+
+| Source row | Role | Core witnesses | Outside pair supports |
+|---|---|---|---|
+| `151:6` | equality connector | `[0]` | `[3,5]` private-halo only; `[3,8]` ledger hit at core `0`; `[5,8]` ledger hit at core `2` |
+
+All three outside pairs are private in every deletion halo. Two pairs,
+`[3,8]` and `[5,8]`, also hit the existing private-pair ledger. The remaining
+pair, `[3,5]`, is private-halo-only.
+
+The row center `6` remains private in every deletion closure. No deletion
+closure contains more than one witness from the row, so this is the hardest
+row-pressure subcase left after the closure-exposed and one-outside-label
+packets.
+
+## Reading
+
+This packet narrows the next bridge question:
+
+```text
+Can genuine rich-class geometry force an equality-connector row from one
+bootstrap-core witness plus an outside pair with partial private-pair ledger
+support?
+```
+
+The packet does not answer that question. It records that the outside-pair
+case is the only subcase where the existing private-pair ledger makes direct
+contact with the missing `T12/F16` row-pressure gaps.

--- a/docs/bootstrap-t12-row-pressure.md
+++ b/docs/bootstrap-t12-row-pressure.md
@@ -77,6 +77,11 @@ The row `151:6` has only one core witness. It needs an outside pair, and two
 of its possible outside pairs, `[3,8]` and `[5,8]`, hit the existing
 private-pair ledger.
 
+The focused outside-pair packet
+[`bootstrap-t12-outside-pair.md`](bootstrap-t12-outside-pair.md) records this
+last subcase separately. It distinguishes the two ledger-hit support pairs
+from the private-halo-only support pair `[3,5]`.
+
 ## Reading
 
 This narrows the next proof-mining question:

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -497,6 +497,13 @@ and one is internal to the deletion closure for core vertex `2`. This is a
 diagnostic decomposition only, not a theorem that singleton supports or row
 centers are forced by Euclidean geometry.
 
+The outside-pair packet in `docs/bootstrap-t12-outside-pair.md` isolates the
+single pair-supported row, `151:6`. It has one bootstrap-core witness and
+three outside-pair supports; all three supports are private in every deletion
+halo, and two also hit the private-pair ledger. This is still a diagnostic
+decomposition only, not a theorem that a private-pair ledger hit forces an
+equality-connector row in genuine geometry.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -43,6 +43,9 @@ Use this queue when no more specific issue is selected.
    The one-outside-label subpacket in `docs/bootstrap-t12-one-outside.md`
    isolates the three singleton-support rows where a future bridge would need
    to force one outside label without relying on private-pair capacity.
+   The outside-pair subpacket in `docs/bootstrap-t12-outside-pair.md` isolates
+   the remaining pair-supported row, where private-pair capacity makes partial
+   direct contact but still does not force the missing equality connector.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,6 +150,8 @@ put detailed reconciliation in the canonical synthesis.
   gaps.
 - [`bootstrap-t12-one-outside.md`](bootstrap-t12-one-outside.md):
   focused packet isolating the three singleton-support T12 row-pressure gaps.
+- [`bootstrap-t12-outside-pair.md`](bootstrap-t12-outside-pair.md):
+  focused packet isolating the remaining pair-supported T12 row-pressure gap.
 - [`bridge-negative-controls.md`](bridge-negative-controls.md): exact
   guardrails for incidence-only and fragile-cover-only bridge claims.
 - [`n7-fano-enumeration.md`](n7-fano-enumeration.md): reproducible `n=7`

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -333,6 +333,9 @@ condition that the surviving multi-block family does not automatically satisfy:
 - bootstrap/T12 one-outside-label evidence, as recorded in
   `docs/bootstrap-t12-one-outside.md`, isolating the three singleton-support
   rows where pair-capacity arguments do not directly apply.
+- bootstrap/T12 outside-pair evidence, as recorded in
+  `docs/bootstrap-t12-outside-pair.md`, isolating the remaining row where the
+  private-pair ledger has partial direct support.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -173,6 +173,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_one_outside.json"
       verifier: "scripts/check_bootstrap_t12_one_outside.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; isolates rows 81:8, 151:5, and 151:8 by singleton outside-label support, but does not prove missing rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_outside_pair"
+      status: "outside-pair subpacket for the remaining pair-supported T12 row-pressure gap"
+      artifact: "data/certificates/bootstrap_t12_outside_pair.json"
+      verifier: "scripts/check_bootstrap_t12_outside_pair.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates row 151:6 by outside-pair support and partial private-pair ledger hits, but does not prove missing rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2075,6 +2075,68 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_outside_pair
+    path: data/certificates/bootstrap_t12_outside_pair.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_outside_pair.py
+    command: python scripts/check_bootstrap_t12_outside_pair.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_outside_pair.py
+    check_command: python scripts/check_bootstrap_t12_outside_pair.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Outside-pair packet for the two tight n=9 bootstrap/T12 records; not a proof that the missing row is forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_outside_pair.v1
+      status: BOOTSTRAP_T12_OUTSIDE_PAIR_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 151
+      summary.outside_pair_row_record_count: 1
+      summary.row_centers_by_source_id.151:
+        - 6
+      summary.support_pair_option_count: 3
+      summary.support_pair_counts.3-5: 1
+      summary.support_pair_counts.3-8: 1
+      summary.support_pair_counts.5-8: 1
+      summary.support_label_counts.3: 2
+      summary.support_label_counts.5: 2
+      summary.support_label_counts.8: 2
+      summary.support_pair_mode_counts.LEDGER_PRIVATE_PAIR_HIT: 2
+      summary.support_pair_mode_counts.PRIVATE_HALO_ONLY: 1
+      summary.private_halo_containment_count_distribution.4: 3
+      summary.support_pairs_private_in_all_deletion_halos_count: 3
+      summary.ledger_private_pair_support_hit_count: 2
+      summary.ledger_private_pair_support_miss_count: 1
+      summary.ledger_hit_support_pairs:
+        - [3, 8]
+        - [5, 8]
+      summary.ledger_miss_support_pairs:
+        - [3, 5]
+      summary.ledger_private_pair_core_vertices:
+        - 0
+        - 2
+      summary.row_center_private_in_all_deletions_count: 1
+      summary.role_counts.equality_connector_row: 1
+      summary.activation_deficit_counts.2: 1
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_outside_pair.py
+      provenance.command: python scripts/check_bootstrap_t12_outside_pair.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - missing T12 row centers are forced
+      - outside pair proves missing rows are forced
+      - private-pair ledger hit proves row-center forcing
+      - equality connector row is forced
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/scripts/check_bootstrap_t12_outside_pair.py
+++ b/scripts/check_bootstrap_t12_outside_pair.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 outside-pair packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_outside_pair import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_outside_pair_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 outside-pair row")
+    print(f"records: {summary['outside_pair_row_record_count']}")
+    print(f"row centers: {summary['row_centers_by_source_id']}")
+    print(f"support pairs: {summary['support_pair_counts']}")
+    print(f"support modes: {summary['support_pair_mode_counts']}")
+    print(f"ledger hits: {summary['ledger_hit_support_pairs']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned outside-pair counts")
+    args = parser.parse_args()
+
+    generated = build_t12_outside_pair_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated outside-pair packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 outside-pair artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 outside-pair expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_outside_pair.py
+++ b/src/erdos97/bootstrap_t12_outside_pair.py
@@ -1,0 +1,362 @@
+"""Outside-pair packet for the bootstrap/T12 target.
+
+This module isolates the row-pressure subcase where a missing T12/F16 row has
+one bootstrap-core witness and needs an outside pair while its row center
+remains private in every deletion closure.  It is proof-mining bookkeeping only
+and does not prove that any missing row is geometrically forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_row_pressure import build_t12_row_pressure_payload
+
+
+SCHEMA = "erdos97.bootstrap_t12_outside_pair.v1"
+STATUS = "BOOTSTRAP_T12_OUTSIDE_PAIR_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Outside-pair packet for the two tight n=9 bootstrap/T12 records; "
+    "isolates the single missing T12/F16 row center that needs an outside pair "
+    "while the row center remains private in every deletion closure. This "
+    "does not prove that the missing row is forced, does not prove n=9, does "
+    "not prove the bridge, and does not claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / "bootstrap_t12_outside_pair.json"
+
+PRESSURE_CLASS = "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER"
+LEDGER_HIT_MODE = "LEDGER_PRIVATE_PAIR_HIT"
+PRIVATE_HALO_ONLY_MODE = "PRIVATE_HALO_ONLY"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _pair(values: Sequence[Any]) -> tuple[int, int]:
+    a, b = int(values[0]), int(values[1])
+    if a == b:
+        raise ValueError("pair endpoints must be distinct")
+    return tuple(sorted((a, b)))
+
+
+def _pair_key(values: Sequence[Any]) -> str:
+    a, b = _pair(values)
+    return f"{a}-{b}"
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _support_pair_mode(hit: Mapping[str, Any]) -> str:
+    if bool(hit["ledger_private_pair_hit"]):
+        return LEDGER_HIT_MODE
+    return PRIVATE_HALO_ONLY_MODE
+
+
+def _support_pair_option(
+    *,
+    row_record: Mapping[str, Any],
+    hit: Mapping[str, Any],
+) -> dict[str, object]:
+    support_pair = list(_pair(hit["support"]))
+    core_witnesses = _int_list(row_record["bootstrap_core_witnesses"])
+    row_center_private_core_vertices = _int_list(row_record["row_center_private_core_vertices"])
+    private_halo_core_vertices = _int_list(hit["private_halo_core_vertices"])
+    missing_private_halo_core_vertices = sorted(
+        set(row_center_private_core_vertices) - set(private_halo_core_vertices)
+    )
+    activation_witnesses = sorted(set(core_witnesses) | set(support_pair))
+
+    return {
+        "support_pair": support_pair,
+        "support_pair_key": _pair_key(support_pair),
+        "activation_witnesses_from_core_plus_pair": activation_witnesses,
+        "activation_witness_count": len(activation_witnesses),
+        "activation_ready_with_pair": len(activation_witnesses) >= 3,
+        "private_halo_core_vertices": private_halo_core_vertices,
+        "private_halo_containment_count": int(hit["private_halo_containment_count"]),
+        "pair_private_in_all_deletion_halos": not missing_private_halo_core_vertices,
+        "missing_private_halo_core_vertices": missing_private_halo_core_vertices,
+        "ledger_private_pair_core_vertices": _int_list(hit["ledger_private_pair_core_vertices"]),
+        "ledger_private_pair_hit": bool(hit["ledger_private_pair_hit"]),
+        "support_pair_mode": _support_pair_mode(hit),
+    }
+
+
+def _outside_pair_record(row_record: Mapping[str, Any]) -> dict[str, object]:
+    support_pair_options = [
+        _support_pair_option(row_record=row_record, hit=hit)
+        for hit in row_record["support_hits"]
+    ]
+    support_pair_options.sort(key=lambda option: str(option["support_pair_key"]))
+    support_mode_counts = Counter(
+        str(option["support_pair_mode"]) for option in support_pair_options
+    )
+    witness_counts_by_deletion_core = {
+        str(exposure["core_vertex"]): int(exposure["witness_count_in_closure"])
+        for exposure in row_record["deletion_closure_exposures"]
+    }
+
+    return {
+        "source_record_id": int(row_record["source_record_id"]),
+        "classification_assignment_id": str(row_record["classification_assignment_id"]),
+        "row_center": int(row_record["row_center"]),
+        "roles": [str(role) for role in row_record["roles"]],
+        "witnesses": _int_list(row_record["witnesses"]),
+        "bootstrap_core_witnesses": _int_list(row_record["bootstrap_core_witnesses"]),
+        "outside_witnesses": _int_list(row_record["outside_witnesses"]),
+        "activation_deficit_from_bootstrap_core": int(
+            row_record["activation_deficit_from_bootstrap_core"]
+        ),
+        "outside_support_kind": str(row_record["outside_support_kind"]),
+        "pressure_class": str(row_record["pressure_class"]),
+        "row_center_private_core_vertices": _int_list(row_record["row_center_private_core_vertices"]),
+        "row_center_private_in_all_deletion_closures": bool(
+            row_record["row_center_private_in_all_deletion_closures"]
+        ),
+        "max_witness_count_in_deletion_closure": int(
+            row_record["max_witness_count_in_deletion_closure"]
+        ),
+        "witness_counts_by_deletion_core": witness_counts_by_deletion_core,
+        "support_pair_options": support_pair_options,
+        "support_pair_option_count": len(support_pair_options),
+        "support_pair_modes": _json_counter(support_mode_counts),
+        "ledger_private_pair_support_hit_count": int(
+            row_record["ledger_private_pair_support_hit_count"]
+        ),
+    }
+
+
+def _outside_pair_records(row_pressure: Mapping[str, Any]) -> list[dict[str, object]]:
+    row_records = row_pressure.get("row_records")
+    if not isinstance(row_records, list):
+        raise AssertionError("row-pressure payload row_records must be a list")
+    records = [
+        _outside_pair_record(row_record)
+        for row_record in row_records
+        if row_record["pressure_class"] == PRESSURE_CLASS
+    ]
+    records.sort(key=lambda record: (int(record["source_record_id"]), int(record["row_center"])))
+    return records
+
+
+def build_t12_outside_pair_payload() -> dict[str, object]:
+    """Return the deterministic outside-pair bootstrap/T12 packet."""
+
+    row_pressure = build_t12_row_pressure_payload()
+    records = _outside_pair_records(row_pressure)
+
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    role_counts = Counter(role for record in records for role in record["roles"])
+    support_pair_counts: Counter[str] = Counter()
+    support_label_counts: Counter[int] = Counter()
+    support_mode_counts: Counter[str] = Counter()
+    containment_counts: Counter[int] = Counter()
+    ledger_hit_pairs: list[list[int]] = []
+    ledger_miss_pairs: list[list[int]] = []
+    ledger_core_vertices: set[int] = set()
+    private_in_all_count = 0
+    for record in records:
+        source_id = int(record["source_record_id"])
+        row_center = int(record["row_center"])
+        rows_by_source[source_id].append(row_center)
+        for option in record["support_pair_options"]:
+            support_pair = _int_list(option["support_pair"])
+            support_pair_counts[str(option["support_pair_key"])] += 1
+            for label in support_pair:
+                support_label_counts[label] += 1
+            support_mode = str(option["support_pair_mode"])
+            support_mode_counts[support_mode] += 1
+            containment_counts[int(option["private_halo_containment_count"])] += 1
+            if bool(option["pair_private_in_all_deletion_halos"]):
+                private_in_all_count += 1
+            if bool(option["ledger_private_pair_hit"]):
+                ledger_hit_pairs.append(support_pair)
+                ledger_core_vertices.update(_int_list(option["ledger_private_pair_core_vertices"]))
+            else:
+                ledger_miss_pairs.append(support_pair)
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates a fixed selected-row outside-pair gap; it does not prove the row is forced.",
+            "Private-pair ledger hits are bookkeeping contacts, not Euclidean rich-class certificates.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted(rows_by_source),
+            "outside_pair_row_record_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "support_pair_option_count": sum(
+                int(record["support_pair_option_count"]) for record in records
+            ),
+            "support_pair_counts": _json_counter(support_pair_counts),
+            "support_label_counts": _json_counter(support_label_counts),
+            "support_pair_mode_counts": _json_counter(support_mode_counts),
+            "private_halo_containment_count_distribution": _json_counter(containment_counts),
+            "support_pairs_private_in_all_deletion_halos_count": private_in_all_count,
+            "ledger_private_pair_support_hit_count": len(ledger_hit_pairs),
+            "ledger_private_pair_support_miss_count": len(ledger_miss_pairs),
+            "ledger_hit_support_pairs": sorted(ledger_hit_pairs),
+            "ledger_miss_support_pairs": sorted(ledger_miss_pairs),
+            "ledger_private_pair_core_vertices": sorted(ledger_core_vertices),
+            "row_center_private_in_all_deletions_count": sum(
+                1 for record in records if record["row_center_private_in_all_deletion_closures"]
+            ),
+            "role_counts": _json_counter(role_counts),
+            "activation_deficit_counts": {"2": len(records)},
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can a future bridge force an equality-connector row from one "
+                "bootstrap-core witness plus an outside pair with partial "
+                "private-pair ledger support?"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_row_pressure.json",
+                "role": "source row-pressure records and outside-pair supports",
+                "schema": row_pressure.get("schema"),
+                "status": row_pressure.get("status"),
+                "trust": row_pressure.get("trust"),
+            }
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_outside_pair.py",
+            "command": "python scripts/check_bootstrap_t12_outside_pair.py --write --assert-expected",
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the outside-pair packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 outside-pair schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 outside-pair status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [151],
+        "outside_pair_row_record_count": 1,
+        "row_centers_by_source_id": {"151": [6]},
+        "support_pair_option_count": 3,
+        "support_pair_counts": {"3-5": 1, "3-8": 1, "5-8": 1},
+        "support_label_counts": {"3": 2, "5": 2, "8": 2},
+        "support_pair_mode_counts": {
+            LEDGER_HIT_MODE: 2,
+            PRIVATE_HALO_ONLY_MODE: 1,
+        },
+        "private_halo_containment_count_distribution": {"4": 3},
+        "support_pairs_private_in_all_deletion_halos_count": 3,
+        "ledger_private_pair_support_hit_count": 2,
+        "ledger_private_pair_support_miss_count": 1,
+        "ledger_hit_support_pairs": [[3, 8], [5, 8]],
+        "ledger_miss_support_pairs": [[3, 5]],
+        "ledger_private_pair_core_vertices": [0, 2],
+        "row_center_private_in_all_deletions_count": 1,
+        "role_counts": {"equality_connector_row": 1},
+        "activation_deficit_counts": {"2": 1},
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    if len(records) != 1:
+        raise AssertionError("outside-pair packet should contain exactly one row")
+    record = records[0]
+    expected_record = {
+        "source_record_id": 151,
+        "classification_assignment_id": "A152",
+        "row_center": 6,
+        "roles": ["equality_connector_row"],
+        "witnesses": [0, 3, 5, 8],
+        "bootstrap_core_witnesses": [0],
+        "outside_witnesses": [3, 5, 8],
+        "activation_deficit_from_bootstrap_core": 2,
+        "outside_support_kind": "outside_2_set",
+        "pressure_class": PRESSURE_CLASS,
+        "row_center_private_core_vertices": [0, 1, 2, 4],
+        "row_center_private_in_all_deletion_closures": True,
+        "max_witness_count_in_deletion_closure": 1,
+        "witness_counts_by_deletion_core": {"0": 0, "1": 1, "2": 1, "4": 1},
+        "support_pair_option_count": 3,
+        "support_pair_modes": {
+            LEDGER_HIT_MODE: 2,
+            PRIVATE_HALO_ONLY_MODE: 1,
+        },
+        "ledger_private_pair_support_hit_count": 2,
+    }
+    for key, expected in expected_record.items():
+        if record.get(key) != expected:
+            raise AssertionError(f"outside-pair record {key} is {record.get(key)!r}, expected {expected!r}")
+
+    expected_pairs = {
+        "3-5": {
+            "support_pair": [3, 5],
+            "mode": PRIVATE_HALO_ONLY_MODE,
+            "ledger_core_vertices": [],
+        },
+        "3-8": {
+            "support_pair": [3, 8],
+            "mode": LEDGER_HIT_MODE,
+            "ledger_core_vertices": [0],
+        },
+        "5-8": {
+            "support_pair": [5, 8],
+            "mode": LEDGER_HIT_MODE,
+            "ledger_core_vertices": [2],
+        },
+    }
+    options = record.get("support_pair_options")
+    if not isinstance(options, list):
+        raise AssertionError("support_pair_options must be a list")
+    by_key = {str(option["support_pair_key"]): option for option in options}
+    if set(by_key) != set(expected_pairs):
+        raise AssertionError("unexpected outside-pair support options")
+    for key, expected in expected_pairs.items():
+        option = by_key[key]
+        if option["support_pair"] != expected["support_pair"]:
+            raise AssertionError(f"support pair {key} changed")
+        if option["support_pair_mode"] != expected["mode"]:
+            raise AssertionError(f"support pair {key} mode changed")
+        if option["ledger_private_pair_core_vertices"] != expected["ledger_core_vertices"]:
+            raise AssertionError(f"support pair {key} ledger core vertices changed")
+        if not option["activation_ready_with_pair"]:
+            raise AssertionError(f"support pair {key} is not activation-ready")
+        if option["activation_witness_count"] != 3:
+            raise AssertionError(f"support pair {key} activation count changed")
+        if not option["pair_private_in_all_deletion_halos"]:
+            raise AssertionError(f"support pair {key} is no longer private in all halos")

--- a/tests/test_bootstrap_t12_outside_pair.py
+++ b/tests/test_bootstrap_t12_outside_pair.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from erdos97.bootstrap_t12_outside_pair import (
+    LEDGER_HIT_MODE,
+    PRIVATE_HALO_ONLY_MODE,
+    assert_expected_payload,
+    build_t12_outside_pair_payload,
+)
+
+
+def test_bootstrap_t12_outside_pair_expected_payload() -> None:
+    payload = build_t12_outside_pair_payload()
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["outside_pair_row_record_count"] == 1
+    assert summary["support_pair_option_count"] == 3
+    assert summary["forcing_target_status"] == "OPEN_TARGET_NOT_PROVED"
+
+
+def test_bootstrap_t12_outside_pair_isolates_expected_row() -> None:
+    payload = build_t12_outside_pair_payload()
+    record = payload["records"][0]
+
+    assert record["source_record_id"] == 151
+    assert record["classification_assignment_id"] == "A152"
+    assert record["row_center"] == 6
+    assert record["roles"] == ["equality_connector_row"]
+    assert record["witnesses"] == [0, 3, 5, 8]
+    assert record["bootstrap_core_witnesses"] == [0]
+    assert record["outside_witnesses"] == [3, 5, 8]
+    assert record["row_center_private_in_all_deletion_closures"]
+
+
+def test_bootstrap_t12_outside_pair_support_modes() -> None:
+    payload = build_t12_outside_pair_payload()
+    record = payload["records"][0]
+    actual = [
+        (option["support_pair"], option["support_pair_mode"])
+        for option in record["support_pair_options"]
+    ]
+
+    assert actual == [
+        ([3, 5], PRIVATE_HALO_ONLY_MODE),
+        ([3, 8], LEDGER_HIT_MODE),
+        ([5, 8], LEDGER_HIT_MODE),
+    ]
+
+
+def test_bootstrap_t12_outside_pair_support_activation_and_privacy() -> None:
+    payload = build_t12_outside_pair_payload()
+    record = payload["records"][0]
+
+    for option in record["support_pair_options"]:
+        assert option["activation_ready_with_pair"]
+        assert option["activation_witness_count"] == 3
+        assert option["pair_private_in_all_deletion_halos"]
+        assert option["private_halo_containment_count"] == 4
+
+
+def test_bootstrap_t12_outside_pair_ledger_hits_are_partial() -> None:
+    payload = build_t12_outside_pair_payload()
+    record = payload["records"][0]
+    by_key = {
+        option["support_pair_key"]: option
+        for option in record["support_pair_options"]
+    }
+
+    assert not by_key["3-5"]["ledger_private_pair_hit"]
+    assert by_key["3-8"]["ledger_private_pair_core_vertices"] == [0]
+    assert by_key["5-8"]["ledger_private_pair_core_vertices"] == [2]
+
+
+def test_bootstrap_t12_outside_pair_expected_payload_rejects_drift() -> None:
+    payload = build_t12_outside_pair_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["ledger_private_pair_support_hit_count"] = 3
+
+    with pytest.raises(AssertionError, match="ledger_private_pair_support_hit_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- Add a generated bootstrap/T12 outside-pair diagnostic packet for the remaining row-pressure gap `151:6`.
- Add a checker, module, tests, and JSON certificate for the three outside-pair supports and their partial private-pair ledger hits.
- Wire the packet into README, STATE, RESULTS, claims, review priorities, backlog, index, and provenance metadata with explicit non-overclaiming language.

## Validation

- `python scripts/check_bootstrap_t12_outside_pair.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_t12_outside_pair.py -q`
- `python -m ruff check src\erdos97\bootstrap_t12_outside_pair.py scripts\check_bootstrap_t12_outside_pair.py tests\test_bootstrap_t12_outside_pair.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`