### PR TITLE
Add T12 open connector pair packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the hard strict-endpoint subpacket isolating rows `151:7` and `151:8`,
   read
   [`docs/bootstrap-t12-hard-strict-endpoints.md`](docs/bootstrap-t12-hard-strict-endpoints.md).
+- For the open connector-pair subpacket isolating row `151:5`, read
+  [`docs/bootstrap-t12-open-connector-pair.md`](docs/bootstrap-t12-open-connector-pair.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -226,6 +226,14 @@ bookkeeping only; see `docs/bootstrap-t12-hard-strict-endpoints.md`,
 `scripts/check_bootstrap_t12_hard_strict_endpoints.py`, and
 `data/certificates/bootstrap_t12_hard_strict_endpoints.json`.
 
+The open connector-pair subpacket isolates the remaining open connector
+requirement from that map. Source `151`, row `5` needs connector pair `[7,8]`;
+the deletion closure for core vertex `2` and the singleton supports each see
+only one connector endpoint. This is still diagnostic bookkeeping only; see
+`docs/bootstrap-t12-open-connector-pair.md`,
+`scripts/check_bootstrap_t12_open_connector_pair.py`, and
+`data/certificates/bootstrap_t12_open_connector_pair.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -118,6 +118,13 @@ while `151:8` has singleton supports that split endpoints `5` and `7`. This
 is diagnostic bookkeeping only, not a theorem that the missing endpoints are
 forced. See `docs/bootstrap-t12-hard-strict-endpoints.md`.
 
+An open connector-pair subpacket now isolates row `151:5`. Its stored
+equality connector needs outside pair `[7,8]`; the deletion closure for core
+vertex `2` sees only endpoint `7`, and singleton supports `7` and `8` split
+the pair one endpoint at a time. This is diagnostic bookkeeping only, not a
+theorem that the connector endpoints or row are forced. See
+`docs/bootstrap-t12-open-connector-pair.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_open_connector_pair.json
+++ b/data/certificates/bootstrap_t12_open_connector_pair.json
@@ -1,0 +1,294 @@
+{
+  "claim_scope": "Open connector-pair diagnostic for the two tight n=9 bootstrap/T12 records; isolates the equality-connector pair requirement that remains unmet after bootstrap-core, support, and deletion-closure checks. This does not prove that the missing row or connector endpoints are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates a fixed selected-row equality-connector pair gap; it does not prove endpoints or rows are forced.",
+    "Singleton or deletion-closure partial visibility is bookkeeping, not a Euclidean rich-class certificate.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_open_connector_pair.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_open_connector_pair.py"
+  },
+  "records": [
+    {
+      "bootstrap_core_witnesses": [
+        2,
+        4
+      ],
+      "bridge_lemma_target": "Explain how a singleton-activated row can also supply both outside endpoints of its equality-connector pair.",
+      "classification_assignment_id": "A152",
+      "closure_evaluations": [
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [],
+          "core_vertex": 0,
+          "missing_required_witnesses": [
+            7,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "status": "DISJOINT"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [],
+          "core_vertex": 1,
+          "missing_required_witnesses": [
+            7,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "status": "DISJOINT"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            7
+          ],
+          "core_vertex": 2,
+          "missing_required_witnesses": [
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        },
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [],
+          "core_vertex": 4,
+          "missing_required_witnesses": [
+            7,
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "status": "DISJOINT"
+        }
+      ],
+      "closure_sufficient_count": 0,
+      "connector_requirement_id": "151:5:connector:1:0",
+      "from_pair": [
+        5,
+        7
+      ],
+      "missing_connector_endpoint_count": 2,
+      "missing_from_bootstrap_core": [
+        7,
+        8
+      ],
+      "non_required_row_witnesses": [
+        2,
+        4
+      ],
+      "open_connector_gap_type": "SINGLETON_SUPPORTS_SPLIT_CONNECTOR_PAIR",
+      "outside_witnesses": [
+        7,
+        8
+      ],
+      "partial_closure_count": 1,
+      "partial_closures": [
+        {
+          "activation_ready_in_closure": false,
+          "available_required_witnesses": [
+            7
+          ],
+          "core_vertex": 2,
+          "missing_required_witnesses": [
+            8
+          ],
+          "row_center_in_closure": false,
+          "row_exposed_in_closure": false,
+          "status": "PARTIAL"
+        }
+      ],
+      "partial_support_count": 2,
+      "partial_supports": [
+        {
+          "available_required_witnesses": [
+            7
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            8
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            7
+          ]
+        },
+        {
+          "available_required_witnesses": [
+            8
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            7
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            8
+          ]
+        }
+      ],
+      "path_index": 0,
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "required_witnesses": [
+        7,
+        8
+      ],
+      "requirement_size": 2,
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 5,
+      "row_target_status": "SINGLETON_ROW_OPEN_CONNECTOR_PAIR",
+      "source_record_id": 151,
+      "step_index": 1,
+      "support_evaluations": [
+        {
+          "available_required_witnesses": [
+            7
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            8
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            7
+          ]
+        },
+        {
+          "available_required_witnesses": [
+            8
+          ],
+          "ledger_private_pair_hit": false,
+          "missing_required_witnesses": [
+            7
+          ],
+          "private_halo_core_vertices": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "status": "PARTIAL",
+          "support": [
+            8
+          ]
+        }
+      ],
+      "support_packet_summary": {
+        "ledger_private_pair_support_hit_count": 0,
+        "private_halo_containment_counts": [
+          3,
+          4
+        ],
+        "support_label_modes": [
+          "INTERNAL_TO_ONE_DELETION_CLOSURE",
+          "PRIVATE_IN_ALL_DELETION_HALOS"
+        ],
+        "support_labels": [
+          7,
+          8
+        ],
+        "support_packet": "bootstrap_t12_one_outside"
+      },
+      "support_sufficient_count": 0,
+      "to_pair": [
+        5,
+        8
+      ],
+      "witnesses": [
+        2,
+        4,
+        7,
+        8
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_open_connector_pair.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_activation_requirements.json",
+      "role": "source equality-connector pair requirements and evaluations",
+      "schema": "erdos97.bootstrap_t12_activation_requirements.v1",
+      "status": "BOOTSTRAP_T12_ACTIVATION_REQUIREMENTS_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_bridge_target_map.json",
+      "role": "source open connector row target and bridge obligation",
+      "schema": "erdos97.bootstrap_t12_bridge_target_map.v1",
+      "status": "BOOTSTRAP_T12_BRIDGE_TARGET_MAP_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_OPEN_CONNECTOR_PAIR_DIAGNOSTIC_ONLY",
+  "summary": {
+    "closure_evaluation_status_counts": {
+      "DISJOINT": 3,
+      "PARTIAL": 1
+    },
+    "closure_sufficient_requirement_count": 0,
+    "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "missing_connector_endpoint_label_counts": {
+      "7": 1,
+      "8": 1
+    },
+    "next_bridge_question": "Can a singleton-activated row be forced to carry both outside endpoints of an equality-connector pair, rather than only one endpoint at a time?",
+    "open_connector_gap_type_counts": {
+      "SINGLETON_SUPPORTS_SPLIT_CONNECTOR_PAIR": 1
+    },
+    "open_connector_requirement_ids": [
+      "151:5:connector:1:0"
+    ],
+    "open_connector_row_count": 1,
+    "partial_closure_count": 1,
+    "partial_support_count": 2,
+    "pressure_class_counts": {
+      "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 1
+    },
+    "role_counts": {
+      "equality_connector_row": 1
+    },
+    "row_centers_by_source_id": {
+      "151": [
+        5
+      ]
+    },
+    "row_target_status_counts": {
+      "SINGLETON_ROW_OPEN_CONNECTOR_PAIR": 1
+    },
+    "source_record_ids": [
+      151
+    ],
+    "split_singleton_partial_rows": [
+      "151:5"
+    ],
+    "support_evaluation_status_counts": {
+      "PARTIAL": 2
+    },
+    "support_sufficient_requirement_count": 0
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-bridge-target-map.md
+++ b/docs/bootstrap-t12-bridge-target-map.md
@@ -85,6 +85,11 @@ The hard strict-endpoint follow-up in
 control and the mixed row `151:8`, where singleton supports split the strict
 endpoint set.
 
+The open connector-pair follow-up in
+`docs/bootstrap-t12-open-connector-pair.md` isolates the second negative
+control, row `151:5`, where singleton supports and one deletion closure see
+only one endpoint of connector pair `[7,8]`.
+
 ## What This Does Not Prove
 
 This artifact does not prove that any missing T12 row is forced, does not prove

--- a/docs/bootstrap-t12-open-connector-pair.md
+++ b/docs/bootstrap-t12-open-connector-pair.md
@@ -1,0 +1,83 @@
+# Bootstrap T12 Open Connector Pair
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the equality-connector pair requirement that remains open
+in the joined T12 bridge-target map. It answers a narrower question than row
+forcing:
+
+```text
+Which connector pair is still not supplied by the bootstrap core, deletion
+closures, or stored singleton support options?
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_open_connector_pair.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_open_connector_pair.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_open_connector_pair.json`.
+
+## Scope
+
+The input packets are:
+
+- `data/certificates/bootstrap_t12_activation_requirements.json`;
+- `data/certificates/bootstrap_t12_bridge_target_map.json`.
+
+This packet is not full rich-class data. An open connector pair is an unmet
+relation requirement inside the stored fixed-row T12/F16 quotient certificate;
+it is not a theorem that the pair is geometrically forced.
+
+## Results
+
+There is one open equality-connector requirement:
+
+| Source | Row | Requirement | Required connector pair | Current deficit |
+|---:|---:|---|---|---|
+| `151` | `5` | `151:5:connector:1:0` | `[7,8]` | singleton `7` misses `8`; singleton `8` misses `7` |
+
+Headline counts:
+
+```text
+open connector rows: 1
+closure-sufficient connector requirements: 0
+support-sufficient connector requirements: 0
+partial deletion closures: 1
+partial singleton supports: 2
+missing connector endpoint labels: 7, 8
+```
+
+## Negative-Control Reading
+
+Row `151:5` is the open connector-pair negative control. Its bootstrap core
+contains row witnesses `[2,4]`, while the stored equality connector needs the
+outside pair `[7,8]`.
+
+The deletion closure for core vertex `2` sees endpoint `7`, but not endpoint
+`8`, and the row center `5` is not in that closure. The singleton support
+options also split the connector pair: support `7` supplies only `[7]` and
+misses `8`, while support `8` supplies only `[8]` and misses `7`.
+
+## What This Does Not Prove
+
+This artifact does not prove that any connector endpoint, row center, or rich
+class is forced. It does not prove `n=9`, does not prove the bootstrap bridge,
+does not independently review the vertex-circle checker, and does not alter
+the official/global status of Erdos Problem #97.
+
+## Reviewer Focus
+
+The exact next bridge question is whether a singleton-activated row can be
+forced to carry both outside endpoints of an equality-connector pair, rather
+than only one endpoint at a time. A future lemma would need a genuine
+geometric reason that rejects the split-support state above without assuming
+the fixed selected row is already present.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -525,6 +525,13 @@ only `[0,1]` of the strict endpoint set `[0,1,6]`; row `151:8` has singleton
 supports that split the strict endpoint set `[1,5,7]`. This is diagnostic
 bookkeeping only, not a lemma that strict endpoint sets are forced.
 
+The open connector-pair packet in
+`docs/bootstrap-t12-open-connector-pair.md` isolates the remaining open
+connector row. Row `151:5` needs equality-connector pair `[7,8]`, but the
+deletion closure for core vertex `2` and the two singleton supports each supply
+only one connector endpoint. This is diagnostic bookkeeping only, not a lemma
+that connector pairs or missing rows are forced.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -60,6 +60,10 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-hard-strict-endpoints.md` isolates rows `151:7` and
    `151:8`, where strict-edge endpoint sets are still incomplete after closure
    and singleton-support checks.
+   The open connector-pair subpacket in
+   `docs/bootstrap-t12-open-connector-pair.md` isolates row `151:5`, where the
+   connector pair `[7,8]` is still split across singleton support and partial
+   closure evidence.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-hard-strict-endpoints.md`](bootstrap-t12-hard-strict-endpoints.md):
   focused packet isolating the hard strict-edge endpoint gaps in rows `151:7`
   and `151:8`.
+- [`bootstrap-t12-open-connector-pair.md`](bootstrap-t12-open-connector-pair.md):
+  focused packet isolating the open equality-connector pair gap in row
+  `151:5`.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -348,6 +348,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-t12-hard-strict-endpoints.md`, isolating `151:7` and
   `151:8` as the rows where strict-edge endpoint sets are still not supplied
   by closure exposure or singleton support.
+- bootstrap/T12 open connector-pair evidence, as recorded in
+  `docs/bootstrap-t12-open-connector-pair.md`, isolating `151:5` as the row
+  where connector pair `[7,8]` is still split across singleton support and
+  partial closure evidence.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -193,6 +193,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_hard_strict_endpoints.json"
       verifier: "scripts/check_bootstrap_t12_hard_strict_endpoints.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; isolates incomplete strict-edge endpoint sets in rows 151:7 and 151:8, but does not prove endpoints or rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_open_connector_pair"
+      status: "open connector-pair subpacket for the remaining open T12/F16 row target"
+      artifact: "data/certificates/bootstrap_t12_open_connector_pair.json"
+      verifier: "scripts/check_bootstrap_t12_open_connector_pair.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates incomplete equality-connector pair support in row 151:5, but does not prove endpoints or rows are forced and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2155,6 +2155,59 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_open_connector_pair
+    path: data/certificates/bootstrap_t12_open_connector_pair.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_open_connector_pair.py
+    command: python scripts/check_bootstrap_t12_open_connector_pair.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_open_connector_pair.py
+    check_command: python scripts/check_bootstrap_t12_open_connector_pair.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Open connector-pair diagnostic for the two tight n=9 bootstrap-core rows; not a proof that endpoints or missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_open_connector_pair.v1
+      status: BOOTSTRAP_T12_OPEN_CONNECTOR_PAIR_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 151
+      summary.open_connector_row_count: 1
+      summary.row_centers_by_source_id.151:
+        - 5
+      summary.open_connector_requirement_ids:
+        - "151:5:connector:1:0"
+      summary.open_connector_gap_type_counts.SINGLETON_SUPPORTS_SPLIT_CONNECTOR_PAIR: 1
+      summary.missing_connector_endpoint_label_counts.7: 1
+      summary.missing_connector_endpoint_label_counts.8: 1
+      summary.closure_sufficient_requirement_count: 0
+      summary.support_sufficient_requirement_count: 0
+      summary.partial_closure_count: 1
+      summary.partial_support_count: 2
+      summary.support_evaluation_status_counts.PARTIAL: 2
+      summary.closure_evaluation_status_counts.DISJOINT: 3
+      summary.closure_evaluation_status_counts.PARTIAL: 1
+      summary.split_singleton_partial_rows:
+        - "151:5"
+      summary.forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_open_connector_pair.py
+      provenance.command: python scripts/check_bootstrap_t12_open_connector_pair.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - connector endpoints are forced
+      - open connector pairs are forced
+      - partial closure exposure proves a connector pair
+      - singleton support proves connector pair forcing
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_open_connector_pair.py
+++ b/scripts/check_bootstrap_t12_open_connector_pair.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 open connector-pair packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_open_connector_pair import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_open_connector_pair_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 open connector pair")
+    print(f"open connector rows: {summary['open_connector_row_count']}")
+    print(f"gap types: {summary['open_connector_gap_type_counts']}")
+    print(
+        "missing connector endpoint labels: "
+        f"{summary['missing_connector_endpoint_label_counts']}"
+    )
+    print(f"partial closures: {summary['partial_closure_count']}")
+    print(f"partial singleton supports: {summary['partial_support_count']}")
+    print(f"target status: {summary['forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned counts")
+    args = parser.parse_args()
+
+    generated = build_t12_open_connector_pair_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 open connector-pair artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 open connector-pair expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_open_connector_pair.py
+++ b/src/erdos97/bootstrap_t12_open_connector_pair.py
@@ -1,0 +1,394 @@
+"""Open connector-pair packet for the bootstrap/T12 target.
+
+This module isolates the equality-connector pair requirement that remains open
+in the T12 bridge-target map. It is proof-mining bookkeeping only; it does not
+prove that any missing row or connector endpoint is forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from erdos97.bootstrap_t12_activation_requirements import (
+    KIND_CONNECTOR,
+    build_t12_activation_requirements_payload,
+)
+from erdos97.bootstrap_t12_bridge_target_map import (
+    RELATION_OPEN_CONNECTOR,
+    build_t12_bridge_target_map_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_open_connector_pair.v1"
+STATUS = "BOOTSTRAP_T12_OPEN_CONNECTOR_PAIR_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Open connector-pair diagnostic for the two tight n=9 bootstrap/T12 "
+    "records; isolates the equality-connector pair requirement that remains "
+    "unmet after bootstrap-core, support, and deletion-closure checks. This "
+    "does not prove that the missing row or connector endpoints are forced, "
+    "does not prove n=9, does not prove the bridge, and does not claim a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_open_connector_pair.json"
+)
+
+GAP_SINGLETON_SPLIT_PAIR = "SINGLETON_SUPPORTS_SPLIT_CONNECTOR_PAIR"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _record_key(record: Mapping[str, Any]) -> tuple[int, int]:
+    return int(record["source_record_id"]), int(record["row_center"])
+
+
+def _index_records(records: Iterable[Mapping[str, Any]]) -> dict[tuple[int, int], Mapping[str, Any]]:
+    return {_record_key(record): record for record in records}
+
+
+def _available_required_witnesses(
+    requirement: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+) -> list[int]:
+    required = set(_int_list(requirement["required_witnesses"]))
+    available = set(_int_list(evaluation["available_witnesses"]))
+    return sorted(required & available)
+
+
+def _closure_eval_record(
+    requirement: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+) -> dict[str, object]:
+    return {
+        "core_vertex": int(evaluation["core_vertex"]),
+        "row_center_in_closure": bool(evaluation["row_center_in_closure"]),
+        "row_exposed_in_closure": bool(evaluation["row_exposed_in_closure"]),
+        "activation_ready_in_closure": bool(evaluation["activation_ready_in_closure"]),
+        "available_required_witnesses": _available_required_witnesses(
+            requirement, evaluation
+        ),
+        "missing_required_witnesses": _int_list(
+            evaluation["missing_required_witnesses"]
+        ),
+        "status": str(evaluation["status"]),
+    }
+
+
+def _support_eval_record(
+    requirement: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+) -> dict[str, object]:
+    return {
+        "support": _int_list(evaluation["support"]),
+        "available_required_witnesses": _available_required_witnesses(
+            requirement, evaluation
+        ),
+        "missing_required_witnesses": _int_list(
+            evaluation["missing_required_witnesses"]
+        ),
+        "status": str(evaluation["status"]),
+        "ledger_private_pair_hit": bool(evaluation["ledger_private_pair_hit"]),
+        "private_halo_core_vertices": _int_list(
+            evaluation["private_halo_core_vertices"]
+        ),
+    }
+
+
+def _connector_gap_type(bridge_record: Mapping[str, Any]) -> str:
+    row_target_status = str(bridge_record["row_target_status"])
+    if row_target_status == "SINGLETON_ROW_OPEN_CONNECTOR_PAIR":
+        return GAP_SINGLETON_SPLIT_PAIR
+    raise AssertionError(f"unexpected open connector target status {row_target_status!r}")
+
+
+def _open_connector_record(
+    *,
+    activation_record: Mapping[str, Any],
+    connector_requirement: Mapping[str, Any],
+    bridge_record: Mapping[str, Any],
+) -> dict[str, object]:
+    required = set(_int_list(connector_requirement["required_witnesses"]))
+    witnesses = set(_int_list(activation_record["witnesses"]))
+    closure_evaluations = [
+        _closure_eval_record(connector_requirement, evaluation)
+        for evaluation in connector_requirement["closure_evaluations"]
+    ]
+    support_evaluations = [
+        _support_eval_record(connector_requirement, evaluation)
+        for evaluation in connector_requirement["support_evaluations"]
+    ]
+    partial_closures = [
+        evaluation
+        for evaluation in closure_evaluations
+        if evaluation["status"] == "PARTIAL"
+    ]
+    partial_supports = [
+        evaluation
+        for evaluation in support_evaluations
+        if evaluation["status"] == "PARTIAL"
+    ]
+    missing_labels = _int_list(connector_requirement["missing_from_bootstrap_core"])
+
+    return {
+        "source_record_id": int(activation_record["source_record_id"]),
+        "classification_assignment_id": str(
+            activation_record["classification_assignment_id"]
+        ),
+        "row_center": int(activation_record["row_center"]),
+        "roles": [str(role) for role in activation_record["roles"]],
+        "pressure_class": str(activation_record["pressure_class"]),
+        "row_target_status": str(bridge_record["row_target_status"]),
+        "open_connector_gap_type": _connector_gap_type(bridge_record),
+        "connector_requirement_id": str(connector_requirement["requirement_id"]),
+        "step_index": int(connector_requirement["step_index"]),
+        "path_index": int(connector_requirement["path_index"]),
+        "from_pair": _int_list(connector_requirement["from_pair"]),
+        "to_pair": _int_list(connector_requirement["to_pair"]),
+        "required_witnesses": sorted(required),
+        "requirement_size": int(connector_requirement["requirement_size"]),
+        "witnesses": sorted(witnesses),
+        "bootstrap_core_witnesses": _int_list(
+            activation_record["bootstrap_core_witnesses"]
+        ),
+        "outside_witnesses": _int_list(activation_record["outside_witnesses"]),
+        "non_required_row_witnesses": sorted(witnesses - required),
+        "missing_from_bootstrap_core": missing_labels,
+        "missing_connector_endpoint_count": len(missing_labels),
+        "closure_sufficient_count": int(
+            connector_requirement["closure_sufficient_count"]
+        ),
+        "support_sufficient_count": int(
+            connector_requirement["support_sufficient_count"]
+        ),
+        "closure_evaluations": closure_evaluations,
+        "partial_closure_count": len(partial_closures),
+        "partial_closures": partial_closures,
+        "support_evaluations": support_evaluations,
+        "partial_support_count": len(partial_supports),
+        "partial_supports": partial_supports,
+        "support_packet_summary": bridge_record["support_packet_summary"],
+        "bridge_lemma_target": str(bridge_record["bridge_lemma_target"]),
+    }
+
+
+def build_t12_open_connector_pair_payload() -> dict[str, object]:
+    """Return the deterministic open connector-pair packet."""
+
+    activation = build_t12_activation_requirements_payload()
+    bridge_map = build_t12_bridge_target_map_payload()
+    bridge_by_key = _index_records(bridge_map["records"])
+
+    records = []
+    for activation_record in activation["records"]:
+        key = _record_key(activation_record)
+        bridge_record = bridge_by_key[key]
+        for requirement in activation_record["requirements"]:
+            if requirement["kind"] != KIND_CONNECTOR:
+                continue
+            if RELATION_OPEN_CONNECTOR not in bridge_record["relation_state_counts"]:
+                continue
+            records.append(
+                _open_connector_record(
+                    activation_record=activation_record,
+                    connector_requirement=requirement,
+                    bridge_record=bridge_record,
+                )
+            )
+    records.sort(key=lambda record: (int(record["source_record_id"]), int(record["row_center"])))
+
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    gap_type_counts: Counter[str] = Counter()
+    pressure_counts: Counter[str] = Counter()
+    target_status_counts: Counter[str] = Counter()
+    role_counts: Counter[str] = Counter()
+    missing_endpoint_counts: Counter[int] = Counter()
+    support_status_counts: Counter[str] = Counter()
+    closure_status_counts: Counter[str] = Counter()
+    for record in records:
+        rows_by_source[int(record["source_record_id"])].append(int(record["row_center"]))
+        gap_type_counts[str(record["open_connector_gap_type"])] += 1
+        pressure_counts[str(record["pressure_class"])] += 1
+        target_status_counts[str(record["row_target_status"])] += 1
+        role_counts.update(str(role) for role in record["roles"])
+        missing_endpoint_counts.update(_int_list(record["missing_from_bootstrap_core"]))
+        support_status_counts.update(
+            str(evaluation["status"]) for evaluation in record["support_evaluations"]
+        )
+        closure_status_counts.update(
+            str(evaluation["status"]) for evaluation in record["closure_evaluations"]
+        )
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates a fixed selected-row equality-connector pair gap; it does not prove endpoints or rows are forced.",
+            "Singleton or deletion-closure partial visibility is bookkeeping, not a Euclidean rich-class certificate.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted(rows_by_source),
+            "open_connector_row_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "open_connector_requirement_ids": [
+                str(record["connector_requirement_id"]) for record in records
+            ],
+            "open_connector_gap_type_counts": _json_counter(gap_type_counts),
+            "pressure_class_counts": _json_counter(pressure_counts),
+            "row_target_status_counts": _json_counter(target_status_counts),
+            "role_counts": _json_counter(role_counts),
+            "missing_connector_endpoint_label_counts": _json_counter(
+                missing_endpoint_counts
+            ),
+            "closure_sufficient_requirement_count": sum(
+                int(record["closure_sufficient_count"]) for record in records
+            ),
+            "support_sufficient_requirement_count": sum(
+                int(record["support_sufficient_count"]) for record in records
+            ),
+            "partial_closure_count": sum(
+                int(record["partial_closure_count"]) for record in records
+            ),
+            "partial_support_count": sum(
+                int(record["partial_support_count"]) for record in records
+            ),
+            "support_evaluation_status_counts": _json_counter(support_status_counts),
+            "closure_evaluation_status_counts": _json_counter(closure_status_counts),
+            "split_singleton_partial_rows": [
+                f"{record['source_record_id']}:{record['row_center']}"
+                for record in records
+                if record["open_connector_gap_type"] == GAP_SINGLETON_SPLIT_PAIR
+            ],
+            "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can a singleton-activated row be forced to carry both "
+                "outside endpoints of an equality-connector pair, rather than "
+                "only one endpoint at a time?"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_activation_requirements.json",
+                "role": "source equality-connector pair requirements and evaluations",
+                "schema": activation.get("schema"),
+                "status": activation.get("status"),
+                "trust": activation.get("trust"),
+            },
+            {
+                "path": "data/certificates/bootstrap_t12_bridge_target_map.json",
+                "role": "source open connector row target and bridge obligation",
+                "schema": bridge_map.get("schema"),
+                "status": bridge_map.get("status"),
+                "trust": bridge_map.get("trust"),
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_open_connector_pair.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_open_connector_pair.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the open connector-pair packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 open-connector schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 open-connector status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [151],
+        "open_connector_row_count": 1,
+        "row_centers_by_source_id": {"151": [5]},
+        "open_connector_requirement_ids": ["151:5:connector:1:0"],
+        "open_connector_gap_type_counts": {GAP_SINGLETON_SPLIT_PAIR: 1},
+        "pressure_class_counts": {
+            "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 1,
+        },
+        "row_target_status_counts": {
+            "SINGLETON_ROW_OPEN_CONNECTOR_PAIR": 1,
+        },
+        "role_counts": {"equality_connector_row": 1},
+        "missing_connector_endpoint_label_counts": {"7": 1, "8": 1},
+        "closure_sufficient_requirement_count": 0,
+        "support_sufficient_requirement_count": 0,
+        "partial_closure_count": 1,
+        "partial_support_count": 2,
+        "support_evaluation_status_counts": {"PARTIAL": 2},
+        "closure_evaluation_status_counts": {"DISJOINT": 3, "PARTIAL": 1},
+        "split_singleton_partial_rows": ["151:5"],
+        "forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    by_key = {_record_key(record): record for record in records}
+    if set(by_key) != {(151, 5)}:
+        raise AssertionError("unexpected open connector record keys")
+
+    row_5 = by_key[(151, 5)]
+    if row_5["required_witnesses"] != [7, 8]:
+        raise AssertionError("151:5 required connector pair changed")
+    if row_5["missing_from_bootstrap_core"] != [7, 8]:
+        raise AssertionError("151:5 missing connector endpoints changed")
+    if row_5["bootstrap_core_witnesses"] != [2, 4]:
+        raise AssertionError("151:5 bootstrap core witnesses changed")
+    if row_5["non_required_row_witnesses"] != [2, 4]:
+        raise AssertionError("151:5 non-required row witnesses changed")
+    support_missing = {
+        tuple(item["support"]): item["missing_required_witnesses"]
+        for item in row_5["support_evaluations"]
+    }
+    if support_missing != {(7,): [8], (8,): [7]}:
+        raise AssertionError("151:5 singleton support split changed")
+    partial_closures = row_5["partial_closures"]
+    if len(partial_closures) != 1:
+        raise AssertionError("151:5 should have exactly one partial closure")
+    if partial_closures[0]["core_vertex"] != 2:
+        raise AssertionError("151:5 partial closure core vertex changed")
+    if partial_closures[0]["missing_required_witnesses"] != [8]:
+        raise AssertionError("151:5 partial closure missing endpoint changed")
+    if partial_closures[0]["row_center_in_closure"]:
+        raise AssertionError("151:5 partial closure should not contain row center")

--- a/tests/test_bootstrap_t12_open_connector_pair.py
+++ b/tests/test_bootstrap_t12_open_connector_pair.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.bootstrap_t12_open_connector_pair import (
+    DEFAULT_ARTIFACT,
+    GAP_SINGLETON_SPLIT_PAIR,
+    assert_expected_payload,
+    build_t12_open_connector_pair_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _records(payload: dict[str, object]) -> dict[tuple[int, int], dict[str, object]]:
+    return {
+        (int(record["source_record_id"]), int(record["row_center"])): record
+        for record in payload["records"]
+    }
+
+
+def test_open_connector_counts_and_scope() -> None:
+    payload = build_t12_open_connector_pair_payload()
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_OPEN_CONNECTOR_PAIR_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "does not prove that the missing row or connector endpoints are forced" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert payload["summary"]["open_connector_row_count"] == 1
+    assert payload["summary"]["open_connector_requirement_ids"] == [
+        "151:5:connector:1:0"
+    ]
+
+
+def test_open_connector_singleton_supports_split_pair() -> None:
+    payload = build_t12_open_connector_pair_payload()
+    row_5 = _records(payload)[(151, 5)]
+    assert row_5["open_connector_gap_type"] == GAP_SINGLETON_SPLIT_PAIR
+    assert row_5["required_witnesses"] == [7, 8]
+    assert row_5["non_required_row_witnesses"] == [2, 4]
+    assert row_5["missing_from_bootstrap_core"] == [7, 8]
+    support_missing = {
+        tuple(item["support"]): item["missing_required_witnesses"]
+        for item in row_5["support_evaluations"]
+    }
+    assert support_missing == {(7,): [8], (8,): [7]}
+    assert row_5["support_sufficient_count"] == 0
+    assert row_5["partial_support_count"] == 2
+
+
+def test_open_connector_partial_closure_negative_control() -> None:
+    payload = build_t12_open_connector_pair_payload()
+    row_5 = _records(payload)[(151, 5)]
+    assert row_5["closure_sufficient_count"] == 0
+    assert row_5["partial_closure_count"] == 1
+    partial = row_5["partial_closures"][0]
+    assert partial["core_vertex"] == 2
+    assert partial["available_required_witnesses"] == [7]
+    assert partial["missing_required_witnesses"] == [8]
+    assert not partial["row_center_in_closure"]
+    assert not partial["activation_ready_in_closure"]
+
+
+def test_open_connector_support_packet_summary() -> None:
+    payload = build_t12_open_connector_pair_payload()
+    row_5 = _records(payload)[(151, 5)]
+    assert row_5["support_packet_summary"] == {
+        "ledger_private_pair_support_hit_count": 0,
+        "private_halo_containment_counts": [3, 4],
+        "support_label_modes": [
+            "INTERNAL_TO_ONE_DELETION_CLOSURE",
+            "PRIVATE_IN_ALL_DELETION_HALOS",
+        ],
+        "support_labels": [7, 8],
+        "support_packet": "bootstrap_t12_one_outside",
+    }
+
+
+def test_open_connector_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_open_connector_pair_payload()
+
+
+def test_open_connector_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_open_connector_pair.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["open_connector_requirement_ids"] == [
+        "151:5:connector:1:0",
+    ]
+
+
+def test_open_connector_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_open_connector_pair.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_open_connector_pair.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_open_connector_pair.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )


### PR DESCRIPTION
## Summary

- Add a generated bootstrap/T12 open connector-pair packet isolating row `151:5` and requirement `151:5:connector:1:0`.
- Add the checker, unit tests, docs, and metadata/provenance entries for the packet.
- Preserve diagnostic scope: no connector endpoint forcing, row forcing, `n=9`, bridge proof, counterexample, or global-status claim.

## Verification

Focused checks:

```bash
python scripts/check_bootstrap_t12_open_connector_pair.py --check --assert-expected --json
python -m pytest tests/test_bootstrap_t12_open_connector_pair.py -q
python -m ruff check src\erdos97\bootstrap_t12_open_connector_pair.py scripts\check_bootstrap_t12_open_connector_pair.py tests\test_bootstrap_t12_open_connector_pair.py
```

Fast tier:

```bash
python scripts/check_text_clean.py
python scripts/check_status_consistency.py
python scripts/check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

`python -m pytest -q` completed with `686 passed, 281 deselected`.