### PR TITLE
Add T12 relation-sufficient row packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/bootstrap-t12-hard-strict-endpoints.md`](docs/bootstrap-t12-hard-strict-endpoints.md).
 - For the open connector-pair subpacket isolating row `151:5`, read
   [`docs/bootstrap-t12-open-connector-pair.md`](docs/bootstrap-t12-open-connector-pair.md).
+- For the relation-sufficient row subpacket isolating rows `81:3`, `81:8`,
+  and `151:6`, read
+  [`docs/bootstrap-t12-relation-sufficient-rows.md`](docs/bootstrap-t12-relation-sufficient-rows.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -234,6 +234,15 @@ only one connector endpoint. This is still diagnostic bookkeeping only; see
 `scripts/check_bootstrap_t12_open_connector_pair.py`, and
 `data/certificates/bootstrap_t12_open_connector_pair.json`.
 
+The relation-sufficient row subpacket isolates the three rows from that map
+whose connector requirements are already bootstrap-core sufficient or
+support-sufficient: `81:3`, `81:8`, and `151:6`. It keeps the remaining
+row/rich-class forcing target explicit rather than promoting relation evidence
+to a bridge theorem. This is still diagnostic bookkeeping only; see
+`docs/bootstrap-t12-relation-sufficient-rows.md`,
+`scripts/check_bootstrap_t12_relation_sufficient_rows.py`, and
+`data/certificates/bootstrap_t12_relation_sufficient_rows.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -125,6 +125,13 @@ the pair one endpoint at a time. This is diagnostic bookkeeping only, not a
 theorem that the connector endpoints or row are forced. See
 `docs/bootstrap-t12-open-connector-pair.md`.
 
+A relation-sufficient row subpacket now isolates rows `81:3`, `81:8`, and
+`151:6`. Their stored connector requirements are already bootstrap-core
+sufficient or support-sufficient, but the packet keeps the row/rich-class
+forcing step open. This is diagnostic bookkeeping only, not a theorem that
+the relation-sufficient rows are forced. See
+`docs/bootstrap-t12-relation-sufficient-rows.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_relation_sufficient_rows.json
+++ b/data/certificates/bootstrap_t12_relation_sufficient_rows.json
@@ -1,0 +1,298 @@
+{
+  "claim_scope": "Relation-sufficient row diagnostic for the two tight n=9 bootstrap/T12 records; isolates rows whose connector requirements are already supplied by bootstrap-core or support diagnostics, while row/rich-class forcing remains an open bridge target. This does not prove that the missing rows are forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates relation-sufficient fixed selected rows; it does not prove row or rich-class forcing.",
+    "Bootstrap-core or support sufficiency for a role requirement is not a Euclidean certificate that the whole row is forced.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_relation_sufficient_rows.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_relation_sufficient_rows.py"
+  },
+  "records": [
+    {
+      "activation_deficit_from_bootstrap_core": 0,
+      "bootstrap_core_witnesses": [
+        0,
+        1,
+        4
+      ],
+      "bridge_lemma_target": "Turn a full-row deletion-closure exposure into a genuine equality-connector rich class.",
+      "classification_assignment_id": "A082",
+      "outside_witnesses": [
+        6
+      ],
+      "pressure_class": "ALREADY_PRESENT_IN_A_DELETION_CLOSURE",
+      "relation_state_counts": {
+        "BOOTSTRAP_CORE_SUFFICIENT": 1
+      },
+      "relation_sufficient_requirement_count": 1,
+      "relation_sufficient_requirements": [
+        {
+          "bootstrap_core_status": "SUFFICIENT",
+          "closure_sufficient_count": 1,
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [],
+          "relation_state": "BOOTSTRAP_CORE_SUFFICIENT",
+          "required_witnesses": [
+            0,
+            1
+          ],
+          "requirement_id": "81:3:connector:2:0",
+          "support_sufficient_count": 0
+        }
+      ],
+      "requirement_count": 1,
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 3,
+      "row_center_private_in_all_deletion_closures": false,
+      "row_forcing_gap_type": "FULL_ROW_CLOSURE_EXPOSURE_NEEDS_RICH_CLASS_FORCING",
+      "row_target_status": "CLOSURE_FULL_ROW_CONNECTOR",
+      "source_record_id": 81,
+      "support_packet_summary": {
+        "closure_exposure_mode": "CENTER_AND_FULL_ROW_IN_CLOSURE",
+        "exposed_core_vertex": 2,
+        "full_row_contained_in_exposure_closure": true,
+        "outside_witnesses_private": [],
+        "support_packet": "bootstrap_t12_closure_exposed",
+        "witnesses_in_closure": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 1,
+      "bootstrap_core_witnesses": [
+        0,
+        2
+      ],
+      "bridge_lemma_target": "Force the private row center plus one singleton outside support; the connector pair itself is already bootstrap-core visible.",
+      "classification_assignment_id": "A082",
+      "outside_witnesses": [
+        5,
+        6
+      ],
+      "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+      "relation_state_counts": {
+        "BOOTSTRAP_CORE_SUFFICIENT": 1
+      },
+      "relation_sufficient_requirement_count": 1,
+      "relation_sufficient_requirements": [
+        {
+          "bootstrap_core_status": "SUFFICIENT",
+          "closure_sufficient_count": 0,
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [],
+          "relation_state": "BOOTSTRAP_CORE_SUFFICIENT",
+          "required_witnesses": [
+            0,
+            2
+          ],
+          "requirement_id": "81:8:connector:0:0",
+          "support_sufficient_count": 2
+        }
+      ],
+      "requirement_count": 1,
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 8,
+      "row_center_private_in_all_deletion_closures": true,
+      "row_forcing_gap_type": "CORE_CONNECTOR_VISIBLE_NEEDS_PRIVATE_ROW_ACTIVATION",
+      "row_target_status": "CORE_CONNECTOR_WITH_SINGLETON_ROW_ACTIVATION",
+      "source_record_id": 81,
+      "support_packet_summary": {
+        "ledger_private_pair_support_hit_count": 0,
+        "private_halo_containment_counts": [
+          4,
+          3
+        ],
+        "support_label_modes": [
+          "PRIVATE_IN_ALL_DELETION_HALOS",
+          "INTERNAL_TO_ONE_DELETION_CLOSURE"
+        ],
+        "support_labels": [
+          5,
+          6
+        ],
+        "support_packet": "bootstrap_t12_one_outside"
+      },
+      "witnesses": [
+        0,
+        2,
+        5,
+        6
+      ]
+    },
+    {
+      "activation_deficit_from_bootstrap_core": 2,
+      "bootstrap_core_witnesses": [
+        0
+      ],
+      "bridge_lemma_target": "Promote the outside-pair support, with partial private-pair ledger contact, to an equality-connector row-forcing lemma.",
+      "classification_assignment_id": "A152",
+      "outside_witnesses": [
+        3,
+        5,
+        8
+      ],
+      "pressure_class": "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER",
+      "relation_state_counts": {
+        "SUPPORT_SUFFICIENT": 1
+      },
+      "relation_sufficient_requirement_count": 1,
+      "relation_sufficient_requirements": [
+        {
+          "bootstrap_core_status": "PARTIAL",
+          "closure_sufficient_count": 0,
+          "kind": "equality_connector_pair",
+          "missing_from_bootstrap_core": [
+            8
+          ],
+          "relation_state": "SUPPORT_SUFFICIENT",
+          "required_witnesses": [
+            0,
+            8
+          ],
+          "requirement_id": "151:6:connector:2:0",
+          "support_sufficient_count": 2
+        }
+      ],
+      "requirement_count": 1,
+      "roles": [
+        "equality_connector_row"
+      ],
+      "row_center": 6,
+      "row_center_private_in_all_deletion_closures": true,
+      "row_forcing_gap_type": "OUTSIDE_PAIR_SUPPORT_NEEDS_CONNECTOR_ROW_FORCING",
+      "row_target_status": "OUTSIDE_PAIR_CONNECTOR_PARTIAL_LEDGER",
+      "source_record_id": 151,
+      "support_packet_summary": {
+        "ledger_hit_support_pairs": [
+          [
+            3,
+            8
+          ],
+          [
+            5,
+            8
+          ]
+        ],
+        "ledger_miss_support_pairs": [
+          [
+            3,
+            5
+          ]
+        ],
+        "ledger_private_pair_support_hit_count": 2,
+        "support_packet": "bootstrap_t12_outside_pair",
+        "support_pair_modes": [
+          "PRIVATE_HALO_ONLY",
+          "LEDGER_PRIVATE_PAIR_HIT",
+          "LEDGER_PRIVATE_PAIR_HIT"
+        ],
+        "support_pairs": [
+          [
+            3,
+            5
+          ],
+          [
+            3,
+            8
+          ],
+          [
+            5,
+            8
+          ]
+        ]
+      },
+      "witnesses": [
+        0,
+        3,
+        5,
+        8
+      ]
+    }
+  ],
+  "schema": "erdos97.bootstrap_t12_relation_sufficient_rows.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_bridge_target_map.json",
+      "role": "source relation states, support packets, and bridge targets",
+      "schema": "erdos97.bootstrap_t12_bridge_target_map.v1",
+      "status": "BOOTSTRAP_T12_BRIDGE_TARGET_MAP_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_RELATION_SUFFICIENT_ROWS_DIAGNOSTIC_ONLY",
+  "summary": {
+    "excluded_hard_or_open_rows": [
+      "151:5",
+      "151:7",
+      "151:8"
+    ],
+    "next_bridge_question": "Can relation-sufficient connector evidence be upgraded to genuine row/rich-class forcing for these three T12 targets?",
+    "pressure_class_counts": {
+      "ALREADY_PRESENT_IN_A_DELETION_CLOSURE": 1,
+      "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 1,
+      "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER": 1
+    },
+    "relation_state_counts": {
+      "BOOTSTRAP_CORE_SUFFICIENT": 2,
+      "SUPPORT_SUFFICIENT": 1
+    },
+    "relation_sufficient_requirement_ids": [
+      "81:3:connector:2:0",
+      "81:8:connector:0:0",
+      "151:6:connector:2:0"
+    ],
+    "relation_sufficient_row_count": 3,
+    "requirement_kind_counts": {
+      "equality_connector_pair": 3
+    },
+    "role_counts": {
+      "equality_connector_row": 3
+    },
+    "row_centers_by_source_id": {
+      "151": [
+        6
+      ],
+      "81": [
+        3,
+        8
+      ]
+    },
+    "row_forcing_gap_type_counts": {
+      "CORE_CONNECTOR_VISIBLE_NEEDS_PRIVATE_ROW_ACTIVATION": 1,
+      "FULL_ROW_CLOSURE_EXPOSURE_NEEDS_RICH_CLASS_FORCING": 1,
+      "OUTSIDE_PAIR_SUPPORT_NEEDS_CONNECTOR_ROW_FORCING": 1
+    },
+    "row_forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "row_target_status_counts": {
+      "CLOSURE_FULL_ROW_CONNECTOR": 1,
+      "CORE_CONNECTOR_WITH_SINGLETON_ROW_ACTIVATION": 1,
+      "OUTSIDE_PAIR_CONNECTOR_PARTIAL_LEDGER": 1
+    },
+    "source_record_ids": [
+      81,
+      151
+    ],
+    "support_packet_counts": {
+      "bootstrap_t12_closure_exposed": 1,
+      "bootstrap_t12_one_outside": 1,
+      "bootstrap_t12_outside_pair": 1
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-bridge-target-map.md
+++ b/docs/bootstrap-t12-bridge-target-map.md
@@ -90,6 +90,12 @@ The open connector-pair follow-up in
 control, row `151:5`, where singleton supports and one deletion closure see
 only one endpoint of connector pair `[7,8]`.
 
+The relation-sufficient row follow-up in
+`docs/bootstrap-t12-relation-sufficient-rows.md` isolates the complementary
+positive-control bucket: rows `81:3`, `81:8`, and `151:6`, where connector
+relation evidence is already bootstrap-core sufficient or support-sufficient,
+but row/rich-class forcing remains an open bridge target.
+
 ## What This Does Not Prove
 
 This artifact does not prove that any missing T12 row is forced, does not prove

--- a/docs/bootstrap-t12-relation-sufficient-rows.md
+++ b/docs/bootstrap-t12-relation-sufficient-rows.md
@@ -1,0 +1,94 @@
+# Bootstrap T12 Relation-Sufficient Rows
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the T12 bridge-target rows whose stored connector relation
+requirements are already supplied by bootstrap-core or support diagnostics,
+while the row/rich-class forcing step remains open. It answers a narrower
+question than row forcing:
+
+```text
+Which T12 row targets have relation evidence already available, but still need
+a geometric argument that the whole selected row is forced?
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_relation_sufficient_rows.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_relation_sufficient_rows.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_relation_sufficient_rows.json`.
+
+## Scope
+
+The input packet is:
+
+- `data/certificates/bootstrap_t12_bridge_target_map.json`.
+
+This packet is not full rich-class data. A relation-sufficient row is a fixed
+selected-row bridge target whose connector requirement is already visible in
+the bootstrap core or in stored support options. That is not a theorem that
+the row itself is geometrically forced.
+
+## Results
+
+There are three relation-sufficient row targets:
+
+| Source | Row | Requirement | Relation state | Row-forcing gap |
+|---:|---:|---|---|---|
+| `81` | `3` | `81:3:connector:2:0` | bootstrap-core sufficient | full-row closure exposure still needs rich-class forcing |
+| `81` | `8` | `81:8:connector:0:0` | bootstrap-core sufficient | core connector visible, but private singleton row activation remains |
+| `151` | `6` | `151:6:connector:2:0` | support sufficient | outside-pair support still needs connector row forcing |
+
+Headline counts:
+
+```text
+relation-sufficient rows: 3
+bootstrap-core sufficient requirements: 2
+support-sufficient requirements: 1
+closure-exposed support packets: 1
+one-outside-label support packets: 1
+outside-pair support packets: 1
+excluded hard/open rows: 151:5, 151:7, 151:8
+```
+
+## Reading
+
+Row `81:3` is the cleanest closure-exposed positive control: the deletion
+closure contains the row center and all four selected row witnesses, and the
+stored connector pair `[0,1]` is already in the bootstrap core. A future bridge
+lemma would still need to turn this fixed-row closure exposure into an actual
+equality-connector rich class.
+
+Row `81:8` has connector pair `[0,2]` already in the bootstrap core, and its
+outside labels `[5,6]` have singleton support options. The missing step is not
+the relation itself; it is the geometric argument that a private row center
+plus singleton support activates the whole row.
+
+Row `151:6` has connector pair `[0,8]`, with support-sufficient outside-pair
+options and two private-pair ledger hits, `[3,8]` and `[5,8]`. The packet keeps
+that as partial support only; it does not promote the ledger contact to row
+forcing.
+
+## What This Does Not Prove
+
+This artifact does not prove that any relation-sufficient row, connector
+endpoint, row center, or rich class is forced. It does not prove `n=9`, does
+not prove the bootstrap bridge, does not independently review the
+vertex-circle checker, and does not alter the official/global status of Erdos
+Problem #97.
+
+## Reviewer Focus
+
+The exact next bridge question is whether relation-sufficient connector
+evidence can be upgraded to genuine row/rich-class forcing for rows `81:3`,
+`81:8`, and `151:6`. This is intentionally separate from the hard strict
+endpoint packet and the open connector-pair packet.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -532,6 +532,12 @@ deletion closure for core vertex `2` and the two singleton supports each supply
 only one connector endpoint. This is diagnostic bookkeeping only, not a lemma
 that connector pairs or missing rows are forced.
 
+The relation-sufficient row packet in
+`docs/bootstrap-t12-relation-sufficient-rows.md` isolates rows `81:3`, `81:8`,
+and `151:6`. Their connector requirements are already bootstrap-core
+sufficient or support-sufficient, but this is still diagnostic bookkeeping
+only, not a lemma that those rows or rich classes are forced.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -64,6 +64,10 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-open-connector-pair.md` isolates row `151:5`, where the
    connector pair `[7,8]` is still split across singleton support and partial
    closure evidence.
+   The relation-sufficient row subpacket in
+   `docs/bootstrap-t12-relation-sufficient-rows.md` isolates rows `81:3`,
+   `81:8`, and `151:6`, where connector relation evidence is already present
+   but row/rich-class forcing remains open.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-open-connector-pair.md`](bootstrap-t12-open-connector-pair.md):
   focused packet isolating the open equality-connector pair gap in row
   `151:5`.
+- [`bootstrap-t12-relation-sufficient-rows.md`](bootstrap-t12-relation-sufficient-rows.md):
+  focused packet isolating rows `81:3`, `81:8`, and `151:6`, where connector
+  relation evidence is already present but row/rich-class forcing remains
+  open.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -352,6 +352,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-t12-open-connector-pair.md`, isolating `151:5` as the row
   where connector pair `[7,8]` is still split across singleton support and
   partial closure evidence.
+- bootstrap/T12 relation-sufficient row evidence, as recorded in
+  `docs/bootstrap-t12-relation-sufficient-rows.md`, isolating `81:3`, `81:8`,
+  and `151:6` as rows where connector relation evidence is present but
+  row/rich-class forcing remains open.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -198,6 +198,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_open_connector_pair.json"
       verifier: "scripts/check_bootstrap_t12_open_connector_pair.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; isolates incomplete equality-connector pair support in row 151:5, but does not prove endpoints or rows are forced and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_relation_sufficient_rows"
+      status: "relation-sufficient row subpacket for the three T12/F16 row targets whose connector requirements are already supplied"
+      artifact: "data/certificates/bootstrap_t12_relation_sufficient_rows.json"
+      verifier: "scripts/check_bootstrap_t12_relation_sufficient_rows.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates rows 81:3, 81:8, and 151:6 where connector relation evidence is present but row/rich-class forcing remains open, and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2208,6 +2208,66 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_relation_sufficient_rows
+    path: data/certificates/bootstrap_t12_relation_sufficient_rows.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_relation_sufficient_rows.py
+    command: python scripts/check_bootstrap_t12_relation_sufficient_rows.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_relation_sufficient_rows.py
+    check_command: python scripts/check_bootstrap_t12_relation_sufficient_rows.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Relation-sufficient row diagnostic for the two tight n=9 bootstrap-core rows; not a proof that endpoints or missing rows are forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_relation_sufficient_rows.v1
+      status: BOOTSTRAP_T12_RELATION_SUFFICIENT_ROWS_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 81
+        - 151
+      summary.relation_sufficient_row_count: 3
+      summary.row_centers_by_source_id.81:
+        - 3
+        - 8
+      summary.row_centers_by_source_id.151:
+        - 6
+      summary.relation_sufficient_requirement_ids:
+        - "81:3:connector:2:0"
+        - "81:8:connector:0:0"
+        - "151:6:connector:2:0"
+      summary.relation_state_counts.BOOTSTRAP_CORE_SUFFICIENT: 2
+      summary.relation_state_counts.SUPPORT_SUFFICIENT: 1
+      summary.requirement_kind_counts.equality_connector_pair: 3
+      summary.row_forcing_gap_type_counts.FULL_ROW_CLOSURE_EXPOSURE_NEEDS_RICH_CLASS_FORCING: 1
+      summary.row_forcing_gap_type_counts.CORE_CONNECTOR_VISIBLE_NEEDS_PRIVATE_ROW_ACTIVATION: 1
+      summary.row_forcing_gap_type_counts.OUTSIDE_PAIR_SUPPORT_NEEDS_CONNECTOR_ROW_FORCING: 1
+      summary.support_packet_counts.bootstrap_t12_closure_exposed: 1
+      summary.support_packet_counts.bootstrap_t12_one_outside: 1
+      summary.support_packet_counts.bootstrap_t12_outside_pair: 1
+      summary.excluded_hard_or_open_rows:
+        - "151:5"
+        - "151:7"
+        - "151:8"
+      summary.row_forcing_target_status: OPEN_TARGET_NOT_PROVED
+      provenance.generator: scripts/check_bootstrap_t12_relation_sufficient_rows.py
+      provenance.command: python scripts/check_bootstrap_t12_relation_sufficient_rows.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - connector relation evidence proves row forcing
+      - support sufficiency proves a rich class
+      - closure exposure proves a row is forced
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_relation_sufficient_rows.py
+++ b/scripts/check_bootstrap_t12_relation_sufficient_rows.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 relation-sufficient row packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_relation_sufficient_rows import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_relation_sufficient_rows_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 relation-sufficient rows")
+    print(f"relation-sufficient rows: {summary['relation_sufficient_row_count']}")
+    print(f"relation states: {summary['relation_state_counts']}")
+    print(f"row-forcing gaps: {summary['row_forcing_gap_type_counts']}")
+    print(f"excluded hard/open rows: {summary['excluded_hard_or_open_rows']}")
+    print(f"target status: {summary['row_forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned counts")
+    args = parser.parse_args()
+
+    generated = build_t12_relation_sufficient_rows_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(
+                f"{artifact} is stale relative to regenerated packet"
+            )
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 relation-sufficient artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 relation-sufficient expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_relation_sufficient_rows.py
+++ b/src/erdos97/bootstrap_t12_relation_sufficient_rows.py
@@ -1,0 +1,355 @@
+"""Relation-sufficient row packet for the bootstrap/T12 target.
+
+This module isolates the T12 bridge-target rows whose role-sensitive relation
+requirements are already supplied by bootstrap-core or support diagnostics,
+while the actual row/rich-class forcing step remains open. It is proof-mining
+bookkeeping only; it does not prove that any missing row is forced.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from erdos97.bootstrap_t12_bridge_target_map import (
+    RELATION_BOOTSTRAP_CORE,
+    RELATION_CLOSURE,
+    RELATION_HARD_STRICT,
+    RELATION_OPEN,
+    RELATION_OPEN_CONNECTOR,
+    RELATION_SUPPORT,
+    build_t12_bridge_target_map_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_relation_sufficient_rows.v1"
+STATUS = "BOOTSTRAP_T12_RELATION_SUFFICIENT_ROWS_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Relation-sufficient row diagnostic for the two tight n=9 bootstrap/T12 "
+    "records; isolates rows whose connector requirements are already supplied "
+    "by bootstrap-core or support diagnostics, while row/rich-class forcing "
+    "remains an open bridge target. This does not prove that the missing rows "
+    "are forced, does not prove n=9, does not prove the bridge, and does not "
+    "claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_relation_sufficient_rows.json"
+)
+
+RELATION_SUFFICIENT_STATES = {
+    RELATION_BOOTSTRAP_CORE,
+    RELATION_CLOSURE,
+    RELATION_SUPPORT,
+}
+RELATION_BLOCKER_STATES = {
+    RELATION_HARD_STRICT,
+    RELATION_OPEN,
+    RELATION_OPEN_CONNECTOR,
+}
+
+GAP_FULL_ROW_CLOSURE = "FULL_ROW_CLOSURE_EXPOSURE_NEEDS_RICH_CLASS_FORCING"
+GAP_SINGLETON_ACTIVATION = "CORE_CONNECTOR_VISIBLE_NEEDS_PRIVATE_ROW_ACTIVATION"
+GAP_OUTSIDE_PAIR_SUPPORT = "OUTSIDE_PAIR_SUPPORT_NEEDS_CONNECTOR_ROW_FORCING"
+
+ROW_FORCING_GAP_TYPES = {
+    "CLOSURE_FULL_ROW_CONNECTOR": GAP_FULL_ROW_CLOSURE,
+    "CORE_CONNECTOR_WITH_SINGLETON_ROW_ACTIVATION": GAP_SINGLETON_ACTIVATION,
+    "OUTSIDE_PAIR_CONNECTOR_PARTIAL_LEDGER": GAP_OUTSIDE_PAIR_SUPPORT,
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _record_key(record: Mapping[str, Any]) -> tuple[int, int]:
+    return int(record["source_record_id"]), int(record["row_center"])
+
+
+def _row_key_string(record: Mapping[str, Any]) -> str:
+    return f"{record['source_record_id']}:{record['row_center']}"
+
+
+def _relation_sufficient_requirements(
+    record: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    requirements = []
+    for requirement in record["requirements"]:
+        relation_state = str(requirement["relation_state"])
+        if relation_state not in RELATION_SUFFICIENT_STATES:
+            continue
+        requirements.append(
+            {
+                "requirement_id": str(requirement["requirement_id"]),
+                "kind": str(requirement["kind"]),
+                "required_witnesses": _int_list(
+                    requirement["required_witnesses"]
+                ),
+                "relation_state": relation_state,
+                "bootstrap_core_status": str(requirement["bootstrap_core_status"]),
+                "support_sufficient_count": int(
+                    requirement["support_sufficient_count"]
+                ),
+                "closure_sufficient_count": int(
+                    requirement["closure_sufficient_count"]
+                ),
+                "missing_from_bootstrap_core": _int_list(
+                    requirement["missing_from_bootstrap_core"]
+                ),
+            }
+        )
+    return requirements
+
+
+def _is_relation_sufficient_row(record: Mapping[str, Any]) -> bool:
+    relation_states = set(str(state) for state in record["relation_state_counts"])
+    return bool(relation_states) and relation_states <= RELATION_SUFFICIENT_STATES
+
+
+def _has_blocker_state(record: Mapping[str, Any]) -> bool:
+    relation_states = set(str(state) for state in record["relation_state_counts"])
+    return bool(relation_states & RELATION_BLOCKER_STATES)
+
+
+def _gap_type(record: Mapping[str, Any]) -> str:
+    row_target_status = str(record["row_target_status"])
+    try:
+        return ROW_FORCING_GAP_TYPES[row_target_status]
+    except KeyError as exc:
+        raise AssertionError(
+            f"unexpected relation-sufficient target status {row_target_status!r}"
+        ) from exc
+
+
+def _relation_sufficient_record(record: Mapping[str, Any]) -> dict[str, object]:
+    relation_requirements = _relation_sufficient_requirements(record)
+    return {
+        "source_record_id": int(record["source_record_id"]),
+        "classification_assignment_id": str(record["classification_assignment_id"]),
+        "row_center": int(record["row_center"]),
+        "roles": [str(role) for role in record["roles"]],
+        "witnesses": _int_list(record["witnesses"]),
+        "bootstrap_core_witnesses": _int_list(record["bootstrap_core_witnesses"]),
+        "outside_witnesses": _int_list(record["outside_witnesses"]),
+        "activation_deficit_from_bootstrap_core": int(
+            record["activation_deficit_from_bootstrap_core"]
+        ),
+        "row_center_private_in_all_deletion_closures": bool(
+            record["row_center_private_in_all_deletion_closures"]
+        ),
+        "pressure_class": str(record["pressure_class"]),
+        "support_packet_summary": record["support_packet_summary"],
+        "requirement_count": int(record["requirement_count"]),
+        "relation_sufficient_requirement_count": len(relation_requirements),
+        "relation_sufficient_requirements": relation_requirements,
+        "relation_state_counts": {
+            str(state): int(count)
+            for state, count in record["relation_state_counts"].items()
+        },
+        "row_target_status": str(record["row_target_status"]),
+        "row_forcing_gap_type": _gap_type(record),
+        "bridge_lemma_target": str(record["bridge_lemma_target"]),
+    }
+
+
+def build_t12_relation_sufficient_rows_payload() -> dict[str, object]:
+    """Return the deterministic relation-sufficient row packet."""
+
+    bridge_map = build_t12_bridge_target_map_payload()
+    all_records = bridge_map["records"]
+    records = [
+        _relation_sufficient_record(record)
+        for record in all_records
+        if _is_relation_sufficient_row(record)
+    ]
+    records.sort(key=lambda record: (int(record["source_record_id"]), int(record["row_center"])))
+
+    excluded_hard_or_open = [
+        _row_key_string(record) for record in all_records if _has_blocker_state(record)
+    ]
+    rows_by_source: defaultdict[int, list[int]] = defaultdict(list)
+    gap_type_counts: Counter[str] = Counter()
+    pressure_counts: Counter[str] = Counter()
+    target_status_counts: Counter[str] = Counter()
+    role_counts: Counter[str] = Counter()
+    support_packet_counts: Counter[str] = Counter()
+    relation_state_counts: Counter[str] = Counter()
+    requirement_kind_counts: Counter[str] = Counter()
+    for record in records:
+        rows_by_source[int(record["source_record_id"])].append(int(record["row_center"]))
+        gap_type_counts[str(record["row_forcing_gap_type"])] += 1
+        pressure_counts[str(record["pressure_class"])] += 1
+        target_status_counts[str(record["row_target_status"])] += 1
+        role_counts.update(str(role) for role in record["roles"])
+        support_packet_counts[str(record["support_packet_summary"]["support_packet"])] += 1
+        for requirement in record["relation_sufficient_requirements"]:
+            relation_state_counts[str(requirement["relation_state"])] += 1
+            requirement_kind_counts[str(requirement["kind"])] += 1
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates relation-sufficient fixed selected rows; it does not prove row or rich-class forcing.",
+            "Bootstrap-core or support sufficiency for a role requirement is not a Euclidean certificate that the whole row is forced.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": sorted(rows_by_source),
+            "relation_sufficient_row_count": len(records),
+            "row_centers_by_source_id": {
+                str(source_id): centers for source_id, centers in sorted(rows_by_source.items())
+            },
+            "relation_sufficient_requirement_ids": [
+                str(requirement["requirement_id"])
+                for record in records
+                for requirement in record["relation_sufficient_requirements"]
+            ],
+            "relation_state_counts": _json_counter(relation_state_counts),
+            "requirement_kind_counts": _json_counter(requirement_kind_counts),
+            "row_forcing_gap_type_counts": _json_counter(gap_type_counts),
+            "pressure_class_counts": _json_counter(pressure_counts),
+            "row_target_status_counts": _json_counter(target_status_counts),
+            "role_counts": _json_counter(role_counts),
+            "support_packet_counts": _json_counter(support_packet_counts),
+            "excluded_hard_or_open_rows": sorted(excluded_hard_or_open),
+            "row_forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+            "next_bridge_question": (
+                "Can relation-sufficient connector evidence be upgraded to "
+                "genuine row/rich-class forcing for these three T12 targets?"
+            ),
+        },
+        "records": records,
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_bridge_target_map.json",
+                "role": "source relation states, support packets, and bridge targets",
+                "schema": bridge_map.get("schema"),
+                "status": bridge_map.get("status"),
+                "trust": bridge_map.get("trust"),
+            }
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_relation_sufficient_rows.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_relation_sufficient_rows.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the relation-sufficient row packet."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected bootstrap/T12 relation-sufficient schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected bootstrap/T12 relation-sufficient status")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [81, 151],
+        "relation_sufficient_row_count": 3,
+        "row_centers_by_source_id": {"81": [3, 8], "151": [6]},
+        "relation_sufficient_requirement_ids": [
+            "81:3:connector:2:0",
+            "81:8:connector:0:0",
+            "151:6:connector:2:0",
+        ],
+        "relation_state_counts": {
+            RELATION_BOOTSTRAP_CORE: 2,
+            RELATION_SUPPORT: 1,
+        },
+        "requirement_kind_counts": {"equality_connector_pair": 3},
+        "row_forcing_gap_type_counts": {
+            GAP_FULL_ROW_CLOSURE: 1,
+            GAP_OUTSIDE_PAIR_SUPPORT: 1,
+            GAP_SINGLETON_ACTIVATION: 1,
+        },
+        "pressure_class_counts": {
+            "ALREADY_PRESENT_IN_A_DELETION_CLOSURE": 1,
+            "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER": 1,
+            "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER": 1,
+        },
+        "row_target_status_counts": {
+            "CLOSURE_FULL_ROW_CONNECTOR": 1,
+            "CORE_CONNECTOR_WITH_SINGLETON_ROW_ACTIVATION": 1,
+            "OUTSIDE_PAIR_CONNECTOR_PARTIAL_LEDGER": 1,
+        },
+        "role_counts": {"equality_connector_row": 3},
+        "support_packet_counts": {
+            "bootstrap_t12_closure_exposed": 1,
+            "bootstrap_t12_one_outside": 1,
+            "bootstrap_t12_outside_pair": 1,
+        },
+        "excluded_hard_or_open_rows": ["151:5", "151:7", "151:8"],
+        "row_forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary {key} is {summary.get(key)!r}, expected {expected!r}")
+
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("records must be a list")
+    by_key = {_record_key(record): record for record in records}
+    if set(by_key) != {(81, 3), (81, 8), (151, 6)}:
+        raise AssertionError("unexpected relation-sufficient record keys")
+
+    row_81_3 = by_key[(81, 3)]
+    if row_81_3["row_forcing_gap_type"] != GAP_FULL_ROW_CLOSURE:
+        raise AssertionError("81:3 gap type changed")
+    if not row_81_3["support_packet_summary"]["full_row_contained_in_exposure_closure"]:
+        raise AssertionError("81:3 must remain full-row closure exposed")
+    if row_81_3["relation_sufficient_requirements"][0]["relation_state"] != RELATION_BOOTSTRAP_CORE:
+        raise AssertionError("81:3 relation state changed")
+
+    row_81_8 = by_key[(81, 8)]
+    if row_81_8["row_forcing_gap_type"] != GAP_SINGLETON_ACTIVATION:
+        raise AssertionError("81:8 gap type changed")
+    if row_81_8["support_packet_summary"]["support_labels"] != [5, 6]:
+        raise AssertionError("81:8 singleton support labels changed")
+    if not row_81_8["row_center_private_in_all_deletion_closures"]:
+        raise AssertionError("81:8 private row-center flag changed")
+
+    row_151_6 = by_key[(151, 6)]
+    if row_151_6["row_forcing_gap_type"] != GAP_OUTSIDE_PAIR_SUPPORT:
+        raise AssertionError("151:6 gap type changed")
+    requirement = row_151_6["relation_sufficient_requirements"][0]
+    if requirement["relation_state"] != RELATION_SUPPORT:
+        raise AssertionError("151:6 relation state changed")
+    if requirement["required_witnesses"] != [0, 8]:
+        raise AssertionError("151:6 connector witnesses changed")
+    support_summary = row_151_6["support_packet_summary"]
+    if support_summary["ledger_hit_support_pairs"] != [[3, 8], [5, 8]]:
+        raise AssertionError("151:6 ledger hit support pairs changed")
+    if support_summary["ledger_miss_support_pairs"] != [[3, 5]]:
+        raise AssertionError("151:6 ledger miss support pairs changed")

--- a/tests/test_bootstrap_t12_relation_sufficient_rows.py
+++ b/tests/test_bootstrap_t12_relation_sufficient_rows.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.bootstrap_t12_bridge_target_map import (
+    RELATION_BOOTSTRAP_CORE,
+    RELATION_SUPPORT,
+)
+from erdos97.bootstrap_t12_relation_sufficient_rows import (
+    DEFAULT_ARTIFACT,
+    GAP_FULL_ROW_CLOSURE,
+    GAP_OUTSIDE_PAIR_SUPPORT,
+    GAP_SINGLETON_ACTIVATION,
+    assert_expected_payload,
+    build_t12_relation_sufficient_rows_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _records(payload: dict[str, object]) -> dict[tuple[int, int], dict[str, object]]:
+    return {
+        (int(record["source_record_id"]), int(record["row_center"])): record
+        for record in payload["records"]
+    }
+
+
+def test_relation_sufficient_counts_and_scope() -> None:
+    payload = build_t12_relation_sufficient_rows_payload()
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_RELATION_SUFFICIENT_ROWS_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "row/rich-class forcing remains an open bridge target" in claim_scope
+    assert "does not prove that the missing rows are forced" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert payload["summary"]["relation_sufficient_row_count"] == 3
+    assert payload["summary"]["excluded_hard_or_open_rows"] == [
+        "151:5",
+        "151:7",
+        "151:8",
+    ]
+
+
+def test_relation_sufficient_full_row_closure_gap() -> None:
+    payload = build_t12_relation_sufficient_rows_payload()
+    row_81_3 = _records(payload)[(81, 3)]
+    assert row_81_3["row_forcing_gap_type"] == GAP_FULL_ROW_CLOSURE
+    assert row_81_3["row_target_status"] == "CLOSURE_FULL_ROW_CONNECTOR"
+    assert row_81_3["support_packet_summary"]["support_packet"] == (
+        "bootstrap_t12_closure_exposed"
+    )
+    assert row_81_3["support_packet_summary"][
+        "full_row_contained_in_exposure_closure"
+    ]
+    requirement = row_81_3["relation_sufficient_requirements"][0]
+    assert requirement["requirement_id"] == "81:3:connector:2:0"
+    assert requirement["relation_state"] == RELATION_BOOTSTRAP_CORE
+    assert requirement["required_witnesses"] == [0, 1]
+    assert requirement["closure_sufficient_count"] == 1
+
+
+def test_relation_sufficient_singleton_activation_gap() -> None:
+    payload = build_t12_relation_sufficient_rows_payload()
+    row_81_8 = _records(payload)[(81, 8)]
+    assert row_81_8["row_forcing_gap_type"] == GAP_SINGLETON_ACTIVATION
+    assert row_81_8["row_target_status"] == (
+        "CORE_CONNECTOR_WITH_SINGLETON_ROW_ACTIVATION"
+    )
+    assert row_81_8["row_center_private_in_all_deletion_closures"]
+    assert row_81_8["support_packet_summary"]["support_labels"] == [5, 6]
+    assert row_81_8["support_packet_summary"]["private_halo_containment_counts"] == [
+        4,
+        3,
+    ]
+    requirement = row_81_8["relation_sufficient_requirements"][0]
+    assert requirement["requirement_id"] == "81:8:connector:0:0"
+    assert requirement["relation_state"] == RELATION_BOOTSTRAP_CORE
+    assert requirement["support_sufficient_count"] == 2
+    assert requirement["missing_from_bootstrap_core"] == []
+
+
+def test_relation_sufficient_outside_pair_support_gap() -> None:
+    payload = build_t12_relation_sufficient_rows_payload()
+    row_151_6 = _records(payload)[(151, 6)]
+    assert row_151_6["row_forcing_gap_type"] == GAP_OUTSIDE_PAIR_SUPPORT
+    assert row_151_6["row_target_status"] == "OUTSIDE_PAIR_CONNECTOR_PARTIAL_LEDGER"
+    assert row_151_6["support_packet_summary"]["support_packet"] == (
+        "bootstrap_t12_outside_pair"
+    )
+    assert row_151_6["support_packet_summary"]["ledger_hit_support_pairs"] == [
+        [3, 8],
+        [5, 8],
+    ]
+    assert row_151_6["support_packet_summary"]["ledger_miss_support_pairs"] == [
+        [3, 5],
+    ]
+    requirement = row_151_6["relation_sufficient_requirements"][0]
+    assert requirement["requirement_id"] == "151:6:connector:2:0"
+    assert requirement["relation_state"] == RELATION_SUPPORT
+    assert requirement["required_witnesses"] == [0, 8]
+    assert requirement["missing_from_bootstrap_core"] == [8]
+    assert requirement["support_sufficient_count"] == 2
+
+
+def test_relation_sufficient_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_relation_sufficient_rows_payload()
+
+
+def test_relation_sufficient_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_relation_sufficient_rows.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["relation_sufficient_requirement_ids"] == [
+        "81:3:connector:2:0",
+        "81:8:connector:0:0",
+        "151:6:connector:2:0",
+    ]
+
+
+def test_relation_sufficient_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_relation_sufficient_rows.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_relation_sufficient_rows.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_relation_sufficient_rows.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )


### PR DESCRIPTION
## Summary
- Add a generator/checker and checked JSON artifact for the three relation-sufficient T12 row targets: `81:3`, `81:8`, and `151:6`.
- Document the packet as diagnostic-only, with explicit exclusions for the hard/open rows `151:5`, `151:7`, and `151:8`.
- Register the artifact in metadata/provenance and add regression tests for pinned counts and row-level summaries.

## Checks
- `python scripts/check_bootstrap_t12_relation_sufficient_rows.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_relation_sufficient_rows.py -q`
- `python -m ruff check src\erdos97\bootstrap_t12_relation_sufficient_rows.py scripts\check_bootstrap_t12_relation_sufficient_rows.py tests\test_bootstrap_t12_relation_sufficient_rows.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`693 passed, 281 deselected`)