### PR TITLE
Add bootstrap T12 81:3 rich-triple contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the focused `81:3` closure target, where full-row deletion-closure
   exposure, relation sufficiency, and the final T12 connector role meet, read
   [`docs/bootstrap-t12-81-3-closure-target.md`](docs/bootstrap-t12-81-3-closure-target.md).
+- For the follow-up `81:3` rich-triple connector contract, which reduces the
+  target from full-row forcing to the pair `[0,1]` and records the exact
+  connector-avoiding escape, read
+  [`docs/bootstrap-t12-81-3-rich-triple-contract.md`](docs/bootstrap-t12-81-3-rich-triple-contract.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -254,6 +254,18 @@ is still diagnostic bookkeeping only; see
 `scripts/check_bootstrap_t12_81_3_closure_target.py`, and
 `data/certificates/bootstrap_t12_81_3_closure_target.json`.
 
+The follow-up `81:3` rich-triple connector contract records the weaker local
+conditional actually needed by the T12 equality connector. Any genuine rich
+class at center `3` containing witnesses `0` and `1` gives `[1,3]=[0,3]`; the
+full fixed row `[0,1,4,6]` is not required for that connector. The packet also
+pins the connector-avoiding escape: activation through the fixed witness set
+must use `[0,4,6]` or `[1,4,6]`, so label `6` must be available before center
+`3`. This remains diagnostic bookkeeping only, not a proof that the rich class
+or row is forced; see
+`docs/bootstrap-t12-81-3-rich-triple-contract.md`,
+`scripts/check_bootstrap_t12_81_3_rich_triple_contract.py`, and
+`data/certificates/bootstrap_t12_81_3_rich_triple_contract.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -139,6 +139,15 @@ the final equality connector `[1,3]=[0,3]` in the `T12/F16` local strict-cycle
 packet. The missing step is still genuine row/rich-class forcing, not more
 fixed-row bookkeeping. See `docs/bootstrap-t12-81-3-closure-target.md`.
 
+A follow-up `81:3` rich-triple connector contract weakens that target: the
+full fixed row is not needed for the stored connector, only a genuine rich
+class at center `3` containing witnesses `0` and `1`. The checked packet proves
+only this local conditional and records the exact remaining escape: every rich
+class at center `3` must avoid the pair `[0,1]`, so any connector-avoiding
+activation through the fixed row must first expose label `6`. This is still
+diagnostic bookkeeping only, not a row-forcing theorem. See
+`docs/bootstrap-t12-81-3-rich-triple-contract.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_81_3_rich_triple_contract.json
+++ b/data/certificates/bootstrap_t12_81_3_rich_triple_contract.json
@@ -1,0 +1,319 @@
+{
+  "activation_triple_analysis": {
+    "all_witness_triples": [
+      [
+        0,
+        1,
+        4
+      ],
+      [
+        0,
+        1,
+        6
+      ],
+      [
+        0,
+        4,
+        6
+      ],
+      [
+        1,
+        4,
+        6
+      ]
+    ],
+    "connector_avoiding_activation_triples": [
+      [
+        0,
+        4,
+        6
+      ],
+      [
+        1,
+        4,
+        6
+      ]
+    ],
+    "connector_avoiding_triples_all_use_outside_witness_6": true,
+    "connector_forcing_triples": [
+      [
+        0,
+        1,
+        4
+      ],
+      [
+        0,
+        1,
+        6
+      ]
+    ],
+    "connector_pair": [
+      0,
+      1
+    ],
+    "seed_activation_triple": [
+      0,
+      1,
+      4
+    ],
+    "seed_activation_uses_connector_pair": true,
+    "seed_activation_uses_outside_witness_6": false,
+    "target_witnesses": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "claim_scope": "Focused local connector contract for source 81 row 3: any genuine rich class at center 3 that contains witnesses 0 and 1 supplies the T12/F16 equality connector [1,3]=[0,3]. This proves only that exact local conditional and the remaining escape shape; it does not prove the rich class exists, does not prove row forcing, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "escape_mechanism": {
+    "available_connector_avoiding_triples_in_fixed_row": [
+      [
+        0,
+        4,
+        6
+      ],
+      [
+        1,
+        4,
+        6
+      ]
+    ],
+    "escape_condition": "To avoid the connector equality at center 3, every genuine rich class centered at 3 must avoid containing witnesses 0 and 1 together.",
+    "next_target": "Order-resolved rich-class closure: either force the seed activation [0,1,4] at center 3, or certify how label 6 becomes available first without already entering the connector.",
+    "outside_label_required_before_connector_avoiding_activation": 6,
+    "status": "CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1",
+    "why_label_6_matters": "The deletion seed [0,1,4] already contains the connector pair. The only triples from the fixed witness set that avoid that pair are [0,4,6] and [1,4,6], both of which require label 6 to be available before center 3 activates."
+  },
+  "interpretation_warnings": [
+    "This packet proves only the local conditional from a genuine rich class containing witnesses 0 and 1 to the connector equality [1,3]=[0,3].",
+    "It does not prove that such a rich class exists at center 3.",
+    "It does not prove full row 81:3, row/rich-class forcing, n=9, the bridge, or a counterexample.",
+    "Connector-avoiding activation remains an open exact escape mechanism requiring separate analysis."
+  ],
+  "local_conditional_lemma": {
+    "conclusion": "The selected-distance equality [1,3]=[0,3] holds.",
+    "hypothesis": "At center 3, a genuine rich distance class contains witnesses 0 and 1.",
+    "name": "81:3 connector-pair rich-class contract",
+    "non_claims": [
+      "does not prove any rich class contains witnesses 0 and 1",
+      "does not prove the full fixed row [0,1,4,6]",
+      "does not prove the T12/F16 local packet is geometrically available"
+    ],
+    "proof": "A rich distance class at center 3 consists of vertices at one common distance from p_3. If witnesses 0 and 1 both belong to such a class, then |p_3-p_1|=|p_3-p_0|, which is exactly the connector equality [1,3]=[0,3].",
+    "status": "EXACT_LOCAL_CONDITIONAL"
+  },
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_rich_triple_contract.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_81_3_closure_target.json",
+      "role": "source focused 81:3 closure target packet",
+      "schema": "erdos97.bootstrap_t12_81_3_closure_target.v1",
+      "status": "BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_closure_target": {
+    "closure_labels": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "exposed_core_vertex": 2,
+    "relation_requirement_id": "81:3:connector:2:0",
+    "required_connector_pair": [
+      0,
+      1
+    ],
+    "row_forcing_gap_type": "FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING",
+    "source_artifact": "data/certificates/bootstrap_t12_81_3_closure_target.json",
+    "source_schema": "erdos97.bootstrap_t12_81_3_closure_target.v1",
+    "source_status": "BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY",
+    "source_trust": "REVIEW_PENDING_DIAGNOSTIC",
+    "t12_connector_pair_chain": [
+      [
+        1,
+        3
+      ],
+      [
+        0,
+        3
+      ]
+    ],
+    "t12_role": {
+      "assignment_id": "A082",
+      "conditional_use": "Conditional: if a future bridge proves row 81:3 as a genuine rich class, this row supplies the T12 equality [1,3]=[0,3].",
+      "connector_pair_chain": [
+        [
+          1,
+          3
+        ],
+        [
+          0,
+          3
+        ]
+      ],
+      "cycle_step": 2,
+      "equality_step": {
+        "left_pair": [
+          1,
+          3
+        ],
+        "right_pair": [
+          0,
+          3
+        ],
+        "row": 3
+      },
+      "family_id": "F16",
+      "role": "final_equality_connector",
+      "row_center": 3,
+      "selected_row": [
+        3,
+        0,
+        1,
+        4,
+        6
+      ],
+      "strict_inequality_before_connector": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          1,
+          2
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          7
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          3,
+          6,
+          7
+        ]
+      },
+      "template_id": "T12",
+      "witnesses": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    "target_row_center": 3,
+    "target_row_key": "81:3",
+    "target_witnesses": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "status": "BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY",
+  "summary": {
+    "closure_labels": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "connector_avoiding_activation_triples": [
+      [
+        0,
+        4,
+        6
+      ],
+      [
+        1,
+        4,
+        6
+      ]
+    ],
+    "connector_distance_pairs": [
+      [
+        1,
+        3
+      ],
+      [
+        0,
+        3
+      ]
+    ],
+    "connector_forcing_triples": [
+      [
+        0,
+        1,
+        4
+      ],
+      [
+        0,
+        1,
+        6
+      ]
+    ],
+    "connector_pair": [
+      0,
+      1
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "escape_status": "CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1",
+    "exposed_core_vertex": 2,
+    "full_row_forcing_required_for_connector": false,
+    "local_conditional_lemma_status": "EXACT_LOCAL_CONDITIONAL",
+    "next_bridge_question": "Can the real rich-class closure force activation at center 3 from the connector triple [0,1,4], or must any connector-avoiding activation first expose label 6?",
+    "rich_class_existence_status": "OPEN_TARGET_NOT_PROVED",
+    "rich_triple_gap_type": "PAIR_CONNECTOR_CONTRACT_NOT_RICH_CLASS_EXISTENCE",
+    "seed_activation_forces_connector": true,
+    "seed_activation_triple": [
+      0,
+      1,
+      4
+    ],
+    "source_record_ids": [
+      81
+    ],
+    "target_row_center": 3,
+    "target_row_key": "81:3",
+    "target_witnesses": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-closure-target.md
+++ b/docs/bootstrap-t12-81-3-closure-target.md
@@ -116,3 +116,11 @@ rich-class or equality-connector forcing?
 
 If not, the escape packet should say exactly how a realizable rich-class
 catalogue avoids the connector despite the fixed-row closure evidence.
+
+The follow-up packet
+`docs/bootstrap-t12-81-3-rich-triple-contract.md` records the first reduction
+of this question: full-row forcing is not needed for the stored connector. It
+is enough for a genuine rich class at center `3` to contain witnesses `0` and
+`1`; avoiding that connector requires every such rich class to avoid the pair
+`[0,1]`, so any connector-avoiding activation through the fixed witness set
+must expose label `6` first.

--- a/docs/bootstrap-t12-81-3-rich-triple-contract.md
+++ b/docs/bootstrap-t12-81-3-rich-triple-contract.md
@@ -1,0 +1,104 @@
+# Bootstrap T12 81:3 Rich-Triple Contract
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note records the next, weaker target after the focused `81:3` closure
+packet. The full fixed row is not needed for the stored `T12/F16` equality
+connector. It is enough for a genuine rich distance class at center `3` to
+contain witnesses `0` and `1`.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_rich_triple_contract.json`.
+
+## Scope
+
+The input packet is
+`data/certificates/bootstrap_t12_81_3_closure_target.json`.
+
+This packet proves only a local conditional:
+
+```text
+If a genuine rich distance class at center 3 contains witnesses 0 and 1,
+then [1,3]=[0,3].
+```
+
+The proof is just the definition of a rich distance class at center `3`. If
+both witnesses are in the same class, then `|p_3-p_1|=|p_3-p_0|`, which is the
+connector equality used by the `T12/F16` local strict-cycle packet.
+
+The packet does not prove that such a rich class exists, does not prove the
+full fixed row `3 -> [0,1,4,6]`, and does not prove that the `T12/F16` local
+packet is geometrically available.
+
+## Triple Partition
+
+For the fixed row witnesses
+
+```text
+[0,1,4,6]
+```
+
+the three-witness activation triples split as follows:
+
+```text
+connector-forcing triples: [0,1,4], [0,1,6]
+connector-avoiding triples: [0,4,6], [1,4,6]
+```
+
+The deletion seed from the closure-target packet is:
+
+```text
+[0,1,4]
+```
+
+So activation from that seed would force the connector pair `[0,1]`. The only
+activation triples from the fixed witness set that avoid the connector pair
+both require label `6`.
+
+## Escape Mechanism
+
+The precise remaining escape is:
+
+```text
+CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1
+```
+
+To avoid the equality connector at center `3`, every genuine rich class
+centered at `3` must avoid containing witnesses `0` and `1` together. If center
+`3` still activates through the fixed-row witness set, it must activate through
+`[0,4,6]` or `[1,4,6]`, so label `6` must become available before center `3`
+activates.
+
+## Next Target
+
+The next proof-facing question is now order-resolved rather than full-row
+resolved:
+
+```text
+Can real rich-class closure force activation at center 3 from [0,1,4],
+or must any connector-avoiding activation first expose label 6?
+```
+
+Either outcome would reduce the bridge gap. A positive result gives the
+needed connector without proving the full fixed row. A negative result should
+be packaged as an exact escape packet explaining how label `6` becomes
+available first without already forcing the connector.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It only records the exact local
+conditional and the smaller escape target left open after the `81:3`
+closure-target packet.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -546,6 +546,15 @@ T12 equality connector `[1,3]=[0,3]` if the row is genuinely available. The
 packet keeps that conditional: it is not a lemma that closure membership
 forces a rich class or equality connector.
 
+The follow-up `81:3` rich-triple connector contract in
+`docs/bootstrap-t12-81-3-rich-triple-contract.md` weakens the target from full
+row forcing to a pair-level local conditional. If a genuine rich class at
+center `3` contains witnesses `0` and `1`, then the connector equality
+`[1,3]=[0,3]` follows immediately. The packet does not prove such a rich class
+exists. Its value is to isolate the exact escape: every rich class at center
+`3` must avoid the pair `[0,1]`, and any connector-avoiding activation through
+the fixed witness set must use label `6` before center `3` activates.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -73,6 +73,12 @@ Use this queue when no more specific issue is selected.
    loop: full-row closure exposure and relation sufficiency meet there, and
    the row supplies the final `T12/F16` connector only if a future bridge
    proves genuine row/rich-class forcing.
+   The follow-up `81:3` rich-triple connector contract in
+   `docs/bootstrap-t12-81-3-rich-triple-contract.md` reduces the next target:
+   the stored T12 connector only needs witnesses `0` and `1` in one genuine
+   rich class at center `3`. The next useful PR should attack the
+   order-resolved escape: either force activation from `[0,1,4]`, or certify
+   how label `6` becomes available first without forcing the connector.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-closure-target.md`](bootstrap-t12-81-3-closure-target.md):
   focused packet isolating the unique `81:3` target where full-row closure
   exposure, relation sufficiency, and the final T12 connector role meet.
+- [`bootstrap-t12-81-3-rich-triple-contract.md`](bootstrap-t12-81-3-rich-triple-contract.md):
+  follow-up packet reducing the `81:3` target to the connector pair `[0,1]`
+  and recording the exact connector-avoiding escape through label `6`.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -361,6 +361,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   where full-row deletion-closure exposure, relation sufficiency, and the
   final `T12/F16` equality connector role coincide; this is still an open
   row/rich-class forcing target.
+- bootstrap/T12 focused `81:3` rich-triple contract evidence, as recorded in
+  `docs/bootstrap-t12-81-3-rich-triple-contract.md`, weakening the target to
+  the connector pair `[0,1]`: any genuine rich class at center `3` containing
+  that pair gives `[1,3]=[0,3]`, while a connector-avoiding activation must
+  expose label `6` first.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -208,6 +208,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_closure_target.json"
       verifier: "scripts/check_bootstrap_t12_81_3_closure_target.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; isolates row 81:3 as the first full-row closure target and final T12 connector, but does not prove row/rich-class forcing and does not prove n=9 or the bridge"
+    - pattern: "bootstrap_t12_81_3_rich_triple_contract"
+      status: "focused connector-pair contract for the 81:3 T12/F16 target"
+      artifact: "data/certificates/bootstrap_t12_81_3_rich_triple_contract.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; proves only the local conditional from a genuine rich class at center 3 containing witnesses 0 and 1 to connector [1,3]=[0,3], but does not prove rich-class existence, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2337,6 +2337,89 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_rich_triple_contract
+    path: data/certificates/bootstrap_t12_81_3_rich_triple_contract.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_rich_triple_contract.py
+    command: python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_rich_triple_contract.py
+    check_command: python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused 81:3 rich-triple connector contract diagnostic; proves only the local conditional from a genuine rich class at center 3 containing witnesses 0 and 1 to connector [1,3]=[0,3], not rich-class existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_rich_triple_contract.v1
+      status: BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.target_row_center: 3
+      summary.target_witnesses:
+        - 0
+        - 1
+        - 4
+        - 6
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.exposed_core_vertex: 2
+      summary.closure_labels:
+        - 0
+        - 1
+        - 3
+        - 4
+        - 6
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.connector_distance_pairs:
+        - [1, 3]
+        - [0, 3]
+      summary.connector_forcing_triples:
+        - [0, 1, 4]
+        - [0, 1, 6]
+      summary.connector_avoiding_activation_triples:
+        - [0, 4, 6]
+        - [1, 4, 6]
+      summary.seed_activation_triple:
+        - 0
+        - 1
+        - 4
+      summary.seed_activation_forces_connector: true
+      summary.full_row_forcing_required_for_connector: false
+      summary.local_conditional_lemma_status: EXACT_LOCAL_CONDITIONAL
+      summary.rich_class_existence_status: OPEN_TARGET_NOT_PROVED
+      summary.escape_status: CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1
+      summary.rich_triple_gap_type: PAIR_CONNECTOR_CONTRACT_NOT_RICH_CLASS_EXISTENCE
+      local_conditional_lemma.conclusion: The selected-distance equality [1,3]=[0,3] holds.
+      activation_triple_analysis.connector_avoiding_triples_all_use_outside_witness_6: true
+      escape_mechanism.outside_label_required_before_connector_avoiding_activation: 6
+      source_closure_target.source_schema: erdos97.bootstrap_t12_81_3_closure_target.v1
+      source_closure_target.row_forcing_gap_type: FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING
+      provenance.generator: scripts/check_bootstrap_t12_81_3_rich_triple_contract.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - closure exposure proves row 81:3 is forced
+      - full-row containment proves a rich class
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the connector-pair contract proves rich-class existence
+      - the connector-pair contract proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_rich_triple_contract.py
+++ b/scripts/check_bootstrap_t12_81_3_rich_triple_contract.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 rich-triple connector contract packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_rich_triple_contract import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_rich_triple_contract_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 rich-triple contract")
+    print(f"target row: {summary['target_row_key']}")
+    print(f"connector pair: {summary['connector_pair']}")
+    print(f"connector-forcing triples: {summary['connector_forcing_triples']}")
+    print(
+        "connector-avoiding triples: "
+        f"{summary['connector_avoiding_activation_triples']}"
+    )
+    print(f"escape status: {summary['escape_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_rich_triple_contract_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 rich-triple artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 rich-triple expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_rich_triple_contract.py
+++ b/src/erdos97/bootstrap_t12_81_3_rich_triple_contract.py
@@ -1,0 +1,389 @@
+"""Rich-triple connector contract for the bootstrap/T12 81:3 target.
+
+This packet is the next rung after the focused 81:3 closure-target packet.
+It records a weaker exact local contract than full-row forcing: the T12/F16
+connector only needs witnesses ``0`` and ``1`` to lie in one rich class at
+center ``3``.  The packet also records the precise escape shape left open by
+that observation.  It is diagnostic bookkeeping only and does not prove that
+any rich class is forced.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_closure_target import (
+    DEFAULT_ARTIFACT as CLOSURE_TARGET_ARTIFACT,
+    ROW_FORCING_GAP as CLOSURE_TARGET_ROW_FORCING_GAP,
+    SCHEMA as CLOSURE_TARGET_SCHEMA,
+    STATUS as CLOSURE_TARGET_STATUS,
+    TARGET_CLOSURE_LABELS,
+    TARGET_DELETION_SEED,
+    TARGET_EXPOSED_CORE_VERTEX,
+    TARGET_REQUIREMENT_ID,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+    TARGET_SOURCE_RECORD_ID,
+    TARGET_WITNESSES,
+    TRUST as CLOSURE_TARGET_TRUST,
+    build_t12_81_3_closure_target_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_rich_triple_contract.v1"
+STATUS = "BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused local connector contract for source 81 row 3: any genuine rich "
+    "class at center 3 that contains witnesses 0 and 1 supplies the T12/F16 "
+    "equality connector [1,3]=[0,3]. This proves only that exact local "
+    "conditional and the remaining escape shape; it does not prove the rich "
+    "class exists, does not prove row forcing, does not prove n=9, does not "
+    "prove the bridge, and does not claim a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_rich_triple_contract.json"
+)
+
+CONNECTOR_PAIR = [0, 1]
+CONNECTOR_DISTANCE_PAIRS = [[1, 3], [0, 3]]
+CONNECTOR_FORCING_TRIPLES = [[0, 1, 4], [0, 1, 6]]
+CONNECTOR_AVOIDING_ACTIVATION_TRIPLES = [[0, 4, 6], [1, 4, 6]]
+SEED_ACTIVATION_TRIPLE = [0, 1, 4]
+ESCAPE_STATUS = "CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1"
+LOCAL_CONDITIONAL_STATUS = "EXACT_LOCAL_CONDITIONAL"
+RICH_CLASS_EXISTENCE_STATUS = "OPEN_TARGET_NOT_PROVED"
+RICH_TRIPLE_GAP = "PAIR_CONNECTOR_CONTRACT_NOT_RICH_CLASS_EXISTENCE"
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _triples(values: Sequence[int]) -> list[list[int]]:
+    return [list(triple) for triple in itertools.combinations(sorted(values), 3)]
+
+
+def _contains_connector_pair(triple: Sequence[int]) -> bool:
+    return all(label in triple for label in CONNECTOR_PAIR)
+
+
+def _activation_triples() -> dict[str, object]:
+    all_triples = _triples(TARGET_WITNESSES)
+    connector_forcing = [
+        triple for triple in all_triples if _contains_connector_pair(triple)
+    ]
+    connector_avoiding = [
+        triple for triple in all_triples if not _contains_connector_pair(triple)
+    ]
+    return {
+        "target_witnesses": TARGET_WITNESSES,
+        "all_witness_triples": all_triples,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_forcing_triples": connector_forcing,
+        "connector_avoiding_activation_triples": connector_avoiding,
+        "seed_activation_triple": SEED_ACTIVATION_TRIPLE,
+        "seed_activation_uses_connector_pair": _contains_connector_pair(
+            SEED_ACTIVATION_TRIPLE
+        ),
+        "seed_activation_uses_outside_witness_6": 6 in SEED_ACTIVATION_TRIPLE,
+        "connector_avoiding_triples_all_use_outside_witness_6": all(
+            6 in triple for triple in connector_avoiding
+        ),
+    }
+
+
+def _closure_target_summary(
+    closure_target: Mapping[str, Any],
+) -> dict[str, object]:
+    summary = closure_target.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("closure target summary must be a mapping")
+    target = closure_target.get("target_record")
+    if not isinstance(target, Mapping):
+        raise AssertionError("closure target record must be a mapping")
+    source_artifact = CLOSURE_TARGET_ARTIFACT.relative_to(REPO_ROOT).as_posix()
+    return {
+        "source_artifact": source_artifact,
+        "source_schema": closure_target.get("schema"),
+        "source_status": closure_target.get("status"),
+        "source_trust": closure_target.get("trust"),
+        "target_row_key": summary.get("target_row_key"),
+        "target_row_center": summary.get("target_row_center"),
+        "target_witnesses": summary.get("target_witnesses"),
+        "deletion_seed": summary.get("deletion_seed"),
+        "exposed_core_vertex": summary.get("exposed_core_vertex"),
+        "closure_labels": summary.get("closure_labels"),
+        "required_connector_pair": summary.get("required_connector_pair"),
+        "t12_connector_pair_chain": summary.get("t12_connector_pair_chain"),
+        "row_forcing_gap_type": summary.get("row_forcing_gap_type"),
+        "relation_requirement_id": TARGET_REQUIREMENT_ID,
+        "t12_role": target.get("t12_strict_cycle_role"),
+    }
+
+
+def build_t12_81_3_rich_triple_contract_payload() -> dict[str, object]:
+    """Return the deterministic rich-triple connector contract packet."""
+
+    closure_target = build_t12_81_3_closure_target_payload()
+    activation = _activation_triples()
+    closure_summary = _closure_target_summary(closure_target)
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet proves only the local conditional from a genuine rich class containing witnesses 0 and 1 to the connector equality [1,3]=[0,3].",
+            "It does not prove that such a rich class exists at center 3.",
+            "It does not prove full row 81:3, row/rich-class forcing, n=9, the bridge, or a counterexample.",
+            "Connector-avoiding activation remains an open exact escape mechanism requiring separate analysis.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [TARGET_SOURCE_RECORD_ID],
+            "target_row_center": TARGET_ROW_CENTER,
+            "target_witnesses": TARGET_WITNESSES,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+            "closure_labels": TARGET_CLOSURE_LABELS,
+            "connector_pair": CONNECTOR_PAIR,
+            "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+            "connector_forcing_triples": CONNECTOR_FORCING_TRIPLES,
+            "connector_avoiding_activation_triples": (
+                CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+            ),
+            "seed_activation_triple": SEED_ACTIVATION_TRIPLE,
+            "seed_activation_forces_connector": True,
+            "full_row_forcing_required_for_connector": False,
+            "local_conditional_lemma_status": LOCAL_CONDITIONAL_STATUS,
+            "rich_class_existence_status": RICH_CLASS_EXISTENCE_STATUS,
+            "escape_status": ESCAPE_STATUS,
+            "rich_triple_gap_type": RICH_TRIPLE_GAP,
+            "next_bridge_question": (
+                "Can the real rich-class closure force activation at center 3 "
+                "from the connector triple [0,1,4], or must any connector-"
+                "avoiding activation first expose label 6?"
+            ),
+        },
+        "local_conditional_lemma": {
+            "name": "81:3 connector-pair rich-class contract",
+            "status": LOCAL_CONDITIONAL_STATUS,
+            "hypothesis": (
+                "At center 3, a genuine rich distance class contains witnesses "
+                "0 and 1."
+            ),
+            "conclusion": "The selected-distance equality [1,3]=[0,3] holds.",
+            "proof": (
+                "A rich distance class at center 3 consists of vertices at one "
+                "common distance from p_3. If witnesses 0 and 1 both belong to "
+                "such a class, then |p_3-p_1|=|p_3-p_0|, which is exactly the "
+                "connector equality [1,3]=[0,3]."
+            ),
+            "non_claims": [
+                "does not prove any rich class contains witnesses 0 and 1",
+                "does not prove the full fixed row [0,1,4,6]",
+                "does not prove the T12/F16 local packet is geometrically available",
+            ],
+        },
+        "activation_triple_analysis": activation,
+        "escape_mechanism": {
+            "status": ESCAPE_STATUS,
+            "escape_condition": (
+                "To avoid the connector equality at center 3, every genuine "
+                "rich class centered at 3 must avoid containing witnesses 0 "
+                "and 1 together."
+            ),
+            "available_connector_avoiding_triples_in_fixed_row": (
+                CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+            ),
+            "outside_label_required_before_connector_avoiding_activation": 6,
+            "why_label_6_matters": (
+                "The deletion seed [0,1,4] already contains the connector "
+                "pair. The only triples from the fixed witness set that avoid "
+                "that pair are [0,4,6] and [1,4,6], both of which require "
+                "label 6 to be available before center 3 activates."
+            ),
+            "next_target": (
+                "Order-resolved rich-class closure: either force the seed "
+                "activation [0,1,4] at center 3, or certify how label 6 becomes "
+                "available first without already entering the connector."
+            ),
+        },
+        "source_closure_target": closure_summary,
+        "source_artifacts": [
+            {
+                "path": CLOSURE_TARGET_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+                "role": "source focused 81:3 closure target packet",
+                "schema": CLOSURE_TARGET_SCHEMA,
+                "status": CLOSURE_TARGET_STATUS,
+                "trust": CLOSURE_TARGET_TRUST,
+            }
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline values for the rich-triple contract packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [TARGET_SOURCE_RECORD_ID],
+        "target_row_center": TARGET_ROW_CENTER,
+        "target_witnesses": TARGET_WITNESSES,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+        "closure_labels": TARGET_CLOSURE_LABELS,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+        "connector_forcing_triples": CONNECTOR_FORCING_TRIPLES,
+        "connector_avoiding_activation_triples": (
+            CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+        ),
+        "seed_activation_triple": SEED_ACTIVATION_TRIPLE,
+        "seed_activation_forces_connector": True,
+        "full_row_forcing_required_for_connector": False,
+        "local_conditional_lemma_status": LOCAL_CONDITIONAL_STATUS,
+        "rich_class_existence_status": RICH_CLASS_EXISTENCE_STATUS,
+        "escape_status": ESCAPE_STATUS,
+        "rich_triple_gap_type": RICH_TRIPLE_GAP,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    warnings = payload.get("interpretation_warnings")
+    if not isinstance(warnings, Sequence):
+        raise AssertionError("interpretation_warnings must be a sequence")
+    if not any("does not prove that such a rich class exists" in str(w) for w in warnings):
+        raise AssertionError("warnings must preserve the rich-class existence gap")
+    if not any("does not prove full row 81:3" in str(w) for w in warnings):
+        raise AssertionError("warnings must preserve the no-row-forcing guardrail")
+
+    lemma = payload.get("local_conditional_lemma")
+    if not isinstance(lemma, Mapping):
+        raise AssertionError("local_conditional_lemma must be a mapping")
+    if lemma.get("status") != LOCAL_CONDITIONAL_STATUS:
+        raise AssertionError("local conditional lemma status drifted")
+    if lemma.get("conclusion") != "The selected-distance equality [1,3]=[0,3] holds.":
+        raise AssertionError("connector conclusion drifted")
+    non_claims = lemma.get("non_claims")
+    if not isinstance(non_claims, Sequence):
+        raise AssertionError("local conditional non_claims must be a sequence")
+    if not any("does not prove any rich class" in str(item) for item in non_claims):
+        raise AssertionError("local lemma must not claim rich-class existence")
+
+    activation = payload.get("activation_triple_analysis")
+    if not isinstance(activation, Mapping):
+        raise AssertionError("activation_triple_analysis must be a mapping")
+    expected_activation = {
+        "target_witnesses": TARGET_WITNESSES,
+        "all_witness_triples": [
+            [0, 1, 4],
+            [0, 1, 6],
+            [0, 4, 6],
+            [1, 4, 6],
+        ],
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_forcing_triples": CONNECTOR_FORCING_TRIPLES,
+        "connector_avoiding_activation_triples": (
+            CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+        ),
+        "seed_activation_triple": SEED_ACTIVATION_TRIPLE,
+        "seed_activation_uses_connector_pair": True,
+        "seed_activation_uses_outside_witness_6": False,
+        "connector_avoiding_triples_all_use_outside_witness_6": True,
+    }
+    for key, expected in expected_activation.items():
+        if activation.get(key) != expected:
+            raise AssertionError(
+                f"activation {key} is {activation.get(key)!r}, expected {expected!r}"
+            )
+
+    escape = payload.get("escape_mechanism")
+    if not isinstance(escape, Mapping):
+        raise AssertionError("escape_mechanism must be a mapping")
+    if escape.get("status") != ESCAPE_STATUS:
+        raise AssertionError("escape mechanism status drifted")
+    if escape.get("available_connector_avoiding_triples_in_fixed_row") != (
+        CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+    ):
+        raise AssertionError("connector-avoiding triples drifted")
+    if escape.get("outside_label_required_before_connector_avoiding_activation") != 6:
+        raise AssertionError("connector-avoiding escape must require label 6")
+
+    source = payload.get("source_closure_target")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_closure_target must be a mapping")
+    expected_source = {
+        "source_schema": CLOSURE_TARGET_SCHEMA,
+        "source_status": CLOSURE_TARGET_STATUS,
+        "source_trust": CLOSURE_TARGET_TRUST,
+        "target_row_key": TARGET_ROW_KEY,
+        "target_row_center": TARGET_ROW_CENTER,
+        "target_witnesses": TARGET_WITNESSES,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+        "closure_labels": TARGET_CLOSURE_LABELS,
+        "required_connector_pair": CONNECTOR_PAIR,
+        "t12_connector_pair_chain": CONNECTOR_DISTANCE_PAIRS,
+        "row_forcing_gap_type": CLOSURE_TARGET_ROW_FORCING_GAP,
+        "relation_requirement_id": TARGET_REQUIREMENT_ID,
+    }
+    for key, expected in expected_source.items():
+        if source.get(key) != expected:
+            raise AssertionError(
+                f"source_closure_target {key} is {source.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_rich_triple_contract.py
+++ b/tests/test_bootstrap_t12_81_3_rich_triple_contract.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_rich_triple_contract import (
+    DEFAULT_ARTIFACT,
+    ESCAPE_STATUS,
+    LOCAL_CONDITIONAL_STATUS,
+    RICH_CLASS_EXISTENCE_STATUS,
+    RICH_TRIPLE_GAP,
+    assert_expected_payload,
+    build_t12_81_3_rich_triple_contract_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_81_3_rich_triple_contract_counts_and_scope() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "does not prove the rich class exists" in claim_scope
+    assert "does not prove row forcing" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert "does not claim a counterexample" in claim_scope
+
+
+def test_81_3_rich_triple_contract_summary() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["target_row_center"] == 3
+    assert summary["target_witnesses"] == [0, 1, 4, 6]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["connector_distance_pairs"] == [[1, 3], [0, 3]]
+    assert summary["connector_forcing_triples"] == [[0, 1, 4], [0, 1, 6]]
+    assert summary["connector_avoiding_activation_triples"] == [
+        [0, 4, 6],
+        [1, 4, 6],
+    ]
+    assert summary["seed_activation_triple"] == [0, 1, 4]
+    assert summary["seed_activation_forces_connector"]
+    assert not summary["full_row_forcing_required_for_connector"]
+    assert summary["local_conditional_lemma_status"] == LOCAL_CONDITIONAL_STATUS
+    assert summary["rich_class_existence_status"] == RICH_CLASS_EXISTENCE_STATUS
+    assert summary["escape_status"] == ESCAPE_STATUS
+    assert summary["rich_triple_gap_type"] == RICH_TRIPLE_GAP
+
+
+def test_81_3_rich_triple_contract_local_lemma_is_conditional() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    lemma = payload["local_conditional_lemma"]
+
+    assert lemma["status"] == "EXACT_LOCAL_CONDITIONAL"
+    assert "contains witnesses 0 and 1" in lemma["hypothesis"]
+    assert lemma["conclusion"] == "The selected-distance equality [1,3]=[0,3] holds."
+    assert "|p_3-p_1|=|p_3-p_0|" in lemma["proof"]
+    assert any("does not prove any rich class" in item for item in lemma["non_claims"])
+    assert any("does not prove the full fixed row" in item for item in lemma["non_claims"])
+
+
+def test_81_3_rich_triple_activation_triples_partition_escape() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    activation = payload["activation_triple_analysis"]
+
+    assert activation["all_witness_triples"] == [
+        [0, 1, 4],
+        [0, 1, 6],
+        [0, 4, 6],
+        [1, 4, 6],
+    ]
+    assert activation["connector_forcing_triples"] == [[0, 1, 4], [0, 1, 6]]
+    assert activation["connector_avoiding_activation_triples"] == [
+        [0, 4, 6],
+        [1, 4, 6],
+    ]
+    assert activation["seed_activation_uses_connector_pair"]
+    assert not activation["seed_activation_uses_outside_witness_6"]
+    assert activation["connector_avoiding_triples_all_use_outside_witness_6"]
+
+    forcing = activation["connector_forcing_triples"]
+    avoiding = activation["connector_avoiding_activation_triples"]
+    assert all(0 in triple and 1 in triple for triple in forcing)
+    assert all(not (0 in triple and 1 in triple) for triple in avoiding)
+    assert all(6 in triple for triple in avoiding)
+
+
+def test_81_3_rich_triple_escape_mechanism_names_next_target() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    escape = payload["escape_mechanism"]
+
+    assert escape["status"] == ESCAPE_STATUS
+    assert "avoid containing witnesses 0 and 1 together" in escape["escape_condition"]
+    assert escape["available_connector_avoiding_triples_in_fixed_row"] == [
+        [0, 4, 6],
+        [1, 4, 6],
+    ]
+    assert escape["outside_label_required_before_connector_avoiding_activation"] == 6
+    assert "[0,1,4]" in escape["why_label_6_matters"]
+    assert "Order-resolved rich-class closure" in escape["next_target"]
+
+
+def test_81_3_rich_triple_source_closure_target_matches_previous_packet() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    source = payload["source_closure_target"]
+
+    assert source["source_schema"] == "erdos97.bootstrap_t12_81_3_closure_target.v1"
+    assert source["source_status"] == "BOOTSTRAP_T12_81_3_CLOSURE_TARGET_DIAGNOSTIC_ONLY"
+    assert source["target_row_key"] == "81:3"
+    assert source["target_row_center"] == 3
+    assert source["required_connector_pair"] == [0, 1]
+    assert source["t12_connector_pair_chain"] == [[1, 3], [0, 3]]
+    assert source["row_forcing_gap_type"] == "FIXED_FULL_ROW_CLOSURE_NOT_RICH_CLASS_FORCING"
+    assert source["relation_requirement_id"] == "81:3:connector:2:0"
+
+
+def test_81_3_rich_triple_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_81_3_rich_triple_contract_payload()
+
+
+def test_81_3_rich_triple_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["target_row_key"] == "81:3"
+    assert payload["summary"]["escape_status"] == ESCAPE_STATUS
+
+
+def test_81_3_rich_triple_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_81_3_rich_triple_contract.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_81_3_rich_triple_expected_payload_rejects_drift() -> None:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["connector_pair"] = [0, 4]
+
+    with pytest.raises(AssertionError, match="connector_pair"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary
- add a generated `81:3` rich-triple connector contract packet reducing the target from full-row forcing to the connector pair `[0,1]`
- record the exact local conditional `[0,1]` in one genuine rich class at center `3` implies `[1,3]=[0,3]`, while preserving that rich-class existence remains open
- document the connector-avoiding escape through label `6` and wire the artifact into docs and provenance metadata

## Tests
- `python scripts/check_bootstrap_t12_81_3_rich_triple_contract.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --cached --check`
- `python -m ruff check .`
- `python -m pytest -q` (`711 passed, 281 deselected`)