### PR TITLE
Add T12 activation-support diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the outside-pair subpacket isolating the remaining pair-supported T12
   row-pressure row, read
   [`docs/bootstrap-t12-outside-pair.md`](docs/bootstrap-t12-outside-pair.md).
+- For the role-sensitive T12 activation-support requirement ledger separating
+  connector pairs and strict-edge endpoint sets from unproved row forcing, read
+  [`docs/bootstrap-t12-activation-requirements.md`](docs/bootstrap-t12-activation-requirements.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -196,6 +196,17 @@ private-halo-only. This is still diagnostic bookkeeping only; see
 `scripts/check_bootstrap_t12_outside_pair.py`, and
 `data/certificates/bootstrap_t12_outside_pair.json`.
 
+The activation-support requirement ledger refines those T12 row gaps by
+separating relation requirements from unproved row forcing. Across the six
+missing row centers it records five equality-connector pair requirements and
+two strict-edge endpoint-set requirements. Two connector requirements are
+already satisfied at the bootstrap-core witness level, three requirements have
+stored support options that supply the needed witnesses, and two strict-edge
+requirements remain hard. This is still diagnostic bookkeeping only; see
+`docs/bootstrap-t12-activation-requirements.md`,
+`scripts/check_bootstrap_t12_activation_requirements.py`, and
+`data/certificates/bootstrap_t12_activation_requirements.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -94,6 +94,15 @@ every deletion halo; `[3,8]` and `[5,8]` also hit the private-pair ledger,
 while `[3,5]` is private-halo-only. This is still diagnostic bookkeeping only,
 not a row-forcing theorem. See `docs/bootstrap-t12-outside-pair.md`.
 
+A role-sensitive activation-support ledger now separates the witness subsets
+actually needed by the stored T12/F16 quotient certificate from the unproved
+row-forcing problem. It records five equality-connector pair requirements and
+two strict-edge endpoint-set requirements across the six missing row centers;
+in particular, source `151` row `7` is closure-exposed through `[0,1,4]` but
+still misses endpoint `6` for its strict edge. This remains diagnostic
+bookkeeping only, not a proof that any missing row is forced. See
+`docs/bootstrap-t12-activation-requirements.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_activation_requirements.json
+++ b/data/certificates/bootstrap_t12_activation_requirements.json
@@ -1,0 +1,1368 @@
+{
+  "claim_scope": "Role-sensitive activation-requirement diagnostic for the two tight n=9 bootstrap/T12 records; records the minimal witness subsets needed for T12/F16 quotient connectors and strict edges only. This does not prove that the missing rows are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet classifies fixed selected-row T12 activation requirements; it does not prove the rows are forced.",
+    "A connector pair or strict-edge endpoint set is a relation requirement, not a Euclidean rich-class certificate.",
+    "Support sufficiency is conditional on the row center/rich class being genuinely activated.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_activation_requirements.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_activation_requirements.py"
+  },
+  "records": [
+    {
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "classification_assignment_id": "A082",
+      "diagnosis": {
+        "all_requirements_satisfied_by_bootstrap_core": true,
+        "any_requirement_satisfied_by_deletion_closure": true,
+        "any_requirement_satisfied_by_support_option": false,
+        "connector_requirement_count": 1,
+        "hard_strict_requirement_ids": [],
+        "strict_requirement_count": 0
+      },
+      "outside_support_kind": "core_sufficient",
+      "outside_support_subsets": [],
+      "outside_witnesses": [
+        6
+      ],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "requirement_count": 1,
+      "requirements": [
+        {
+          "bootstrap_core_status": "SUFFICIENT",
+          "bootstrap_core_witnesses": [
+            0,
+            1,
+            4
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                4
+              ],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                0
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                4
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [
+                1
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": true,
+              "available_witnesses": [
+                0,
+                1,
+                4,
+                6
+              ],
+              "closure_labels": [
+                0,
+                1,
+                3,
+                4,
+                6
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [],
+              "row_center_in_closure": true,
+              "row_exposed_in_closure": true,
+              "status": "SUFFICIENT",
+              "witness_status": "SUFFICIENT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                1
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "WITNESSES_ONLY",
+              "witness_status": "SUFFICIENT"
+            }
+          ],
+          "closure_sufficient_count": 1,
+          "connector_row": 3,
+          "from_pair": [
+            1,
+            3
+          ],
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [],
+          "path_index": 0,
+          "reason": "connector equality needs the two non-center endpoints in one rich class at the connector row center",
+          "required_witnesses": [
+            0,
+            1
+          ],
+          "requirement_id": "81:3:connector:2:0",
+          "requirement_size": 2,
+          "step_index": 2,
+          "support_evaluations": [],
+          "support_sufficient_count": 0,
+          "to_pair": [
+            0,
+            3
+          ]
+        }
+      ],
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 3,
+      "row_center_private_in_all_deletion_closures": false,
+      "source_record_id": 81,
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "bootstrap_core_witnesses": [
+        0,
+        2
+      ],
+      "classification_assignment_id": "A082",
+      "diagnosis": {
+        "all_requirements_satisfied_by_bootstrap_core": true,
+        "any_requirement_satisfied_by_deletion_closure": false,
+        "any_requirement_satisfied_by_support_option": true,
+        "connector_requirement_count": 1,
+        "hard_strict_requirement_ids": [],
+        "strict_requirement_count": 0
+      },
+      "outside_support_kind": "outside_1_set",
+      "outside_support_subsets": [
+        [
+          5
+        ],
+        [
+          6
+        ]
+      ],
+      "outside_witnesses": [
+        5,
+        6
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "requirement_count": 1,
+      "requirements": [
+        {
+          "bootstrap_core_status": "SUFFICIENT",
+          "bootstrap_core_witnesses": [
+            0,
+            2
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                2
+              ],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                0
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                2
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "WITNESSES_ONLY",
+              "witness_status": "SUFFICIENT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                6
+              ],
+              "closure_labels": [
+                0,
+                1,
+                3,
+                4,
+                6
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [
+                2
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                2
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "WITNESSES_ONLY",
+              "witness_status": "SUFFICIENT"
+            }
+          ],
+          "closure_sufficient_count": 0,
+          "connector_row": 8,
+          "from_pair": [
+            0,
+            8
+          ],
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [],
+          "path_index": 0,
+          "reason": "connector equality needs the two non-center endpoints in one rich class at the connector row center",
+          "required_witnesses": [
+            0,
+            2
+          ],
+          "requirement_id": "81:8:connector:0:0",
+          "requirement_size": 2,
+          "step_index": 0,
+          "support_evaluations": [
+            {
+              "available_witnesses": [
+                0,
+                2,
+                5
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "SUFFICIENT",
+              "support": [
+                5
+              ]
+            },
+            {
+              "available_witnesses": [
+                0,
+                2,
+                6
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                4
+              ],
+              "status": "SUFFICIENT",
+              "support": [
+                6
+              ]
+            }
+          ],
+          "support_sufficient_count": 2,
+          "to_pair": [
+            2,
+            8
+          ]
+        }
+      ],
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 81,
+      "witnesses": [
+        0,
+        2,
+        5,
+        6
+      ]
+    },
+    {
+      "bootstrap_core_witnesses": [
+        2,
+        4
+      ],
+      "classification_assignment_id": "A152",
+      "diagnosis": {
+        "all_requirements_satisfied_by_bootstrap_core": false,
+        "any_requirement_satisfied_by_deletion_closure": false,
+        "any_requirement_satisfied_by_support_option": false,
+        "connector_requirement_count": 1,
+        "hard_strict_requirement_ids": [],
+        "strict_requirement_count": 0
+      },
+      "outside_support_kind": "outside_1_set",
+      "outside_support_subsets": [
+        [
+          7
+        ],
+        [
+          8
+        ]
+      ],
+      "outside_witnesses": [
+        7,
+        8
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "requirement_count": 1,
+      "requirements": [
+        {
+          "bootstrap_core_status": "DISJOINT",
+          "bootstrap_core_witnesses": [
+            2,
+            4
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                2,
+                4
+              ],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                7,
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "DISJOINT",
+              "witness_status": "DISJOINT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                2,
+                4
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [
+                7,
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "DISJOINT",
+              "witness_status": "DISJOINT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                4,
+                7
+              ],
+              "closure_labels": [
+                0,
+                1,
+                4,
+                7
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                2
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [
+                7,
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "DISJOINT",
+              "witness_status": "DISJOINT"
+            }
+          ],
+          "closure_sufficient_count": 0,
+          "connector_row": 5,
+          "from_pair": [
+            5,
+            7
+          ],
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [
+            7,
+            8
+          ],
+          "path_index": 0,
+          "reason": "connector equality needs the two non-center endpoints in one rich class at the connector row center",
+          "required_witnesses": [
+            7,
+            8
+          ],
+          "requirement_id": "151:5:connector:1:0",
+          "requirement_size": 2,
+          "step_index": 1,
+          "support_evaluations": [
+            {
+              "available_witnesses": [
+                2,
+                4,
+                7
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [
+                8
+              ],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                4
+              ],
+              "status": "PARTIAL",
+              "support": [
+                7
+              ]
+            },
+            {
+              "available_witnesses": [
+                2,
+                4,
+                8
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [
+                7
+              ],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "PARTIAL",
+              "support": [
+                8
+              ]
+            }
+          ],
+          "support_sufficient_count": 0,
+          "to_pair": [
+            5,
+            8
+          ]
+        }
+      ],
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 5,
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "witnesses": [
+        2,
+        4,
+        7,
+        8
+      ]
+    },
+    {
+      "bootstrap_core_witnesses": [
+        0
+      ],
+      "classification_assignment_id": "A152",
+      "diagnosis": {
+        "all_requirements_satisfied_by_bootstrap_core": false,
+        "any_requirement_satisfied_by_deletion_closure": false,
+        "any_requirement_satisfied_by_support_option": true,
+        "connector_requirement_count": 1,
+        "hard_strict_requirement_ids": [],
+        "strict_requirement_count": 0
+      },
+      "outside_support_kind": "outside_2_set",
+      "outside_support_subsets": [
+        [
+          3,
+          5
+        ],
+        [
+          3,
+          8
+        ],
+        [
+          5,
+          8
+        ]
+      ],
+      "outside_witnesses": [
+        3,
+        5,
+        8
+      ],
+      "pressure_class": "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER",
+      "requirement_count": 1,
+      "requirements": [
+        {
+          "bootstrap_core_status": "PARTIAL",
+          "bootstrap_core_witnesses": [
+            0
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                0,
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "DISJOINT",
+              "witness_status": "DISJOINT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0
+              ],
+              "closure_labels": [
+                0,
+                1,
+                4,
+                7
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [
+                8
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            }
+          ],
+          "closure_sufficient_count": 0,
+          "connector_row": 6,
+          "from_pair": [
+            6,
+            8
+          ],
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [
+            8
+          ],
+          "path_index": 0,
+          "reason": "connector equality needs the two non-center endpoints in one rich class at the connector row center",
+          "required_witnesses": [
+            0,
+            8
+          ],
+          "requirement_id": "151:6:connector:2:0",
+          "requirement_size": 2,
+          "step_index": 2,
+          "support_evaluations": [
+            {
+              "available_witnesses": [
+                0,
+                3,
+                5
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [
+                8
+              ],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "PARTIAL",
+              "support": [
+                3,
+                5
+              ]
+            },
+            {
+              "available_witnesses": [
+                0,
+                3,
+                8
+              ],
+              "ledger_private_pair_hit": true,
+              "missing_required_witnesses": [],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "SUFFICIENT",
+              "support": [
+                3,
+                8
+              ]
+            },
+            {
+              "available_witnesses": [
+                0,
+                5,
+                8
+              ],
+              "ledger_private_pair_hit": true,
+              "missing_required_witnesses": [],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "SUFFICIENT",
+              "support": [
+                5,
+                8
+              ]
+            }
+          ],
+          "support_sufficient_count": 2,
+          "to_pair": [
+            0,
+            6
+          ]
+        }
+      ],
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 6,
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "witnesses": [
+        0,
+        3,
+        5,
+        8
+      ]
+    },
+    {
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "classification_assignment_id": "A152",
+      "diagnosis": {
+        "all_requirements_satisfied_by_bootstrap_core": false,
+        "any_requirement_satisfied_by_deletion_closure": false,
+        "any_requirement_satisfied_by_support_option": false,
+        "connector_requirement_count": 0,
+        "hard_strict_requirement_ids": [
+          "151:7:strict:0"
+        ],
+        "strict_requirement_count": 1
+      },
+      "outside_support_kind": "core_sufficient",
+      "outside_support_subsets": [],
+      "outside_witnesses": [
+        6
+      ],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "requirement_count": 1,
+      "requirements": [
+        {
+          "bootstrap_core_status": "PARTIAL",
+          "bootstrap_core_witnesses": [
+            0,
+            1,
+            4
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                4
+              ],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                0,
+                6
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                4
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [
+                1,
+                6
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": true,
+              "available_witnesses": [
+                0,
+                1,
+                4
+              ],
+              "closure_labels": [
+                0,
+                1,
+                4,
+                7
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [
+                6
+              ],
+              "row_center_in_closure": true,
+              "row_exposed_in_closure": true,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                0,
+                1
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [
+                6
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            }
+          ],
+          "closure_sufficient_count": 0,
+          "inner_pair": [
+            0,
+            1
+          ],
+          "kind": "strict_edge_endpoint_set",
+          "missing_from_bootstrap_core": [
+            6
+          ],
+          "outer_pair": [
+            0,
+            6
+          ],
+          "reason": "strict vertex-circle comparison needs all endpoints of the outer and inner witness chords in one rich class",
+          "required_witnesses": [
+            0,
+            1,
+            6
+          ],
+          "requirement_id": "151:7:strict:0",
+          "requirement_size": 3,
+          "step_index": 0,
+          "strict_row": 7,
+          "support_evaluations": [],
+          "support_sufficient_count": 0
+        }
+      ],
+      "roles": [
+        "strict_edge_row"
+      ],
+      "row_center": 7,
+      "row_center_private_in_all_deletion_closures": false,
+      "source_record_id": 151,
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "bootstrap_core_witnesses": [
+        1,
+        2
+      ],
+      "classification_assignment_id": "A152",
+      "diagnosis": {
+        "all_requirements_satisfied_by_bootstrap_core": false,
+        "any_requirement_satisfied_by_deletion_closure": false,
+        "any_requirement_satisfied_by_support_option": true,
+        "connector_requirement_count": 1,
+        "hard_strict_requirement_ids": [
+          "151:8:strict:1"
+        ],
+        "strict_requirement_count": 1
+      },
+      "outside_support_kind": "outside_1_set",
+      "outside_support_subsets": [
+        [
+          5
+        ],
+        [
+          7
+        ]
+      ],
+      "outside_witnesses": [
+        5,
+        7
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "requirement_count": 2,
+      "requirements": [
+        {
+          "bootstrap_core_status": "PARTIAL",
+          "bootstrap_core_witnesses": [
+            1,
+            2
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                2
+              ],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                5,
+                7
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                2
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [
+                1,
+                5,
+                7
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "DISJOINT",
+              "witness_status": "DISJOINT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                7
+              ],
+              "closure_labels": [
+                0,
+                1,
+                4,
+                7
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [
+                5
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                2
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [
+                5,
+                7
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            }
+          ],
+          "closure_sufficient_count": 0,
+          "inner_pair": [
+            5,
+            7
+          ],
+          "kind": "strict_edge_endpoint_set",
+          "missing_from_bootstrap_core": [
+            5,
+            7
+          ],
+          "outer_pair": [
+            1,
+            7
+          ],
+          "reason": "strict vertex-circle comparison needs all endpoints of the outer and inner witness chords in one rich class",
+          "required_witnesses": [
+            1,
+            5,
+            7
+          ],
+          "requirement_id": "151:8:strict:1",
+          "requirement_size": 3,
+          "step_index": 1,
+          "strict_row": 8,
+          "support_evaluations": [
+            {
+              "available_witnesses": [
+                1,
+                2,
+                5
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [
+                7
+              ],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "PARTIAL",
+              "support": [
+                5
+              ]
+            },
+            {
+              "available_witnesses": [
+                1,
+                2,
+                7
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [
+                5
+              ],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                4
+              ],
+              "status": "PARTIAL",
+              "support": [
+                7
+              ]
+            }
+          ],
+          "support_sufficient_count": 0
+        },
+        {
+          "bootstrap_core_status": "PARTIAL",
+          "bootstrap_core_witnesses": [
+            1,
+            2
+          ],
+          "closure_evaluations": [
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                2
+              ],
+              "closure_labels": [
+                1,
+                2,
+                4
+              ],
+              "core_vertex": 0,
+              "missing_required_witnesses": [
+                5
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                2
+              ],
+              "closure_labels": [
+                0,
+                2,
+                4
+              ],
+              "core_vertex": 1,
+              "missing_required_witnesses": [
+                5
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                7
+              ],
+              "closure_labels": [
+                0,
+                1,
+                4,
+                7
+              ],
+              "core_vertex": 2,
+              "missing_required_witnesses": [
+                2,
+                5
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "DISJOINT",
+              "witness_status": "DISJOINT"
+            },
+            {
+              "activation_ready_in_closure": false,
+              "available_witnesses": [
+                1,
+                2
+              ],
+              "closure_labels": [
+                0,
+                1,
+                2
+              ],
+              "core_vertex": 4,
+              "missing_required_witnesses": [
+                5
+              ],
+              "row_center_in_closure": false,
+              "row_exposed_in_closure": false,
+              "status": "PARTIAL",
+              "witness_status": "PARTIAL"
+            }
+          ],
+          "closure_sufficient_count": 0,
+          "connector_row": 8,
+          "from_pair": [
+            5,
+            8
+          ],
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [
+            5
+          ],
+          "path_index": 1,
+          "reason": "connector equality needs the two non-center endpoints in one rich class at the connector row center",
+          "required_witnesses": [
+            2,
+            5
+          ],
+          "requirement_id": "151:8:connector:1:1",
+          "requirement_size": 2,
+          "step_index": 1,
+          "support_evaluations": [
+            {
+              "available_witnesses": [
+                1,
+                2,
+                5
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                2,
+                4
+              ],
+              "status": "SUFFICIENT",
+              "support": [
+                5
+              ]
+            },
+            {
+              "available_witnesses": [
+                1,
+                2,
+                7
+              ],
+              "ledger_private_pair_hit": false,
+              "missing_required_witnesses": [
+                5
+              ],
+              "private_halo_core_vertices": [
+                0,
+                1,
+                4
+              ],
+              "status": "PARTIAL",
+              "support": [
+                7
+              ]
+            }
+          ],
+          "support_sufficient_count": 1,
+          "to_pair": [
+            2,
+            8
+          ]
+        }
+      ],
+      "roles": [
+        "strict_edge_row",
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_in_all_deletion_closures": true,
+      "source_record_id": 151,
+      "witnesses": [
+        1,
+        2,
+        5,
+        7
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_activation_requirements.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+      "role": "source T12/F16 strict-cycle rows and cycle steps",
+      "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+      "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_row_pressure.json",
+      "role": "source row-pressure records and support options",
+      "schema": "erdos97.bootstrap_t12_row_pressure.v1",
+      "status": "BOOTSTRAP_T12_ROW_PRESSURE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_ACTIVATION_REQUIREMENTS_DIAGNOSTIC_ONLY",
+  "summary": {
+    "bootstrap_core_sufficient_requirement_count": 2,
+    "bootstrap_core_sufficient_requirement_ids": [
+      "81:3:connector:2:0",
+      "81:8:connector:0:0"
+    ],
+    "closure_sufficient_requirement_count": 1,
+    "closure_sufficient_requirement_ids": [
+      "81:3:connector:2:0"
+    ],
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "hard_strict_requirement_count": 2,
+    "hard_strict_requirement_ids": [
+      "151:7:strict:0",
+      "151:8:strict:1"
+    ],
+    "main_negative_control": "source 151 row 7 is closure-exposed through witnesses [0,1,4], but its T12 strict edge needs endpoint set [0,1,6]",
+    "requirement_count": 7,
+    "requirement_kind_counts": {
+      "equality_connector_pair": 5,
+      "strict_edge_endpoint_set": 2
+    },
+    "row_centers_by_source_id": {
+      "151": [
+        5,
+        6,
+        7,
+        8
+      ],
+      "81": [
+        3,
+        8
+      ]
+    },
+    "row_record_count": 6,
+    "source_record_ids": [
+      81,
+      151
+    ],
+    "support_sufficient_requirement_count": 3,
+    "support_sufficient_requirement_ids": [
+      "81:8:connector:0:0",
+      "151:6:connector:2:0",
+      "151:8:connector:1:1"
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-activation-requirements.md
+++ b/docs/bootstrap-t12-activation-requirements.md
@@ -1,0 +1,96 @@
+# Bootstrap T12 Activation-Support Requirements
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note refines the bootstrap/T12 row-pressure packets by asking a smaller
+question than "is the full missing row forced?":
+
+```text
+Which witness subset is actually needed for the stored T12/F16 quotient
+connector or strict edge?
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_activation_requirements.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_activation_requirements.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_activation_requirements.json`.
+
+## Scope
+
+The input is fixed selected-row proof-mining data from:
+
+- `data/certificates/bootstrap_vertex_circle_overlay.json`;
+- `data/certificates/bootstrap_t12_row_pressure.json`.
+
+The artifact is not full rich-class data and does not prove that any missing
+row is geometrically forced. It classifies only the relation requirements
+inside the stored T12/F16 local strict-cycle certificate.
+
+For an equality connector row with center `c`, the relation requirement is the
+pair of non-center endpoints needed to force one quotient equality. For a
+strict-edge row, the relation requirement is the union of the outer and inner
+chord endpoints needed for the vertex-circle comparison.
+
+## Results
+
+The two tight bootstrap/T12 sources have six missing row centers and seven
+role-sensitive relation requirements.
+
+| Source | Row | Roles | Requirement status |
+|---:|---:|---|---|
+| `81` | `3` | equality connector | connector pair already in the bootstrap-core witnesses; also closure-sufficient |
+| `81` | `8` | equality connector | connector pair already in the bootstrap-core witnesses; singleton supports still matter for row activation |
+| `151` | `5` | equality connector | needs outside pair `{7,8}`; either singleton alone is only partial |
+| `151` | `6` | equality connector | needs endpoint `8`; support pairs `{3,8}` and `{5,8}` suffice, `{3,5}` does not |
+| `151` | `7` | strict edge | closure-exposed but still missing private endpoint `6` for the strict edge |
+| `151` | `8` | strict edge and equality connector | support `{5}` suffices for the connector, but no singleton support suffices for the strict edge |
+
+Headline counts:
+
+```text
+row records: 6
+relation requirements: 7
+equality connector requirements: 5
+strict-edge endpoint requirements: 2
+bootstrap-core-sufficient requirements: 2
+support-sufficient requirements: 3
+closure-sufficient requirements: 1
+hard strict requirements: 2
+```
+
+## Negative-Control Reading
+
+The main guardrail is source `151`, row `7`. The deletion closure exposes row
+center `7` and witnesses `[0,1,4]`, but the stored T12 strict edge needs
+endpoint set `[0,1,6]`. Thus "center plus three visible target witnesses" is
+not enough to force the strict edge used by the T12 certificate.
+
+This is a reporting negative control, not a polygon and not a counterexample.
+
+## What This Does Not Prove
+
+This artifact does not prove that any missing T12 row is forced, does not prove
+`n=9`, does not prove the bootstrap bridge, does not independently review the
+vertex-circle checker, and does not alter the official/global status of Erdos
+Problem #97.
+
+## Reviewer Focus
+
+Check that the artifact keeps three notions separate:
+
+- relation requirement: the pair or endpoint set used by the stored T12
+  quotient certificate;
+- activation support: a stored bootstrap/row-pressure support option that
+  supplies enough witnesses for that relation requirement;
+- row forcing: the unproved geometric bridge step that would make the row or
+  rich class exist in a genuine minimal counterexample.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -46,6 +46,11 @@ Use this queue when no more specific issue is selected.
    The outside-pair subpacket in `docs/bootstrap-t12-outside-pair.md` isolates
    the remaining pair-supported row, where private-pair capacity makes partial
    direct contact but still does not force the missing equality connector.
+   The activation-support requirement ledger in
+   `docs/bootstrap-t12-activation-requirements.md` separates the stored T12
+   connector-pair and strict-edge endpoint requirements from the still-unproved
+   row-forcing step, with source `151` row `7` as the main closure-exposure
+   negative control.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-forcing-targets.md`](bootstrap-t12-forcing-targets.md):
   follow-up target ledger naming the missing `T12/F16` row centers and direct
   private-pair contacts for the two tight bootstrap rows.
+- [`bootstrap-t12-activation-requirements.md`](bootstrap-t12-activation-requirements.md):
+  role-sensitive diagnostic separating stored T12 connector-pair and
+  strict-edge endpoint requirements from unproved row-forcing claims.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1917,6 +1917,58 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_activation_requirements
+    path: data/certificates/bootstrap_t12_activation_requirements.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_activation_requirements.py
+    command: python scripts/check_bootstrap_t12_activation_requirements.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_activation_requirements.py
+    check_command: python scripts/check_bootstrap_t12_activation_requirements.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Role-sensitive T12/F16 activation-support requirement diagnostic for the two tight n=9 bootstrap-core rows; not a proof that the missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_activation_requirements.v1
+      status: BOOTSTRAP_T12_ACTIVATION_REQUIREMENTS_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 81
+        - 151
+      summary.row_record_count: 6
+      summary.row_centers_by_source_id.81:
+        - 3
+        - 8
+      summary.row_centers_by_source_id.151:
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.requirement_count: 7
+      summary.requirement_kind_counts.equality_connector_pair: 5
+      summary.requirement_kind_counts.strict_edge_endpoint_set: 2
+      summary.bootstrap_core_sufficient_requirement_count: 2
+      summary.support_sufficient_requirement_count: 3
+      summary.closure_sufficient_requirement_count: 1
+      summary.hard_strict_requirement_count: 2
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_activation_requirements.py
+      provenance.command: python scripts/check_bootstrap_t12_activation_requirements.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - activation support proves row-center forcing
+      - closure exposure proves a strict edge
+      - private-pair ledger hit proves row-center forcing
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/reports/gpt55_runs/PP-2026-05-11-summary.md
+++ b/reports/gpt55_runs/PP-2026-05-11-summary.md
@@ -1,0 +1,77 @@
+# PP-2026-05-11 Prompt-Pack Run Summary
+
+Date: 2026-05-11
+
+Prompt pack:
+`C:/Users/User/Desktop/code/erd archive/outputs/data/1/3/10/erdos97_gpt55_prompt_pack.zip`
+
+Status: implementation summary only. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+## Runs
+
+| Run id | Prompt | Focus | Outcome |
+|---|---|---|---|
+| `PP-2026-05-11-MASTER-A` | `01_master_reusable_prompt.md` | bootstrap/T12 closure activation | Selected the T12 activation-support requirement ledger as the best small PR. |
+| `PP-2026-05-11-MASTER-B` | `01_master_reusable_prompt.md` | relation-skeleton catalog | Recommended a future normalized vertex-circle relation-skeleton catalog. |
+| `PP-2026-05-11-EXTRACT-A` | `02_relation_skeleton_extractor.md` | T10/T11/T12 strict cycles | Consolidated directed quotient-cycle skeletons; future catalog material. |
+| `PP-2026-05-11-EXTRACT-B` | `02_relation_skeleton_extractor.md` | T01/T03/T04 self-edges | Consolidated selected-path self-edge skeletons; future catalog material. |
+| `PP-2026-05-11-FRAGILE-A` | `03_fragile_cover_bridge_hunter.md` | critical-radius dependency cycles | Marked dependency-cycle acyclicity as a failed route; kept weak radius identities as possible diagnostics. |
+| `PP-2026-05-11-FRAGILE-B` | `03_fragile_cover_bridge_hunter.md` | vertex-circle gate for fragile extensions | Framed vertex-circle acyclicity as a necessary gate, not a bridge closure. |
+| `PP-2026-05-11-KALMANSON-A` | `04_kalmanson_template_miner.md` | Kalmanson template comparison | Recommended landing the T12 activation-support PR first; Kalmanson QE2 template mining is a follow-up. |
+| `PP-2026-05-11-NEGCTRL-A` | `05_negative_control_generator.md` | naive closure activation | Produced the core-triple activation decoy: closure exposure does not force the T12 fourth endpoint. |
+| `PP-2026-05-11-LOCAL-A` | `06_local_lemma_minimizer.md` | T12 role minimization | Minimized T12 to connector pairs and strict-edge endpoint sets. |
+| `PP-2026-05-11-CLOSURE-A` | `07_closure_activation_bridge.md` | closure activation | Proved only a conditional activation statement; unconditional closure activation stays unproved. |
+| `PP-2026-05-11-REVIEW-A` | `08_adversarial_reviewer.md` | proposed PR review | Accepted with edits: use activation-support wording and keep fixed-diagnostic scope explicit. |
+| `PP-2026-05-11-FALSIFIER-A` | `11_bridge_falsifier.md` | proposed PR falsification | Falsified overstrong readings; identified `151:7` as the main closure-exposure negative control. |
+
+`09_codex_pr_builder.md` was applied by the main Codex thread to produce this
+small PR. `10_run_ledger_template.md` supplied this report shape.
+
+## Selected Output
+
+The selected PR output is the bootstrap/T12 activation-support requirement
+packet:
+
+- `docs/bootstrap-t12-activation-requirements.md`
+- `data/certificates/bootstrap_t12_activation_requirements.json`
+- `src/erdos97/bootstrap_t12_activation_requirements.py`
+- `scripts/check_bootstrap_t12_activation_requirements.py`
+- `tests/test_bootstrap_t12_activation_requirements.py`
+
+This was chosen over the relation-skeleton catalog and Kalmanson template
+mining because it is smaller, directly connected to the newest bootstrap/T12
+bridge gap, and guarded by both adversarial and negative-control prompt runs.
+
+## Newness Check
+
+Existing artifacts already recorded:
+
+- the two tight bootstrap/T12 sources;
+- their missing row centers;
+- row-pressure classes;
+- closure-exposed, one-outside-label, and outside-pair subpackets.
+
+The new packet records which witness subsets are actually needed by the stored
+T12 quotient certificate:
+
+- equality connector pair requirements;
+- strict-edge endpoint-set requirements;
+- whether bootstrap-core witnesses, stored support options, or deletion
+  closures supply those relation requirements.
+
+## Exact Nonclaims
+
+This run does not prove that any missing row is forced, does not prove `n=9`,
+does not prove the bootstrap bridge, does not independently review the
+vertex-circle checker, and does not alter the official/global status of Erdos
+Problem #97.
+
+## Follow-Up Queue
+
+1. Add the normalized relation-skeleton catalog for all 12 `n=9`
+   vertex-circle templates.
+2. Add a Kalmanson QE2/support-four template diagnostic, keeping C29 as the
+   no-QE2 blocker.
+3. Attack the hard strict requirements in source `151`, especially row `7`
+   needing endpoint `6`.

--- a/scripts/check_bootstrap_t12_activation_requirements.py
+++ b/scripts/check_bootstrap_t12_activation_requirements.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 activation-requirement packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_activation_requirements import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_activation_requirements_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 activation requirements")
+    print(f"row records: {summary['row_record_count']}")
+    print(f"requirements: {summary['requirement_count']}")
+    print(f"kinds: {summary['requirement_kind_counts']}")
+    print(f"bootstrap-core sufficient: {summary['bootstrap_core_sufficient_requirement_ids']}")
+    print(f"support sufficient: {summary['support_sufficient_requirement_ids']}")
+    print(f"closure sufficient: {summary['closure_sufficient_requirement_ids']}")
+    print(f"hard strict requirements: {summary['hard_strict_requirement_ids']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument("--check", action="store_true", help="compare artifact to regenerated payload")
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned counts")
+    args = parser.parse_args()
+
+    generated = build_t12_activation_requirements_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 activation-requirement artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 activation-requirement expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_activation_requirements.py
+++ b/src/erdos97/bootstrap_t12_activation_requirements.py
@@ -1,0 +1,495 @@
+"""Role-sensitive activation requirements for the bootstrap/T12 target.
+
+This module refines the bootstrap/T12 row-pressure diagnostics by recording
+which witness subsets are actually needed for the T12 quotient connectors and
+strict vertex-circle edges. It is proof-mining bookkeeping only; it does not
+prove that any missing row is forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_row_pressure import build_t12_row_pressure_payload
+from erdos97.bootstrap_vertex_circle_overlay import build_overlay_payload
+
+
+SCHEMA = "erdos97.bootstrap_t12_activation_requirements.v1"
+STATUS = "BOOTSTRAP_T12_ACTIVATION_REQUIREMENTS_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Role-sensitive activation-requirement diagnostic for the two tight n=9 "
+    "bootstrap/T12 records; records the minimal witness subsets needed for "
+    "T12/F16 quotient connectors and strict edges only. This does not prove "
+    "that the missing rows are forced, does not prove n=9, does not prove the "
+    "bridge, and does not claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bootstrap_t12_activation_requirements.json"
+)
+
+TARGET_TEMPLATE_ID = "T12"
+TARGET_FAMILY_ID = "F16"
+
+KIND_CONNECTOR = "equality_connector_pair"
+KIND_STRICT = "strict_edge_endpoint_set"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _pair(values: Sequence[Any]) -> tuple[int, int]:
+    if len(values) != 2:
+        raise ValueError("pair must contain exactly two endpoints")
+    a, b = int(values[0]), int(values[1])
+    if a == b:
+        raise ValueError("pair endpoints must be distinct")
+    return tuple(sorted((a, b)))
+
+
+def _pair_json(values: Sequence[Any]) -> list[int]:
+    return list(_pair(values))
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _other_endpoint(pair: Sequence[Any], center: int) -> int:
+    endpoints = _pair(pair)
+    if center == endpoints[0]:
+        return endpoints[1]
+    if center == endpoints[1]:
+        return endpoints[0]
+    raise AssertionError(f"row center {center} is not an endpoint of pair {list(endpoints)}")
+
+
+def _status_for_available(required: set[int], available: set[int]) -> str:
+    if required <= available:
+        return "SUFFICIENT"
+    if required & available:
+        return "PARTIAL"
+    return "DISJOINT"
+
+
+def _missing(required: set[int], available: set[int]) -> list[int]:
+    return sorted(required - available)
+
+
+def _row_pressure_by_source_center(row_pressure: Mapping[str, Any]) -> dict[tuple[int, int], dict[str, Any]]:
+    rows = row_pressure.get("row_records")
+    if not isinstance(rows, list):
+        raise AssertionError("row-pressure payload must contain row_records")
+    out: dict[tuple[int, int], dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise AssertionError("row-pressure row_records must contain objects")
+        key = (int(row["source_record_id"]), int(row["row_center"]))
+        out[key] = row
+    return out
+
+
+def _requirements_from_cycle(source_id: int, vertex_circle: Mapping[str, Any]) -> dict[int, list[dict[str, object]]]:
+    """Return relation requirements keyed by row center."""
+
+    requirements: defaultdict[int, list[dict[str, object]]] = defaultdict(list)
+    steps = vertex_circle.get("cycle_steps")
+    if not isinstance(steps, list):
+        raise AssertionError("vertex-circle overlay must contain cycle_steps")
+
+    for step_index, step in enumerate(steps):
+        strict = step["strict_inequality"]
+        strict_row = int(strict["row"])
+        outer_pair = _pair_json(strict["outer_pair"])
+        inner_pair = _pair_json(strict["inner_pair"])
+        strict_required = sorted(set(outer_pair) | set(inner_pair))
+        requirements[strict_row].append(
+            {
+                "requirement_id": f"{source_id}:{strict_row}:strict:{step_index}",
+                "kind": KIND_STRICT,
+                "step_index": step_index,
+                "strict_row": strict_row,
+                "outer_pair": outer_pair,
+                "inner_pair": inner_pair,
+                "required_witnesses": strict_required,
+                "requirement_size": len(strict_required),
+                "reason": (
+                    "strict vertex-circle comparison needs all endpoints of "
+                    "the outer and inner witness chords in one rich class"
+                ),
+            }
+        )
+
+        equality = step["equality_to_next_outer_pair"]
+        previous_pair = _pair_json(equality["start_pair"])
+        path = equality.get("path")
+        if not isinstance(path, list):
+            raise AssertionError("equality connector path must be a list")
+        for path_index, link in enumerate(path):
+            row = int(link["row"])
+            next_pair = _pair_json(link["next_pair"])
+            required = sorted({_other_endpoint(previous_pair, row), _other_endpoint(next_pair, row)})
+            requirements[row].append(
+                {
+                    "requirement_id": f"{source_id}:{row}:connector:{step_index}:{path_index}",
+                    "kind": KIND_CONNECTOR,
+                    "step_index": step_index,
+                    "path_index": path_index,
+                    "connector_row": row,
+                    "from_pair": previous_pair,
+                    "to_pair": next_pair,
+                    "required_witnesses": required,
+                    "requirement_size": len(required),
+                    "reason": (
+                        "connector equality needs the two non-center endpoints "
+                        "in one rich class at the connector row center"
+                    ),
+                }
+            )
+            previous_pair = next_pair
+    return dict(requirements)
+
+
+def _support_evaluations(
+    row_record: Mapping[str, Any],
+    requirement: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    required = set(_int_list(requirement["required_witnesses"]))
+    bootstrap = set(_int_list(row_record["bootstrap_core_witnesses"]))
+    evaluations = []
+    for support in row_record.get("support_hits", []):
+        if not isinstance(support, dict):
+            raise AssertionError("support_hits entries must be objects")
+        support_labels = set(_int_list(support["support"]))
+        available = bootstrap | support_labels
+        evaluations.append(
+            {
+                "support": sorted(support_labels),
+                "available_witnesses": sorted(available),
+                "status": _status_for_available(required, available),
+                "missing_required_witnesses": _missing(required, available),
+                "ledger_private_pair_hit": bool(support.get("ledger_private_pair_hit", False)),
+                "private_halo_core_vertices": _int_list(
+                    support.get("private_halo_core_vertices", [])
+                ),
+            }
+        )
+    return evaluations
+
+
+def _closure_evaluations(
+    row_record: Mapping[str, Any],
+    requirement: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    required = set(_int_list(requirement["required_witnesses"]))
+    out = []
+    for exposure in row_record.get("deletion_closure_exposures", []):
+        if not isinstance(exposure, dict):
+            raise AssertionError("deletion_closure_exposures entries must be objects")
+        available = set(_int_list(exposure["witnesses_in_closure"]))
+        witness_status = _status_for_available(required, available)
+        row_center_in_closure = bool(exposure["row_center_in_closure"])
+        if witness_status == "SUFFICIENT" and not row_center_in_closure:
+            status = "WITNESSES_ONLY"
+        else:
+            status = witness_status
+        out.append(
+            {
+                "core_vertex": int(exposure["core_vertex"]),
+                "closure_labels": _int_list(exposure["closure_labels"]),
+                "row_center_in_closure": row_center_in_closure,
+                "row_exposed_in_closure": bool(exposure["row_exposed_in_closure"]),
+                "activation_ready_in_closure": bool(exposure["activation_ready_in_closure"]),
+                "available_witnesses": sorted(available),
+                "witness_status": witness_status,
+                "status": status,
+                "missing_required_witnesses": _missing(required, available),
+            }
+        )
+    return out
+
+
+def _enrich_requirement(
+    row_record: Mapping[str, Any],
+    requirement: Mapping[str, Any],
+) -> dict[str, object]:
+    required = set(_int_list(requirement["required_witnesses"]))
+    bootstrap = set(_int_list(row_record["bootstrap_core_witnesses"]))
+    support_evaluations = _support_evaluations(row_record, requirement)
+    closure_evaluations = _closure_evaluations(row_record, requirement)
+    enriched = dict(requirement)
+    enriched.update(
+        {
+            "bootstrap_core_witnesses": sorted(bootstrap),
+            "bootstrap_core_status": _status_for_available(required, bootstrap),
+            "missing_from_bootstrap_core": _missing(required, bootstrap),
+            "support_evaluations": support_evaluations,
+            "support_sufficient_count": sum(
+                1 for item in support_evaluations if item["status"] == "SUFFICIENT"
+            ),
+            "closure_evaluations": closure_evaluations,
+            "closure_sufficient_count": sum(
+                1 for item in closure_evaluations if item["status"] == "SUFFICIENT"
+            ),
+        }
+    )
+    return enriched
+
+
+def _record_for_row(
+    *,
+    source_id: int,
+    row_record: Mapping[str, Any],
+    requirements: list[dict[str, object]],
+) -> dict[str, object]:
+    enriched_requirements = [_enrich_requirement(row_record, req) for req in requirements]
+    return {
+        "source_record_id": source_id,
+        "classification_assignment_id": str(row_record["classification_assignment_id"]),
+        "row_center": int(row_record["row_center"]),
+        "roles": [str(role) for role in row_record["roles"]],
+        "pressure_class": str(row_record["pressure_class"]),
+        "witnesses": _int_list(row_record["witnesses"]),
+        "bootstrap_core_witnesses": _int_list(row_record["bootstrap_core_witnesses"]),
+        "outside_witnesses": _int_list(row_record["outside_witnesses"]),
+        "outside_support_kind": str(row_record["outside_support_kind"]),
+        "outside_support_subsets": [
+            _int_list(subset) for subset in row_record["outside_support_subsets"]
+        ],
+        "row_center_private_in_all_deletion_closures": bool(
+            row_record["row_center_private_in_all_deletion_closures"]
+        ),
+        "requirement_count": len(enriched_requirements),
+        "requirements": enriched_requirements,
+        "diagnosis": _row_diagnosis(enriched_requirements),
+    }
+
+
+def _row_diagnosis(requirements: Sequence[Mapping[str, Any]]) -> dict[str, object]:
+    strict = [req for req in requirements if req["kind"] == KIND_STRICT]
+    connector = [req for req in requirements if req["kind"] == KIND_CONNECTOR]
+    all_bootstrap = all(req["bootstrap_core_status"] == "SUFFICIENT" for req in requirements)
+    any_support = any(int(req["support_sufficient_count"]) > 0 for req in requirements)
+    any_closure = any(int(req["closure_sufficient_count"]) > 0 for req in requirements)
+    hard_strict = [
+        req["requirement_id"]
+        for req in strict
+        if req["bootstrap_core_status"] != "SUFFICIENT"
+        and int(req["support_sufficient_count"]) == 0
+        and int(req["closure_sufficient_count"]) == 0
+    ]
+    return {
+        "connector_requirement_count": len(connector),
+        "strict_requirement_count": len(strict),
+        "all_requirements_satisfied_by_bootstrap_core": all_bootstrap,
+        "any_requirement_satisfied_by_support_option": any_support,
+        "any_requirement_satisfied_by_deletion_closure": any_closure,
+        "hard_strict_requirement_ids": hard_strict,
+    }
+
+
+def build_t12_activation_requirements_payload() -> dict[str, object]:
+    """Return the deterministic bootstrap/T12 activation-requirement packet."""
+
+    overlay = build_overlay_payload()
+    row_pressure = build_t12_row_pressure_payload()
+    pressure_by_key = _row_pressure_by_source_center(row_pressure)
+
+    records = []
+    for overlay_record in overlay["records"]:
+        vertex_circle = overlay_record["vertex_circle"]
+        if vertex_circle["template_id"] != TARGET_TEMPLATE_ID:
+            continue
+        if vertex_circle["family_id"] != TARGET_FAMILY_ID:
+            continue
+        source_id = int(overlay_record["source_record_id"])
+        requirements_by_row = _requirements_from_cycle(source_id, vertex_circle)
+        gap_centers = sorted(set(_int_list(vertex_circle["cycle_row_centers_outside_bootstrap_core"])))
+        for row_center in gap_centers:
+            row_record = pressure_by_key[(source_id, row_center)]
+            row_requirements = requirements_by_row.get(row_center, [])
+            if not row_requirements:
+                raise AssertionError(f"missing requirements for source {source_id} row {row_center}")
+            records.append(
+                _record_for_row(
+                    source_id=source_id,
+                    row_record=row_record,
+                    requirements=row_requirements,
+                )
+            )
+
+    records.sort(key=lambda row: (int(row["source_record_id"]), int(row["row_center"])))
+    requirement_rows = [
+        requirement
+        for record in records
+        for requirement in record["requirements"]
+    ]
+    kind_counts = Counter(str(req["kind"]) for req in requirement_rows)
+    bootstrap_sufficient = [
+        str(req["requirement_id"])
+        for req in requirement_rows
+        if req["bootstrap_core_status"] == "SUFFICIENT"
+    ]
+    support_sufficient = [
+        str(req["requirement_id"])
+        for req in requirement_rows
+        if int(req["support_sufficient_count"]) > 0
+    ]
+    closure_sufficient = [
+        str(req["requirement_id"])
+        for req in requirement_rows
+        if int(req["closure_sufficient_count"]) > 0
+    ]
+    hard_strict = [
+        str(req["requirement_id"])
+        for req in requirement_rows
+        if req["kind"] == KIND_STRICT
+        and req["bootstrap_core_status"] != "SUFFICIENT"
+        and int(req["support_sufficient_count"]) == 0
+        and int(req["closure_sufficient_count"]) == 0
+    ]
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet classifies fixed selected-row T12 activation requirements; it does not prove the rows are forced.",
+            "A connector pair or strict-edge endpoint set is a relation requirement, not a Euclidean rich-class certificate.",
+            "Support sufficiency is conditional on the row center/rich class being genuinely activated.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted({int(row["source_record_id"]) for row in records}),
+            "row_record_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): [
+                    int(row["row_center"])
+                    for row in records
+                    if int(row["source_record_id"]) == source_id
+                ]
+                for source_id in sorted({int(row["source_record_id"]) for row in records})
+            },
+            "requirement_count": len(requirement_rows),
+            "requirement_kind_counts": _json_counter(kind_counts),
+            "bootstrap_core_sufficient_requirement_ids": bootstrap_sufficient,
+            "bootstrap_core_sufficient_requirement_count": len(bootstrap_sufficient),
+            "support_sufficient_requirement_ids": support_sufficient,
+            "support_sufficient_requirement_count": len(support_sufficient),
+            "closure_sufficient_requirement_ids": closure_sufficient,
+            "closure_sufficient_requirement_count": len(closure_sufficient),
+            "hard_strict_requirement_ids": hard_strict,
+            "hard_strict_requirement_count": len(hard_strict),
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "main_negative_control": (
+                "source 151 row 7 is closure-exposed through witnesses [0,1,4], "
+                "but its T12 strict edge needs endpoint set [0,1,6]"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+                "role": "source T12/F16 strict-cycle rows and cycle steps",
+                "schema": overlay.get("schema"),
+                "status": overlay.get("status"),
+                "trust": overlay.get("trust"),
+            },
+            {
+                "path": "data/certificates/bootstrap_t12_row_pressure.json",
+                "role": "source row-pressure records and support options",
+                "schema": row_pressure.get("schema"),
+                "status": row_pressure.get("status"),
+                "trust": row_pressure.get("trust"),
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_activation_requirements.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_activation_requirements.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the activation-requirement packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 activation-requirements schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 activation-requirements status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [81, 151],
+        "row_record_count": 6,
+        "row_centers_by_source_id": {"81": [3, 8], "151": [5, 6, 7, 8]},
+        "requirement_count": 7,
+        "requirement_kind_counts": {
+            KIND_CONNECTOR: 5,
+            KIND_STRICT: 2,
+        },
+        "bootstrap_core_sufficient_requirement_ids": [
+            "81:3:connector:2:0",
+            "81:8:connector:0:0",
+        ],
+        "bootstrap_core_sufficient_requirement_count": 2,
+        "support_sufficient_requirement_ids": [
+            "81:8:connector:0:0",
+            "151:6:connector:2:0",
+            "151:8:connector:1:1",
+        ],
+        "support_sufficient_requirement_count": 3,
+        "closure_sufficient_requirement_ids": [
+            "81:3:connector:2:0",
+        ],
+        "closure_sufficient_requirement_count": 1,
+        "hard_strict_requirement_ids": [
+            "151:7:strict:0",
+            "151:8:strict:1",
+        ],
+        "hard_strict_requirement_count": 2,
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    if len(records) != 6:
+        raise AssertionError("expected six row activation-requirement records")
+    for record in records:
+        if not isinstance(record, dict):
+            raise AssertionError("records must contain objects")
+        for requirement in record["requirements"]:
+            required = set(_int_list(requirement["required_witnesses"]))
+            if not required:
+                raise AssertionError("requirements must have required witnesses")
+            if requirement["kind"] == KIND_CONNECTOR and len(required) != 2:
+                raise AssertionError("connector requirements must be witness pairs")
+            if requirement["kind"] == KIND_STRICT and len(required) < 3:
+                raise AssertionError("strict-edge requirements must have at least three endpoints")

--- a/tests/test_bootstrap_t12_activation_requirements.py
+++ b/tests/test_bootstrap_t12_activation_requirements.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.bootstrap_t12_activation_requirements import (
+    DEFAULT_ARTIFACT,
+    KIND_CONNECTOR,
+    KIND_STRICT,
+    assert_expected_payload,
+    build_t12_activation_requirements_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirements(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    out = {}
+    for record in payload["records"]:
+        for requirement in record["requirements"]:
+            out[requirement["requirement_id"]] = requirement
+    return out
+
+
+def test_activation_requirement_counts_and_scope() -> None:
+    payload = build_t12_activation_requirements_payload()
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_ACTIVATION_REQUIREMENTS_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "does not prove that the missing rows are forced" in claim_scope
+    assert "does not prove n=9" in claim_scope
+
+
+def test_activation_requirements_separate_connectors_from_strict_edges() -> None:
+    payload = build_t12_activation_requirements_payload()
+    requirements = _requirements(payload)
+    assert requirements["81:3:connector:2:0"]["kind"] == KIND_CONNECTOR
+    assert requirements["81:3:connector:2:0"]["required_witnesses"] == [0, 1]
+    assert requirements["151:7:strict:0"]["kind"] == KIND_STRICT
+    assert requirements["151:7:strict:0"]["required_witnesses"] == [0, 1, 6]
+
+
+def test_activation_requirements_keep_closure_negative_control() -> None:
+    payload = build_t12_activation_requirements_payload()
+    requirements = _requirements(payload)
+    strict_151_7 = requirements["151:7:strict:0"]
+    assert strict_151_7["missing_from_bootstrap_core"] == [6]
+    assert strict_151_7["closure_sufficient_count"] == 0
+    exposed = [
+        item
+        for item in strict_151_7["closure_evaluations"]
+        if item["row_exposed_in_closure"]
+    ]
+    assert len(exposed) == 1
+    assert exposed[0]["available_witnesses"] == [0, 1, 4]
+    assert exposed[0]["missing_required_witnesses"] == [6]
+    assert exposed[0]["status"] == "PARTIAL"
+
+
+def test_activation_requirements_distinguish_outside_pair_supports() -> None:
+    payload = build_t12_activation_requirements_payload()
+    requirements = _requirements(payload)
+    connector_151_6 = requirements["151:6:connector:2:0"]
+    support_statuses = {
+        tuple(item["support"]): item["status"]
+        for item in connector_151_6["support_evaluations"]
+    }
+    assert support_statuses[(3, 5)] == "PARTIAL"
+    assert support_statuses[(3, 8)] == "SUFFICIENT"
+    assert support_statuses[(5, 8)] == "SUFFICIENT"
+
+
+def test_activation_requirements_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_activation_requirements_payload()
+
+
+def test_activation_requirement_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_activation_requirements.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["requirement_count"] == 7
+
+
+def test_activation_requirement_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_activation_requirements.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_activation_requirements.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_activation_requirements.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )


### PR DESCRIPTION
## Summary

- add a generated bootstrap/T12 activation-support requirement packet separating equality-connector pairs from strict-edge endpoint sets
- document the diagnostic scope and prompt-pack run selection, including the `151:7` closure-exposure negative control
- register the new artifact in provenance metadata and cover the generator/checker with focused tests

## Verification

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_bootstrap_t12_activation_requirements.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_activation_requirements.py -q`

`make verify-fast` was attempted locally, but this PowerShell environment does not have `make`; the component commands above passed.