### PR TITLE
[codex] Add relation skeleton catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   read [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 - For the derived `n=9` vertex-circle template lemma-candidate catalog, read
   [`docs/n9-vertex-circle-template-lemma-catalog.md`](docs/n9-vertex-circle-template-lemma-catalog.md).
+- For the first relation-skeleton extraction from focused `n=9`
+  vertex-circle local packets, read
+  [`docs/relation-skeleton-catalog.md`](docs/relation-skeleton-catalog.md).
 - For the review-pending `n=10` singleton-slice finite-case draft, read
   [`docs/n10-vertex-circle-singleton-slices.md`](docs/n10-vertex-circle-singleton-slices.md).
 - For a compact human-readable proof-note draft excluding bad convex octagons,
@@ -379,6 +382,7 @@ python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --as
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json

--- a/data/certificates/relation_skeleton_catalog.json
+++ b/data/certificates/relation_skeleton_catalog.json
@@ -1,0 +1,522 @@
+{
+  "catalog_scope": "vertex-circle selected-distance quotient skeletons",
+  "claim_scope": "Two-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "contradiction_type_counts": {
+    "strict_directed_cycle": 1,
+    "strict_self_edge": 1
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "interpretation": [
+    "This catalog extracts relation skeletons from two focused local lemma packets.",
+    "Each entry separates selected-distance quotient equalities from vertex-circle strict inequalities.",
+    "The catalog is intended to support reusable local-lemma review and bridge proof mining.",
+    "No proof of the n=9 case is claimed.",
+    "No proof of Erdos Problem #97 and no counterexample are claimed."
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_relation_skeleton_catalog.py --assert-expected --write",
+    "generator": "scripts/check_relation_skeleton_catalog.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.relation_skeleton_catalog.v1",
+  "skeleton_count": 2,
+  "skeleton_ids": [
+    "VC-T01-F09-strict-self-edge",
+    "VC-T10-F12-strict-directed-cycle"
+  ],
+  "skeletons": [
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          8
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 6,
+        "assignment_ids": [
+          "A014",
+          "A024",
+          "A031",
+          "A140",
+          "A166",
+          "A175"
+        ],
+        "families": [
+          "F09"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 6
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 3 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            1,
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            2,
+            0,
+            1,
+            4,
+            6
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              8
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              2
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              0,
+              2
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              2
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T01-F09-strict-self-edge",
+      "source_family_id": "F09",
+      "source_packet": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+      "source_template_id": "T01",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a directed strict cycle of length 2 after selected-distance quotienting.",
+        "cycle_length": 2,
+        "kind": "strict_directed_cycle",
+        "obstruction": "directed strict cycle in the quotient graph",
+        "quotient_cycle": [
+          {
+            "cycle_step": 0,
+            "equality_chain_to_next_outer_pair": [
+              [
+                0,
+                3
+              ],
+              [
+                3,
+                6
+              ],
+              [
+                1,
+                6
+              ]
+            ],
+            "next_outer_pair": [
+              1,
+              6
+            ],
+            "strict_from_pair": [
+              0,
+              6
+            ],
+            "strict_to_pair": [
+              0,
+              3
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "equality_chain_to_next_outer_pair": [
+              [
+                0,
+                1
+              ],
+              [
+                0,
+                6
+              ]
+            ],
+            "next_outer_pair": [
+              0,
+              6
+            ],
+            "strict_from_pair": [
+              1,
+              6
+            ],
+            "strict_to_pair": [
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "contradiction_type": "strict_directed_cycle",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A020",
+          "A040",
+          "A047",
+          "A071",
+          "A080",
+          "A081",
+          "A083",
+          "A093",
+          "A095",
+          "A111",
+          "A126",
+          "A147",
+          "A151",
+          "A153",
+          "A154",
+          "A157",
+          "A164",
+          "A180"
+        ],
+        "families": [
+          "F12"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 4 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          [
+            3,
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            6,
+            1,
+            3,
+            4,
+            7
+          ],
+          [
+            8,
+            0,
+            3,
+            6,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              0,
+              3
+            ],
+            [
+              3,
+              6
+            ],
+            [
+              1,
+              6
+            ]
+          ],
+          [
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              6
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "cycle_step": 0,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  0,
+                  3
+                ],
+                "right_pair": [
+                  3,
+                  6
+                ],
+                "row": 3
+              },
+              {
+                "left_pair": [
+                  3,
+                  6
+                ],
+                "right_pair": [
+                  1,
+                  6
+                ],
+                "row": 6
+              }
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  0,
+                  1
+                ],
+                "right_pair": [
+                  0,
+                  6
+                ],
+                "row": 0
+              }
+            ]
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              0,
+              6
+            ],
+            "outer_span": 2,
+            "row": 8,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              0,
+              3,
+              6,
+              7
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              0,
+              1
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "outer_span": 2,
+            "row": 3,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              4,
+              6,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T10-F12-strict-directed-cycle",
+      "source_family_id": "F12",
+      "source_packet": "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
+      "source_template_id": "T10",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    }
+  ],
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+      "role": "focused T01/F09 self-edge local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
+      "role": "focused T10/F12 strict-cycle local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,9 @@ put detailed reconciliation in the canonical synthesis.
   crossing CSP for two-overlap patterns.
 - [`vertex-circle-order-filter.md`](vertex-circle-order-filter.md): exact
   row-wise convexity-distance filter for cyclic orders.
+- [`relation-skeleton-catalog.md`](relation-skeleton-catalog.md): first
+  review-pending relation-skeleton extraction for T01 self-edge and T10
+  strict-cycle vertex-circle quotient motifs; proof-mining aid only.
 - [`reciprocal-radial-budget.md`](reciprocal-radial-budget.md): local
   middle-witness reciprocal-radial budget packet; a research packet, not a
   global obstruction.

--- a/docs/relation-skeleton-catalog.md
+++ b/docs/relation-skeleton-catalog.md
@@ -1,0 +1,129 @@
+# Relation-skeleton Catalog
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note records a first narrow relation-skeleton extraction for proof
+mining. It does not claim a proof of `n=9`, does not claim a counterexample,
+does not complete independent review of the exhaustive checker, and does not
+update the official/global status of Erdos Problem #97.
+
+## Scope
+
+The checked artifact is
+`data/certificates/relation_skeleton_catalog.json`. It currently contains two
+vertex-circle selected-distance quotient skeletons extracted from focused
+local lemma packets:
+
+```text
+VC-T01-F09-strict-self-edge
+VC-T10-F12-strict-directed-cycle
+```
+
+This is intentionally smaller than the full 12-template `n=9` catalog. The
+goal is to give reviewers a reusable object shape before adding Kalmanson,
+row-Ptolemy, or additional vertex-circle templates.
+
+## Skeleton Fields
+
+Each skeleton separates:
+
+```text
+hypotheses:
+    cyclic order
+    selected rows
+    minimal local hypotheses
+relation_quotient:
+    selected-distance equality steps
+    equality chains among ordinary pair distances
+    strict edges from vertex-circle chord monotonicity
+conclusion:
+    strict self-edge or directed strict cycle in the quotient graph
+coverage:
+    source template/family and assignment ids
+guardrails:
+    what the skeleton does not prove
+```
+
+The common relation-skeleton object is deliberately about quotient relations,
+not coordinates. It records which ordinary pair distances are identified by
+selected rows and which strict inequalities are forced by the cyclic
+vertex-circle order.
+
+## Current Entries
+
+### T01/F09 Self-edge
+
+The three selected rows
+
+```text
+0: {1,2,4,8}
+1: {0,3,5,8}
+2: {0,1,4,6}
+```
+
+force the equality chain
+
+```text
+[1,8] = [0,1] = [0,2] = [1,2].
+```
+
+The row-0 vertex-circle order `[1,2,4,8]` gives the strict inequality
+
+```text
+[1,8] > [1,2].
+```
+
+Thus the selected-distance quotient strict graph has a strict self-edge.
+
+### T10/F12 Strict Cycle
+
+The four selected rows
+
+```text
+0: {1,2,5,6}
+3: {0,1,4,6}
+6: {1,3,4,7}
+8: {0,3,6,7}
+```
+
+force the quotient cycle
+
+```text
+[0,6] > [0,3] = [3,6] = [1,6]
+[1,6] > [0,1] = [0,6].
+```
+
+Thus the selected-distance quotient strict graph has a directed strict cycle
+of length two.
+
+## Commands
+
+Generate and check the catalog:
+
+```bash
+python scripts/check_relation_skeleton_catalog.py \
+  --assert-expected \
+  --write
+
+python scripts/check_relation_skeleton_catalog.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the targeted artifact tests:
+
+```bash
+python -m pytest tests/test_relation_skeleton_catalog.py -q -m "artifact"
+```
+
+## Review Standard
+
+A reviewer should be able to restate each skeleton as a local lemma without
+using `T01`, `T10`, `F09`, or `F12` as theorem names. The proof obligation is
+to check that the listed selected rows force the displayed quotient equalities
+and that the listed vertex-circle order forces the displayed strict edge or
+cycle.
+
+This catalog is a proof-mining aid. It is not an independent proof of the
+`n=9` finite case, not a global theorem, and not evidence for a counterexample.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -864,6 +864,43 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: relation_skeleton_catalog
+    path: data/certificates/relation_skeleton_catalog.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_relation_skeleton_catalog.py
+    command: python scripts/check_relation_skeleton_catalog.py --assert-expected --write
+    checker: scripts/check_relation_skeleton_catalog.py
+    check_command: python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Two-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.relation_skeleton_catalog.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Two-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      catalog_scope: vertex-circle selected-distance quotient skeletons
+      n: 9
+      row_size: 4
+      skeleton_count: 2
+      contradiction_type_counts.strict_directed_cycle: 1
+      contradiction_type_counts.strict_self_edge: 1
+      skeleton_ids:
+        - VC-T01-F09-strict-self-edge
+        - VC-T10-F12-strict-directed-cycle
+      provenance.command: python scripts/check_relation_skeleton_catalog.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - T01 or T10 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the relation-skeleton catalog is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t11_strict_cycle_lemma_packet
     path: data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_relation_skeleton_catalog.py
+++ b/scripts/check_relation_skeleton_catalog.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Generate or check the focused relation-skeleton catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_t01_self_edge_lemma_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_T01_PACKET,
+    load_source_payloads as load_t01_sources,
+    validate_payload as validate_t01_packet,
+)
+from check_n9_vertex_circle_t10_strict_cycle_lemma_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_T10_PACKET,
+    load_source_payloads as load_t10_sources,
+    validate_payload as validate_t10_packet,
+)
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.relation_skeleton_catalog import (  # noqa: E402
+    CLAIM_SCOPE,
+    EXPECTED_CONTRADICTION_TYPE_COUNTS,
+    EXPECTED_SKELETON_IDS,
+    EXPECTED_SOURCE_ARTIFACTS,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_relation_skeleton_catalog,
+    relation_skeleton_catalog_payload,
+)
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "relation_skeleton_catalog.json"
+
+EXPECTED_TOP_LEVEL_KEYS = {
+    "catalog_scope",
+    "claim_scope",
+    "contradiction_type_counts",
+    "cyclic_order",
+    "interpretation",
+    "n",
+    "provenance",
+    "row_size",
+    "schema",
+    "skeleton_count",
+    "skeleton_ids",
+    "skeletons",
+    "source_artifacts",
+    "status",
+    "trust",
+}
+EXPECTED_SKELETON_KEYS = {
+    "conclusion",
+    "contradiction_type",
+    "coverage",
+    "does_not_prove",
+    "hypotheses",
+    "obstruction_system",
+    "relation_quotient",
+    "review_status",
+    "skeleton_id",
+    "source_family_id",
+    "source_packet",
+    "source_template_id",
+    "verifier",
+}
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def load_source_payloads(
+    *,
+    t01_packet_path: Path = DEFAULT_T01_PACKET,
+    t10_packet_path: Path = DEFAULT_T10_PACKET,
+) -> dict[str, Any]:
+    """Load source packets used by the relation-skeleton catalog."""
+
+    return {
+        "t01_packet": load_artifact(_resolve(t01_packet_path)),
+        "t10_packet": load_artifact(_resolve(t10_packet_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    t01_packet = source_payloads.get("t01_packet")
+    t10_packet = source_payloads.get("t10_packet")
+    if not isinstance(t01_packet, dict):
+        errors.append("source T01 packet must be an object")
+    else:
+        try:
+            t01_sources = load_t01_sources()
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"could not load T01 source packets: {exc}")
+        else:
+            errors.extend(
+                f"source T01 packet invalid: {error}"
+                for error in validate_t01_packet(
+                    t01_packet,
+                    source_payloads=t01_sources,
+                    recompute=False,
+                )
+            )
+    if not isinstance(t10_packet, dict):
+        errors.append("source T10 packet must be an object")
+    else:
+        try:
+            t10_sources = load_t10_sources()
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"could not load T10 source packets: {exc}")
+        else:
+            errors.extend(
+                f"source T10 packet invalid: {error}"
+                for error in validate_t10_packet(
+                    t10_packet,
+                    source_payloads=t10_sources,
+                    recompute=False,
+                )
+            )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return relation_skeleton_catalog_payload(
+            source_payloads["t01_packet"],
+            source_payloads["t10_packet"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound relation skeleton catalog failed: {exc}")
+        return None
+
+
+def _skeletons_by_id(payload: dict[str, Any], errors: list[str]) -> dict[str, dict[str, Any]]:
+    skeletons = payload.get("skeletons")
+    if not isinstance(skeletons, list):
+        errors.append("skeletons must be a list")
+        return {}
+    if len(skeletons) != len(EXPECTED_SKELETON_IDS):
+        errors.append(
+            f"skeletons length mismatch: expected {len(EXPECTED_SKELETON_IDS)}, "
+            f"got {len(skeletons)}"
+        )
+    by_id: dict[str, dict[str, Any]] = {}
+    for skeleton in skeletons:
+        if not isinstance(skeleton, dict):
+            errors.append("skeleton entries must be objects")
+            continue
+        if set(skeleton) != EXPECTED_SKELETON_KEYS:
+            errors.append(
+                f"{skeleton.get('skeleton_id', '<unknown>')} keys mismatch: "
+                f"expected {sorted(EXPECTED_SKELETON_KEYS)!r}, got {sorted(skeleton)!r}"
+            )
+        skeleton_id = str(skeleton.get("skeleton_id"))
+        if skeleton_id in by_id:
+            errors.append(f"duplicate skeleton id: {skeleton_id}")
+        by_id[skeleton_id] = skeleton
+    if set(by_id) != set(EXPECTED_SKELETON_IDS):
+        errors.append(
+            f"skeleton ids mismatch: expected {list(EXPECTED_SKELETON_IDS)!r}, "
+            f"got {sorted(by_id)!r}"
+        )
+    return {
+        skeleton_id: by_id[skeleton_id]
+        for skeleton_id in EXPECTED_SKELETON_IDS
+        if skeleton_id in by_id
+    }
+
+
+def _validate_source_artifacts(payload: dict[str, Any], errors: list[str]) -> None:
+    artifacts = payload.get("source_artifacts")
+    if not isinstance(artifacts, list):
+        errors.append("source_artifacts must be a list")
+        return
+    paths = [artifact.get("path") for artifact in artifacts if isinstance(artifact, dict)]
+    expect_equal(errors, "source_artifact paths", paths, list(EXPECTED_SOURCE_ARTIFACTS))
+
+
+def _validate_t01_skeleton(skeleton: dict[str, Any], errors: list[str]) -> None:
+    expect_equal(errors, "T01 contradiction_type", skeleton.get("contradiction_type"), "strict_self_edge")
+    expect_equal(errors, "T01 source_template_id", skeleton.get("source_template_id"), "T01")
+    expect_equal(errors, "T01 source_family_id", skeleton.get("source_family_id"), "F09")
+    coverage = skeleton.get("coverage")
+    if not isinstance(coverage, dict):
+        errors.append("T01 coverage must be an object")
+    else:
+        expect_equal(errors, "T01 assignment_count", coverage.get("assignment_count"), 6)
+        expect_equal(errors, "T01 families", coverage.get("families"), ["F09"])
+    relation = skeleton.get("relation_quotient")
+    if not isinstance(relation, dict):
+        errors.append("T01 relation_quotient must be an object")
+    else:
+        strict_edges = relation.get("strict_edges")
+        if not isinstance(strict_edges, list) or len(strict_edges) != 1:
+            errors.append("T01 must record exactly one displayed strict edge")
+        expect_equal(
+            errors,
+            "T01 equality_chains",
+            relation.get("equality_chains"),
+            [[[1, 8], [0, 1], [0, 2], [1, 2]]],
+        )
+    conclusion = skeleton.get("conclusion")
+    if not isinstance(conclusion, dict):
+        errors.append("T01 conclusion must be an object")
+    else:
+        expect_equal(errors, "T01 conclusion kind", conclusion.get("kind"), "strict_self_edge")
+        expect_equal(errors, "T01 quotient_class", conclusion.get("quotient_class"), [0, 1])
+        if "itself" not in str(conclusion.get("obstruction", "")):
+            errors.append("T01 obstruction must describe a self-edge")
+
+
+def _validate_t10_skeleton(skeleton: dict[str, Any], errors: list[str]) -> None:
+    expect_equal(
+        errors,
+        "T10 contradiction_type",
+        skeleton.get("contradiction_type"),
+        "strict_directed_cycle",
+    )
+    expect_equal(errors, "T10 source_template_id", skeleton.get("source_template_id"), "T10")
+    expect_equal(errors, "T10 source_family_id", skeleton.get("source_family_id"), "F12")
+    coverage = skeleton.get("coverage")
+    if not isinstance(coverage, dict):
+        errors.append("T10 coverage must be an object")
+    else:
+        expect_equal(errors, "T10 assignment_count", coverage.get("assignment_count"), 18)
+        expect_equal(errors, "T10 families", coverage.get("families"), ["F12"])
+    relation = skeleton.get("relation_quotient")
+    if not isinstance(relation, dict):
+        errors.append("T10 relation_quotient must be an object")
+    else:
+        strict_edges = relation.get("strict_edges")
+        if not isinstance(strict_edges, list) or len(strict_edges) != 2:
+            errors.append("T10 must record exactly two displayed strict edges")
+        expect_equal(
+            errors,
+            "T10 equality_chains",
+            relation.get("equality_chains"),
+            [[[0, 3], [3, 6], [1, 6]], [[0, 1], [0, 6]]],
+        )
+    conclusion = skeleton.get("conclusion")
+    if not isinstance(conclusion, dict):
+        errors.append("T10 conclusion must be an object")
+    else:
+        expect_equal(errors, "T10 conclusion kind", conclusion.get("kind"), "strict_directed_cycle")
+        expect_equal(errors, "T10 cycle_length", conclusion.get("cycle_length"), 2)
+        quotient_cycle = conclusion.get("quotient_cycle")
+        if not isinstance(quotient_cycle, list) or len(quotient_cycle) != 2:
+            errors.append("T10 quotient_cycle must contain two cycle steps")
+
+
+def _validate_skeletons(payload: dict[str, Any], errors: list[str]) -> None:
+    skeletons = _skeletons_by_id(payload, errors)
+    if EXPECTED_SKELETON_IDS[0] in skeletons:
+        _validate_t01_skeleton(skeletons[EXPECTED_SKELETON_IDS[0]], errors)
+    if EXPECTED_SKELETON_IDS[1] in skeletons:
+        _validate_t10_skeleton(skeletons[EXPECTED_SKELETON_IDS[1]], errors)
+    for skeleton_id, skeleton in skeletons.items():
+        expect_equal(errors, f"{skeleton_id} review_status", skeleton.get("review_status"), "review_pending")
+        expect_equal(
+            errors,
+            f"{skeleton_id} obstruction_system",
+            skeleton.get("obstruction_system"),
+            "vertex_circle_selected_distance_quotient",
+        )
+        does_not_prove = skeleton.get("does_not_prove")
+        if not isinstance(does_not_prove, list) or "Erdos Problem #97" not in does_not_prove:
+            errors.append(f"{skeleton_id} must preserve the global no-proof guardrail")
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for the relation-skeleton catalog."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "catalog_scope": "vertex-circle selected-distance quotient skeletons",
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "skeleton_count": 2,
+        "skeleton_ids": list(EXPECTED_SKELETON_IDS),
+        "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the n=9 no-proof statement")
+        if not any("No proof of Erdos Problem #97" in item for item in interpretation):
+            errors.append("interpretation must preserve the global no-proof statement")
+
+    _validate_source_artifacts(payload, errors)
+    _validate_skeletons(payload, errors)
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(errors, "source_artifacts", payload.get("source_artifacts"), expected_payload["source_artifacts"])
+
+    try:
+        assert_expected_relation_skeleton_catalog(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected relation skeleton catalog constants failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "relation skeleton catalog", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "skeleton_count": object_payload.get("skeleton_count"),
+        "skeleton_ids": object_payload.get("skeleton_ids"),
+        "contradiction_type_counts": object_payload.get("contradiction_type_counts"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--t01-packet", type=Path, default=DEFAULT_T01_PACKET)
+    parser.add_argument("--t10-packet", type=Path, default=DEFAULT_T10_PACKET)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            t01_packet_path=args.t01_packet,
+            t10_packet_path=args.t10_packet,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = relation_skeleton_catalog_payload(sources["t01_packet"], sources["t10_packet"])
+        if args.assert_expected:
+            assert_expected_relation_skeleton_catalog(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("relation-skeleton catalog")
+        print(f"artifact: {summary['artifact']}")
+        print(f"skeletons: {summary['skeleton_count']}")
+        print(f"types: {summary['contradiction_type_counts']}")
+        if args.check or args.assert_expected:
+            print("OK: relation-skeleton catalog checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -291,6 +291,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="relation_skeleton_catalog",
+        command=(
+            "python",
+            "scripts/check_relation_skeleton_catalog.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Two-entry relation-skeleton catalog for focused n=9 "
+            "vertex-circle quotient motifs; proof-mining scaffolding only, "
+            "not a proof of n=9, counterexample, or independent review "
+            "completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t11_strict_cycle_lemma_packet",
         command=(
             "python",

--- a/src/erdos97/relation_skeleton_catalog.py
+++ b/src/erdos97/relation_skeleton_catalog.py
@@ -1,0 +1,338 @@
+"""Build a small relation-skeleton catalog from focused local lemma packets.
+
+This module is proof-mining scaffolding. It extracts a common typed view of
+two existing vertex-circle quotient obstructions. It does not prove the full
+n=9 case, does not claim a counterexample, and does not update the global
+status of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA = "erdos97.relation_skeleton_catalog.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Two-entry relation-skeleton catalog for focused n=9 vertex-circle "
+    "selected-distance quotient obstructions; proof-mining scaffolding only, "
+    "not a proof of n=9, not a counterexample, not an independent review of "
+    "the exhaustive checker, and not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_relation_skeleton_catalog.py",
+    "command": "python scripts/check_relation_skeleton_catalog.py --assert-expected --write",
+}
+
+EXPECTED_SKELETON_IDS = (
+    "VC-T01-F09-strict-self-edge",
+    "VC-T10-F12-strict-directed-cycle",
+)
+EXPECTED_CONTRADICTION_TYPE_COUNTS = {
+    "strict_directed_cycle": 1,
+    "strict_self_edge": 1,
+}
+EXPECTED_SOURCE_ARTIFACTS = (
+    "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
+)
+DOES_NOT_PROVE = (
+    "n=9",
+    "Erdos Problem #97",
+    "a counterexample",
+    "independent review of the n=9 exhaustive checker",
+)
+
+
+def _source_artifacts(t01_packet: Mapping[str, Any], t10_packet: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": EXPECTED_SOURCE_ARTIFACTS[0],
+            "role": "focused T01/F09 self-edge local lemma packet",
+            "schema": t01_packet.get("schema"),
+            "status": t01_packet.get("status"),
+            "trust": t01_packet.get("trust"),
+        },
+        {
+            "path": EXPECTED_SOURCE_ARTIFACTS[1],
+            "role": "focused T10/F12 strict-cycle local lemma packet",
+            "schema": t10_packet.get("schema"),
+            "status": t10_packet.get("status"),
+            "trust": t10_packet.get("trust"),
+        },
+    ]
+
+
+def _coverage_from_t01(packet: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "assignment_count": int(packet["assignment_count"]),
+        "assignment_ids": list(packet["assignment_ids"]),
+        "family_count": int(packet["family_count"]),
+        "families": [str(packet["family_id"])],
+        "orbit_size_sum": int(packet["orbit_size"]),
+    }
+
+
+def _coverage_from_t10(packet: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "assignment_count": int(packet["assignment_count"]),
+        "assignment_ids": list(packet["assignment_ids"]),
+        "family_count": int(packet["family_count"]),
+        "families": list(packet["family_ids"]),
+        "orbit_size_sum": int(packet["orbit_size_sum"]),
+    }
+
+
+def _minimal_hypotheses(row_count: int) -> list[str]:
+    return [
+        "natural cyclic order on labels 0..8",
+        f"the listed {row_count} selected rows are exact equidistant 4-tie rows",
+        "strict convexity makes vertex-circle chord monotonicity applicable",
+        "only the displayed local rows and quotient relations are used",
+    ]
+
+
+def _strict_edge_from_t01(packet: Mapping[str, Any]) -> dict[str, Any]:
+    strict = packet["strict_inequality"]
+    return {
+        "source": "vertex_circle_chord_monotonicity",
+        "row": int(strict["row"]),
+        "witness_order": list(strict["witness_order"]),
+        "outer_pair": list(strict["outer_pair"]),
+        "inner_pair": list(strict["inner_pair"]),
+        "outer_class": list(strict["outer_class"]),
+        "inner_class": list(strict["inner_class"]),
+        "outer_span": int(strict["outer_span"]),
+        "inner_span": int(strict["inner_span"]),
+    }
+
+
+def _strict_edge_from_cycle_step(step: Mapping[str, Any]) -> dict[str, Any]:
+    strict = step["strict_inequality"]
+    return {
+        "source": "vertex_circle_chord_monotonicity",
+        "row": int(strict["row"]),
+        "witness_order": list(strict["witness_order"]),
+        "outer_pair": list(strict["outer_pair"]),
+        "inner_pair": list(strict["inner_pair"]),
+        "outer_class": list(strict["outer_class"]),
+        "inner_class": list(strict["inner_class"]),
+        "outer_span": int(strict["outer_span"]),
+        "inner_span": int(strict["inner_span"]),
+    }
+
+
+def _t01_skeleton(packet: Mapping[str, Any]) -> dict[str, Any]:
+    equality_steps = list(packet["local_lemma"]["selected_distance_equalities"])
+    strict_edge = _strict_edge_from_t01(packet)
+    return {
+        "skeleton_id": EXPECTED_SKELETON_IDS[0],
+        "source_packet": EXPECTED_SOURCE_ARTIFACTS[0],
+        "source_template_id": str(packet["template_id"]),
+        "source_family_id": str(packet["family_id"]),
+        "obstruction_system": "vertex_circle_selected_distance_quotient",
+        "contradiction_type": "strict_self_edge",
+        "review_status": "review_pending",
+        "coverage": _coverage_from_t01(packet),
+        "hypotheses": {
+            "cyclic_order": list(packet["cyclic_order"]),
+            "selected_rows": list(packet["core_selected_rows"]),
+            "minimal_local_hypotheses": _minimal_hypotheses(int(packet["core_size"])),
+        },
+        "relation_quotient": {
+            "equality_steps": equality_steps,
+            "equality_chains": [list(packet["equality_chain"])],
+            "strict_edges": [strict_edge],
+        },
+        "conclusion": {
+            "kind": "strict_self_edge",
+            "quotient_class": strict_edge["outer_class"],
+            "strict_from_pair": strict_edge["outer_pair"],
+            "strict_to_pair": strict_edge["inner_pair"],
+            "obstruction": "strict edge from a quotient class to itself",
+            "contradiction_statement": str(packet["local_lemma"]["contradiction"]),
+        },
+        "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json",
+        "does_not_prove": list(DOES_NOT_PROVE),
+    }
+
+
+def _t10_family_packet(packet: Mapping[str, Any]) -> Mapping[str, Any]:
+    family_packets = packet["family_packets"]
+    if not isinstance(family_packets, Sequence) or len(family_packets) != 1:
+        raise ValueError("T10 packet must contain exactly one family packet")
+    family_packet = family_packets[0]
+    if not isinstance(family_packet, Mapping):
+        raise ValueError("T10 family packet must be a mapping")
+    if family_packet.get("family_id") != "F12":
+        raise ValueError("T10 family packet must be F12")
+    return family_packet
+
+
+def _cycle_steps(family_packet: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    steps = family_packet["cycle_steps"]
+    if not isinstance(steps, list):
+        raise ValueError("T10 cycle_steps must be a list")
+    return steps
+
+
+def _t10_quotient_cycle(family_packet: Mapping[str, Any]) -> list[dict[str, Any]]:
+    quotient_cycle = []
+    for chain in family_packet["cycle_pair_chain"]:
+        quotient_cycle.append(
+            {
+                "cycle_step": int(chain["cycle_step"]),
+                "strict_from_pair": list(chain["strict_from_outer_pair"]),
+                "strict_to_pair": list(chain["strict_to_inner_pair"]),
+                "equality_chain_to_next_outer_pair": list(
+                    chain["equality_chain_to_next_outer_pair"]
+                ),
+                "next_outer_pair": list(chain["next_outer_pair"]),
+            }
+        )
+    return quotient_cycle
+
+
+def _t10_skeleton(packet: Mapping[str, Any]) -> dict[str, Any]:
+    family_packet = _t10_family_packet(packet)
+    steps = _cycle_steps(family_packet)
+    strict_edges = [_strict_edge_from_cycle_step(step) for step in steps]
+    return {
+        "skeleton_id": EXPECTED_SKELETON_IDS[1],
+        "source_packet": EXPECTED_SOURCE_ARTIFACTS[1],
+        "source_template_id": str(packet["template_id"]),
+        "source_family_id": str(family_packet["family_id"]),
+        "obstruction_system": "vertex_circle_selected_distance_quotient",
+        "contradiction_type": "strict_directed_cycle",
+        "review_status": "review_pending",
+        "coverage": _coverage_from_t10(packet),
+        "hypotheses": {
+            "cyclic_order": list(packet["cyclic_order"]),
+            "selected_rows": list(family_packet["core_selected_rows"]),
+            "minimal_local_hypotheses": _minimal_hypotheses(int(family_packet["core_size"])),
+        },
+        "relation_quotient": {
+            "equality_steps": list(family_packet["local_lemma"]["selected_distance_equalities"]),
+            "equality_chains": [
+                list(item["equality_chain_to_next_outer_pair"])
+                for item in family_packet["cycle_pair_chain"]
+            ],
+            "strict_edges": strict_edges,
+        },
+        "conclusion": {
+            "kind": "strict_directed_cycle",
+            "cycle_length": int(family_packet["cycle_length"]),
+            "quotient_cycle": _t10_quotient_cycle(family_packet),
+            "obstruction": "directed strict cycle in the quotient graph",
+            "contradiction_statement": str(family_packet["local_lemma"]["contradiction"]),
+        },
+        "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json",
+        "does_not_prove": list(DOES_NOT_PROVE),
+    }
+
+
+def relation_skeleton_catalog_payload(
+    t01_packet: Mapping[str, Any],
+    t10_packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the two-entry relation-skeleton catalog."""
+
+    skeletons = [_t01_skeleton(t01_packet), _t10_skeleton(t10_packet)]
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "catalog_scope": "vertex-circle selected-distance quotient skeletons",
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "skeleton_count": len(skeletons),
+        "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
+        "skeleton_ids": list(EXPECTED_SKELETON_IDS),
+        "skeletons": skeletons,
+        "interpretation": [
+            "This catalog extracts relation skeletons from two focused local lemma packets.",
+            "Each entry separates selected-distance quotient equalities from vertex-circle strict inequalities.",
+            "The catalog is intended to support reusable local-lemma review and bridge proof mining.",
+            "No proof of the n=9 case is claimed.",
+            "No proof of Erdos Problem #97 and no counterexample are claimed.",
+        ],
+        "source_artifacts": _source_artifacts(t01_packet, t10_packet),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_relation_skeleton_catalog(payload)
+    return payload
+
+
+def _skeletons_by_id(payload: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    skeletons = payload.get("skeletons")
+    if not isinstance(skeletons, list):
+        raise AssertionError("skeletons must be a list")
+    by_id = {
+        str(skeleton["skeleton_id"]): skeleton
+        for skeleton in skeletons
+        if isinstance(skeleton, Mapping) and "skeleton_id" in skeleton
+    }
+    if set(by_id) != set(EXPECTED_SKELETON_IDS):
+        raise AssertionError(f"unexpected skeleton ids: {sorted(by_id)!r}")
+    return {skeleton_id: by_id[skeleton_id] for skeleton_id in EXPECTED_SKELETON_IDS}
+
+
+def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> None:
+    """Assert stable constants for the relation-skeleton catalog."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "catalog_scope": "vertex-circle selected-distance quotient skeletons",
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "skeleton_count": 2,
+        "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
+        "skeleton_ids": list(EXPECTED_SKELETON_IDS),
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}")
+
+    skeletons = _skeletons_by_id(payload)
+    t01 = skeletons[EXPECTED_SKELETON_IDS[0]]
+    t10 = skeletons[EXPECTED_SKELETON_IDS[1]]
+
+    if t01["contradiction_type"] != "strict_self_edge":
+        raise AssertionError("T01 skeleton must be a strict self-edge")
+    if t01["source_template_id"] != "T01" or t01["source_family_id"] != "F09":
+        raise AssertionError("T01 skeleton source ids changed")
+    if t01["coverage"]["assignment_count"] != 6:
+        raise AssertionError("T01 skeleton assignment count changed")
+    if t01["conclusion"]["kind"] != "strict_self_edge":
+        raise AssertionError("T01 skeleton conclusion kind changed")
+    if t01["conclusion"]["quotient_class"] != [0, 1]:
+        raise AssertionError("T01 skeleton quotient class changed")
+    if len(t01["relation_quotient"]["strict_edges"]) != 1:
+        raise AssertionError("T01 skeleton must have one displayed strict edge")
+
+    if t10["contradiction_type"] != "strict_directed_cycle":
+        raise AssertionError("T10 skeleton must be a strict directed cycle")
+    if t10["source_template_id"] != "T10" or t10["source_family_id"] != "F12":
+        raise AssertionError("T10 skeleton source ids changed")
+    if t10["coverage"]["assignment_count"] != 18:
+        raise AssertionError("T10 skeleton assignment count changed")
+    if t10["conclusion"]["kind"] != "strict_directed_cycle":
+        raise AssertionError("T10 skeleton conclusion kind changed")
+    if t10["conclusion"]["cycle_length"] != 2:
+        raise AssertionError("T10 skeleton cycle length changed")
+    if len(t10["relation_quotient"]["strict_edges"]) != 2:
+        raise AssertionError("T10 skeleton must have two displayed strict edges")
+
+    for skeleton in skeletons.values():
+        if skeleton["review_status"] != "review_pending":
+            raise AssertionError("all skeletons must remain review-pending")
+        if skeleton["does_not_prove"] != list(DOES_NOT_PROVE):
+            raise AssertionError("does_not_prove guardrail changed")

--- a/tests/test_relation_skeleton_catalog.py
+++ b/tests/test_relation_skeleton_catalog.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.relation_skeleton_catalog import (
+    EXPECTED_SKELETON_IDS,
+    assert_expected_relation_skeleton_catalog,
+    relation_skeleton_catalog_payload,
+)
+from scripts.check_relation_skeleton_catalog import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _skeletons_by_id(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {item["skeleton_id"]: item for item in payload["skeletons"]}  # type: ignore[index]
+
+
+def test_relation_skeleton_catalog_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_relation_skeleton_catalog(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "proof-mining scaffolding only" in payload["claim_scope"]
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["skeleton_count"] == 2
+    assert payload["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
+    assert payload["contradiction_type_counts"] == {
+        "strict_directed_cycle": 1,
+        "strict_self_edge": 1,
+    }
+
+
+def test_relation_skeleton_catalog_records_t01_self_edge() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    skeleton = _skeletons_by_id(payload)["VC-T01-F09-strict-self-edge"]
+
+    assert skeleton["source_template_id"] == "T01"
+    assert skeleton["source_family_id"] == "F09"
+    assert skeleton["contradiction_type"] == "strict_self_edge"
+    assert skeleton["coverage"]["assignment_count"] == 6  # type: ignore[index]
+    assert skeleton["hypotheses"]["selected_rows"] == [  # type: ignore[index]
+        [0, 1, 2, 4, 8],
+        [1, 0, 3, 5, 8],
+        [2, 0, 1, 4, 6],
+    ]
+    assert skeleton["relation_quotient"]["equality_chains"] == [  # type: ignore[index]
+        [[1, 8], [0, 1], [0, 2], [1, 2]]
+    ]
+    assert skeleton["relation_quotient"]["strict_edges"] == [  # type: ignore[index]
+        {
+            "source": "vertex_circle_chord_monotonicity",
+            "row": 0,
+            "witness_order": [1, 2, 4, 8],
+            "outer_pair": [1, 8],
+            "inner_pair": [1, 2],
+            "outer_class": [0, 1],
+            "inner_class": [0, 1],
+            "outer_span": 3,
+            "inner_span": 1,
+        }
+    ]
+    assert skeleton["conclusion"]["kind"] == "strict_self_edge"  # type: ignore[index]
+    assert skeleton["conclusion"]["quotient_class"] == [0, 1]  # type: ignore[index]
+
+
+def test_relation_skeleton_catalog_records_t10_strict_cycle() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    skeleton = _skeletons_by_id(payload)["VC-T10-F12-strict-directed-cycle"]
+
+    assert skeleton["source_template_id"] == "T10"
+    assert skeleton["source_family_id"] == "F12"
+    assert skeleton["contradiction_type"] == "strict_directed_cycle"
+    assert skeleton["coverage"]["assignment_count"] == 18  # type: ignore[index]
+    assert skeleton["hypotheses"]["selected_rows"] == [  # type: ignore[index]
+        [0, 1, 2, 5, 6],
+        [3, 0, 1, 4, 6],
+        [6, 1, 3, 4, 7],
+        [8, 0, 3, 6, 7],
+    ]
+    assert skeleton["relation_quotient"]["equality_chains"] == [  # type: ignore[index]
+        [[0, 3], [3, 6], [1, 6]],
+        [[0, 1], [0, 6]],
+    ]
+    assert skeleton["conclusion"]["kind"] == "strict_directed_cycle"  # type: ignore[index]
+    assert skeleton["conclusion"]["cycle_length"] == 2  # type: ignore[index]
+    assert skeleton["conclusion"]["quotient_cycle"] == [  # type: ignore[index]
+        {
+            "cycle_step": 0,
+            "strict_from_pair": [0, 6],
+            "strict_to_pair": [0, 3],
+            "equality_chain_to_next_outer_pair": [[0, 3], [3, 6], [1, 6]],
+            "next_outer_pair": [1, 6],
+        },
+        {
+            "cycle_step": 1,
+            "strict_from_pair": [1, 6],
+            "strict_to_pair": [0, 1],
+            "equality_chain_to_next_outer_pair": [[0, 1], [0, 6]],
+            "next_outer_pair": [0, 6],
+        },
+    ]
+
+
+def test_relation_skeleton_catalog_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["skeleton_count"] == 2
+    assert summary["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
+
+
+def test_relation_skeleton_catalog_rejects_missing_global_guardrail() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if not item.startswith("No proof of Erdos")
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("global no-proof" in error for error in errors)
+
+
+def test_relation_skeleton_catalog_rejects_tampered_t01_conclusion() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    skeleton = _skeletons_by_id(payload)["VC-T01-F09-strict-self-edge"]
+    skeleton["conclusion"]["quotient_class"] = [0, 3]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("T01 quotient_class mismatch" in error for error in errors)
+    assert any("expected relation skeleton catalog constants failed" in error for error in errors)
+
+
+def test_relation_skeleton_catalog_rejects_tampered_t10_cycle() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    skeleton = _skeletons_by_id(payload)["VC-T10-F12-strict-directed-cycle"]
+    skeleton["conclusion"]["cycle_length"] = 3  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("T10 cycle_length mismatch" in error for error in errors)
+    assert any("expected relation skeleton catalog constants failed" in error for error in errors)
+
+
+def test_relation_skeleton_catalog_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    sources["t01_packet"]["assignment_count"] = 7
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any("source T01 packet invalid" in error for error in errors)
+
+
+@pytest.mark.artifact
+def test_relation_skeleton_catalog_artifact_matches_generator() -> None:
+    sources = load_source_payloads()
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == relation_skeleton_catalog_payload(
+        sources["t01_packet"],
+        sources["t10_packet"],
+    )
+
+
+@pytest.mark.artifact
+def test_relation_skeleton_catalog_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_relation_skeleton_catalog.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["skeleton_count"] == 2
+    assert payload["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
+
+
+@pytest.mark.artifact
+def test_relation_skeleton_catalog_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "relation_skeleton_catalog.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_relation_skeleton_catalog.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["artifact"] == str(out.resolve())
+
+
+def test_relation_skeleton_catalog_write_check_rejects_mismatched_paths(tmp_path: Path) -> None:
+    out = tmp_path / "relation_skeleton_catalog.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_relation_skeleton_catalog.py",
+            "--write",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(DEFAULT_ARTIFACT),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "--write --check requires matching --artifact/--out" in result.stderr


### PR DESCRIPTION
## Summary

- Add a two-entry relation-skeleton catalog for the focused T01/F09 self-edge and T10/F12 strict-cycle vertex-circle quotient motifs.
- Add a generator/checker, generated JSON artifact, tests, and proof-mining documentation.
- Wire the catalog into the generated-artifact manifest, artifact audit list, README command list, docs index, and `verify-n9-review`.

## Scope

This remains `REVIEW_PENDING_DIAGNOSTIC_ONLY`: it is proof-mining scaffolding, not a proof of `n=9`, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.

## Validation

- `python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_relation_skeleton_catalog.py -q`
- `python -m pytest tests/test_relation_skeleton_catalog.py -q -m "artifact"`
- `python -m pytest -q` -> `635 passed, 281 deselected`