### PR TITLE
Add closure activation negative controls

### DIFF
--- a/data/certificates/bootstrap_t12_anti_activation_negative_control.json
+++ b/data/certificates/bootstrap_t12_anti_activation_negative_control.json
@@ -1,0 +1,151 @@
+{
+  "anti_activation_row": {
+    "center": 7,
+    "contains_core_witnesses": [
+      0,
+      1,
+      4
+    ],
+    "excluded_target_witness": 6,
+    "replacement_witness": 3,
+    "row": [
+      0,
+      1,
+      3,
+      4
+    ],
+    "target_row": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "claim_status": "abstract_full_selected_row_closure_stress_test_only",
+  "closure_seed": [
+    0,
+    1,
+    4
+  ],
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9
+  ],
+  "date": "2026-05-10",
+  "expected_checks": {
+    "adjacent_intersections_size_at_most_1": true,
+    "cover_ok": true,
+    "pairwise_intersection_and_crossing_ok": true,
+    "self_exclusion_ok": true,
+    "uniformity_ok": true
+  },
+  "expected_closure": [
+    0,
+    1,
+    4,
+    7
+  ],
+  "expected_closure_steps": [
+    {
+      "added_center": 7,
+      "row": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "support": [
+        0,
+        1,
+        4
+      ]
+    }
+  ],
+  "n": 10,
+  "nonclaims": [
+    "Not a Euclidean realization.",
+    "Not a counterexample to Erdos Problem #97.",
+    "Not a proof that closure activation is false for genuine minimal counterexamples.",
+    "Not checked as avoiding all vertex-circle, Kalmanson, row-Ptolemy, or algebraic obstruction templates."
+  ],
+  "run_id": "RS-2026-05-10-A",
+  "selected_rows": {
+    "0": [
+      1,
+      2,
+      5,
+      9
+    ],
+    "1": [
+      0,
+      2,
+      4,
+      7
+    ],
+    "2": [
+      1,
+      3,
+      5,
+      7
+    ],
+    "3": [
+      1,
+      4,
+      8,
+      9
+    ],
+    "4": [
+      0,
+      2,
+      5,
+      8
+    ],
+    "5": [
+      2,
+      6,
+      7,
+      9
+    ],
+    "6": [
+      4,
+      5,
+      7,
+      8
+    ],
+    "7": [
+      0,
+      1,
+      3,
+      4
+    ],
+    "8": [
+      0,
+      5,
+      6,
+      9
+    ],
+    "9": [
+      2,
+      3,
+      6,
+      8
+    ]
+  },
+  "source_provenance": {
+    "prompt_pack": "00_common_prelude.md + 01_master_reusable_prompt.md, with closure-activation/negative-control focus",
+    "source_run": "User-supplied GPT-5.5 Pro run RS-2026-05-10-A, shared on 2026-05-11."
+  },
+  "status": "EXACT_NEGATIVE_CONTROL",
+  "targeted_overstrong_bridge": "Closure exposure of center 7 with witnesses 0,1,4 forces selected row 7->{0,1,4,6}.",
+  "title": "Full selected-row closure-exposure anti-activation control",
+  "trust_label": "NEGATIVE_CONTROL",
+  "type": "bootstrap_t12_full_row_anti_activation_negative_control_v1"
+}

--- a/data/certificates/closure_activation_negative_controls.json
+++ b/data/certificates/closure_activation_negative_controls.json
@@ -1,0 +1,368 @@
+{
+  "claim_status": "abstract_rich_class_closure_stress_tests_only",
+  "controls": [
+    {
+      "closure": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "intended_exposure_mode": "CENTER_AND_CORE_WITNESSES_IN_CLOSURE",
+      "name": "NC1_three_core_trigger_unpinned_fourth",
+      "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": true,
+      "pair_checks": [],
+      "passes_intended_negative_control": true,
+      "required_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "required_core_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "rich_classes": {
+        "7": [
+          [
+            0,
+            1,
+            4,
+            5
+          ]
+        ]
+      },
+      "role_lesson": "Closure from the three core witnesses activates some rich row through the triple, but not the named fourth witness 6.",
+      "seed": [
+        0,
+        1,
+        4
+      ],
+      "target_center": 7,
+      "target_center_in_closure": true,
+      "target_role": "strict_edge_pinned_fourth_needed",
+      "target_row": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "target_row_active_at_center": false,
+      "target_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "vertices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "closure": [
+        0,
+        1,
+        3,
+        4,
+        6
+      ],
+      "cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "intended_exposure_mode": "CENTER_AND_FULL_TARGET_LABELS_IN_CLOSURE_BUT_TARGET_ROW_INACTIVE",
+      "name": "NC2_full_label_visibility_without_center_class_membership",
+      "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": true,
+      "pair_checks": [
+        {
+          "cap_ok": true,
+          "centers": [
+            3,
+            6
+          ],
+          "crossing_ok_when_two_overlap": true,
+          "intersection": [
+            1,
+            4
+          ],
+          "ok": true
+        }
+      ],
+      "passes_intended_negative_control": true,
+      "required_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "required_core_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "rich_classes": {
+        "3": [
+          [
+            0,
+            1,
+            4,
+            5
+          ]
+        ],
+        "6": [
+          [
+            1,
+            3,
+            4,
+            7
+          ]
+        ]
+      },
+      "role_lesson": "The target fourth label can enter closure for an independent reason without belonging to the target center's rich class.",
+      "seed": [
+        0,
+        1,
+        4
+      ],
+      "target_center": 3,
+      "target_center_in_closure": true,
+      "target_role": "full_label_visibility_target",
+      "target_row": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "target_row_active_at_center": false,
+      "target_witnesses_in_closure": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "vertices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "closure": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "intended_exposure_mode": "CENTER_AND_CORE_WITNESSES_IN_CLOSURE",
+      "name": "CE-private-fourth-switch/source-151-row-7",
+      "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": true,
+      "pair_checks": [],
+      "passes_intended_negative_control": true,
+      "required_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "required_core_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "rich_classes": {
+        "7": [
+          [
+            0,
+            1,
+            4,
+            8
+          ]
+        ]
+      },
+      "role_lesson": "A different fourth witness activates the center through the same core triple.",
+      "seed": [
+        0,
+        1,
+        4
+      ],
+      "target_center": 7,
+      "target_center_in_closure": true,
+      "target_role": "strict_edge_pinned_fourth_needed",
+      "target_row": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "target_row_active_at_center": false,
+      "target_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "vertices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "closure": [
+        0,
+        1,
+        3,
+        4,
+        6
+      ],
+      "cyclic_order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "intended_exposure_mode": "CENTER_AND_FULL_TARGET_LABELS_IN_CLOSURE_BUT_TARGET_ROW_INACTIVE",
+      "name": "CE-full-label-containment-switch/source-81-row-3",
+      "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": true,
+      "pair_checks": [
+        {
+          "cap_ok": true,
+          "centers": [
+            3,
+            6
+          ],
+          "crossing_ok_when_two_overlap": true,
+          "intersection": [
+            0,
+            4
+          ],
+          "ok": true
+        }
+      ],
+      "passes_intended_negative_control": true,
+      "required_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "required_core_witnesses_in_closure": [
+        0,
+        1,
+        4
+      ],
+      "rich_classes": {
+        "3": [
+          [
+            0,
+            1,
+            4,
+            8
+          ]
+        ],
+        "6": [
+          [
+            0,
+            3,
+            4,
+            5
+          ]
+        ]
+      },
+      "role_lesson": "Full target-label visibility remains weaker than same-class membership at the target center.",
+      "seed": [
+        0,
+        1,
+        4
+      ],
+      "target_center": 3,
+      "target_center_in_closure": true,
+      "target_role": "full_label_visibility_target",
+      "target_row": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "target_row_active_at_center": false,
+      "target_witnesses_in_closure": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "vertices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    }
+  ],
+  "date": "2026-05-10",
+  "nonclaims": [
+    "Not a polygon.",
+    "Not a counterexample to Erdos Problem #97.",
+    "Not a Euclidean realizability certificate.",
+    "Only stress-tests closure-exposure-to-exact-row activation bridges."
+  ],
+  "run_id": "RS-2026-05-10-CE-A",
+  "schema": "erdos97.closure_activation_negative_controls.v1",
+  "status": "NEGATIVE_CONTROL_ABSTRACT_RICH_CLASS_ONLY",
+  "trust_label": "NEGATIVE_CONTROL"
+}

--- a/data/certificates/closure_activation_wrong_fourth_negative_control.json
+++ b/data/certificates/closure_activation_wrong_fourth_negative_control.json
@@ -1,0 +1,122 @@
+{
+  "activation_target": {
+    "closure_seed": [
+      0,
+      1,
+      4
+    ],
+    "expected_closure_from_seed": [
+      0,
+      1,
+      4,
+      7
+    ],
+    "exposed_center": 7,
+    "exposed_triple": [
+      0,
+      1,
+      4
+    ],
+    "target_fourth_not_forced": 6,
+    "target_row_that_should_not_be_inferred": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "wrong_fourth": 9
+  },
+  "claim_status": "abstract_incidence_closure_stress_test_only",
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9
+  ],
+  "date": "2026-05-10",
+  "n": 10,
+  "nonclaims": [
+    "This is not a polygon.",
+    "This is not a counterexample to Erdos Problem #97.",
+    "This is not a Euclidean realizability certificate.",
+    "This does not refute T12-style lemmas that assume exact selected rows.",
+    "This does not refute activation lemmas with extra criticality, uniqueness, radius-order, Ptolemy, or Kalmanson hypotheses."
+  ],
+  "run_id": "RS-2026-05-10-A",
+  "selected_rows": {
+    "0": [
+      1,
+      2,
+      6,
+      9
+    ],
+    "1": [
+      0,
+      2,
+      4,
+      7
+    ],
+    "2": [
+      3,
+      4,
+      8,
+      9
+    ],
+    "3": [
+      1,
+      4,
+      5,
+      6
+    ],
+    "4": [
+      2,
+      5,
+      7,
+      9
+    ],
+    "5": [
+      0,
+      3,
+      6,
+      8
+    ],
+    "6": [
+      1,
+      3,
+      5,
+      7
+    ],
+    "7": [
+      0,
+      1,
+      4,
+      9
+    ],
+    "8": [
+      3,
+      6,
+      7,
+      9
+    ],
+    "9": [
+      0,
+      2,
+      5,
+      8
+    ]
+  },
+  "source_provenance": {
+    "prompt_pack": "00_common_prelude + 07_closure_activation_bridge + 11_bridge_falsifier posture",
+    "source_run": "User-supplied GPT-5.5 Pro run RS-2026-05-10-A, shared on 2026-05-11."
+  },
+  "status": "EXACT_NEGATIVE_CONTROL",
+  "title": "Wrong-fourth closure activation negative control",
+  "trust_label": "NEGATIVE_CONTROL",
+  "type": "closure_activation_wrong_fourth_negative_control_v1"
+}

--- a/data/certificates/closure_visibility_anti_activation_control.json
+++ b/data/certificates/closure_visibility_anti_activation_control.json
@@ -1,0 +1,165 @@
+{
+  "claim_status": "abstract_incidence_closure_stress_test_only",
+  "claimed_bridge_that_this_falsifies": "If a deletion closure contains a target row center and three target witnesses, then the target center's active row contains those three target witnesses, or the specified target row is forced.",
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "date": "2026-05-10",
+  "expected_closure_steps": [
+    {
+      "closure": [
+        0,
+        1,
+        4
+      ],
+      "step": 0
+    },
+    {
+      "activate_center": 3,
+      "closure": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "step": 1,
+      "using_row_center": 3,
+      "using_triple": [
+        0,
+        1,
+        4
+      ]
+    },
+    {
+      "activate_center": 7,
+      "closure": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "step": 2,
+      "using_row_center": 7,
+      "using_triple": [
+        0,
+        3,
+        4
+      ]
+    }
+  ],
+  "expected_failure_of_target_activation": {
+    "target_center_activated_by_target_triple": false,
+    "target_center_in_final_closure": true,
+    "target_row_present_at_center": false,
+    "target_triple_contained_in_target_center_row": false,
+    "target_witnesses_in_final_closure": true
+  },
+  "expected_pairwise_checks": {
+    "four_uniformity": true,
+    "max_pairwise_row_intersection": 2,
+    "self_exclusion": true,
+    "two_overlap_crossing_pairs": [
+      {
+        "source_chord": [
+          3,
+          7
+        ],
+        "witness_chord": [
+          0,
+          4
+        ]
+      }
+    ]
+  },
+  "nonclaims": [
+    "This is not a polygon.",
+    "This is not a counterexample to Erdos Problem #97.",
+    "This is not a Euclidean realizability certificate.",
+    "This does not refute activation lemmas that require provenance.",
+    "This does not refute activation lemmas with critical-row uniqueness or all-fourth obstruction hypotheses."
+  ],
+  "rich_rows": [
+    {
+      "activating_triple": [
+        0,
+        1,
+        4
+      ],
+      "center": 3,
+      "intended_activation_step": 1,
+      "role": "helper row: adds center 3 from the seed closure",
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "activating_triple": [
+        0,
+        3,
+        4
+      ],
+      "center": 7,
+      "intended_activation_step": 2,
+      "role": "alternative row at target center; activates 7 through a different triple",
+      "witnesses": [
+        0,
+        3,
+        4,
+        8
+      ]
+    }
+  ],
+  "run_id": "RS-2026-05-10-A",
+  "seed_closure": [
+    0,
+    1,
+    4
+  ],
+  "source_provenance": {
+    "prompt_pack": "01_master_reusable_prompt.md after 00_common_prelude.md",
+    "source_run": "User-supplied GPT-5.5 Pro run RS-2026-05-10-A, shared on 2026-05-11."
+  },
+  "status": "EXACT_NEGATIVE_CONTROL",
+  "target": {
+    "center": 7,
+    "private_outside_witness": 6,
+    "source_row": "151:7-style closure-exposed target",
+    "target_row": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "target_witnesses": [
+      0,
+      1,
+      4
+    ]
+  },
+  "title": "Closure-visibility anti-activation negative control",
+  "trust_label": "NEGATIVE_CONTROL",
+  "type": "closure_visibility_anti_activation_control_v1",
+  "vertices": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ]
+}

--- a/docs/closure-activation-negative-controls.md
+++ b/docs/closure-activation-negative-controls.md
@@ -1,0 +1,269 @@
+# Closure Activation Negative Controls
+
+Status: `EXACT_NEGATIVE_CONTROL` / `PROVENANCE`. No general proof of Erdos
+Problem #97 is claimed. No counterexample is claimed.
+
+This note records RS-2026-05-10-A stress tests for closure-activation
+bridge work. Their purpose is narrow: prevent a proof route from silently
+upgrading deletion-closure exposure into a fixed selected-row forcing lemma.
+
+Run the wrong-fourth replay checker with:
+
+```bash
+python scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json
+```
+
+Run the aggregate rich-class replay checker with:
+
+```bash
+python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json
+```
+
+Run the full selected-row anti-activation checker with:
+
+```bash
+python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json
+```
+
+Run the closure-visibility replay checker with:
+
+```bash
+python scripts/check_closure_visibility_anti_activation_control.py --assert-expected --json
+```
+
+Regenerate the checked JSON artifacts with:
+
+```bash
+python scripts/check_closure_activation_wrong_fourth_negative_control.py --write
+python scripts/check_closure_activation_negative_controls.py --write
+python scripts/check_bootstrap_t12_anti_activation_negative_control.py --write
+python scripts/check_closure_visibility_anti_activation_control.py --write
+```
+
+## Wrong-fourth control
+
+The checked artifact is
+`data/certificates/closure_activation_wrong_fourth_negative_control.json`.
+It uses cyclic order:
+
+```text
+0,1,2,3,4,5,6,7,8,9
+```
+
+and selected rows:
+
+```text
+0 -> {1,2,6,9}
+1 -> {0,2,4,7}
+2 -> {3,4,8,9}
+3 -> {1,4,5,6}
+4 -> {2,5,7,9}
+5 -> {0,3,6,8}
+6 -> {1,3,5,7}
+7 -> {0,1,4,9}
+8 -> {3,6,7,9}
+9 -> {0,2,5,8}
+```
+
+Starting from seed `{0,1,4}`, the rich-triple closure rule adds any center
+whose selected row already has at least three witnesses in the current closure.
+The computed closure is:
+
+```text
+cl({0,1,4}) = {0,1,4,7}
+```
+
+Thus the closure exposes center `7` and the triple `{0,1,4}`. But row `7` is
+`{0,1,4,9}`, not `{0,1,4,6}`. The target fourth `6` remains outside the
+closure, and the target row `{0,1,4,6}` is absent from the selected-row system.
+
+## Checked hypotheses
+
+The replay checker verifies:
+
+- every row has four distinct witnesses;
+- no center appears in its own row;
+- row-pair intersections have size at most two;
+- witness-pairs occur together in at most two rows;
+- every two-overlap source chord crosses its common-witness chord in the
+  supplied cyclic order;
+- the seed closure is exactly `{0,1,4,7}`;
+- the exposed row has the wrong fourth witness `9`, while the target fourth
+  `6` is not forced.
+
+These are abstract finite checks only. They do not use Euclidean coordinates,
+critical-radius ordering, exact rich-class uniqueness, triangle inequalities,
+Ptolemy identities, or Kalmanson inequalities.
+
+## Bridge lesson
+
+This control blocks only the overstrong activation principle:
+
+```text
+center plus three target witnesses visible in a deletion closure
+=> the fixed selected row with the desired fourth witness is forced.
+```
+
+It does not refute the T12 strict-cycle local lemma packet, because that packet
+assumes exact selected rows. It also does not refute a future activation lemma
+with an additional condition that identifies the fourth witness, such as
+criticality, rich-class uniqueness, radius ordering, row-substitution
+obstructions, or an all-fourth obstruction check.
+
+## Rich-class fourth-switch controls
+
+The checked aggregate artifact is
+`data/certificates/closure_activation_negative_controls.json`. It records four
+small abstract rich-class controls from runs `RS-2026-05-10-CE-A` and
+`RS-2026-05-10-A`.
+
+Two minimal role-focused controls are named directly:
+
+```text
+NC1_three_core_trigger_unpinned_fourth
+NC2_full_label_visibility_without_center_class_membership
+```
+
+`NC1` uses rich class `{0,1,4,5}` at center `7` to activate the center from
+seed `{0,1,4}` while leaving the target row `{0,1,4,6}` inactive. `NC2` uses
+rich classes `{0,1,4,5}` at center `3` and `{1,3,4,7}` at center `6`; closure
+then contains all labels of target row `{0,1,4,6}`, but label `6` entered for
+an independent reason and still is not in center `3`'s rich class.
+
+The first control targets the source-151 strict-edge row-pressure shape:
+
+```text
+seed = {0,1,4}
+target center = 7
+target row = 7 -> {0,1,4,6}
+rich class at 7 = {0,1,4,8}
+closure = {0,1,4,7}
+```
+
+The center and core witnesses are closure-exposed, and the center is activated
+by the exposed triple, but the fourth witness is `8` rather than the target
+private witness `6`. Thus closure activation through the core triple still
+does not identify the exact strict-edge row.
+
+The second control targets the source-81 row-pressure shape:
+
+```text
+seed = {0,1,4}
+target center = 3
+target row = 3 -> {0,1,4,6}
+rich class at 3 = {0,1,4,8}
+rich class at 6 = {0,3,4,5}
+closure = {0,1,3,4,6}
+```
+
+Here the closure contains the target center and all four target row labels
+`{0,1,4,6}`, but the target row is still inactive at center `3`. The listed
+rich rows share `{0,4}`, and the source chord `{3,6}` crosses the witness chord
+`{0,4}` in the supplied cyclic order.
+
+These controls motivate a sharper row-pressure split:
+
+```text
+pair_connector_activated:
+  needed equality endpoints lie inside the triggering triple.
+
+pinned_fourth_needed:
+  the named fourth witness is certified to lie in the same rich class.
+
+interval_stability_needed:
+  the actual activated row supports the same vertex-circle strict inequality.
+```
+
+The aggregate checker intentionally proves neither side of that split. It only
+keeps the abstract countermodels replayable.
+
+## Full selected-row anti-activation control
+
+The checked artifact is
+`data/certificates/bootstrap_t12_anti_activation_negative_control.json`. It is
+a full abstract selected-row incidence system on cyclic order:
+
+```text
+0,1,2,3,4,5,6,7,8,9
+```
+
+with selected rows:
+
+```text
+0 -> {1,2,5,9}
+1 -> {0,2,4,7}
+2 -> {1,3,5,7}
+3 -> {1,4,8,9}
+4 -> {0,2,5,8}
+5 -> {2,6,7,9}
+6 -> {4,5,7,8}
+7 -> {0,1,3,4}
+8 -> {0,5,6,9}
+9 -> {2,3,6,8}
+```
+
+The closure seed is `{0,1,4}`. Row `7` contains all three seed witnesses, so
+closure adds center `7` and then stops:
+
+```text
+cl({0,1,4}) = {0,1,4,7}
+```
+
+But the row at center `7` is `{0,1,3,4}`, not the target row `{0,1,4,6}`. This
+is a full-row incidence-level anti-activation object: it verifies
+four-uniformity, self-exclusion, vertex cover, row-pair cap, two-overlap
+crossing in the supplied cyclic order, and adjacent row-pair intersections of
+size at most one.
+
+It is still not a Euclidean realization certificate and not evidence of a
+counterexample. It only rules out deriving the pinned fourth witness `6` from
+these abstract incidence and closure checks alone.
+
+## Closure-visibility anti-activation control
+
+The checked artifact is
+`data/certificates/closure_visibility_anti_activation_control.json`.
+It uses cyclic order:
+
+```text
+0,1,2,3,4,5,6,7,8
+```
+
+and two sparse rich rows:
+
+```text
+3 -> {0,1,4,6}
+7 -> {0,3,4,8}
+```
+
+The target row-pressure shape is center `7`, target witnesses `{0,1,4}`,
+private target witness `6`, and target row `{0,1,4,6}`. Starting from seed
+`{0,1,4}`, closure proceeds as:
+
+```text
+{0,1,4}
+  -> add 3 via {0,1,4}
+  -> {0,1,3,4}
+  -> add 7 via {0,3,4}
+  -> {0,1,3,4,7}
+```
+
+At the end, the closure contains center `7` and all target witnesses
+`{0,1,4}`. But center `7` entered through the different triple `{0,3,4}`; its
+row is `{0,3,4,8}`, which contains neither the target triple `{0,1,4}` nor the
+target row `{0,1,4,6}`.
+
+The replay checker verifies four-uniformity, self-exclusion, the row-pair cap,
+the witness-pair cap, and the two-overlap crossing of source chord `{3,7}` with
+witness chord `{0,4}` in the supplied cyclic order.
+
+This control blocks only the overstrong visibility principle:
+
+```text
+center c in cl(A) and target triple T subset cl(A)
+=> c has a selected/rich row containing T.
+```
+
+It does not refute a bridge lemma that includes activation provenance, such as
+"center `c` entered closure because of target triple `T`", nor a lemma that
+adds critical-row uniqueness or an all-fourth obstruction check.

--- a/scripts/check_bootstrap_t12_anti_activation_negative_control.py
+++ b/scripts/check_bootstrap_t12_anti_activation_negative_control.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 full-row anti-activation negative control."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.closure_activation_negative_controls import (  # noqa: E402
+    assert_full_row_anti_activation_expected,
+    full_row_anti_activation_control_certificate,
+    full_row_anti_activation_summary,
+    validate_full_row_anti_activation_certificate,
+)
+
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "bootstrap_t12_anti_activation_negative_control.json"
+)
+
+
+def load_payload(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("artifact top level must be a JSON object")
+    return payload
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="load and check --artifact instead of generating the built-in payload",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print JSON summary")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write the built-in payload to --artifact",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    try:
+        payload = (
+            load_payload(artifact)
+            if args.check
+            else full_row_anti_activation_control_certificate()
+        )
+        errors = validate_full_row_anti_activation_certificate(payload)
+        if args.assert_expected and not errors:
+            assert_full_row_anti_activation_expected(payload)
+    except (OSError, ValueError, AssertionError) as exc:
+        errors = [str(exc)]
+        payload = {}
+
+    if args.write and not args.check and not errors:
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if errors:
+        if args.json:
+            print(json.dumps({"ok": False, "errors": errors}, indent=2))
+        else:
+            for error in errors:
+                print(error, file=sys.stderr)
+        return 1
+
+    summary = full_row_anti_activation_summary(payload)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("bootstrap/T12 full-row anti-activation negative control")
+        print(f"closure: {summary['closure_result']}")
+        print(f"anti-activation row: {summary['anti_activation_row']['row']}")
+        if args.assert_expected:
+            print("OK: full-row anti-activation expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_closure_activation_negative_controls.py
+++ b/scripts/check_closure_activation_negative_controls.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Check aggregate closure-activation rich-class negative controls."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.closure_activation_negative_controls import (  # noqa: E402
+    assert_rich_class_activation_controls_expected,
+    rich_class_activation_controls_certificate,
+    rich_class_activation_controls_summary,
+    validate_rich_class_activation_controls_certificate,
+)
+
+
+DEFAULT_CERTIFICATE = (
+    ROOT / "data" / "certificates" / "closure_activation_negative_controls.json"
+)
+
+
+def load_payload(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("certificate top level must be a JSON object")
+    return payload
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--certificate",
+        type=Path,
+        default=DEFAULT_CERTIFICATE,
+        help="certificate path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="load and check --certificate instead of generating the built-in payload",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print JSON summary")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write the built-in payload to --certificate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    certificate = args.certificate
+    if not certificate.is_absolute():
+        certificate = ROOT / certificate
+
+    try:
+        payload = (
+            load_payload(certificate)
+            if args.check
+            else rich_class_activation_controls_certificate()
+        )
+        errors = validate_rich_class_activation_controls_certificate(payload)
+        if args.assert_expected and not errors:
+            assert_rich_class_activation_controls_expected(payload)
+    except (OSError, ValueError, AssertionError) as exc:
+        errors = [str(exc)]
+        payload = {}
+
+    if args.write and not args.check and not errors:
+        certificate.parent.mkdir(parents=True, exist_ok=True)
+        certificate.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if errors:
+        if args.json:
+            print(json.dumps({"ok": False, "errors": errors}, indent=2))
+        else:
+            for error in errors:
+                print(error, file=sys.stderr)
+        return 1
+
+    summary = rich_class_activation_controls_summary(payload)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("closure activation rich-class negative controls")
+        print(f"control count: {summary['control_count']}")
+        for control in summary["controls"]:
+            print(
+                f"{control['name']}: closure={control['closure']} "
+                f"target_row_active={control['target_row_active_at_center']}"
+            )
+        if args.assert_expected:
+            print("OK: aggregate closure-activation expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_closure_activation_wrong_fourth_negative_control.py
+++ b/scripts/check_closure_activation_wrong_fourth_negative_control.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Check the wrong-fourth closure-activation negative control."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.closure_activation_negative_controls import (  # noqa: E402
+    assert_wrong_fourth_expected,
+    certificate_summary,
+    validate_wrong_fourth_certificate,
+    wrong_fourth_negative_control_certificate,
+)
+
+
+DEFAULT_CERTIFICATE = (
+    ROOT / "data" / "certificates" / "closure_activation_wrong_fourth_negative_control.json"
+)
+
+
+def load_payload(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("certificate top level must be a JSON object")
+    return payload
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--certificate",
+        type=Path,
+        default=DEFAULT_CERTIFICATE,
+        help="certificate path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="load and check --certificate instead of generating the built-in payload",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print JSON summary")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write the built-in payload to --certificate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    certificate = args.certificate
+    if not certificate.is_absolute():
+        certificate = ROOT / certificate
+
+    try:
+        payload = (
+            load_payload(certificate)
+            if args.check
+            else wrong_fourth_negative_control_certificate()
+        )
+        errors = validate_wrong_fourth_certificate(payload)
+        if args.assert_expected and not errors:
+            assert_wrong_fourth_expected(payload)
+    except (OSError, ValueError, AssertionError) as exc:
+        errors = [str(exc)]
+        payload = {}
+
+    if args.write and not args.check and not errors:
+        certificate.parent.mkdir(parents=True, exist_ok=True)
+        certificate.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if errors:
+        if args.json:
+            print(json.dumps({"ok": False, "errors": errors}, indent=2))
+        else:
+            for error in errors:
+                print(error, file=sys.stderr)
+        return 1
+
+    summary = certificate_summary(payload)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("closure activation wrong-fourth negative control")
+        print(f"n: {summary['n']}")
+        print(f"closure: {summary['closure']}")
+        print(f"exposed row: {summary['exposed_row']}")
+        print(f"target row absent: {summary['target_row_absent']}")
+        if args.assert_expected:
+            print("OK: wrong-fourth negative-control expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_closure_visibility_anti_activation_control.py
+++ b/scripts/check_closure_visibility_anti_activation_control.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Check the closure-visibility anti-activation negative control."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.closure_activation_negative_controls import (  # noqa: E402
+    assert_visibility_anti_activation_expected,
+    validate_visibility_anti_activation_certificate,
+    visibility_anti_activation_control_certificate,
+    visibility_anti_activation_summary,
+)
+
+
+DEFAULT_CERTIFICATE = (
+    ROOT / "data" / "certificates" / "closure_visibility_anti_activation_control.json"
+)
+
+
+def load_payload(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("certificate top level must be a JSON object")
+    return payload
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "certificate",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_CERTIFICATE,
+        help="certificate path to check or write",
+    )
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--check", action="store_true", help="accepted for symmetry")
+    parser.add_argument("--json", action="store_true", help="print JSON summary")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write the built-in payload to the certificate path",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    certificate = args.certificate
+    if not certificate.is_absolute():
+        certificate = ROOT / certificate
+
+    try:
+        if args.write:
+            payload = visibility_anti_activation_control_certificate()
+        else:
+            payload = load_payload(certificate)
+        errors = validate_visibility_anti_activation_certificate(payload)
+        if args.assert_expected and not errors:
+            assert_visibility_anti_activation_expected(payload)
+    except (OSError, ValueError, AssertionError) as exc:
+        errors = [str(exc)]
+        payload = {}
+
+    if args.write and not errors:
+        certificate.parent.mkdir(parents=True, exist_ok=True)
+        certificate.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if errors:
+        if args.json:
+            print(json.dumps({"ok": False, "errors": errors}, indent=2))
+        else:
+            for error in errors:
+                print(error, file=sys.stderr)
+        return 1
+
+    summary = visibility_anti_activation_summary(payload)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("closure visibility anti-activation negative control")
+        print(f"final closure: {summary['final_closure']}")
+        print(
+            "target triple active at center: "
+            f"{summary['target_triple_contained_in_target_center_row']}"
+        )
+        print(
+            "target center activated by target triple: "
+            f"{summary['target_center_activated_by_target_triple']}"
+        )
+        if args.assert_expected:
+            print("OK: closure-visibility expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/closure_activation_negative_controls.py
+++ b/src/erdos97/closure_activation_negative_controls.py
@@ -1,0 +1,1488 @@
+"""Negative controls for closure-activation bridge claims.
+
+These helpers are finite abstract incidence checks.  They do not certify
+Euclidean realizability and they do not obstruct Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any, Sequence
+
+from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
+
+
+Rows = list[list[int]]
+
+
+def rich_class_activation_controls_certificate() -> dict[str, Any]:
+    """Return the RS-2026-05-10-CE-A rich-class controls."""
+
+    return {
+        "schema": "erdos97.closure_activation_negative_controls.v1",
+        "run_id": "RS-2026-05-10-CE-A",
+        "date": "2026-05-10",
+        "status": "NEGATIVE_CONTROL_ABSTRACT_RICH_CLASS_ONLY",
+        "trust_label": "NEGATIVE_CONTROL",
+        "claim_status": "abstract_rich_class_closure_stress_tests_only",
+        "nonclaims": [
+            "Not a polygon.",
+            "Not a counterexample to Erdos Problem #97.",
+            "Not a Euclidean realizability certificate.",
+            "Only stress-tests closure-exposure-to-exact-row activation bridges.",
+        ],
+        "controls": [
+            {
+                "name": "NC1_three_core_trigger_unpinned_fourth",
+                "vertices": list(range(9)),
+                "cyclic_order": list(range(9)),
+                "seed": [0, 1, 4],
+                "target_center": 7,
+                "target_row": [0, 1, 4, 6],
+                "target_role": "strict_edge_pinned_fourth_needed",
+                "required_core_witnesses": [0, 1, 4],
+                "rich_classes": {"7": [[0, 1, 4, 5]]},
+                "intended_exposure_mode": "CENTER_AND_CORE_WITNESSES_IN_CLOSURE",
+                "role_lesson": (
+                    "Closure from the three core witnesses activates some "
+                    "rich row through the triple, but not the named fourth "
+                    "witness 6."
+                ),
+                "closure": [0, 1, 4, 7],
+                "target_center_in_closure": True,
+                "required_core_witnesses_in_closure": [0, 1, 4],
+                "target_witnesses_in_closure": [0, 1, 4],
+                "target_row_active_at_center": False,
+                "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+                "pair_checks": [],
+                "passes_intended_negative_control": True,
+            },
+            {
+                "name": "NC2_full_label_visibility_without_center_class_membership",
+                "vertices": list(range(9)),
+                "cyclic_order": list(range(9)),
+                "seed": [0, 1, 4],
+                "target_center": 3,
+                "target_row": [0, 1, 4, 6],
+                "target_role": "full_label_visibility_target",
+                "required_core_witnesses": [0, 1, 4],
+                "rich_classes": {
+                    "3": [[0, 1, 4, 5]],
+                    "6": [[1, 3, 4, 7]],
+                },
+                "intended_exposure_mode": (
+                    "CENTER_AND_FULL_TARGET_LABELS_IN_CLOSURE_BUT_TARGET_ROW_INACTIVE"
+                ),
+                "role_lesson": (
+                    "The target fourth label can enter closure for an "
+                    "independent reason without belonging to the target "
+                    "center's rich class."
+                ),
+                "closure": [0, 1, 3, 4, 6],
+                "target_center_in_closure": True,
+                "required_core_witnesses_in_closure": [0, 1, 4],
+                "target_witnesses_in_closure": [0, 1, 4, 6],
+                "target_row_active_at_center": False,
+                "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+                "pair_checks": [
+                    {
+                        "centers": [3, 6],
+                        "intersection": [1, 4],
+                        "cap_ok": True,
+                        "crossing_ok_when_two_overlap": True,
+                        "ok": True,
+                    }
+                ],
+                "passes_intended_negative_control": True,
+            },
+            {
+                "name": "CE-private-fourth-switch/source-151-row-7",
+                "vertices": list(range(9)),
+                "cyclic_order": list(range(9)),
+                "seed": [0, 1, 4],
+                "target_center": 7,
+                "target_row": [0, 1, 4, 6],
+                "target_role": "strict_edge_pinned_fourth_needed",
+                "required_core_witnesses": [0, 1, 4],
+                "rich_classes": {"7": [[0, 1, 4, 8]]},
+                "intended_exposure_mode": "CENTER_AND_CORE_WITNESSES_IN_CLOSURE",
+                "role_lesson": (
+                    "A different fourth witness activates the center through "
+                    "the same core triple."
+                ),
+                "closure": [0, 1, 4, 7],
+                "target_center_in_closure": True,
+                "required_core_witnesses_in_closure": [0, 1, 4],
+                "target_witnesses_in_closure": [0, 1, 4],
+                "target_row_active_at_center": False,
+                "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+                "pair_checks": [],
+                "passes_intended_negative_control": True,
+            },
+            {
+                "name": "CE-full-label-containment-switch/source-81-row-3",
+                "vertices": list(range(9)),
+                "cyclic_order": list(range(9)),
+                "seed": [0, 1, 4],
+                "target_center": 3,
+                "target_row": [0, 1, 4, 6],
+                "target_role": "full_label_visibility_target",
+                "required_core_witnesses": [0, 1, 4],
+                "rich_classes": {
+                    "3": [[0, 1, 4, 8]],
+                    "6": [[0, 3, 4, 5]],
+                },
+                "intended_exposure_mode": (
+                    "CENTER_AND_FULL_TARGET_LABELS_IN_CLOSURE_BUT_TARGET_ROW_INACTIVE"
+                ),
+                "role_lesson": (
+                    "Full target-label visibility remains weaker than "
+                    "same-class membership at the target center."
+                ),
+                "closure": [0, 1, 3, 4, 6],
+                "target_center_in_closure": True,
+                "required_core_witnesses_in_closure": [0, 1, 4],
+                "target_witnesses_in_closure": [0, 1, 4, 6],
+                "target_row_active_at_center": False,
+                "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+                "pair_checks": [
+                    {
+                        "centers": [3, 6],
+                        "intersection": [0, 4],
+                        "cap_ok": True,
+                        "crossing_ok_when_two_overlap": True,
+                        "ok": True,
+                    }
+                ],
+                "passes_intended_negative_control": True,
+            },
+        ],
+    }
+
+
+def visibility_anti_activation_control_certificate() -> dict[str, Any]:
+    """Return the RS-2026-05-10-A closure-visibility control."""
+
+    return {
+        "type": "closure_visibility_anti_activation_control_v1",
+        "run_id": "RS-2026-05-10-A",
+        "date": "2026-05-10",
+        "title": "Closure-visibility anti-activation negative control",
+        "trust_label": "NEGATIVE_CONTROL",
+        "status": "EXACT_NEGATIVE_CONTROL",
+        "claim_status": "abstract_incidence_closure_stress_test_only",
+        "vertices": list(range(9)),
+        "cyclic_order": list(range(9)),
+        "seed_closure": [0, 1, 4],
+        "target": {
+            "source_row": "151:7-style closure-exposed target",
+            "center": 7,
+            "target_witnesses": [0, 1, 4],
+            "private_outside_witness": 6,
+            "target_row": [0, 1, 4, 6],
+        },
+        "rich_rows": [
+            {
+                "center": 3,
+                "witnesses": [0, 1, 4, 6],
+                "intended_activation_step": 1,
+                "activating_triple": [0, 1, 4],
+                "role": "helper row: adds center 3 from the seed closure",
+            },
+            {
+                "center": 7,
+                "witnesses": [0, 3, 4, 8],
+                "intended_activation_step": 2,
+                "activating_triple": [0, 3, 4],
+                "role": (
+                    "alternative row at target center; activates 7 through "
+                    "a different triple"
+                ),
+            },
+        ],
+        "claimed_bridge_that_this_falsifies": (
+            "If a deletion closure contains a target row center and three "
+            "target witnesses, then the target center's active row contains "
+            "those three target witnesses, or the specified target row is forced."
+        ),
+        "expected_closure_steps": [
+            {"step": 0, "closure": [0, 1, 4]},
+            {
+                "step": 1,
+                "activate_center": 3,
+                "using_row_center": 3,
+                "using_triple": [0, 1, 4],
+                "closure": [0, 1, 3, 4],
+            },
+            {
+                "step": 2,
+                "activate_center": 7,
+                "using_row_center": 7,
+                "using_triple": [0, 3, 4],
+                "closure": [0, 1, 3, 4, 7],
+            },
+        ],
+        "expected_pairwise_checks": {
+            "self_exclusion": True,
+            "four_uniformity": True,
+            "max_pairwise_row_intersection": 2,
+            "two_overlap_crossing_pairs": [
+                {"source_chord": [3, 7], "witness_chord": [0, 4]}
+            ],
+        },
+        "expected_failure_of_target_activation": {
+            "target_center_in_final_closure": True,
+            "target_witnesses_in_final_closure": True,
+            "target_row_present_at_center": False,
+            "target_triple_contained_in_target_center_row": False,
+            "target_center_activated_by_target_triple": False,
+        },
+        "source_provenance": {
+            "prompt_pack": "01_master_reusable_prompt.md after 00_common_prelude.md",
+            "source_run": (
+                "User-supplied GPT-5.5 Pro run RS-2026-05-10-A, "
+                "shared on 2026-05-11."
+            ),
+        },
+        "nonclaims": [
+            "This is not a polygon.",
+            "This is not a counterexample to Erdos Problem #97.",
+            "This is not a Euclidean realizability certificate.",
+            "This does not refute activation lemmas that require provenance.",
+            (
+                "This does not refute activation lemmas with critical-row "
+                "uniqueness or all-fourth obstruction hypotheses."
+            ),
+        ],
+    }
+
+
+def full_row_anti_activation_control_certificate() -> dict[str, Any]:
+    """Return the full-row bootstrap/T12 anti-activation control."""
+
+    return {
+        "type": "bootstrap_t12_full_row_anti_activation_negative_control_v1",
+        "run_id": "RS-2026-05-10-A",
+        "date": "2026-05-10",
+        "title": "Full selected-row closure-exposure anti-activation control",
+        "trust_label": "NEGATIVE_CONTROL",
+        "status": "EXACT_NEGATIVE_CONTROL",
+        "claim_status": "abstract_full_selected_row_closure_stress_test_only",
+        "n": 10,
+        "cyclic_order": list(range(10)),
+        "selected_rows": {
+            "0": [1, 2, 5, 9],
+            "1": [0, 2, 4, 7],
+            "2": [1, 3, 5, 7],
+            "3": [1, 4, 8, 9],
+            "4": [0, 2, 5, 8],
+            "5": [2, 6, 7, 9],
+            "6": [4, 5, 7, 8],
+            "7": [0, 1, 3, 4],
+            "8": [0, 5, 6, 9],
+            "9": [2, 3, 6, 8],
+        },
+        "closure_seed": [0, 1, 4],
+        "expected_closure": [0, 1, 4, 7],
+        "expected_closure_steps": [
+            {
+                "added_center": 7,
+                "row": [0, 1, 3, 4],
+                "support": [0, 1, 4],
+            }
+        ],
+        "anti_activation_row": {
+            "center": 7,
+            "contains_core_witnesses": [0, 1, 4],
+            "excluded_target_witness": 6,
+            "replacement_witness": 3,
+            "row": [0, 1, 3, 4],
+            "target_row": [0, 1, 4, 6],
+        },
+        "expected_checks": {
+            "uniformity_ok": True,
+            "self_exclusion_ok": True,
+            "cover_ok": True,
+            "pairwise_intersection_and_crossing_ok": True,
+            "adjacent_intersections_size_at_most_1": True,
+        },
+        "targeted_overstrong_bridge": (
+            "Closure exposure of center 7 with witnesses 0,1,4 forces "
+            "selected row 7->{0,1,4,6}."
+        ),
+        "source_provenance": {
+            "prompt_pack": (
+                "00_common_prelude.md + 01_master_reusable_prompt.md, "
+                "with closure-activation/negative-control focus"
+            ),
+            "source_run": (
+                "User-supplied GPT-5.5 Pro run RS-2026-05-10-A, "
+                "shared on 2026-05-11."
+            ),
+        },
+        "nonclaims": [
+            "Not a Euclidean realization.",
+            "Not a counterexample to Erdos Problem #97.",
+            (
+                "Not a proof that closure activation is false for genuine "
+                "minimal counterexamples."
+            ),
+            (
+                "Not checked as avoiding all vertex-circle, Kalmanson, "
+                "row-Ptolemy, or algebraic obstruction templates."
+            ),
+        ],
+    }
+
+
+def wrong_fourth_negative_control_certificate() -> dict[str, Any]:
+    """Return the RS-2026-05-10-A wrong-fourth negative control."""
+
+    rows = {
+        "0": [1, 2, 6, 9],
+        "1": [0, 2, 4, 7],
+        "2": [3, 4, 8, 9],
+        "3": [1, 4, 5, 6],
+        "4": [2, 5, 7, 9],
+        "5": [0, 3, 6, 8],
+        "6": [1, 3, 5, 7],
+        "7": [0, 1, 4, 9],
+        "8": [3, 6, 7, 9],
+        "9": [0, 2, 5, 8],
+    }
+    return {
+        "type": "closure_activation_wrong_fourth_negative_control_v1",
+        "run_id": "RS-2026-05-10-A",
+        "date": "2026-05-10",
+        "title": "Wrong-fourth closure activation negative control",
+        "trust_label": "NEGATIVE_CONTROL",
+        "status": "EXACT_NEGATIVE_CONTROL",
+        "claim_status": "abstract_incidence_closure_stress_test_only",
+        "n": 10,
+        "cyclic_order": list(range(10)),
+        "selected_rows": rows,
+        "activation_target": {
+            "closure_seed": [0, 1, 4],
+            "exposed_center": 7,
+            "exposed_triple": [0, 1, 4],
+            "wrong_fourth": 9,
+            "target_fourth_not_forced": 6,
+            "target_row_that_should_not_be_inferred": [0, 1, 4, 6],
+            "expected_closure_from_seed": [0, 1, 4, 7],
+        },
+        "source_provenance": {
+            "prompt_pack": (
+                "00_common_prelude + 07_closure_activation_bridge + "
+                "11_bridge_falsifier posture"
+            ),
+            "source_run": (
+                "User-supplied GPT-5.5 Pro run RS-2026-05-10-A, "
+                "shared on 2026-05-11."
+            ),
+        },
+        "nonclaims": [
+            "This is not a polygon.",
+            "This is not a counterexample to Erdos Problem #97.",
+            "This is not a Euclidean realizability certificate.",
+            "This does not refute T12-style lemmas that assume exact selected rows.",
+            (
+                "This does not refute activation lemmas with extra criticality, "
+                "uniqueness, radius-order, Ptolemy, or Kalmanson hypotheses."
+            ),
+        ],
+    }
+
+
+def rows_from_payload(payload: dict[str, Any]) -> Rows:
+    """Return selected rows as a center-indexed list."""
+
+    n = _expect_int(payload, "n")
+    raw = payload.get("selected_rows", payload.get("rows"))
+    if isinstance(raw, dict):
+        rows: Rows = []
+        for center in range(n):
+            value = raw.get(str(center), raw.get(center))
+            rows.append(_expect_int_list(value, f"selected_rows[{center}]"))
+        return rows
+    if isinstance(raw, list):
+        if len(raw) != n:
+            raise ValueError(f"selected_rows has length {len(raw)}, expected {n}")
+        return [_expect_int_list(row, f"selected_rows[{idx}]") for idx, row in enumerate(raw)]
+    raise ValueError("selected_rows must be a mapping or list")
+
+
+def rich_triple_closure(seed: set[int], rows: Sequence[Sequence[int]]) -> set[int]:
+    """Close a seed by adding centers with at least three visible witnesses."""
+
+    closure = set(seed)
+    changed = True
+    while changed:
+        changed = False
+        for center, witnesses in enumerate(rows):
+            if center in closure:
+                continue
+            if len(set(witnesses) & closure) >= 3:
+                closure.add(center)
+                changed = True
+    return closure
+
+
+def sparse_rich_triple_closure_steps(
+    seed: set[int],
+    rich_rows: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Replay sparse rich-row closure and record each activation."""
+
+    closure = set(seed)
+    steps: list[dict[str, Any]] = [{"step": 0, "closure": sorted(closure)}]
+    changed = True
+    step = 0
+    while changed:
+        changed = False
+        for row in rich_rows:
+            center = _expect_int(row, "center")
+            witnesses = set(_expect_int_list(row.get("witnesses"), "witnesses"))
+            if center in closure:
+                continue
+            visible = sorted(witnesses & closure)
+            if len(visible) < 3:
+                continue
+            step += 1
+            triple = visible[:3]
+            closure.add(center)
+            steps.append(
+                {
+                    "step": step,
+                    "activate_center": center,
+                    "using_row_center": center,
+                    "using_triple": triple,
+                    "closure": sorted(closure),
+                }
+            )
+            changed = True
+    return steps
+
+
+def rich_class_closure(
+    seed: set[int],
+    rich_classes: dict[int, list[set[int]]],
+) -> set[int]:
+    """Close a seed using abstract rich classes, sorted by center."""
+
+    closure = set(seed)
+    changed = True
+    while changed:
+        changed = False
+        for center in sorted(rich_classes):
+            if center in closure:
+                continue
+            if any(len(row & closure) >= 3 for row in rich_classes[center]):
+                closure.add(center)
+                changed = True
+    return closure
+
+
+def certificate_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact replay summary for a closure negative-control payload."""
+
+    rows = rows_from_payload(payload)
+    n = _expect_int(payload, "n")
+    order = _expect_int_list(payload.get("cyclic_order"), "cyclic_order")
+    target = _expect_mapping(payload.get("activation_target"), "activation_target")
+    seed = set(_expect_int_list(target.get("closure_seed"), "closure_seed"))
+    closure = rich_triple_closure(seed, rows)
+    exposed_center = _expect_int(target, "exposed_center")
+    target_row = sorted(
+        _expect_int_list(
+            target.get("target_row_that_should_not_be_inferred"),
+            "target_row_that_should_not_be_inferred",
+        )
+    )
+
+    row_pair_stats = _row_pair_stats(rows)
+    witness_pair_violations = _witness_pair_cap_violations(rows)
+    crossing_violations = _crossing_violations(rows, order)
+    return {
+        "ok": not validate_wrong_fourth_certificate(payload),
+        "n": n,
+        "two_overlap_count": row_pair_stats["two_overlap_count"],
+        "closure": sorted(closure),
+        "exposed_center": exposed_center,
+        "exposed_row": sorted(rows[exposed_center]),
+        "target_row_absent": target_row,
+        "row_pair_cap_ok": not row_pair_stats["row_pair_cap_violations"],
+        "witness_pair_cap_ok": not witness_pair_violations,
+        "two_overlap_crossing_ok": not crossing_violations,
+        "message": (
+            "closure exposure holds, but the specific target fourth is not forced"
+        ),
+    }
+
+
+def full_row_anti_activation_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact replay summary for the full-row anti-activation control."""
+
+    data = _full_row_validation_data(payload)
+    errors = _validate_full_row_from_data(data)
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "closure_result": data["closure_result"],
+        "closure_steps": data["closure_steps"],
+        "anti_activation_row": data["anti_activation_row"],
+        "checks": data["checks"],
+        "covered_vertices": data["covered_vertices"],
+        "indegrees": data["indegrees"],
+        "two_overlap_count": data["two_overlap_count"],
+        "adjacent_intersections": data["adjacent_intersections"],
+        "nonclaims": payload.get("nonclaims", []),
+    }
+
+
+def rich_class_activation_controls_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact replay summary for aggregate rich-class controls."""
+
+    errors = validate_rich_class_activation_controls_certificate(payload)
+    controls = [
+        _rich_class_control_summary(control)
+        for control in _expect_controls(payload.get("controls"))
+    ]
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "control_count": len(controls),
+        "controls": controls,
+        "nonclaims": payload.get("nonclaims", []),
+    }
+
+
+def visibility_anti_activation_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact replay summary for the visibility control."""
+
+    validation = _visibility_validation_data(payload)
+    errors = _validate_visibility_from_data(validation)
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "closure_steps": validation["closure_steps"],
+        "final_closure": validation["final_closure"],
+        "max_pairwise_row_intersection": validation["max_pairwise_row_intersection"],
+        "two_overlap_crossings": validation["two_overlap_crossings"],
+        "target_center_in_final_closure": validation["target_center_in_final_closure"],
+        "target_witnesses_in_final_closure": validation[
+            "target_witnesses_in_final_closure"
+        ],
+        "target_row_present_at_center": validation["target_row_present_at_center"],
+        "target_triple_contained_in_target_center_row": validation[
+            "target_triple_contained_in_target_center_row"
+        ],
+        "target_center_activated_by_target_triple": validation[
+            "target_center_activated_by_target_triple"
+        ],
+        "nonclaim": (
+            "abstract closure/incidence negative control only; "
+            "no Euclidean realization checked"
+        ),
+    }
+
+
+def validate_wrong_fourth_certificate(payload: dict[str, Any]) -> list[str]:
+    """Return validation errors for the wrong-fourth negative control."""
+
+    errors: list[str] = []
+    if payload.get("type") != "closure_activation_wrong_fourth_negative_control_v1":
+        errors.append("unexpected certificate type")
+
+    try:
+        n = _expect_int(payload, "n")
+        rows = rows_from_payload(payload)
+        order = _expect_int_list(payload.get("cyclic_order"), "cyclic_order")
+    except ValueError as exc:
+        return [str(exc)]
+
+    if sorted(order) != list(range(n)):
+        errors.append("cyclic_order must be a permutation of 0..n-1")
+
+    for center, witnesses in enumerate(rows):
+        witness_set = set(witnesses)
+        if len(witnesses) != 4 or len(witness_set) != 4:
+            errors.append(f"row {center} must contain four distinct witnesses")
+        if center in witness_set:
+            errors.append(f"row {center} violates self-exclusion")
+        if any(witness < 0 or witness >= n for witness in witness_set):
+            errors.append(f"row {center} contains a witness outside 0..n-1")
+
+    row_pair_stats = _row_pair_stats(rows)
+    for violation in row_pair_stats["row_pair_cap_violations"]:
+        errors.append(
+            "row-pair cap violation at centers "
+            f"{violation['centers']}: {violation['intersection']}"
+        )
+
+    for violation in _witness_pair_cap_violations(rows):
+        errors.append(
+            "witness-pair cap violation for pair "
+            f"{violation['pair']}: centers {violation['centers']}"
+        )
+
+    for violation in _crossing_violations(rows, order):
+        errors.append(
+            "two-overlap crossing violation for source "
+            f"{violation['source_chord']} and witness {violation['witness_chord']}"
+        )
+
+    try:
+        target = _expect_mapping(payload.get("activation_target"), "activation_target")
+        seed = set(_expect_int_list(target.get("closure_seed"), "closure_seed"))
+        expected_closure = set(
+            _expect_int_list(
+                target.get("expected_closure_from_seed"),
+                "expected_closure_from_seed",
+            )
+        )
+        exposed_center = _expect_int(target, "exposed_center")
+        exposed_triple = set(
+            _expect_int_list(target.get("exposed_triple"), "exposed_triple")
+        )
+        wrong_fourth = _expect_int(target, "wrong_fourth")
+        target_fourth = _expect_int(target, "target_fourth_not_forced")
+        target_row = set(
+            _expect_int_list(
+                target.get("target_row_that_should_not_be_inferred"),
+                "target_row_that_should_not_be_inferred",
+            )
+        )
+    except ValueError as exc:
+        errors.append(str(exc))
+        return errors
+
+    if exposed_center < 0 or exposed_center >= n:
+        errors.append("exposed_center is outside 0..n-1")
+        return errors
+
+    closure = rich_triple_closure(seed, rows)
+    exposed_row = set(rows[exposed_center])
+    if closure != expected_closure:
+        errors.append(
+            f"closure mismatch: got {sorted(closure)}, expected {sorted(expected_closure)}"
+        )
+    if exposed_center not in closure:
+        errors.append("exposed center is not in the computed closure")
+    if not exposed_triple <= closure:
+        errors.append("exposed triple is not contained in the computed closure")
+    if not exposed_triple <= seed:
+        errors.append("exposed triple should already be visible in the seed")
+    if len(exposed_row & seed) < 3:
+        errors.append("exposed center is not activated by three seed witnesses")
+    if wrong_fourth not in exposed_row:
+        errors.append("wrong fourth is not present in the exposed row")
+    if target_fourth in exposed_row:
+        errors.append("target fourth is already present in the exposed row")
+    if target_fourth in closure:
+        errors.append("target fourth is not private to the computed closure")
+    if exposed_row == target_row:
+        errors.append("the exposed row equals the target row")
+    if any(set(row) == target_row for row in rows):
+        errors.append("the target row is present somewhere in the selected system")
+
+    return errors
+
+
+def validate_full_row_anti_activation_certificate(
+    payload: dict[str, Any],
+) -> list[str]:
+    """Return validation errors for the full-row anti-activation control."""
+
+    try:
+        data = _full_row_validation_data(payload)
+    except ValueError as exc:
+        return [str(exc)]
+    return _validate_full_row_from_data(data)
+
+
+def validate_rich_class_activation_controls_certificate(
+    payload: dict[str, Any],
+) -> list[str]:
+    """Return validation errors for the aggregate rich-class controls."""
+
+    errors: list[str] = []
+    if payload.get("schema") != "erdos97.closure_activation_negative_controls.v1":
+        errors.append("unexpected aggregate certificate schema")
+    if payload.get("status") != "NEGATIVE_CONTROL_ABSTRACT_RICH_CLASS_ONLY":
+        errors.append("unexpected aggregate certificate status")
+    try:
+        controls = _expect_controls(payload.get("controls"))
+    except ValueError as exc:
+        return errors + [str(exc)]
+    if not controls:
+        errors.append("controls must not be empty")
+    for index, control in enumerate(controls):
+        errors.extend(
+            f"controls[{index}] {error}"
+            for error in _validate_rich_class_control(control)
+        )
+    return errors
+
+
+def validate_visibility_anti_activation_certificate(
+    payload: dict[str, Any],
+) -> list[str]:
+    """Return validation errors for the closure-visibility control."""
+
+    try:
+        data = _visibility_validation_data(payload)
+    except ValueError as exc:
+        return [str(exc)]
+    return _validate_visibility_from_data(data)
+
+
+def assert_wrong_fourth_expected(payload: dict[str, Any]) -> None:
+    """Assert the stable RS-2026-05-10-A replay values."""
+
+    errors = validate_wrong_fourth_certificate(payload)
+    if errors:
+        raise AssertionError("; ".join(errors))
+    summary = certificate_summary(payload)
+    expected = {
+        "n": 10,
+        "two_overlap_count": 18,
+        "closure": [0, 1, 4, 7],
+        "exposed_center": 7,
+        "exposed_row": [0, 1, 4, 9],
+        "target_row_absent": [0, 1, 4, 6],
+        "row_pair_cap_ok": True,
+        "witness_pair_cap_ok": True,
+        "two_overlap_crossing_ok": True,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(f"{key} is {summary.get(key)!r}, expected {value!r}")
+
+
+def assert_full_row_anti_activation_expected(payload: dict[str, Any]) -> None:
+    """Assert the stable full-row anti-activation replay values."""
+
+    errors = validate_full_row_anti_activation_certificate(payload)
+    if errors:
+        raise AssertionError("; ".join(errors))
+    summary = full_row_anti_activation_summary(payload)
+    expected_checks = {
+        "uniformity_ok": True,
+        "self_exclusion_ok": True,
+        "cover_ok": True,
+        "pairwise_intersection_and_crossing_ok": True,
+        "adjacent_intersections_size_at_most_1": True,
+    }
+    expected_row = {
+        "center": 7,
+        "contains_core_witnesses": [0, 1, 4],
+        "excluded_target_witness": 6,
+        "replacement_witness": 3,
+        "row": [0, 1, 3, 4],
+        "target_row": [0, 1, 4, 6],
+        "target_row_active_at_center": False,
+    }
+    if summary["closure_result"] != [0, 1, 4, 7]:
+        raise AssertionError(f"unexpected closure: {summary['closure_result']!r}")
+    if summary["closure_steps"] != [
+        {"added_center": 7, "row": [0, 1, 3, 4], "support": [0, 1, 4]}
+    ]:
+        raise AssertionError(f"unexpected closure steps: {summary['closure_steps']!r}")
+    if summary["anti_activation_row"] != expected_row:
+        raise AssertionError(f"unexpected anti-activation row: {summary['anti_activation_row']!r}")
+    if summary["checks"] != expected_checks:
+        raise AssertionError(f"unexpected checks: {summary['checks']!r}")
+    if summary["covered_vertices"] != list(range(10)):
+        raise AssertionError(f"unexpected cover: {summary['covered_vertices']!r}")
+
+
+def assert_rich_class_activation_controls_expected(payload: dict[str, Any]) -> None:
+    """Assert the stable RS-2026-05-10-CE-A replay values."""
+
+    errors = validate_rich_class_activation_controls_certificate(payload)
+    if errors:
+        raise AssertionError("; ".join(errors))
+    summary = rich_class_activation_controls_summary(payload)
+    if summary["control_count"] != 4:
+        raise AssertionError("expected exactly four rich-class controls")
+    expected = {
+        "NC1_three_core_trigger_unpinned_fourth": {
+            "closure": [0, 1, 4, 7],
+            "target_center_in_closure": True,
+            "required_core_witnesses_in_closure": [0, 1, 4],
+            "target_witnesses_in_closure": [0, 1, 4],
+            "target_row_active_at_center": False,
+            "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+            "passes_intended_negative_control": True,
+        },
+        "NC2_full_label_visibility_without_center_class_membership": {
+            "closure": [0, 1, 3, 4, 6],
+            "target_center_in_closure": True,
+            "required_core_witnesses_in_closure": [0, 1, 4],
+            "target_witnesses_in_closure": [0, 1, 4, 6],
+            "target_row_active_at_center": False,
+            "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+            "passes_intended_negative_control": True,
+        },
+        "CE-private-fourth-switch/source-151-row-7": {
+            "closure": [0, 1, 4, 7],
+            "target_center_in_closure": True,
+            "required_core_witnesses_in_closure": [0, 1, 4],
+            "target_witnesses_in_closure": [0, 1, 4],
+            "target_row_active_at_center": False,
+            "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+            "passes_intended_negative_control": True,
+        },
+        "CE-full-label-containment-switch/source-81-row-3": {
+            "closure": [0, 1, 3, 4, 6],
+            "target_center_in_closure": True,
+            "required_core_witnesses_in_closure": [0, 1, 4],
+            "target_witnesses_in_closure": [0, 1, 4, 6],
+            "target_row_active_at_center": False,
+            "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": True,
+            "passes_intended_negative_control": True,
+        },
+    }
+    controls = {control["name"]: control for control in summary["controls"]}
+    if set(controls) != set(expected):
+        raise AssertionError(f"unexpected control names: {sorted(controls)}")
+    for name, expected_values in expected.items():
+        for key, value in expected_values.items():
+            actual = controls[name].get(key)
+            if actual != value:
+                raise AssertionError(
+                    f"{name} {key} is {actual!r}, expected {value!r}"
+                )
+
+
+def assert_visibility_anti_activation_expected(payload: dict[str, Any]) -> None:
+    """Assert the stable closure-visibility replay values."""
+
+    errors = validate_visibility_anti_activation_certificate(payload)
+    if errors:
+        raise AssertionError("; ".join(errors))
+    summary = visibility_anti_activation_summary(payload)
+    expected = {
+        "final_closure": [0, 1, 3, 4, 7],
+        "max_pairwise_row_intersection": 2,
+        "two_overlap_crossings": [
+            {"source_chord": [3, 7], "witness_chord": [0, 4]}
+        ],
+        "target_center_in_final_closure": True,
+        "target_witnesses_in_final_closure": [0, 1, 4],
+        "target_row_present_at_center": False,
+        "target_triple_contained_in_target_center_row": False,
+        "target_center_activated_by_target_triple": False,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(f"{key} is {summary.get(key)!r}, expected {value!r}")
+
+
+def _full_row_validation_data(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("type") != "bootstrap_t12_full_row_anti_activation_negative_control_v1":
+        raise ValueError("unexpected full-row anti-activation certificate type")
+    n = _expect_int(payload, "n")
+    order = _expect_int_list(payload.get("cyclic_order"), "cyclic_order")
+    rows = rows_from_payload(payload)
+    seed = set(_expect_int_list(payload.get("closure_seed"), "closure_seed"))
+    expected_closure = _expect_int_list(
+        payload.get("expected_closure"),
+        "expected_closure",
+    )
+    expected_steps = _expect_list_of_mappings(
+        payload.get("expected_closure_steps"),
+        "expected_closure_steps",
+    )
+    anti = _expect_mapping(payload.get("anti_activation_row"), "anti_activation_row")
+    closure_result, closure_steps = _selected_row_closure_with_steps(seed, rows)
+    row_pair_stats = _row_pair_stats(rows)
+    crossing_violations = _crossing_violations(rows, order)
+    cover = sorted({witness for row in rows for witness in row})
+    adjacent = _adjacent_intersections(rows, order)
+    anti_center = _expect_int(anti, "center")
+    anti_row = sorted(rows[anti_center])
+    core = _expect_int_list(
+        anti.get("contains_core_witnesses"),
+        "contains_core_witnesses",
+    )
+    excluded = _expect_int(anti, "excluded_target_witness")
+    replacement = _expect_int(anti, "replacement_witness")
+    target_row = _expect_int_list(anti.get("target_row"), "target_row")
+    anti_summary = {
+        "center": anti_center,
+        "contains_core_witnesses": core,
+        "excluded_target_witness": excluded,
+        "replacement_witness": replacement,
+        "row": anti_row,
+        "target_row": target_row,
+        "target_row_active_at_center": set(rows[anti_center]) == set(target_row),
+    }
+    checks = {
+        "uniformity_ok": all(len(row) == 4 and len(set(row)) == 4 for row in rows),
+        "self_exclusion_ok": all(center not in row for center, row in enumerate(rows)),
+        "cover_ok": cover == list(range(n)),
+        "pairwise_intersection_and_crossing_ok": (
+            not row_pair_stats["row_pair_cap_violations"] and not crossing_violations
+        ),
+        "adjacent_intersections_size_at_most_1": all(
+            len(item["intersection"]) <= 1 for item in adjacent
+        ),
+    }
+    return {
+        "n": n,
+        "order": order,
+        "rows": rows,
+        "closure_result": closure_result,
+        "expected_closure": expected_closure,
+        "closure_steps": closure_steps,
+        "expected_closure_steps": expected_steps,
+        "anti_activation_row": anti_summary,
+        "anti_activation_expected": anti,
+        "checks": checks,
+        "expected_checks": payload.get("expected_checks"),
+        "covered_vertices": cover,
+        "indegrees": _indegrees(rows, n),
+        "two_overlap_count": row_pair_stats["two_overlap_count"],
+        "adjacent_intersections": adjacent,
+        "row_pair_cap_violations": row_pair_stats["row_pair_cap_violations"],
+        "crossing_violations": crossing_violations,
+    }
+
+
+def _validate_full_row_from_data(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    n = data["n"]
+    if sorted(data["order"]) != list(range(n)):
+        errors.append("cyclic_order must be a permutation of 0..n-1")
+    if data["closure_result"] != data["expected_closure"]:
+        errors.append(
+            f"closure mismatch: got {data['closure_result']}, "
+            f"expected {data['expected_closure']}"
+        )
+    if data["closure_steps"] != data["expected_closure_steps"]:
+        errors.append(
+            f"closure steps mismatch: got {data['closure_steps']}, "
+            f"expected {data['expected_closure_steps']}"
+        )
+    if data["checks"] != data["expected_checks"]:
+        errors.append(f"check summary mismatch: got {data['checks']}")
+    anti = data["anti_activation_row"]
+    anti_expected = data["anti_activation_expected"]
+    if anti["row"] != _expect_int_list(anti_expected.get("row"), "anti row"):
+        errors.append("anti-activation row does not match the expected row")
+    if not set(anti["contains_core_witnesses"]) <= set(anti["row"]):
+        errors.append("anti-activation row does not contain all core witnesses")
+    if anti["excluded_target_witness"] in anti["row"]:
+        errors.append("anti-activation row contains the excluded target witness")
+    if anti["replacement_witness"] not in anti["row"]:
+        errors.append("anti-activation row does not contain the replacement witness")
+    if anti["target_row_active_at_center"]:
+        errors.append("target row is unexpectedly active at the exposed center")
+    if data["row_pair_cap_violations"]:
+        errors.append(f"row-pair cap violations: {data['row_pair_cap_violations']}")
+    if data["crossing_violations"]:
+        errors.append(f"crossing violations: {data['crossing_violations']}")
+    return errors
+
+
+def _selected_row_closure_with_steps(
+    seed: set[int],
+    rows: Sequence[Sequence[int]],
+) -> tuple[list[int], list[dict[str, Any]]]:
+    closure = set(seed)
+    steps: list[dict[str, Any]] = []
+    changed = True
+    while changed:
+        changed = False
+        for center, row in enumerate(rows):
+            if center in closure:
+                continue
+            support = sorted(set(row) & closure)
+            if len(support) < 3:
+                continue
+            closure.add(center)
+            steps.append(
+                {
+                    "added_center": center,
+                    "row": sorted(row),
+                    "support": support[:3],
+                }
+            )
+            changed = True
+    return sorted(closure), steps
+
+
+def _adjacent_intersections(
+    rows: Sequence[Sequence[int]],
+    order: Sequence[int],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "centers": [order[idx], order[(idx + 1) % len(order)]],
+            "intersection": sorted(
+                set(rows[order[idx]]) & set(rows[order[(idx + 1) % len(order)]])
+            ),
+        }
+        for idx in range(len(order))
+    ]
+
+
+def _indegrees(rows: Sequence[Sequence[int]], n: int) -> dict[str, int]:
+    return {
+        str(label): sum(1 for row in rows if label in row)
+        for label in range(n)
+    }
+
+
+def _visibility_validation_data(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("type") != "closure_visibility_anti_activation_control_v1":
+        raise ValueError("unexpected certificate type")
+
+    vertices = _expect_int_list(payload.get("vertices"), "vertices")
+    if sorted(vertices) != list(range(len(vertices))):
+        raise ValueError("vertices must be 0..n-1")
+    order = _expect_int_list(payload.get("cyclic_order"), "cyclic_order")
+    rich_rows = _expect_rich_rows(payload.get("rich_rows"))
+    target = _expect_mapping(payload.get("target"), "target")
+    seed = set(_expect_int_list(payload.get("seed_closure"), "seed_closure"))
+    target_center = _expect_int(target, "center")
+    target_witnesses = set(
+        _expect_int_list(target.get("target_witnesses"), "target_witnesses")
+    )
+    target_row = set(_expect_int_list(target.get("target_row"), "target_row"))
+
+    row_errors = _sparse_row_errors(rich_rows, vertices)
+    row_pair_stats = _sparse_row_pair_stats(rich_rows)
+    witness_pair_violations = _sparse_witness_pair_cap_violations(rich_rows, vertices)
+    crossing_violations, crossing_pairs = _sparse_crossing_checks(rich_rows, order)
+    closure_steps = sparse_rich_triple_closure_steps(seed, rich_rows)
+    final_closure = set(closure_steps[-1]["closure"])
+    target_center_rows = [
+        set(_expect_int_list(row.get("witnesses"), "witnesses"))
+        for row in rich_rows
+        if _expect_int(row, "center") == target_center
+    ]
+    target_row_present = any(row == target_row for row in target_center_rows)
+    target_triple_present = any(target_witnesses <= row for row in target_center_rows)
+    activation_steps = [
+        step
+        for step in closure_steps[1:]
+        if step.get("activate_center") == target_center
+    ]
+    target_triple_sorted = sorted(target_witnesses)
+    target_activation = any(
+        step.get("using_triple") == target_triple_sorted for step in activation_steps
+    )
+    return {
+        "vertices": vertices,
+        "order": order,
+        "rich_rows": rich_rows,
+        "target_center": target_center,
+        "target_witnesses": target_witnesses,
+        "target_row": target_row,
+        "row_errors": row_errors,
+        "row_pair_cap_violations": row_pair_stats["row_pair_cap_violations"],
+        "max_pairwise_row_intersection": row_pair_stats["max_row_intersection"],
+        "witness_pair_cap_violations": witness_pair_violations,
+        "crossing_violations": crossing_violations,
+        "two_overlap_crossings": crossing_pairs,
+        "closure_steps": closure_steps,
+        "expected_closure_steps": payload.get("expected_closure_steps"),
+        "final_closure": sorted(final_closure),
+        "target_center_in_final_closure": target_center in final_closure,
+        "target_witnesses_in_final_closure": (
+            sorted(target_witnesses)
+            if target_witnesses <= final_closure
+            else sorted(target_witnesses & final_closure)
+        ),
+        "target_row_present_at_center": target_row_present,
+        "target_triple_contained_in_target_center_row": target_triple_present,
+        "target_center_activated_by_target_triple": target_activation,
+    }
+
+
+def _validate_rich_class_control(control: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    try:
+        summary = _rich_class_control_summary(control)
+    except ValueError as exc:
+        return [str(exc)]
+    for key in (
+        "closure",
+        "target_center_in_closure",
+        "required_core_witnesses_in_closure",
+        "target_witnesses_in_closure",
+        "target_row_active_at_center",
+        "pair_cap_and_two_overlap_crossing_ok_for_listed_rows",
+        "pair_checks",
+        "passes_intended_negative_control",
+    ):
+        if control.get(key) != summary[key]:
+            errors.append(
+                f"{control.get('name', '<unnamed>')} {key} is {control.get(key)!r}, "
+                f"expected {summary[key]!r}"
+            )
+    if summary["row_errors"]:
+        errors.extend(summary["row_errors"])
+    if sorted(summary["cyclic_order"]) != summary["vertices"]:
+        errors.append("cyclic_order must be a permutation of vertices")
+    return errors
+
+
+def _rich_class_control_summary(control: dict[str, Any]) -> dict[str, Any]:
+    name = control.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("control name must be a nonempty string")
+    vertices = _expect_int_list(control.get("vertices"), "vertices")
+    if sorted(vertices) != list(range(len(vertices))):
+        raise ValueError(f"{name} vertices must be 0..n-1")
+    order = _expect_int_list(control.get("cyclic_order"), "cyclic_order")
+    seed = set(_expect_int_list(control.get("seed"), "seed"))
+    target_center = _expect_int(control, "target_center")
+    target_row = set(_expect_int_list(control.get("target_row"), "target_row"))
+    required_core = set(
+        _expect_int_list(
+            control.get("required_core_witnesses"),
+            "required_core_witnesses",
+        )
+    )
+    rich_classes = _rich_classes_from_control(control.get("rich_classes"))
+    closure = rich_class_closure(seed, rich_classes)
+    row_errors = _rich_class_row_errors(rich_classes, vertices)
+    pair_ok, pair_checks = _rich_class_pair_checks(rich_classes, order)
+    target_classes = rich_classes.get(target_center, [])
+    target_row_active = any(target_row <= row for row in target_classes)
+    return {
+        "name": name,
+        "vertices": vertices,
+        "cyclic_order": order,
+        "closure": sorted(closure),
+        "target_center_in_closure": target_center in closure,
+        "required_core_witnesses_in_closure": sorted(required_core & closure),
+        "target_witnesses_in_closure": sorted(target_row & closure),
+        "target_row_active_at_center": target_row_active,
+        "pair_cap_and_two_overlap_crossing_ok_for_listed_rows": pair_ok,
+        "pair_checks": pair_checks,
+        "passes_intended_negative_control": (
+            target_center in closure
+            and required_core <= closure
+            and not target_row_active
+            and pair_ok
+            and not row_errors
+        ),
+        "row_errors": row_errors,
+    }
+
+
+def _validate_visibility_from_data(data: dict[str, Any]) -> list[str]:
+    errors = list(data["row_errors"])
+    if sorted(data["order"]) != data["vertices"]:
+        errors.append("cyclic_order must be a permutation of vertices")
+    for violation in data["row_pair_cap_violations"]:
+        errors.append(
+            "row-pair cap violation at centers "
+            f"{violation['centers']}: {violation['intersection']}"
+        )
+    for violation in data["witness_pair_cap_violations"]:
+        errors.append(
+            "witness-pair cap violation for pair "
+            f"{violation['pair']}: centers {violation['centers']}"
+        )
+    for violation in data["crossing_violations"]:
+        errors.append(
+            "two-overlap crossing violation for source "
+            f"{violation['source_chord']} and witness {violation['witness_chord']}"
+        )
+    if data["closure_steps"] != data["expected_closure_steps"]:
+        errors.append(
+            "closure steps mismatch: got "
+            f"{data['closure_steps']}, expected {data['expected_closure_steps']}"
+        )
+    if not data["target_center_in_final_closure"]:
+        errors.append("target center is not in final closure")
+    if data["target_witnesses_in_final_closure"] != sorted(data["target_witnesses"]):
+        errors.append("target witnesses are not all in final closure")
+    if data["target_row_present_at_center"]:
+        errors.append("target row is unexpectedly present at the target center")
+    if data["target_triple_contained_in_target_center_row"]:
+        errors.append(
+            "target triple is unexpectedly contained in a target-center row"
+        )
+    if data["target_center_activated_by_target_triple"]:
+        errors.append("target center was activated by the target triple")
+    return errors
+
+
+def _rich_classes_from_control(value: object) -> dict[int, list[set[int]]]:
+    if not isinstance(value, dict):
+        raise ValueError("rich_classes must be a mapping")
+    rich_classes: dict[int, list[set[int]]] = {}
+    for raw_center, raw_classes in value.items():
+        try:
+            center = int(raw_center)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("rich_classes keys must be integer-like centers") from exc
+        if not isinstance(raw_classes, list):
+            raise ValueError(f"rich_classes[{center}] must be a list")
+        rich_classes[center] = [
+            set(_expect_int_list(row, f"rich_classes[{center}] row"))
+            for row in raw_classes
+        ]
+    return rich_classes
+
+
+def _rich_class_row_errors(
+    rich_classes: dict[int, list[set[int]]],
+    vertices: Sequence[int],
+) -> list[str]:
+    errors: list[str] = []
+    vertex_set = set(vertices)
+    for center, rows in rich_classes.items():
+        if center not in vertex_set:
+            errors.append(f"row center {center} is outside the vertex set")
+        for row in rows:
+            if len(row) != 4:
+                errors.append(f"row {center} must contain four distinct witnesses")
+            if center in row:
+                errors.append(f"row {center} violates self-exclusion")
+            if not row <= vertex_set:
+                errors.append(f"row {center} contains witnesses outside the vertex set")
+    return errors
+
+
+def _rich_class_pair_checks(
+    rich_classes: dict[int, list[set[int]]],
+    order: Sequence[int],
+) -> tuple[bool, list[dict[str, Any]]]:
+    rows = [
+        (center, row)
+        for center, classes in sorted(rich_classes.items())
+        for row in classes
+    ]
+    checks: list[dict[str, Any]] = []
+    ok = True
+    for (left_center, left_row), (right_center, right_row) in combinations(rows, 2):
+        intersection = sorted(left_row & right_row)
+        cap_ok = len(intersection) <= 2
+        crossing_ok: bool | None = None
+        if len(intersection) == 2:
+            crossing_ok = chords_cross_in_order(
+                normalize_chord(left_center, right_center),
+                normalize_chord(intersection[0], intersection[1]),
+                order,
+            )
+        row_ok = cap_ok and crossing_ok is not False
+        ok = ok and row_ok
+        checks.append(
+            {
+                "centers": [left_center, right_center],
+                "intersection": intersection,
+                "cap_ok": cap_ok,
+                "crossing_ok_when_two_overlap": crossing_ok,
+                "ok": row_ok,
+            }
+        )
+    return ok, checks
+
+
+def _row_pair_stats(rows: Sequence[Sequence[int]]) -> dict[str, Any]:
+    max_intersection = 0
+    two_overlap_count = 0
+    violations: list[dict[str, Any]] = []
+    for left, right in combinations(range(len(rows)), 2):
+        intersection = sorted(set(rows[left]) & set(rows[right]))
+        max_intersection = max(max_intersection, len(intersection))
+        if len(intersection) == 2:
+            two_overlap_count += 1
+        if len(intersection) > 2:
+            violations.append(
+                {
+                    "centers": [left, right],
+                    "intersection": intersection,
+                    "intersection_size": len(intersection),
+                }
+            )
+    return {
+        "max_row_intersection": max_intersection,
+        "two_overlap_count": two_overlap_count,
+        "row_pair_cap_violations": violations,
+    }
+
+
+def _witness_pair_cap_violations(
+    rows: Sequence[Sequence[int]],
+) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    for left, right in combinations(range(len(rows)), 2):
+        centers = [
+            center
+            for center, row in enumerate(rows)
+            if left in row and right in row
+        ]
+        if len(centers) > 2:
+            violations.append(
+                {"pair": [left, right], "centers": centers, "count": len(centers)}
+            )
+    return violations
+
+
+def _sparse_row_errors(
+    rich_rows: Sequence[dict[str, Any]],
+    vertices: Sequence[int],
+) -> list[str]:
+    errors: list[str] = []
+    vertex_set = set(vertices)
+    for row in rich_rows:
+        center = _expect_int(row, "center")
+        witnesses = _expect_int_list(row.get("witnesses"), "witnesses")
+        witness_set = set(witnesses)
+        if center not in vertex_set:
+            errors.append(f"row center {center} is outside the vertex set")
+        if len(witnesses) != 4 or len(witness_set) != 4:
+            errors.append(f"row {center} must contain four distinct witnesses")
+        if center in witness_set:
+            errors.append(f"row {center} violates self-exclusion")
+        if not witness_set <= vertex_set:
+            errors.append(f"row {center} contains witnesses outside the vertex set")
+    return errors
+
+
+def _sparse_row_pair_stats(
+    rich_rows: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    max_intersection = 0
+    violations: list[dict[str, Any]] = []
+    for left, right in combinations(rich_rows, 2):
+        left_center = _expect_int(left, "center")
+        right_center = _expect_int(right, "center")
+        left_witnesses = set(_expect_int_list(left.get("witnesses"), "witnesses"))
+        right_witnesses = set(_expect_int_list(right.get("witnesses"), "witnesses"))
+        intersection = sorted(left_witnesses & right_witnesses)
+        max_intersection = max(max_intersection, len(intersection))
+        if len(intersection) > 2:
+            violations.append(
+                {
+                    "centers": [left_center, right_center],
+                    "intersection": intersection,
+                    "intersection_size": len(intersection),
+                }
+            )
+    return {
+        "max_row_intersection": max_intersection,
+        "row_pair_cap_violations": violations,
+    }
+
+
+def _sparse_witness_pair_cap_violations(
+    rich_rows: Sequence[dict[str, Any]],
+    vertices: Sequence[int],
+) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    for left, right in combinations(vertices, 2):
+        centers = [
+            _expect_int(row, "center")
+            for row in rich_rows
+            if left in _expect_int_list(row.get("witnesses"), "witnesses")
+            and right in _expect_int_list(row.get("witnesses"), "witnesses")
+        ]
+        if len(centers) > 2:
+            violations.append(
+                {"pair": [left, right], "centers": centers, "count": len(centers)}
+            )
+    return violations
+
+
+def _sparse_crossing_checks(
+    rich_rows: Sequence[dict[str, Any]],
+    order: Sequence[int],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    violations: list[dict[str, Any]] = []
+    crossing_pairs: list[dict[str, Any]] = []
+    for left, right in combinations(rich_rows, 2):
+        source = normalize_chord(_expect_int(left, "center"), _expect_int(right, "center"))
+        left_witnesses = set(_expect_int_list(left.get("witnesses"), "witnesses"))
+        right_witnesses = set(_expect_int_list(right.get("witnesses"), "witnesses"))
+        intersection = sorted(left_witnesses & right_witnesses)
+        if len(intersection) != 2:
+            continue
+        witness = normalize_chord(intersection[0], intersection[1])
+        record = {"source_chord": list(source), "witness_chord": list(witness)}
+        if chords_cross_in_order(source, witness, order):
+            crossing_pairs.append(record)
+        else:
+            violations.append(record)
+    return violations, crossing_pairs
+
+
+def _crossing_violations(
+    rows: Sequence[Sequence[int]],
+    order: Sequence[int],
+) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    for left, right in combinations(range(len(rows)), 2):
+        intersection = sorted(set(rows[left]) & set(rows[right]))
+        if len(intersection) != 2:
+            continue
+        source = normalize_chord(left, right)
+        witness = normalize_chord(intersection[0], intersection[1])
+        if not chords_cross_in_order(source, witness, order):
+            violations.append(
+                {
+                    "source_chord": list(source),
+                    "witness_chord": list(witness),
+                }
+            )
+    return violations
+
+
+def _expect_rich_rows(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("rich_rows must be a list")
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(value):
+        if not isinstance(row, dict):
+            raise ValueError(f"rich_rows[{index}] must be a mapping")
+        rows.append(row)
+    return rows
+
+
+def _expect_controls(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("controls must be a list")
+    controls: list[dict[str, Any]] = []
+    for index, control in enumerate(value):
+        if not isinstance(control, dict):
+            raise ValueError(f"controls[{index}] must be a mapping")
+        controls.append(control)
+    return controls
+
+
+def _expect_list_of_mappings(value: object, name: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list")
+    out: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{name}[{index}] must be a mapping")
+        out.append(item)
+    return out
+
+
+def _expect_mapping(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a mapping")
+    return value
+
+
+def _expect_int(mapping: dict[str, Any], key: str) -> int:
+    value = mapping.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _expect_int_list(value: object, name: str) -> list[int]:
+    if not isinstance(value, list) or not all(isinstance(item, int) for item in value):
+        raise ValueError(f"{name} must be a list of integers")
+    return [int(item) for item in value]

--- a/tests/test_closure_activation_negative_controls.py
+++ b/tests/test_closure_activation_negative_controls.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from erdos97.closure_activation_negative_controls import (
+    assert_full_row_anti_activation_expected,
+    assert_rich_class_activation_controls_expected,
+    assert_visibility_anti_activation_expected,
+    assert_wrong_fourth_expected,
+    certificate_summary,
+    full_row_anti_activation_control_certificate,
+    full_row_anti_activation_summary,
+    rich_class_activation_controls_certificate,
+    rich_class_activation_controls_summary,
+    validate_full_row_anti_activation_certificate,
+    validate_rich_class_activation_controls_certificate,
+    validate_visibility_anti_activation_certificate,
+    validate_wrong_fourth_certificate,
+    visibility_anti_activation_control_certificate,
+    visibility_anti_activation_summary,
+    wrong_fourth_negative_control_certificate,
+)
+
+
+def test_wrong_fourth_negative_control_replays_expected_status() -> None:
+    payload = wrong_fourth_negative_control_certificate()
+
+    assert validate_wrong_fourth_certificate(payload) == []
+    assert_wrong_fourth_expected(payload)
+
+    summary = certificate_summary(payload)
+    assert summary["ok"] is True
+    assert summary["two_overlap_count"] == 18
+    assert summary["closure"] == [0, 1, 4, 7]
+    assert summary["exposed_row"] == [0, 1, 4, 9]
+    assert summary["target_row_absent"] == [0, 1, 4, 6]
+
+
+def test_wrong_fourth_negative_control_rejects_target_row_substitution() -> None:
+    payload = wrong_fourth_negative_control_certificate()
+    tampered = deepcopy(payload)
+    rows = tampered["selected_rows"]
+    assert isinstance(rows, dict)
+    rows["7"] = [0, 1, 4, 6]
+    target = tampered["activation_target"]
+    assert isinstance(target, dict)
+    target["wrong_fourth"] = 6
+
+    errors = validate_wrong_fourth_certificate(tampered)
+
+    assert any("target fourth is already present" in error for error in errors)
+    assert any("exposed row equals the target row" in error for error in errors)
+
+
+def test_wrong_fourth_negative_control_rejects_crossing_violation() -> None:
+    payload = wrong_fourth_negative_control_certificate()
+    tampered = deepcopy(payload)
+    rows = tampered["selected_rows"]
+    assert isinstance(rows, dict)
+    rows["0"] = [1, 2, 3, 9]
+
+    errors = validate_wrong_fourth_certificate(tampered)
+
+    assert any("two-overlap crossing violation" in error for error in errors)
+
+
+def test_full_row_anti_activation_control_replays_expected_status() -> None:
+    payload = full_row_anti_activation_control_certificate()
+
+    assert validate_full_row_anti_activation_certificate(payload) == []
+    assert_full_row_anti_activation_expected(payload)
+
+    summary = full_row_anti_activation_summary(payload)
+    assert summary["ok"] is True
+    assert summary["closure_result"] == [0, 1, 4, 7]
+    assert summary["closure_steps"] == [
+        {"added_center": 7, "row": [0, 1, 3, 4], "support": [0, 1, 4]}
+    ]
+    assert summary["anti_activation_row"] == {
+        "center": 7,
+        "contains_core_witnesses": [0, 1, 4],
+        "excluded_target_witness": 6,
+        "replacement_witness": 3,
+        "row": [0, 1, 3, 4],
+        "target_row": [0, 1, 4, 6],
+        "target_row_active_at_center": False,
+    }
+    assert summary["checks"]["cover_ok"] is True
+    assert summary["checks"]["adjacent_intersections_size_at_most_1"] is True
+
+
+def test_full_row_anti_activation_control_rejects_target_fourth() -> None:
+    payload = full_row_anti_activation_control_certificate()
+    tampered = deepcopy(payload)
+    rows = tampered["selected_rows"]
+    assert isinstance(rows, dict)
+    rows["7"] = [0, 1, 4, 6]
+
+    errors = validate_full_row_anti_activation_certificate(tampered)
+
+    assert any("closure steps mismatch" in error for error in errors)
+    assert any("contains the excluded target witness" in error for error in errors)
+    assert any("target row is unexpectedly active" in error for error in errors)
+
+
+def test_full_row_anti_activation_control_rejects_adjacent_overlap() -> None:
+    payload = full_row_anti_activation_control_certificate()
+    tampered = deepcopy(payload)
+    rows = tampered["selected_rows"]
+    assert isinstance(rows, dict)
+    rows["0"] = [0, 2, 4, 7]
+
+    errors = validate_full_row_anti_activation_certificate(tampered)
+
+    assert any("check summary mismatch" in error for error in errors)
+
+
+def test_rich_class_activation_controls_replay_expected_statuses() -> None:
+    payload = rich_class_activation_controls_certificate()
+
+    assert validate_rich_class_activation_controls_certificate(payload) == []
+    assert_rich_class_activation_controls_expected(payload)
+
+    summary = rich_class_activation_controls_summary(payload)
+    assert summary["ok"] is True
+    controls = {control["name"]: control for control in summary["controls"]}
+    nc1 = controls["NC1_three_core_trigger_unpinned_fourth"]
+    assert nc1["closure"] == [0, 1, 4, 7]
+    assert nc1["target_row_active_at_center"] is False
+    nc2 = controls["NC2_full_label_visibility_without_center_class_membership"]
+    assert nc2["closure"] == [0, 1, 3, 4, 6]
+    assert nc2["target_witnesses_in_closure"] == [0, 1, 4, 6]
+    assert nc2["pair_checks"] == [
+        {
+            "centers": [3, 6],
+            "intersection": [1, 4],
+            "cap_ok": True,
+            "crossing_ok_when_two_overlap": True,
+            "ok": True,
+        }
+    ]
+    source151 = controls["CE-private-fourth-switch/source-151-row-7"]
+    assert source151["closure"] == [0, 1, 4, 7]
+    assert source151["target_row_active_at_center"] is False
+    source81 = controls["CE-full-label-containment-switch/source-81-row-3"]
+    assert source81["closure"] == [0, 1, 3, 4, 6]
+    assert source81["target_witnesses_in_closure"] == [0, 1, 4, 6]
+    assert source81["target_row_active_at_center"] is False
+
+
+def test_rich_class_activation_controls_reject_active_target_row() -> None:
+    payload = rich_class_activation_controls_certificate()
+    tampered = deepcopy(payload)
+    controls = tampered["controls"]
+    assert isinstance(controls, list)
+    controls[2]["rich_classes"]["7"] = [[0, 1, 4, 6]]
+
+    errors = validate_rich_class_activation_controls_certificate(tampered)
+
+    assert any("target_row_active_at_center" in error for error in errors)
+    assert any("passes_intended_negative_control" in error for error in errors)
+
+
+def test_rich_class_activation_controls_reject_crossing_loss() -> None:
+    payload = rich_class_activation_controls_certificate()
+    tampered = deepcopy(payload)
+    controls = tampered["controls"]
+    assert isinstance(controls, list)
+    controls[3]["rich_classes"]["6"] = [[0, 1, 4, 5]]
+
+    errors = validate_rich_class_activation_controls_certificate(tampered)
+
+    assert any("pair_checks" in error for error in errors)
+    assert any("passes_intended_negative_control" in error for error in errors)
+
+
+def test_visibility_anti_activation_control_replays_expected_status() -> None:
+    payload = visibility_anti_activation_control_certificate()
+
+    assert validate_visibility_anti_activation_certificate(payload) == []
+    assert_visibility_anti_activation_expected(payload)
+
+    summary = visibility_anti_activation_summary(payload)
+    assert summary["ok"] is True
+    assert summary["final_closure"] == [0, 1, 3, 4, 7]
+    assert summary["target_center_in_final_closure"] is True
+    assert summary["target_witnesses_in_final_closure"] == [0, 1, 4]
+    assert summary["target_row_present_at_center"] is False
+    assert summary["target_triple_contained_in_target_center_row"] is False
+    assert summary["target_center_activated_by_target_triple"] is False
+
+
+def test_visibility_anti_activation_control_rejects_target_triple_row() -> None:
+    payload = visibility_anti_activation_control_certificate()
+    tampered = deepcopy(payload)
+    rows = tampered["rich_rows"]
+    assert isinstance(rows, list)
+    rows[1]["witnesses"] = [0, 1, 4, 8]
+    rows[1]["activating_triple"] = [0, 1, 4]
+    tampered["expected_closure_steps"][2]["using_triple"] = [0, 1, 4]
+
+    errors = validate_visibility_anti_activation_certificate(tampered)
+
+    assert any("target triple is unexpectedly contained" in error for error in errors)
+    assert any("target center was activated by the target triple" in error for error in errors)
+
+
+def test_visibility_anti_activation_control_rejects_visibility_loss() -> None:
+    payload = visibility_anti_activation_control_certificate()
+    tampered = deepcopy(payload)
+    rows = tampered["rich_rows"]
+    assert isinstance(rows, list)
+    rows[0]["witnesses"] = [1, 4, 5, 6]
+
+    errors = validate_visibility_anti_activation_certificate(tampered)
+
+    assert any("target center is not in final closure" in error for error in errors)


### PR DESCRIPTION
## Summary

- add replayable closure-activation negative-control certificates for wrong-fourth, visibility/provenance, aggregate rich-class, and full selected-row anti-activation cases
- add checker entrypoints plus tests covering expected replays and tamper failures
- document the bridge lesson while preserving the repo status: no general proof and no counterexample are claimed

## Verification

- `python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json`
- `python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json`
- `python scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json`
- `python scripts/check_closure_visibility_anti_activation_control.py data/certificates/closure_visibility_anti_activation_control.json --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`