### PR TITLE
Add bootstrap T12 81:3 closure target packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the relation-sufficient row subpacket isolating rows `81:3`, `81:8`,
   and `151:6`, read
   [`docs/bootstrap-t12-relation-sufficient-rows.md`](docs/bootstrap-t12-relation-sufficient-rows.md).
+- For the focused `81:3` closure target, where full-row deletion-closure
+  exposure, relation sufficiency, and the final T12 connector role meet, read
+  [`docs/bootstrap-t12-81-3-closure-target.md`](docs/bootstrap-t12-81-3-closure-target.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -243,6 +243,17 @@ to a bridge theorem. This is still diagnostic bookkeeping only; see
 `scripts/check_bootstrap_t12_relation_sufficient_rows.py`, and
 `data/certificates/bootstrap_t12_relation_sufficient_rows.json`.
 
+The focused `81:3` closure-target packet extracts the cleanest current
+subcase from those ledgers. Source `81` row `3` is the unique
+relation-sufficient target whose full fixed selected row is contained in a
+deletion closure, with closure labels `[0,1,3,4,6]`; it is also the one-step
+T12 equality connector `[1,3]=[0,3]`. The packet records the exact remaining
+gap as fixed full-row closure evidence versus genuine rich-class forcing. This
+is still diagnostic bookkeeping only; see
+`docs/bootstrap-t12-81-3-closure-target.md`,
+`scripts/check_bootstrap_t12_81_3_closure_target.py`, and
+`data/certificates/bootstrap_t12_81_3_closure_target.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -132,6 +132,13 @@ forcing step open. This is diagnostic bookkeeping only, not a theorem that
 the relation-sufficient rows are forced. See
 `docs/bootstrap-t12-relation-sufficient-rows.md`.
 
+A focused `81:3` closure-target packet now isolates the sharpest current
+bridge subcase: source `81` row `3` is the unique relation-sufficient target
+whose full fixed selected row is contained in a deletion closure, and it is
+the final equality connector `[1,3]=[0,3]` in the `T12/F16` local strict-cycle
+packet. The missing step is still genuine row/rich-class forcing, not more
+fixed-row bookkeeping. See `docs/bootstrap-t12-81-3-closure-target.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_81_3_closure_target.json
+++ b/data/certificates/bootstrap_t12_81_3_closure_target.json
@@ -1,0 +1,258 @@
+{
+  "candidate_lemma_contract": {
+    "current_status": "open_diagnostic_target",
+    "desired_conclusion": [
+      "center 3 has a rich class containing witnesses [0,1,4,6]",
+      "or at least center 3 forces the equality connector [1,3]=[0,3]"
+    ],
+    "escape_packet_if_false": "construct a rich-class catalogue in which the deletion closure contains the fixed row labels but center 3 can avoid the required equality connector",
+    "known_insufficient_inputs": [
+      "fixed selected-row membership in a deletion closure",
+      "bootstrap-core sufficiency of the stored connector pair"
+    ],
+    "name": "81:3 full-row closure exposure to equality connector"
+  },
+  "claim_scope": "Focused diagnostic for source 81 row 3: the unique relation-sufficient T12/F16 target whose full fixed selected row is contained in a deletion closure, and the row that supplies the final T12 equality connector. This does not prove the row is forced, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "interpretation_warnings": [
+    "This packet isolates one fixed selected row target; it does not prove row or rich-class forcing.",
+    "Full-row containment in a deletion closure is not by itself a Euclidean rich-class certificate.",
+    "The T12 connector role is conditional on the row being geometrically available.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_closure_target.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_closure_target.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_closure_target.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_closure_exposed.json",
+      "role": "source full-row deletion-closure exposure for 81:3",
+      "schema": "erdos97.bootstrap_t12_closure_exposed.v1",
+      "status": "BOOTSTRAP_T12_CLOSURE_EXPOSED_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_relation_sufficient_rows.json",
+      "role": "source relation-sufficient connector requirement for 81:3",
+      "schema": "erdos97.bootstrap_t12_relation_sufficient_rows.v1",
+      "status": "BOOTSTRAP_T12_RELATION_SUFFICIENT_ROWS_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
+      "role": "source T12/F16 local strict-cycle connector role",
+      "schema": "erdos97.n9_vertex_circle_t12_strict_cycle_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY",
+  "summary": {
+    "closure_labels": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "excluded_closure_exposed_rows": [
+      "151:7"
+    ],
+    "excluded_relation_sufficient_rows": [
+      "151:6",
+      "81:8"
+    ],
+    "exposed_core_vertex": 2,
+    "full_row_closure_relation_sufficient_target_count": 1,
+    "full_row_closure_relation_sufficient_targets": [
+      "81:3"
+    ],
+    "next_bridge_question": "Can the 81:3 full-row deletion-closure exposure be promoted to genuine rich-class or equality-connector forcing?",
+    "relation_sufficient_requirement_ids": [
+      "81:3:connector:2:0"
+    ],
+    "required_connector_pair": [
+      0,
+      1
+    ],
+    "row_forcing_gap_type": "FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING",
+    "row_forcing_target_status": "OPEN_TARGET_NOT_PROVED",
+    "source_record_ids": [
+      81
+    ],
+    "t12_connector_pair_chain": [
+      [
+        1,
+        3
+      ],
+      [
+        0,
+        3
+      ]
+    ],
+    "target_row_center": 3,
+    "target_row_key": "81:3",
+    "target_witnesses": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "target_record": {
+    "bridge_lemma_target": "Turn a full-row deletion-closure exposure into a genuine equality-connector rich class.",
+    "classification_assignment_id": "A082",
+    "closure_exposure_mode": "CENTER_AND_FULL_ROW_IN_CLOSURE",
+    "closure_labels": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "closure_size": 5,
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "exposed_core_vertex": 2,
+    "full_row_contained_in_exposure_closure": true,
+    "known_evidence": [
+      "row center 3 is in the deletion closure for core vertex 2",
+      "all four fixed selected witnesses [0,1,4,6] are in that closure",
+      "the connector pair [0,1] is bootstrap-core sufficient",
+      "the row is a one-step equality connector in the T12/F16 local packet"
+    ],
+    "missing_geometric_promotion": [
+      "prove that closure membership forces a genuine rich class at center 3",
+      "or prove the weaker equality-connector forcing [1,3]=[0,3] at center 3",
+      "or exhibit a precise rich-class escape mechanism for this closure state"
+    ],
+    "outside_witnesses": [
+      6
+    ],
+    "outside_witnesses_in_closure": [
+      6
+    ],
+    "outside_witnesses_private": [],
+    "relation_requirement": {
+      "bootstrap_core_status": "SUFFICIENT",
+      "closure_sufficient_count": 1,
+      "kind": "equality_connector_pair",
+      "missing_from_bootstrap_core": [],
+      "relation_state": "BOOTSTRAP_CORE_SUFFICIENT",
+      "required_witnesses": [
+        0,
+        1
+      ],
+      "requirement_id": "81:3:connector:2:0",
+      "support_sufficient_count": 0
+    },
+    "roles": [
+      "equality_connector_row"
+    ],
+    "row_center": 3,
+    "row_center_in_closure": true,
+    "row_forcing_gap_type": "FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING",
+    "source_record_id": 81,
+    "t12_strict_cycle_role": {
+      "assignment_id": "A082",
+      "conditional_use": "Conditional: if a future bridge proves row 81:3 as a genuine rich class, this row supplies the T12 equality [1,3]=[0,3].",
+      "connector_pair_chain": [
+        [
+          1,
+          3
+        ],
+        [
+          0,
+          3
+        ]
+      ],
+      "cycle_step": 2,
+      "equality_step": {
+        "left_pair": [
+          1,
+          3
+        ],
+        "right_pair": [
+          0,
+          3
+        ],
+        "row": 3
+      },
+      "family_id": "F16",
+      "role": "final_equality_connector",
+      "row_center": 3,
+      "selected_row": [
+        3,
+        0,
+        1,
+        4,
+        6
+      ],
+      "strict_inequality_before_connector": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          7
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          6,
+          7
+        ]
+      },
+      "template_id": "T12",
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    "target_row_key": "81:3",
+    "witnesses": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "witnesses_in_closure": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-closure-target.md
+++ b/docs/bootstrap-t12-81-3-closure-target.md
@@ -1,0 +1,118 @@
+# Bootstrap T12 81:3 Closure Target
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note isolates the current first bootstrap/T12 bridge target: source `81`,
+row center `3`. It is the only row that is both relation-sufficient and fully
+contained in a deletion closure. It also supplies the final equality connector
+in the review-pending `T12/F16` strict-cycle local packet.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_closure_target.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_closure_target.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_closure_target.json`.
+
+## Scope
+
+The input packets are:
+
+- `data/certificates/bootstrap_t12_closure_exposed.json`;
+- `data/certificates/bootstrap_t12_relation_sufficient_rows.json`;
+- `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`.
+
+This packet is still fixed selected-row bookkeeping. Full containment of a
+stored selected row in a deletion closure is not a theorem that a real rich
+distance class must contain that row. The T12 connector role is useful only
+conditionally: it matters if a future bridge proves row `81:3` as a genuine
+rich class, or at least proves the equality connector supplied by that row.
+
+## Target Record
+
+For source `81` / assignment `A082`, the row is:
+
+```text
+center 3 -> witnesses [0,1,4,6]
+```
+
+The exposing deletion closure is for core vertex `2`:
+
+```text
+seed [0,1,4]
+closure labels [0,1,3,4,6]
+```
+
+So the closure contains the row center and all four fixed selected witnesses.
+The relation-sufficient packet records the connector requirement:
+
+```text
+81:3:connector:2:0
+required witnesses [0,1]
+relation state BOOTSTRAP_CORE_SUFFICIENT
+```
+
+The focused packet records the remaining gap as:
+
+```text
+FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING
+```
+
+## T12 Role
+
+In the `T12/F16` local strict-cycle packet, row `3` is the one-step equality
+connector:
+
+```text
+[1,3] = [0,3]
+```
+
+This closes the third strict-cycle step, where row `0` gives the strict edge
+
+```text
+[1,7] > [1,3].
+```
+
+If row `81:3` is genuinely available as a rich selected row, then the stored
+T12 local packet can use it to identify the inner pair `[1,3]` with the next
+outer pair `[0,3]`. The packet does not prove that availability.
+
+## Candidate Lemma Contract
+
+A future proof-facing lemma should prove one of the following:
+
+- center `3` has a rich class containing witnesses `[0,1,4,6]`;
+- center `3` forces at least the equality connector `[1,3]=[0,3]`;
+- or there is a precise rich-class escape mechanism showing how the fixed row
+  can be present in the closure ledger without becoming a usable connector.
+
+The first two outcomes would move this target toward the obstruction machinery.
+The third would sharpen the blocker side of the bridge.
+
+## What This Does Not Prove
+
+This artifact does not prove that row `81:3`, the connector pair, or any rich
+class is forced. It does not prove `n=9`, does not prove the bootstrap bridge,
+does not independently review the vertex-circle checker, and does not alter
+the official/global status of Erdos Problem #97.
+
+## Reviewer Focus
+
+The next useful question is no longer "is `81:3` relation-sufficient?" The
+artifact pins that down. The useful question is:
+
+```text
+Can the 81:3 full-row deletion-closure exposure be promoted to genuine
+rich-class or equality-connector forcing?
+```
+
+If not, the escape packet should say exactly how a realizable rich-class
+catalogue avoids the connector despite the fixed-row closure evidence.

--- a/docs/bootstrap-t12-relation-sufficient-rows.md
+++ b/docs/bootstrap-t12-relation-sufficient-rows.md
@@ -68,6 +68,11 @@ stored connector pair `[0,1]` is already in the bootstrap core. A future bridge
 lemma would still need to turn this fixed-row closure exposure into an actual
 equality-connector rich class.
 
+The focused follow-up packet
+[`bootstrap-t12-81-3-closure-target.md`](bootstrap-t12-81-3-closure-target.md)
+extracts this single row as the current first target. It also records the row's
+conditional role as the final T12 equality connector `[1,3]=[0,3]`.
+
 Row `81:8` has connector pair `[0,2]` already in the bootstrap core, and its
 outside labels `[5,6]` have singleton support options. The missing step is not
 the relation itself; it is the geometric argument that a private row center

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -538,6 +538,14 @@ and `151:6`. Their connector requirements are already bootstrap-core
 sufficient or support-sufficient, but this is still diagnostic bookkeeping
 only, not a lemma that those rows or rich classes are forced.
 
+The focused `81:3` closure-target packet in
+`docs/bootstrap-t12-81-3-closure-target.md` records the smallest current
+positive bridge target. Row `81:3` is the unique relation-sufficient row whose
+full fixed selected row lies in a deletion closure, and it supplies the final
+T12 equality connector `[1,3]=[0,3]` if the row is genuinely available. The
+packet keeps that conditional: it is not a lemma that closure membership
+forces a rich class or equality connector.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -68,6 +68,11 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-relation-sufficient-rows.md` isolates rows `81:3`,
    `81:8`, and `151:6`, where connector relation evidence is already present
    but row/rich-class forcing remains open.
+   The focused `81:3` closure-target packet in
+   `docs/bootstrap-t12-81-3-closure-target.md` is the first target in this
+   loop: full-row closure exposure and relation sufficiency meet there, and
+   the row supplies the final `T12/F16` connector only if a future bridge
+   proves genuine row/rich-class forcing.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,9 @@ put detailed reconciliation in the canonical synthesis.
   focused packet isolating rows `81:3`, `81:8`, and `151:6`, where connector
   relation evidence is already present but row/rich-class forcing remains
   open.
+- [`bootstrap-t12-81-3-closure-target.md`](bootstrap-t12-81-3-closure-target.md):
+  focused packet isolating the unique `81:3` target where full-row closure
+  exposure, relation sufficiency, and the final T12 connector role meet.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -356,6 +356,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/bootstrap-t12-relation-sufficient-rows.md`, isolating `81:3`, `81:8`,
   and `151:6` as rows where connector relation evidence is present but
   row/rich-class forcing remains open.
+- bootstrap/T12 focused `81:3` closure-target evidence, as recorded in
+  `docs/bootstrap-t12-81-3-closure-target.md`, isolating the unique target
+  where full-row deletion-closure exposure, relation sufficiency, and the
+  final `T12/F16` equality connector role coincide; this is still an open
+  row/rich-class forcing target.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -203,6 +203,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_relation_sufficient_rows.json"
       verifier: "scripts/check_bootstrap_t12_relation_sufficient_rows.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; isolates rows 81:3, 81:8, and 151:6 where connector relation evidence is present but row/rich-class forcing remains open, and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_81_3_closure_target"
+      status: "focused target packet for the unique full-row closure-exposed and relation-sufficient T12/F16 row"
+      artifact: "data/certificates/bootstrap_t12_81_3_closure_target.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_closure_target.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; isolates row 81:3 as the first full-row closure target and final T12 connector, but does not prove row/rich-class forcing and does not prove n=9 or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2268,6 +2268,75 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_closure_target
+    path: data/certificates/bootstrap_t12_81_3_closure_target.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_closure_target.py
+    command: python scripts/check_bootstrap_t12_81_3_closure_target.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_closure_target.py
+    check_command: python scripts/check_bootstrap_t12_81_3_closure_target.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused 81:3 full-row closure target diagnostic; not a proof that the row is forced, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_closure_target.v1
+      status: BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.target_row_center: 3
+      summary.target_witnesses:
+        - 0
+        - 1
+        - 4
+        - 6
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.exposed_core_vertex: 2
+      summary.closure_labels:
+        - 0
+        - 1
+        - 3
+        - 4
+        - 6
+      summary.full_row_closure_relation_sufficient_target_count: 1
+      summary.full_row_closure_relation_sufficient_targets:
+        - "81:3"
+      summary.relation_sufficient_requirement_ids:
+        - "81:3:connector:2:0"
+      summary.required_connector_pair:
+        - 0
+        - 1
+      summary.t12_connector_pair_chain:
+        - [1, 3]
+        - [0, 3]
+      summary.row_forcing_gap_type: FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING
+      summary.row_forcing_target_status: OPEN_TARGET_NOT_PROVED
+      target_record.full_row_contained_in_exposure_closure: true
+      target_record.relation_requirement.relation_state: BOOTSTRAP_CORE_SUFFICIENT
+      target_record.t12_strict_cycle_role.role: final_equality_connector
+      provenance.generator: scripts/check_bootstrap_t12_81_3_closure_target.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_closure_target.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - closure exposure proves row 81:3 is forced
+      - full-row containment proves a rich class
+      - the T12 connector role proves row forcing
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_closure_target.py
+++ b/scripts/check_bootstrap_t12_81_3_closure_target.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check the focused bootstrap/T12 81:3 closure-target packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_closure_target import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_closure_target_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 closure target")
+    print(f"target row: {summary['target_row_key']}")
+    print(f"closure labels: {summary['closure_labels']}")
+    print(f"requirement ids: {summary['relation_sufficient_requirement_ids']}")
+    print(f"T12 connector chain: {summary['t12_connector_pair_chain']}")
+    print(f"target status: {summary['row_forcing_target_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned counts")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_closure_target_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 artifact matches regenerated payload")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 closure-target expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_closure_target.py
+++ b/src/erdos97/bootstrap_t12_81_3_closure_target.py
@@ -1,0 +1,463 @@
+"""Focused 81:3 closure-target packet for the bootstrap/T12 bridge.
+
+This module isolates the cleanest current row-forcing target: source ``81``,
+row center ``3``.  The fixed selected row is fully present in one deletion
+closure and supplies the final equality connector in the T12/F16 local
+strict-cycle packet, but this remains diagnostic bookkeeping only.  The packet
+does not prove that the row is geometrically forced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_closure_exposed import (
+    FULL_ROW_MODE,
+    SCHEMA as CLOSURE_EXPOSED_SCHEMA,
+    STATUS as CLOSURE_EXPOSED_STATUS,
+    TRUST as CLOSURE_EXPOSED_TRUST,
+    build_t12_closure_exposed_payload,
+)
+from erdos97.bootstrap_t12_relation_sufficient_rows import (
+    GAP_FULL_ROW_CLOSURE,
+    SCHEMA as RELATION_SUFFICIENT_SCHEMA,
+    STATUS as RELATION_SUFFICIENT_STATUS,
+    TRUST as RELATION_SUFFICIENT_TRUST,
+    build_t12_relation_sufficient_rows_payload,
+)
+from erdos97.n9_vertex_circle_t12_strict_cycle_lemma_packet import (
+    EXPECTED_CORE_SELECTED_ROWS,
+    EXPECTED_CYCLE_STEPS,
+    SCHEMA as T12_STRICT_CYCLE_SCHEMA,
+    STATUS as T12_STRICT_CYCLE_STATUS,
+    TRUST as T12_STRICT_CYCLE_TRUST,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_closure_target.v1"
+STATUS = "BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused diagnostic for source 81 row 3: the unique relation-sufficient "
+    "T12/F16 target whose full fixed selected row is contained in a deletion "
+    "closure, and the row that supplies the final T12 equality connector. "
+    "This does not prove the row is forced, does not prove n=9, does not "
+    "prove the bridge, and does not claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bootstrap_t12_81_3_closure_target.json"
+)
+
+TARGET_SOURCE_RECORD_ID = 81
+TARGET_CLASSIFICATION_ASSIGNMENT_ID = "A082"
+TARGET_ROW_CENTER = 3
+TARGET_ROW_KEY = "81:3"
+TARGET_WITNESSES = [0, 1, 4, 6]
+TARGET_DELETION_SEED = [0, 1, 4]
+TARGET_EXPOSED_CORE_VERTEX = 2
+TARGET_CLOSURE_LABELS = [0, 1, 3, 4, 6]
+TARGET_REQUIREMENT_ID = "81:3:connector:2:0"
+TARGET_REQUIRED_WITNESSES = [0, 1]
+ROW_FORCING_GAP = "FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING"
+TARGET_NEXT_STATUS = "OPEN_TARGET_NOT_PROVED"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _record_key(record: Mapping[str, Any]) -> tuple[int, int]:
+    return int(record["source_record_id"]), int(record["row_center"])
+
+
+def _row_key(record: Mapping[str, Any]) -> str:
+    return f"{record['source_record_id']}:{record['row_center']}"
+
+
+def _records_by_key(payload: Mapping[str, Any]) -> dict[tuple[int, int], Mapping[str, Any]]:
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("payload records must be a list")
+    return {_record_key(record): record for record in records}
+
+
+def _target_relation_records(
+    relation_sufficient: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    records = relation_sufficient.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("relation-sufficient payload records must be a list")
+    return [
+        record
+        for record in records
+        if record["row_forcing_gap_type"] == GAP_FULL_ROW_CLOSURE
+        and record["row_target_status"] == "CLOSURE_FULL_ROW_CONNECTOR"
+    ]
+
+
+def _target_row_from_t12() -> list[int]:
+    for row in EXPECTED_CORE_SELECTED_ROWS:
+        normalized = _int_list(row)
+        if normalized[0] == TARGET_ROW_CENTER:
+            return normalized
+    raise AssertionError("T12/F16 local rows no longer contain row center 3")
+
+
+def _t12_connector_role() -> dict[str, object]:
+    for step_index, step in enumerate(EXPECTED_CYCLE_STEPS):
+        equality = step["equality_to_next_outer_pair"]
+        path = equality["path"]
+        if len(path) == 1 and int(path[0]["row"]) == TARGET_ROW_CENTER:
+            left_pair = _int_list(equality["start_pair"])
+            right_pair = _int_list(equality["end_pair"])
+            return {
+                "template_id": "T12",
+                "family_id": "F16",
+                "assignment_id": TARGET_CLASSIFICATION_ASSIGNMENT_ID,
+                "cycle_step": step_index,
+                "role": "final_equality_connector",
+                "selected_row": _target_row_from_t12(),
+                "row_center": TARGET_ROW_CENTER,
+                "witnesses": TARGET_WITNESSES,
+                "equality_step": {
+                    "row": TARGET_ROW_CENTER,
+                    "left_pair": left_pair,
+                    "right_pair": right_pair,
+                },
+                "connector_pair_chain": [left_pair, right_pair],
+                "strict_inequality_before_connector": step["strict_inequality"],
+                "conditional_use": (
+                    "Conditional: if a future bridge proves row 81:3 as a "
+                    "genuine rich class, this row supplies the T12 equality "
+                    "[1,3]=[0,3]."
+                ),
+            }
+    raise AssertionError("T12/F16 cycle no longer uses row 3 as a one-step connector")
+
+
+def _target_record(
+    *,
+    closure_record: Mapping[str, Any],
+    relation_record: Mapping[str, Any],
+) -> dict[str, object]:
+    requirements = relation_record["relation_sufficient_requirements"]
+    if len(requirements) != 1:
+        raise AssertionError("81:3 must have exactly one relation-sufficient requirement")
+    requirement = requirements[0]
+    return {
+        "source_record_id": TARGET_SOURCE_RECORD_ID,
+        "classification_assignment_id": TARGET_CLASSIFICATION_ASSIGNMENT_ID,
+        "target_row_key": TARGET_ROW_KEY,
+        "row_center": TARGET_ROW_CENTER,
+        "roles": ["equality_connector_row"],
+        "witnesses": TARGET_WITNESSES,
+        "deletion_seed": _int_list(closure_record["deletion_seed"]),
+        "exposed_core_vertex": int(closure_record["exposed_core_vertex"]),
+        "closure_labels": _int_list(closure_record["closure_labels"]),
+        "closure_size": int(closure_record["closure_size"]),
+        "closure_exposure_mode": str(closure_record["closure_exposure_mode"]),
+        "row_center_in_closure": bool(closure_record["row_center_in_closure"]),
+        "full_row_contained_in_exposure_closure": bool(
+            closure_record["full_row_contained_in_exposure_closure"]
+        ),
+        "witnesses_in_closure": _int_list(closure_record["witnesses_in_closure"]),
+        "outside_witnesses": _int_list(closure_record["outside_witnesses"]),
+        "outside_witnesses_in_closure": _int_list(
+            closure_record["outside_witnesses_in_closure"]
+        ),
+        "outside_witnesses_private": _int_list(
+            closure_record["outside_witnesses_private"]
+        ),
+        "relation_requirement": {
+            "requirement_id": str(requirement["requirement_id"]),
+            "kind": str(requirement["kind"]),
+            "required_witnesses": _int_list(requirement["required_witnesses"]),
+            "relation_state": str(requirement["relation_state"]),
+            "bootstrap_core_status": str(requirement["bootstrap_core_status"]),
+            "closure_sufficient_count": int(requirement["closure_sufficient_count"]),
+            "support_sufficient_count": int(requirement["support_sufficient_count"]),
+            "missing_from_bootstrap_core": _int_list(
+                requirement["missing_from_bootstrap_core"]
+            ),
+        },
+        "row_forcing_gap_type": ROW_FORCING_GAP,
+        "known_evidence": [
+            "row center 3 is in the deletion closure for core vertex 2",
+            "all four fixed selected witnesses [0,1,4,6] are in that closure",
+            "the connector pair [0,1] is bootstrap-core sufficient",
+            "the row is a one-step equality connector in the T12/F16 local packet",
+        ],
+        "missing_geometric_promotion": [
+            "prove that closure membership forces a genuine rich class at center 3",
+            "or prove the weaker equality-connector forcing [1,3]=[0,3] at center 3",
+            "or exhibit a precise rich-class escape mechanism for this closure state",
+        ],
+        "t12_strict_cycle_role": _t12_connector_role(),
+        "bridge_lemma_target": str(relation_record["bridge_lemma_target"]),
+    }
+
+
+def build_t12_81_3_closure_target_payload() -> dict[str, object]:
+    """Return the deterministic focused 81:3 closure-target packet."""
+
+    closure_exposed = build_t12_closure_exposed_payload()
+    relation_sufficient = build_t12_relation_sufficient_rows_payload()
+    closure_records = _records_by_key(closure_exposed)
+    relation_records = _records_by_key(relation_sufficient)
+    target_key = (TARGET_SOURCE_RECORD_ID, TARGET_ROW_CENTER)
+    target_closure = closure_records[target_key]
+    target_relation = relation_records[target_key]
+    target_relation_records = _target_relation_records(relation_sufficient)
+    target_row_keys = [_row_key(record) for record in target_relation_records]
+
+    target = _target_record(
+        closure_record=target_closure,
+        relation_record=target_relation,
+    )
+    excluded_relation_sufficient_rows = sorted(
+        _row_key(record)
+        for record in relation_sufficient["records"]
+        if _record_key(record) != target_key
+    )
+    excluded_closure_exposed_rows = sorted(
+        _row_key(record)
+        for record in closure_exposed["records"]
+        if _record_key(record) != target_key
+    )
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet isolates one fixed selected row target; it does not prove row or rich-class forcing.",
+            "Full-row containment in a deletion closure is not by itself a Euclidean rich-class certificate.",
+            "The T12 connector role is conditional on the row being geometrically available.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [TARGET_SOURCE_RECORD_ID],
+            "target_row_center": TARGET_ROW_CENTER,
+            "target_witnesses": TARGET_WITNESSES,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+            "closure_labels": TARGET_CLOSURE_LABELS,
+            "full_row_closure_relation_sufficient_target_count": len(
+                target_relation_records
+            ),
+            "full_row_closure_relation_sufficient_targets": target_row_keys,
+            "relation_sufficient_requirement_ids": [TARGET_REQUIREMENT_ID],
+            "required_connector_pair": TARGET_REQUIRED_WITNESSES,
+            "t12_connector_pair_chain": [[1, 3], [0, 3]],
+            "excluded_relation_sufficient_rows": excluded_relation_sufficient_rows,
+            "excluded_closure_exposed_rows": excluded_closure_exposed_rows,
+            "row_forcing_gap_type": ROW_FORCING_GAP,
+            "row_forcing_target_status": TARGET_NEXT_STATUS,
+            "next_bridge_question": (
+                "Can the 81:3 full-row deletion-closure exposure be promoted "
+                "to genuine rich-class or equality-connector forcing?"
+            ),
+        },
+        "target_record": target,
+        "candidate_lemma_contract": {
+            "name": "81:3 full-row closure exposure to equality connector",
+            "current_status": "open_diagnostic_target",
+            "desired_conclusion": [
+                "center 3 has a rich class containing witnesses [0,1,4,6]",
+                "or at least center 3 forces the equality connector [1,3]=[0,3]",
+            ],
+            "known_insufficient_inputs": [
+                "fixed selected-row membership in a deletion closure",
+                "bootstrap-core sufficiency of the stored connector pair",
+            ],
+            "escape_packet_if_false": (
+                "construct a rich-class catalogue in which the deletion closure "
+                "contains the fixed row labels but center 3 can avoid the "
+                "required equality connector"
+            ),
+        },
+        "source_artifacts": [
+            {
+                "path": "data/certificates/bootstrap_t12_closure_exposed.json",
+                "role": "source full-row deletion-closure exposure for 81:3",
+                "schema": CLOSURE_EXPOSED_SCHEMA,
+                "status": CLOSURE_EXPOSED_STATUS,
+                "trust": CLOSURE_EXPOSED_TRUST,
+            },
+            {
+                "path": "data/certificates/bootstrap_t12_relation_sufficient_rows.json",
+                "role": "source relation-sufficient connector requirement for 81:3",
+                "schema": RELATION_SUFFICIENT_SCHEMA,
+                "status": RELATION_SUFFICIENT_STATUS,
+                "trust": RELATION_SUFFICIENT_TRUST,
+            },
+            {
+                "path": "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
+                "role": "source T12/F16 local strict-cycle connector role",
+                "schema": T12_STRICT_CYCLE_SCHEMA,
+                "status": T12_STRICT_CYCLE_STATUS,
+                "trust": T12_STRICT_CYCLE_TRUST,
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_closure_target.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_closure_target.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def _assert_t12_role(role: Mapping[str, Any]) -> None:
+    expected = {
+        "template_id": "T12",
+        "family_id": "F16",
+        "assignment_id": TARGET_CLASSIFICATION_ASSIGNMENT_ID,
+        "cycle_step": 2,
+        "role": "final_equality_connector",
+        "selected_row": [3, 0, 1, 4, 6],
+        "row_center": TARGET_ROW_CENTER,
+        "witnesses": TARGET_WITNESSES,
+        "equality_step": {
+            "row": TARGET_ROW_CENTER,
+            "left_pair": [1, 3],
+            "right_pair": [0, 3],
+        },
+        "connector_pair_chain": [[1, 3], [0, 3]],
+    }
+    for key, expected_value in expected.items():
+        if role.get(key) != expected_value:
+            raise AssertionError(
+                f"T12 role {key} is {role.get(key)!r}, expected {expected_value!r}"
+            )
+    strict = role.get("strict_inequality_before_connector")
+    if not isinstance(strict, dict):
+        raise AssertionError("T12 role must contain strict_inequality_before_connector")
+    if strict.get("row") != 0:
+        raise AssertionError("81:3 connector should close the strict edge from row 0")
+    if strict.get("outer_pair") != [1, 7] or strict.get("inner_pair") != [1, 3]:
+        raise AssertionError("unexpected T12 strict edge before the 81:3 connector")
+    if "conditional" not in str(role.get("conditional_use", "")).lower():
+        raise AssertionError("T12 role must remain explicitly conditional")
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline counts for the focused 81:3 target packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [TARGET_SOURCE_RECORD_ID],
+        "target_row_center": TARGET_ROW_CENTER,
+        "target_witnesses": TARGET_WITNESSES,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+        "closure_labels": TARGET_CLOSURE_LABELS,
+        "full_row_closure_relation_sufficient_target_count": 1,
+        "full_row_closure_relation_sufficient_targets": [TARGET_ROW_KEY],
+        "relation_sufficient_requirement_ids": [TARGET_REQUIREMENT_ID],
+        "required_connector_pair": TARGET_REQUIRED_WITNESSES,
+        "t12_connector_pair_chain": [[1, 3], [0, 3]],
+        "excluded_relation_sufficient_rows": ["151:6", "81:8"],
+        "excluded_closure_exposed_rows": ["151:7"],
+        "row_forcing_gap_type": ROW_FORCING_GAP,
+        "row_forcing_target_status": TARGET_NEXT_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    target = payload.get("target_record")
+    if not isinstance(target, dict):
+        raise AssertionError("target_record must be a mapping")
+    expected_target = {
+        "source_record_id": TARGET_SOURCE_RECORD_ID,
+        "classification_assignment_id": TARGET_CLASSIFICATION_ASSIGNMENT_ID,
+        "target_row_key": TARGET_ROW_KEY,
+        "row_center": TARGET_ROW_CENTER,
+        "roles": ["equality_connector_row"],
+        "witnesses": TARGET_WITNESSES,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+        "closure_labels": TARGET_CLOSURE_LABELS,
+        "closure_size": 5,
+        "closure_exposure_mode": FULL_ROW_MODE,
+        "row_center_in_closure": True,
+        "full_row_contained_in_exposure_closure": True,
+        "witnesses_in_closure": TARGET_WITNESSES,
+        "outside_witnesses": [6],
+        "outside_witnesses_in_closure": [6],
+        "outside_witnesses_private": [],
+        "row_forcing_gap_type": ROW_FORCING_GAP,
+    }
+    for key, expected in expected_target.items():
+        if target.get(key) != expected:
+            raise AssertionError(
+                f"target_record {key} is {target.get(key)!r}, expected {expected!r}"
+            )
+
+    requirement = target.get("relation_requirement")
+    if not isinstance(requirement, dict):
+        raise AssertionError("target relation_requirement must be a mapping")
+    expected_requirement = {
+        "requirement_id": TARGET_REQUIREMENT_ID,
+        "kind": "equality_connector_pair",
+        "required_witnesses": TARGET_REQUIRED_WITNESSES,
+        "relation_state": "BOOTSTRAP_CORE_SUFFICIENT",
+        "bootstrap_core_status": "SUFFICIENT",
+        "closure_sufficient_count": 1,
+        "support_sufficient_count": 0,
+        "missing_from_bootstrap_core": [],
+    }
+    for key, expected in expected_requirement.items():
+        if requirement.get(key) != expected:
+            raise AssertionError(
+                f"target requirement {key} is {requirement.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+
+    if "does not prove the row is forced" not in payload.get("claim_scope", ""):
+        raise AssertionError("claim scope must preserve the no-row-forcing warning")
+    warnings = payload.get("interpretation_warnings")
+    if not isinstance(warnings, Sequence):
+        raise AssertionError("interpretation_warnings must be a sequence")
+    if not any("not prove row or rich-class forcing" in str(warning) for warning in warnings):
+        raise AssertionError("warnings must preserve the rich-class forcing gap")
+
+    role = target.get("t12_strict_cycle_role")
+    if not isinstance(role, dict):
+        raise AssertionError("target must include a T12 strict-cycle role")
+    _assert_t12_role(role)

--- a/tests/test_bootstrap_t12_81_3_closure_target.py
+++ b/tests/test_bootstrap_t12_81_3_closure_target.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_closure_target import (
+    DEFAULT_ARTIFACT,
+    ROW_FORCING_GAP,
+    assert_expected_payload,
+    build_t12_81_3_closure_target_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_81_3_closure_target_counts_and_scope() -> None:
+    payload = build_t12_81_3_closure_target_payload()
+
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "does not prove the row is forced" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert "does not claim a counterexample" in claim_scope
+    assert payload["summary"]["full_row_closure_relation_sufficient_targets"] == [
+        "81:3"
+    ]
+
+
+def test_81_3_closure_target_isolates_full_row_exposure() -> None:
+    payload = build_t12_81_3_closure_target_payload()
+    target = payload["target_record"]
+
+    assert target["target_row_key"] == "81:3"
+    assert target["row_center"] == 3
+    assert target["witnesses"] == [0, 1, 4, 6]
+    assert target["deletion_seed"] == [0, 1, 4]
+    assert target["exposed_core_vertex"] == 2
+    assert target["closure_labels"] == [0, 1, 3, 4, 6]
+    assert target["row_center_in_closure"]
+    assert target["full_row_contained_in_exposure_closure"]
+    assert target["witnesses_in_closure"] == [0, 1, 4, 6]
+    assert target["outside_witnesses_in_closure"] == [6]
+    assert target["outside_witnesses_private"] == []
+    assert target["row_forcing_gap_type"] == ROW_FORCING_GAP
+
+
+def test_81_3_closure_target_relation_requirement() -> None:
+    payload = build_t12_81_3_closure_target_payload()
+    requirement = payload["target_record"]["relation_requirement"]
+
+    assert requirement["requirement_id"] == "81:3:connector:2:0"
+    assert requirement["kind"] == "equality_connector_pair"
+    assert requirement["required_witnesses"] == [0, 1]
+    assert requirement["relation_state"] == "BOOTSTRAP_CORE_SUFFICIENT"
+    assert requirement["bootstrap_core_status"] == "SUFFICIENT"
+    assert requirement["closure_sufficient_count"] == 1
+    assert requirement["support_sufficient_count"] == 0
+    assert requirement["missing_from_bootstrap_core"] == []
+
+
+def test_81_3_closure_target_t12_role_is_conditional() -> None:
+    payload = build_t12_81_3_closure_target_payload()
+    role = payload["target_record"]["t12_strict_cycle_role"]
+
+    assert role["template_id"] == "T12"
+    assert role["family_id"] == "F16"
+    assert role["assignment_id"] == "A082"
+    assert role["cycle_step"] == 2
+    assert role["selected_row"] == [3, 0, 1, 4, 6]
+    assert role["equality_step"] == {
+        "row": 3,
+        "left_pair": [1, 3],
+        "right_pair": [0, 3],
+    }
+    assert role["connector_pair_chain"] == [[1, 3], [0, 3]]
+    strict = role["strict_inequality_before_connector"]
+    assert strict["row"] == 0
+    assert strict["outer_pair"] == [1, 7]
+    assert strict["inner_pair"] == [1, 3]
+    assert "Conditional: if a future bridge proves" in role["conditional_use"]
+
+
+def test_81_3_closure_target_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_81_3_closure_target_payload()
+
+
+def test_81_3_closure_target_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_closure_target.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["target_row_key"] == "81:3"
+    assert payload["summary"]["row_forcing_gap_type"] == ROW_FORCING_GAP
+
+
+def test_81_3_closure_target_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_81_3_closure_target.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_closure_target.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_closure_target.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_81_3_closure_target_expected_payload_rejects_drift() -> None:
+    payload = build_t12_81_3_closure_target_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["target_row_key"] = "81:8"
+
+    with pytest.raises(AssertionError, match="target_row_key"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a focused verifier-backed packet for the `81:3` full-row closure target
- record its relation-sufficient connector requirement and conditional T12/F16 equality-connector role
- update docs, source metadata, and generated-artifact provenance without promoting row/rich-class forcing

## Verification

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` -> `701 passed, 281 deselected`
