### PR TITLE
Add T12 hard strict endpoint packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the joined T12 bridge-target map that names the exact next lemma target
   for each missing row, read
   [`docs/bootstrap-t12-bridge-target-map.md`](docs/bootstrap-t12-bridge-target-map.md).
+- For the hard strict-endpoint subpacket isolating rows `151:7` and `151:8`,
+  read
+  [`docs/bootstrap-t12-hard-strict-endpoints.md`](docs/bootstrap-t12-hard-strict-endpoints.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -218,6 +218,14 @@ bookkeeping only; see
 `scripts/check_bootstrap_t12_bridge_target_map.py`, and
 `data/certificates/bootstrap_t12_bridge_target_map.json`.
 
+The hard strict-endpoint subpacket isolates the two hard strict requirements
+from that map. Both occur in source `151`: row `7` is closure-exposed but still
+misses endpoint `6`, and row `8` has singleton supports that each supply only
+one of the outside strict endpoints `5` and `7`. This is still diagnostic
+bookkeeping only; see `docs/bootstrap-t12-hard-strict-endpoints.md`,
+`scripts/check_bootstrap_t12_hard_strict_endpoints.py`, and
+`data/certificates/bootstrap_t12_hard_strict_endpoints.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -111,6 +111,13 @@ rows `151:7` and `151:8`, plus the open connector-pair row `151:5`. This is
 still a proof-mining diagnostic only. See
 `docs/bootstrap-t12-bridge-target-map.md`.
 
+A hard strict-endpoint subpacket now isolates rows `151:7` and `151:8`.
+Neither strict-edge endpoint requirement is closure-sufficient or
+support-sufficient: `151:7` is closure-exposed but misses outside endpoint `6`,
+while `151:8` has singleton supports that split endpoints `5` and `7`. This
+is diagnostic bookkeeping only, not a theorem that the missing endpoints are
+forced. See `docs/bootstrap-t12-hard-strict-endpoints.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_hard_strict_endpoints.json
+++ b/data/certificates/bootstrap_t12_hard_strict_endpoints.json
@@ -1,0 +1,412 @@
+{
+  "claim_scope": "Hard strict-endpoint diagnostic for the two tight n=9 bootstrap/T12 records; isolates the strict-edge endpoint-set requirements that remain unmet after bootstrap-core, support, and deletion-closure checks. This does not prove that the missing rows or endpoints are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates fixed selected-row strict-edge endpoint gaps; it does not prove endpoints or rows are forced.",
+    "Partial closure or singleton support is bookkeeping, not a Euclidean rich-class certificate.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_hard_strict_endpoints.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_hard_strict_endpoints.py"
+  },
+  "records": [
+    {
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "bridge_lemma_target": "Add the missing strict-edge endpoint to a closure-exposed row; this is the main negative control.",
+      "classification_assignment_id": "A152",
+      "closure_evaluations": [
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            1
+          ],
+          "core_vertex": 0,
+          "missing_required_witnesses": [
+            0,
+            6
+          ],
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            0
+          ],
+          "core_vertex": 1,
+          "missing_required_witnesses": [
+            1,
+            6
+          ],
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        },
+        {
+          "activation_ready_in_closure": true,
+          "available_required_witnesses": [
+            0,
+            1
+          ],
+          "core_vertex": 2,
+          "missing_required_witnesses": [
+            6
+          ],
+          "row_exposed_in_closure": true,
+          "status": "PARTIAL"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            0,
+            1
+          ],
+          "core_vertex": 4,
+          "missing_required_witnesses": [
+            6
+          ],
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        }
+      ],
+      "closure_sufficient_count": 0,
+      "exposed_closure_evaluations": [
+        {
+          "activation_ready_in_closure": true,
+          "available_required_witnesses": [
+            0,
+            1
+          ],
+          "core_vertex": 2,
+          "missing_required_witnesses": [
+            6
+          ],
+          "row_exposed_in_closure": true,
+          "status": "PARTIAL"
+        }
+      ],
+      "hard_strict_gap_type": "CLOSURE_EXPOSED_MISSING_OUTSIDE_ENDPOINT",
+      "inner_pair": [
+        0,
+        1
+      ],
+      "missing_endpoint_count": 1,
+      "missing_from_bootstrap_core": [
+        6
+      ],
+      "non_required_row_witnesses": [
+        4
+      ],
+      "other_row_requirements": [],
+      "outer_pair": [
+        0,
+        6
+      ],
+      "outside_witnesses": [
+        6
+      ],
+      "partial_support_count": 0,
+      "partial_supports": [],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "required_witnesses": [
+        0,
+        1,
+        6
+      ],
+      "requirement_size": 3,
+      "roles": [
+        "strict_edge_row"
+      ],
+      "row_center": 7,
+      "row_target_status": "CLOSURE_EXPOSED_HARD_STRICT_ENDPOINT",
+      "source_record_id": 151,
+      "step_index": 0,
+      "strict_requirement_id": "151:7:strict:0",
+      "support_evaluations": [],
+      "support_sufficient_count": 0,
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "bootstrap_core_witnesses": [
+        1,
+        2
+      ],
+      "bridge_lemma_target": "Separate the connector support, which one singleton can supply, from the strict-edge endpoint set, which remains unforced.",
+      "classification_assignment_id": "A152",
+      "closure_evaluations": [
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            1
+          ],
+          "core_vertex": 0,
+          "missing_required_witnesses": [
+            5,
+            7
+          ],
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [],
+          "core_vertex": 1,
+          "missing_required_witnesses": [
+            1,
+            5,
+            7
+          ],
+          "row_exposed_in_closure": false,
+          "status": "DISJOINT"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            1,
+            7
+          ],
+          "core_vertex": 2,
+          "missing_required_witnesses": [
+            5
+          ],
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            1
+          ],
+          "core_vertex": 4,
+          "missing_required_witnesses": [
+            5,
+            7
+          ],
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        }
+      ],
+      "closure_sufficient_count": 0,
+      "exposed_closure_evaluations": [],
+      "hard_strict_gap_type": "SINGLETON_SUPPORTS_SPLIT_STRICT_ENDPOINTS",
+      "inner_pair": [
+        5,
+        7
+      ],
+      "missing_endpoint_count": 2,
+      "missing_from_bootstrap_core": [
+        5,
+        7
+      ],
+      "non_required_row_witnesses": [
+        2
+      ],
+      "other_row_requirements": [
+        {
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [
+            5
+          ],
+          "relation_state": "SUPPORT_SUFFICIENT",
+          "required_witnesses": [
+            2,
+            5
+          ],
+          "requirement_id": "151:8:connector:1:1"
+        }
+      ],
+      "outer_pair": [
+        1,
+        7
+      ],
+      "outside_witnesses": [
+        5,
+        7
+      ],
+      "partial_support_count": 2,
+      "partial_supports": [
+        {
+          "available_required_witnesses": [
+            1,
+            5
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            7
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            5
+          ]
+        },
+        {
+          "available_required_witnesses": [
+            1,
+            7
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            5
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            7
+          ]
+        }
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "required_witnesses": [
+        1,
+        5,
+        7
+      ],
+      "requirement_size": 3,
+      "roles": [
+        "strict_edge_row",
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_target_status": "MIXED_SINGLETON_CONNECTOR_AND_HARD_STRICT",
+      "source_record_id": 151,
+      "step_index": 1,
+      "strict_requirement_id": "151:8:strict:1",
+      "support_evaluations": [
+        {
+          "available_required_witnesses": [
+            1,
+            5
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            7
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            5
+          ]
+        },
+        {
+          "available_required_witnesses": [
+            1,
+            7
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            5
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            7
+          ]
+        }
+      ],
+      "support_sufficient_count": 0,
+      "witnesses": [
+        1,
+        2,
+        5,
+        7
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_hard_strict_endpoints.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_activation_requirements.json",
+      "role": "source strict-edge endpoint requirements and evaluations",
+      "schema": "erdos97.bootstrap_t12_activation_requirements.v1",
+      "status": "BOOTSTRAP_T12_ACTIVATION_REQUIREMENTS_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_bridge_target_map.json",
+      "role": "source hard strict row targets and bridge obligations",
+      "schema": "erdos97.bootstrap_t12_bridge_target_map.v1",
+      "status": "BOOTSTRAP_T12_BRIDGE_TARGET_MAP_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_HARD_STRICT_ENDPOINTS_DIAGNOSTIC_ONLY",
+  "summary": {
+    "closure_sufficient_requirement_count": 0,
+    "exposed_closure_partial_rows": [
+      "151:7"
+    ],
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "hard_strict_gap_type_counts": {
+      "CLOSURE_EXPOSED_MISSING_OUTSIDE_ENDPOINT": 1,
+      "SINGLETON_SUPPORTS_SPLIT_STRICT_ENDPOINTS": 1
+    },
+    "hard_strict_requirement_ids": [
+      "151:7:strict:0",
+      "151:8:strict:1"
+    ],
+    "hard_strict_row_count": 2,
+    "missing_endpoint_label_counts": {
+      "5": 1,
+      "6": 1,
+      "7": 1
+    },
+    "next_bridge_question": "Can strict-edge endpoint sets be forced as complete rich-class subsets, rather than one endpoint at a time, in the T12/F16 bootstrap target?",
+    "other_relation_state_counts": {
+      "SUPPORT_SUFFICIENT": 1
+    },
+    "partial_support_count": 2,
+    "pressure_class_counts": {
+      "ALREADY_PRESENT_IN_A_DELETION_CLOSURE": 1,
+      "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 1
+    },
+    "role_counts": {
+      "equality_connector_row": 1,
+      "strict_edge_row": 2
+    },
+    "row_centers_by_source_id": {
+      "151": [
+        7,
+        8
+      ]
+    },
+    "row_target_status_counts": {
+      "CLOSURE_EXPOSED_HARD_STRICT_ENDPOINT": 1,
+      "MIXED_SINGLETON_CONNECTOR_AND_HARD_STRICT": 1
+    },
+    "source_record_ids": [
+      151
+    ],
+    "split_singleton_partial_rows": [
+      "151:8"
+    ],
+    "support_sufficient_requirement_count": 0
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-bridge-target-map.md
+++ b/docs/bootstrap-t12-bridge-target-map.md
@@ -80,6 +80,11 @@ stored equality connector needs the outside pair `[7,8]`. A one-label row
 activation argument would still need to explain why the connector relation
 receives both endpoints.
 
+The hard strict-endpoint follow-up in
+`docs/bootstrap-t12-hard-strict-endpoints.md` isolates the first negative
+control and the mixed row `151:8`, where singleton supports split the strict
+endpoint set.
+
 ## What This Does Not Prove
 
 This artifact does not prove that any missing T12 row is forced, does not prove

--- a/docs/bootstrap-t12-hard-strict-endpoints.md
+++ b/docs/bootstrap-t12-hard-strict-endpoints.md
@@ -1,0 +1,83 @@
+# Bootstrap T12 Hard Strict Endpoints
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the strict-edge endpoint requirements that remain hard in
+the joined T12 bridge-target map. It answers a narrower question than row
+forcing:
+
+```text
+Which strict-edge endpoint sets are still not supplied by the bootstrap core,
+deletion closures, or stored support options?
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_hard_strict_endpoints.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_hard_strict_endpoints.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_hard_strict_endpoints.json`.
+
+## Scope
+
+The input packets are:
+
+- `data/certificates/bootstrap_t12_activation_requirements.json`;
+- `data/certificates/bootstrap_t12_bridge_target_map.json`.
+
+This packet is not full rich-class data. A hard strict endpoint is an unmet
+relation requirement inside the stored fixed-row T12/F16 quotient certificate;
+it is not a theorem that the endpoint is geometrically forced.
+
+## Results
+
+Both hard strict-edge endpoint requirements occur in source `151`.
+
+| Source | Row | Gap type | Required endpoint set | Current deficit |
+|---:|---:|---|---|---|
+| `151` | `7` | closure-exposed missing outside endpoint | `[0,1,6]` | exposed closure has `[0,1]` but misses `6` |
+| `151` | `8` | singleton supports split strict endpoints | `[1,5,7]` | support `5` misses `7`; support `7` misses `5` |
+
+Headline counts:
+
+```text
+hard strict rows: 2
+closure-sufficient strict requirements: 0
+support-sufficient strict requirements: 0
+partial singleton supports: 2
+missing endpoint labels: 5, 6, 7
+```
+
+## Negative-Control Reading
+
+Row `151:7` is the closure-exposed negative control. It is activation-ready in
+the deletion closure for core vertex `2`, but that closure supplies only the
+strict-edge endpoints `[0,1]`; the outside endpoint `6` remains private.
+
+Row `151:8` is the singleton-support negative control. The same row has a
+support-sufficient equality connector through singleton `5`, but the strict
+edge needs `[1,5,7]`. The singleton supports split the strict endpoint set:
+`5` supplies `[1,5]` and misses `7`, while `7` supplies `[1,7]` and misses
+`5`.
+
+## What This Does Not Prove
+
+This artifact does not prove that any strict endpoint, row center, or rich
+class is forced. It does not prove `n=9`, does not prove the bootstrap bridge,
+does not independently review the vertex-circle checker, and does not alter
+the official/global status of Erdos Problem #97.
+
+## Reviewer Focus
+
+The exact next bridge question is whether strict-edge endpoint sets can be
+forced as complete rich-class subsets, rather than one endpoint at a time. A
+future lemma would need a genuine geometric reason that rejects both partial
+states above without assuming the fixed selected row is already present.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -518,6 +518,13 @@ next-lemma targets. It is a proof-mining map only: the hard strict endpoint
 rows `151:7` and `151:8`, and the open connector-pair row `151:5`, remain
 unproved bridge obligations rather than forced geometric rows.
 
+The hard strict-endpoint packet in
+`docs/bootstrap-t12-hard-strict-endpoints.md` isolates the two hard strict
+rows. Row `151:7` is closure-exposed but its exposed deletion closure supplies
+only `[0,1]` of the strict endpoint set `[0,1,6]`; row `151:8` has singleton
+supports that split the strict endpoint set `[1,5,7]`. This is diagnostic
+bookkeeping only, not a lemma that strict endpoint sets are forced.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -56,6 +56,10 @@ Use this queue when no more specific issue is selected.
    targets: hard strict endpoint rows `151:7` and `151:8`, open connector-pair
    row `151:5`, and three relation-sufficient rows that still need row-forcing
    arguments.
+   The hard strict-endpoint subpacket in
+   `docs/bootstrap-t12-hard-strict-endpoints.md` isolates rows `151:7` and
+   `151:8`, where strict-edge endpoint sets are still incomplete after closure
+   and singleton-support checks.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-bridge-target-map.md`](bootstrap-t12-bridge-target-map.md):
   joined diagnostic naming the explicit next bridge-lemma target for each
   missing T12/F16 row.
+- [`bootstrap-t12-hard-strict-endpoints.md`](bootstrap-t12-hard-strict-endpoints.md):
+  focused packet isolating the hard strict-edge endpoint gaps in rows `151:7`
+  and `151:8`.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -344,6 +344,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-t12-bridge-target-map.md`, joining those packets into six
   explicit next-lemma targets, with `151:7`, `151:8`, and `151:5` as the main
   hard/open rows.
+- bootstrap/T12 hard strict-endpoint evidence, as recorded in
+  `docs/bootstrap-t12-hard-strict-endpoints.md`, isolating `151:7` and
+  `151:8` as the rows where strict-edge endpoint sets are still not supplied
+  by closure exposure or singleton support.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -188,6 +188,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_bridge_target_map.json"
       verifier: "scripts/check_bootstrap_t12_bridge_target_map.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; names explicit next-lemma targets for each missing row, but does not prove missing rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_hard_strict_endpoints"
+      status: "hard strict-endpoint subpacket for the two strict T12/F16 row targets"
+      artifact: "data/certificates/bootstrap_t12_hard_strict_endpoints.json"
+      verifier: "scripts/check_bootstrap_t12_hard_strict_endpoints.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates incomplete strict-edge endpoint sets in rows 151:7 and 151:8, but does not prove endpoints or rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2100,6 +2100,61 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_hard_strict_endpoints
+    path: data/certificates/bootstrap_t12_hard_strict_endpoints.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_hard_strict_endpoints.py
+    command: python scripts/check_bootstrap_t12_hard_strict_endpoints.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_hard_strict_endpoints.py
+    check_command: python scripts/check_bootstrap_t12_hard_strict_endpoints.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Hard strict-endpoint diagnostic for the two tight n=9 bootstrap-core rows; not a proof that endpoints or missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_hard_strict_endpoints.v1
+      status: BOOTSTRAP_T12_HARD_STRICT_ENDPOINTS_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 151
+      summary.hard_strict_row_count: 2
+      summary.row_centers_by_source_id.151:
+        - 7
+        - 8
+      summary.hard_strict_requirement_ids:
+        - "151:7:strict:0"
+        - "151:8:strict:1"
+      summary.hard_strict_gap_type_counts.CLOSURE_EXPOSED_MISSING_OUTSIDE_ENDPOINT: 1
+      summary.hard_strict_gap_type_counts.SINGLETON_SUPPORTS_SPLIT_STRICT_ENDPOINTS: 1
+      summary.missing_endpoint_label_counts.5: 1
+      summary.missing_endpoint_label_counts.6: 1
+      summary.missing_endpoint_label_counts.7: 1
+      summary.closure_sufficient_requirement_count: 0
+      summary.support_sufficient_requirement_count: 0
+      summary.partial_support_count: 2
+      summary.other_relation_state_counts.SUPPORT_SUFFICIENT: 1
+      summary.exposed_closure_partial_rows:
+        - "151:7"
+      summary.split_singleton_partial_rows:
+        - "151:8"
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_hard_strict_endpoints.py
+      provenance.command: python scripts/check_bootstrap_t12_hard_strict_endpoints.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - hard strict endpoints are forced
+      - partial closure exposure proves a strict edge
+      - singleton support proves strict endpoint forcing
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_hard_strict_endpoints.py
+++ b/scripts/check_bootstrap_t12_hard_strict_endpoints.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 hard strict-endpoint packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_hard_strict_endpoints import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_hard_strict_endpoints_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 hard strict endpoints")
+    print(f"hard strict rows: {summary['hard_strict_row_count']}")
+    print(f"gap types: {summary['hard_strict_gap_type_counts']}")
+    print(f"missing endpoint labels: {summary['missing_endpoint_label_counts']}")
+    print(f"exposed closure partial rows: {summary['exposed_closure_partial_rows']}")
+    print(f"split singleton rows: {summary['split_singleton_partial_rows']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned counts")
+    args = parser.parse_args()
+
+    generated = build_t12_hard_strict_endpoints_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 hard strict-endpoint artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 hard strict-endpoint expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_hard_strict_endpoints.py
+++ b/src/erdos97/bootstrap_t12_hard_strict_endpoints.py
@@ -1,0 +1,403 @@
+"""Hard strict-endpoint packet for the bootstrap/T12 target.
+
+This module isolates the strict-edge endpoint requirements that remain hard in
+the T12 bridge-target map. It is proof-mining bookkeeping only; it does not
+prove that any missing row or endpoint is forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from erdos97.bootstrap_t12_activation_requirements import (
+    KIND_STRICT,
+    build_t12_activation_requirements_payload,
+)
+from erdos97.bootstrap_t12_bridge_target_map import (
+    RELATION_HARD_STRICT,
+    build_t12_bridge_target_map_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_hard_strict_endpoints.v1"
+STATUS = "BOOTSTRAP_T12_HARD_STRICT_ENDPOINTS_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Hard strict-endpoint diagnostic for the two tight n=9 bootstrap/T12 "
+    "records; isolates the strict-edge endpoint-set requirements that remain "
+    "unmet after bootstrap-core, support, and deletion-closure checks. This "
+    "does not prove that the missing rows or endpoints are forced, does not "
+    "prove n=9, does not prove the bridge, and does not claim a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_hard_strict_endpoints.json"
+)
+
+GAP_CLOSURE_MISSING_OUTSIDE = "CLOSURE_EXPOSED_MISSING_OUTSIDE_ENDPOINT"
+GAP_SPLIT_SINGLETON = "SINGLETON_SUPPORTS_SPLIT_STRICT_ENDPOINTS"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _record_key(record: Mapping[str, Any]) -> tuple[int, int]:
+    return int(record["source_record_id"]), int(record["row_center"])
+
+
+def _index_records(records: Iterable[Mapping[str, Any]]) -> dict[tuple[int, int], Mapping[str, Any]]:
+    return {_record_key(record): record for record in records}
+
+
+def _available_required_witnesses(
+    requirement: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+) -> list[int]:
+    required = set(_int_list(requirement["required_witnesses"]))
+    available = set(_int_list(evaluation["available_witnesses"]))
+    return sorted(required & available)
+
+
+def _closure_eval_record(
+    requirement: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+) -> dict[str, object]:
+    return {
+        "core_vertex": int(evaluation["core_vertex"]),
+        "row_exposed_in_closure": bool(evaluation["row_exposed_in_closure"]),
+        "activation_ready_in_closure": bool(evaluation["activation_ready_in_closure"]),
+        "available_required_witnesses": _available_required_witnesses(
+            requirement, evaluation
+        ),
+        "missing_required_witnesses": _int_list(
+            evaluation["missing_required_witnesses"]
+        ),
+        "status": str(evaluation["status"]),
+    }
+
+
+def _support_eval_record(
+    requirement: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+) -> dict[str, object]:
+    return {
+        "support": _int_list(evaluation["support"]),
+        "available_required_witnesses": _available_required_witnesses(
+            requirement, evaluation
+        ),
+        "missing_required_witnesses": _int_list(
+            evaluation["missing_required_witnesses"]
+        ),
+        "status": str(evaluation["status"]),
+        "ledger_private_pair_hit": bool(evaluation["ledger_private_pair_hit"]),
+        "private_halo_core_vertices": _int_list(
+            evaluation["private_halo_core_vertices"]
+        ),
+    }
+
+
+def _gap_type(bridge_record: Mapping[str, Any]) -> str:
+    row_target_status = str(bridge_record["row_target_status"])
+    if row_target_status == "CLOSURE_EXPOSED_HARD_STRICT_ENDPOINT":
+        return GAP_CLOSURE_MISSING_OUTSIDE
+    if row_target_status == "MIXED_SINGLETON_CONNECTOR_AND_HARD_STRICT":
+        return GAP_SPLIT_SINGLETON
+    raise AssertionError(f"unexpected hard strict target status {row_target_status!r}")
+
+
+def _other_requirements(bridge_record: Mapping[str, Any]) -> list[dict[str, object]]:
+    out = []
+    for requirement in bridge_record["requirements"]:
+        if requirement["kind"] == KIND_STRICT:
+            continue
+        out.append(
+            {
+                "requirement_id": str(requirement["requirement_id"]),
+                "kind": str(requirement["kind"]),
+                "required_witnesses": _int_list(requirement["required_witnesses"]),
+                "relation_state": str(requirement["relation_state"]),
+                "missing_from_bootstrap_core": _int_list(
+                    requirement["missing_from_bootstrap_core"]
+                ),
+            }
+        )
+    return out
+
+
+def _hard_strict_record(
+    *,
+    activation_record: Mapping[str, Any],
+    strict_requirement: Mapping[str, Any],
+    bridge_record: Mapping[str, Any],
+) -> dict[str, object]:
+    required = set(_int_list(strict_requirement["required_witnesses"]))
+    witnesses = set(_int_list(activation_record["witnesses"]))
+    closure_evaluations = [
+        _closure_eval_record(strict_requirement, evaluation)
+        for evaluation in strict_requirement["closure_evaluations"]
+    ]
+    support_evaluations = [
+        _support_eval_record(strict_requirement, evaluation)
+        for evaluation in strict_requirement["support_evaluations"]
+    ]
+    exposed_closure_evaluations = [
+        evaluation
+        for evaluation in closure_evaluations
+        if bool(evaluation["row_exposed_in_closure"])
+    ]
+    partial_supports = [
+        evaluation
+        for evaluation in support_evaluations
+        if evaluation["status"] == "PARTIAL"
+    ]
+    missing_labels = _int_list(strict_requirement["missing_from_bootstrap_core"])
+    gap_type = _gap_type(bridge_record)
+
+    return {
+        "source_record_id": int(activation_record["source_record_id"]),
+        "classification_assignment_id": str(
+            activation_record["classification_assignment_id"]
+        ),
+        "row_center": int(activation_record["row_center"]),
+        "roles": [str(role) for role in activation_record["roles"]],
+        "pressure_class": str(activation_record["pressure_class"]),
+        "row_target_status": str(bridge_record["row_target_status"]),
+        "hard_strict_gap_type": gap_type,
+        "strict_requirement_id": str(strict_requirement["requirement_id"]),
+        "step_index": int(strict_requirement["step_index"]),
+        "outer_pair": _int_list(strict_requirement["outer_pair"]),
+        "inner_pair": _int_list(strict_requirement["inner_pair"]),
+        "required_witnesses": sorted(required),
+        "requirement_size": int(strict_requirement["requirement_size"]),
+        "witnesses": sorted(witnesses),
+        "bootstrap_core_witnesses": _int_list(
+            activation_record["bootstrap_core_witnesses"]
+        ),
+        "outside_witnesses": _int_list(activation_record["outside_witnesses"]),
+        "non_required_row_witnesses": sorted(witnesses - required),
+        "missing_from_bootstrap_core": missing_labels,
+        "missing_endpoint_count": len(missing_labels),
+        "closure_sufficient_count": int(strict_requirement["closure_sufficient_count"]),
+        "support_sufficient_count": int(strict_requirement["support_sufficient_count"]),
+        "closure_evaluations": closure_evaluations,
+        "exposed_closure_evaluations": exposed_closure_evaluations,
+        "support_evaluations": support_evaluations,
+        "partial_support_count": len(partial_supports),
+        "partial_supports": partial_supports,
+        "other_row_requirements": _other_requirements(bridge_record),
+        "bridge_lemma_target": str(bridge_record["bridge_lemma_target"]),
+    }
+
+
+def build_t12_hard_strict_endpoints_payload() -> dict[str, object]:
+    """Return the deterministic hard strict-endpoint packet."""
+
+    activation = build_t12_activation_requirements_payload()
+    bridge_map = build_t12_bridge_target_map_payload()
+    bridge_by_key = _index_records(bridge_map["records"])
+
+    records = []
+    for activation_record in activation["records"]:
+        key = _record_key(activation_record)
+        bridge_record = bridge_by_key[key]
+        for requirement in activation_record["requirements"]:
+            if requirement["kind"] != KIND_STRICT:
+                continue
+            if RELATION_HARD_STRICT not in bridge_record["relation_state_counts"]:
+                continue
+            records.append(
+                _hard_strict_record(
+                    activation_record=activation_record,
+                    strict_requirement=requirement,
+                    bridge_record=bridge_record,
+                )
+            )
+    records.sort(key=lambda record: (int(record["source_record_id"]), int(record["row_center"])))
+
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    gap_type_counts: Counter[str] = Counter()
+    pressure_counts: Counter[str] = Counter()
+    target_status_counts: Counter[str] = Counter()
+    role_counts: Counter[str] = Counter()
+    missing_endpoint_counts: Counter[int] = Counter()
+    other_relation_counts: Counter[str] = Counter()
+    for record in records:
+        rows_by_source[int(record["source_record_id"])].append(int(record["row_center"]))
+        gap_type_counts[str(record["hard_strict_gap_type"])] += 1
+        pressure_counts[str(record["pressure_class"])] += 1
+        target_status_counts[str(record["row_target_status"])] += 1
+        role_counts.update(str(role) for role in record["roles"])
+        missing_endpoint_counts.update(_int_list(record["missing_from_bootstrap_core"]))
+        for requirement in record["other_row_requirements"]:
+            other_relation_counts[str(requirement["relation_state"])] += 1
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates fixed selected-row strict-edge endpoint gaps; it does not prove endpoints or rows are forced.",
+            "Partial closure or singleton support is bookkeeping, not a Euclidean rich-class certificate.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted(rows_by_source),
+            "hard_strict_row_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "hard_strict_requirement_ids": [
+                str(record["strict_requirement_id"]) for record in records
+            ],
+            "hard_strict_gap_type_counts": _json_counter(gap_type_counts),
+            "pressure_class_counts": _json_counter(pressure_counts),
+            "row_target_status_counts": _json_counter(target_status_counts),
+            "role_counts": _json_counter(role_counts),
+            "missing_endpoint_label_counts": _json_counter(missing_endpoint_counts),
+            "closure_sufficient_requirement_count": sum(
+                int(record["closure_sufficient_count"]) for record in records
+            ),
+            "support_sufficient_requirement_count": sum(
+                int(record["support_sufficient_count"]) for record in records
+            ),
+            "partial_support_count": sum(
+                int(record["partial_support_count"]) for record in records
+            ),
+            "other_relation_state_counts": _json_counter(other_relation_counts),
+            "exposed_closure_partial_rows": [
+                f"{record['source_record_id']}:{record['row_center']}"
+                for record in records
+                if record["hard_strict_gap_type"] == GAP_CLOSURE_MISSING_OUTSIDE
+            ],
+            "split_singleton_partial_rows": [
+                f"{record['source_record_id']}:{record['row_center']}"
+                for record in records
+                if record["hard_strict_gap_type"] == GAP_SPLIT_SINGLETON
+            ],
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can strict-edge endpoint sets be forced as complete rich-class "
+                "subsets, rather than one endpoint at a time, in the T12/F16 "
+                "bootstrap target?"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_activation_requirements.json",
+                "role": "source strict-edge endpoint requirements and evaluations",
+                "schema": activation.get("schema"),
+                "status": activation.get("status"),
+                "trust": activation.get("trust"),
+            },
+            {
+                "path": "data/certificates/bootstrap_t12_bridge_target_map.json",
+                "role": "source hard strict row targets and bridge obligations",
+                "schema": bridge_map.get("schema"),
+                "status": bridge_map.get("status"),
+                "trust": bridge_map.get("trust"),
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_hard_strict_endpoints.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_hard_strict_endpoints.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the hard strict-endpoint packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 hard-strict schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 hard-strict status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [151],
+        "hard_strict_row_count": 2,
+        "row_centers_by_source_id": {"151": [7, 8]},
+        "hard_strict_requirement_ids": ["151:7:strict:0", "151:8:strict:1"],
+        "hard_strict_gap_type_counts": {
+            GAP_CLOSURE_MISSING_OUTSIDE: 1,
+            GAP_SPLIT_SINGLETON: 1,
+        },
+        "pressure_class_counts": {
+            "ALREADY_PRESENT_IN_A_DELETION_CLOSURE": 1,
+            "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 1,
+        },
+        "row_target_status_counts": {
+            "CLOSURE_EXPOSED_HARD_STRICT_ENDPOINT": 1,
+            "MIXED_SINGLETON_CONNECTOR_AND_HARD_STRICT": 1,
+        },
+        "role_counts": {"equality_connector_row": 1, "strict_edge_row": 2},
+        "missing_endpoint_label_counts": {"5": 1, "6": 1, "7": 1},
+        "closure_sufficient_requirement_count": 0,
+        "support_sufficient_requirement_count": 0,
+        "partial_support_count": 2,
+        "other_relation_state_counts": {"SUPPORT_SUFFICIENT": 1},
+        "exposed_closure_partial_rows": ["151:7"],
+        "split_singleton_partial_rows": ["151:8"],
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    by_key = {_record_key(record): record for record in records}
+    if set(by_key) != {(151, 7), (151, 8)}:
+        raise AssertionError("unexpected hard strict record keys")
+
+    row_7 = by_key[(151, 7)]
+    if row_7["required_witnesses"] != [0, 1, 6]:
+        raise AssertionError("151:7 required witnesses changed")
+    if row_7["missing_from_bootstrap_core"] != [6]:
+        raise AssertionError("151:7 missing endpoint changed")
+    if row_7["exposed_closure_evaluations"][0]["missing_required_witnesses"] != [6]:
+        raise AssertionError("151:7 exposed closure no longer misses endpoint 6")
+
+    row_8 = by_key[(151, 8)]
+    if row_8["required_witnesses"] != [1, 5, 7]:
+        raise AssertionError("151:8 required witnesses changed")
+    support_missing = {
+        tuple(item["support"]): item["missing_required_witnesses"]
+        for item in row_8["support_evaluations"]
+    }
+    if support_missing != {(5,): [7], (7,): [5]}:
+        raise AssertionError("151:8 singleton support split changed")
+    if row_8["other_row_requirements"][0]["relation_state"] != "SUPPORT_SUFFICIENT":
+        raise AssertionError("151:8 connector support state changed")

--- a/tests/test_bootstrap_t12_hard_strict_endpoints.py
+++ b/tests/test_bootstrap_t12_hard_strict_endpoints.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.bootstrap_t12_hard_strict_endpoints import (
+    DEFAULT_ARTIFACT,
+    GAP_CLOSURE_MISSING_OUTSIDE,
+    GAP_SPLIT_SINGLETON,
+    assert_expected_payload,
+    build_t12_hard_strict_endpoints_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _records(payload: dict[str, object]) -> dict[tuple[int, int], dict[str, object]]:
+    return {
+        (int(record["source_record_id"]), int(record["row_center"])): record
+        for record in payload["records"]
+    }
+
+
+def test_hard_strict_counts_and_scope() -> None:
+    payload = build_t12_hard_strict_endpoints_payload()
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_HARD_STRICT_ENDPOINTS_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "does not prove that the missing rows or endpoints are forced" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert payload["summary"]["hard_strict_row_count"] == 2
+
+
+def test_hard_strict_closure_exposed_negative_control() -> None:
+    payload = build_t12_hard_strict_endpoints_payload()
+    row_7 = _records(payload)[(151, 7)]
+    assert row_7["hard_strict_gap_type"] == GAP_CLOSURE_MISSING_OUTSIDE
+    assert row_7["required_witnesses"] == [0, 1, 6]
+    assert row_7["non_required_row_witnesses"] == [4]
+    assert row_7["missing_from_bootstrap_core"] == [6]
+    exposed = row_7["exposed_closure_evaluations"]
+    assert len(exposed) == 1
+    assert exposed[0]["available_required_witnesses"] == [0, 1]
+    assert exposed[0]["missing_required_witnesses"] == [6]
+
+
+def test_hard_strict_singleton_supports_split_endpoints() -> None:
+    payload = build_t12_hard_strict_endpoints_payload()
+    row_8 = _records(payload)[(151, 8)]
+    assert row_8["hard_strict_gap_type"] == GAP_SPLIT_SINGLETON
+    assert row_8["required_witnesses"] == [1, 5, 7]
+    support_missing = {
+        tuple(item["support"]): item["missing_required_witnesses"]
+        for item in row_8["support_evaluations"]
+    }
+    assert support_missing == {(5,): [7], (7,): [5]}
+    assert row_8["other_row_requirements"] == [
+        {
+            "requirement_id": "151:8:connector:1:1",
+            "kind": "equality_connector_pair",
+            "required_witnesses": [2, 5],
+            "relation_state": "SUPPORT_SUFFICIENT",
+            "missing_from_bootstrap_core": [5],
+        }
+    ]
+
+
+def test_hard_strict_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_hard_strict_endpoints_payload()
+
+
+def test_hard_strict_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_hard_strict_endpoints.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["hard_strict_requirement_ids"] == [
+        "151:7:strict:0",
+        "151:8:strict:1",
+    ]
+
+
+def test_hard_strict_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_hard_strict_endpoints.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_hard_strict_endpoints.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_hard_strict_endpoints.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )


### PR DESCRIPTION
## Summary

- Add a generated bootstrap/T12 hard strict-endpoint packet isolating rows `151:7` and `151:8`.
- Add the checker, unit tests, docs, and metadata/provenance entries for the packet.
- Preserve diagnostic scope: no endpoint forcing, row forcing, `n=9`, bridge proof, counterexample, or global-status claim.

## Verification

Focused checks:

```bash
python scripts/check_bootstrap_t12_hard_strict_endpoints.py --check --assert-expected --json
python -m pytest tests/test_bootstrap_t12_hard_strict_endpoints.py -q
python -m ruff check src\erdos97\bootstrap_t12_hard_strict_endpoints.py scripts\check_bootstrap_t12_hard_strict_endpoints.py tests\test_bootstrap_t12_hard_strict_endpoints.py
```

Fast tier:

```bash
python scripts/check_text_clean.py
python scripts/check_status_consistency.py
python scripts/check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

`python -m pytest -q` completed with `667 passed, 281 deselected`.