### PR TITLE
[codex] Add bootstrap T12 81:3 order escape audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   target from full-row forcing to the pair `[0,1]` and records the exact
   connector-avoiding escape, read
   [`docs/bootstrap-t12-81-3-rich-triple-contract.md`](docs/bootstrap-t12-81-3-rich-triple-contract.md).
+- For the order-resolved `81:3` fixed-row escape audit, where label `6`
+  appears only after center `3` in the fixed singleton-rich closure, read
+  [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -266,6 +266,16 @@ or row is forced; see
 `scripts/check_bootstrap_t12_81_3_rich_triple_contract.py`, and
 `data/certificates/bootstrap_t12_81_3_rich_triple_contract.json`.
 
+The order-resolved `81:3` fixed-row escape audit checks the current
+singleton-rich closure order for that same seed. In the fixed selected-row
+model, `[0,1,4]` enables only center `3`, with trigger `[0,1,4]`; label `6`
+enters later through center `6` with trigger `[0,3,4]`, depending on center
+`3`. Thus the fixed packet does not realize the connector-avoiding escape.
+This is still diagnostic bookkeeping only, not a proof about genuine rich
+classes; see `docs/bootstrap-t12-81-3-order-escape.md`,
+`scripts/check_bootstrap_t12_81_3_order_escape.py`, and
+`data/certificates/bootstrap_t12_81_3_order_escape.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -148,6 +148,14 @@ activation through the fixed row must first expose label `6`. This is still
 diagnostic bookkeeping only, not a row-forcing theorem. See
 `docs/bootstrap-t12-81-3-rich-triple-contract.md`.
 
+An order-resolved `81:3` fixed-row escape audit now checks that the current
+singleton-rich closure from seed `[0,1,4]` does not supply that escape: center
+`3` is the only initial activation, and label `6` is added only afterward via
+trigger `[0,3,4]`, which already uses center `3`. The remaining target is
+genuine rich-class data: either find a pre-`3` supply of label `6` that avoids
+the connector, or prove such a supply impossible under the minimal/rich-class
+hypotheses. See `docs/bootstrap-t12-81-3-order-escape.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_81_3_order_escape.json
+++ b/data/certificates/bootstrap_t12_81_3_order_escape.json
@@ -1,0 +1,453 @@
+{
+  "claim_scope": "Fixed singleton-rich order diagnostic for source 81 row 3: in the fixed selected-row closure from seed [0,1,4], center 3 activates before label 6 is available, and label 6 is then added using a trigger containing center 3. This refines the remaining connector-avoiding escape target, but does not prove genuine rich-class order, does not prove row forcing, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "fixed_singleton_order_audit": {
+    "center_3_before_label_6": true,
+    "center_3_step": {
+      "added_center": 3,
+      "closure_before": [
+        0,
+        1,
+        4
+      ],
+      "label_6_available_before_step": false,
+      "label_6_supply_step": false,
+      "rich_class": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "rich_class_index": 0,
+      "step_index": 0,
+      "target_center_step": true,
+      "trigger_contains_connector_pair": true,
+      "trigger_depends_on_center_3": false,
+      "trigger_uses_label_6": false,
+      "trigger_witnesses": [
+        0,
+        1,
+        4
+      ]
+    },
+    "center_3_step_index": 0,
+    "center_3_trigger": [
+      0,
+      1,
+      4
+    ],
+    "center_3_trigger_forces_connector": true,
+    "classification_assignment_id": "A082",
+    "closure": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "enabled_after_seed_plus_center_3": [
+      {
+        "enabled_center": 6,
+        "rich_class": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "rich_class_index": 0,
+        "trigger_contains_connector_pair": false,
+        "trigger_uses_label_6": false,
+        "trigger_witnesses": [
+          0,
+          3,
+          4
+        ]
+      }
+    ],
+    "generates_all": false,
+    "initial_enabled_activations": [
+      {
+        "enabled_center": 3,
+        "rich_class": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "rich_class_index": 0,
+        "trigger_contains_connector_pair": true,
+        "trigger_uses_label_6": false,
+        "trigger_witnesses": [
+          0,
+          1,
+          4
+        ]
+      }
+    ],
+    "label_6_before_center_3": false,
+    "label_6_step_index": 1,
+    "label_6_supply_depends_on_center_3": true,
+    "label_6_supply_step": {
+      "added_center": 6,
+      "closure_before": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "label_6_available_before_step": false,
+      "label_6_supply_step": true,
+      "rich_class": [
+        0,
+        3,
+        4,
+        7
+      ],
+      "rich_class_index": 0,
+      "step_index": 1,
+      "target_center_step": false,
+      "trigger_contains_connector_pair": false,
+      "trigger_depends_on_center_3": true,
+      "trigger_uses_label_6": false,
+      "trigger_witnesses": [
+        0,
+        3,
+        4
+      ]
+    },
+    "label_6_supply_trigger": [
+      0,
+      3,
+      4
+    ],
+    "order": [
+      0,
+      1,
+      4,
+      3,
+      6
+    ],
+    "post_seed_steps": [
+      {
+        "added_center": 3,
+        "closure_before": [
+          0,
+          1,
+          4
+        ],
+        "label_6_available_before_step": false,
+        "label_6_supply_step": false,
+        "rich_class": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "rich_class_index": 0,
+        "step_index": 0,
+        "target_center_step": true,
+        "trigger_contains_connector_pair": true,
+        "trigger_depends_on_center_3": false,
+        "trigger_uses_label_6": false,
+        "trigger_witnesses": [
+          0,
+          1,
+          4
+        ]
+      },
+      {
+        "added_center": 6,
+        "closure_before": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "label_6_available_before_step": false,
+        "label_6_supply_step": true,
+        "rich_class": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "rich_class_index": 0,
+        "step_index": 1,
+        "target_center_step": false,
+        "trigger_contains_connector_pair": false,
+        "trigger_depends_on_center_3": true,
+        "trigger_uses_label_6": false,
+        "trigger_witnesses": [
+          0,
+          3,
+          4
+        ]
+      }
+    ],
+    "pre_3_label_6_supply_status": "NO_FIXED_SINGLETON_SUPPLY_BEFORE_CENTER_3",
+    "rich_class_model": "singleton_fixed_selected_rows",
+    "seed": [
+      0,
+      1,
+      4
+    ],
+    "selected_rows": [
+      [
+        1,
+        3,
+        6,
+        7
+      ],
+      [
+        2,
+        4,
+        7,
+        8
+      ],
+      [
+        0,
+        3,
+        5,
+        8
+      ],
+      [
+        0,
+        1,
+        4,
+        6
+      ],
+      [
+        1,
+        2,
+        5,
+        7
+      ],
+      [
+        2,
+        3,
+        6,
+        8
+      ],
+      [
+        0,
+        3,
+        4,
+        7
+      ],
+      [
+        1,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        2,
+        5,
+        6
+      ]
+    ],
+    "source_record_id": 81,
+    "target_row_key": "81:3"
+  },
+  "interpretation_warnings": [
+    "This packet audits only the fixed singleton-rich closure order for source 81.",
+    "It does not prove that the fixed selected row 81:3 is a genuine rich class.",
+    "It does not rule out extra genuine rich classes that add label 6 before center 3.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "order_resolved_escape_contract": {
+    "fixed_singleton_result": "The fixed singleton-rich closure does not realize that escape: center 3 is the only initial activation from [0,1,4], and label 6 is supplied only afterward by trigger [0,3,4].",
+    "fixed_singleton_status": "FIXED_SINGLETON_ORDER_ESCAPE_NOT_REALIZED",
+    "genuine_escape_certificate_needed": [
+      "a genuine rich class at some non-3 center that adds label 6 before center 3",
+      "or an exact proof that no such pre-3 label-6 supply exists",
+      "plus guardrails showing that any proposed supply does not already force the T12 connector"
+    ],
+    "required_for_connector_avoiding_activation": "Label 6 must be available before center 3 activates, because the connector-avoiding triples from [0,1,4,6] are [0,4,6] and [1,4,6].",
+    "status": "GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN"
+  },
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_order_escape.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_order_escape.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_order_escape.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_81_3_rich_triple_contract.json",
+      "role": "source 81:3 connector-pair rich-triple contract",
+      "schema": "erdos97.bootstrap_t12_81_3_rich_triple_contract.v1",
+      "status": "BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+      "role": "source selected rows and deletion-closure audit for source 81",
+      "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+      "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_rich_triple_contract": {
+    "connector_avoiding_activation_triples": [
+      [
+        0,
+        4,
+        6
+      ],
+      [
+        1,
+        4,
+        6
+      ]
+    ],
+    "connector_distance_pairs": [
+      [
+        1,
+        3
+      ],
+      [
+        0,
+        3
+      ]
+    ],
+    "connector_forcing_triples": [
+      [
+        0,
+        1,
+        4
+      ],
+      [
+        0,
+        1,
+        6
+      ]
+    ],
+    "connector_pair": [
+      0,
+      1
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "escape_status": "CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1",
+    "rich_class_existence_status": "OPEN_TARGET_NOT_PROVED",
+    "source_artifact": "data/certificates/bootstrap_t12_81_3_rich_triple_contract.json",
+    "source_schema": "erdos97.bootstrap_t12_81_3_rich_triple_contract.v1",
+    "source_status": "BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY",
+    "source_trust": "REVIEW_PENDING_DIAGNOSTIC",
+    "target_row_center": 3,
+    "target_row_key": "81:3",
+    "target_witnesses": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "status": "BOOTSTRAP_T12_81_3_ORDER_ESCAPE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "closure_labels": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "connector_avoiding_activation_triples": [
+      [
+        0,
+        4,
+        6
+      ],
+      [
+        1,
+        4,
+        6
+      ]
+    ],
+    "connector_distance_pairs": [
+      [
+        1,
+        3
+      ],
+      [
+        0,
+        3
+      ]
+    ],
+    "connector_forcing_triples": [
+      [
+        0,
+        1,
+        4
+      ],
+      [
+        0,
+        1,
+        6
+      ]
+    ],
+    "connector_pair": [
+      0,
+      1
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "exposed_core_vertex": 2,
+    "fixed_singleton_center_3_before_label_6": true,
+    "fixed_singleton_center_3_step_index": 0,
+    "fixed_singleton_center_3_trigger": [
+      0,
+      1,
+      4
+    ],
+    "fixed_singleton_center_3_trigger_forces_connector": true,
+    "fixed_singleton_closure": [
+      0,
+      1,
+      3,
+      4,
+      6
+    ],
+    "fixed_singleton_label_6_before_center_3": false,
+    "fixed_singleton_label_6_step_index": 1,
+    "fixed_singleton_label_6_supply_depends_on_center_3": true,
+    "fixed_singleton_label_6_supply_trigger": [
+      0,
+      3,
+      4
+    ],
+    "fixed_singleton_order": [
+      0,
+      1,
+      4,
+      3,
+      6
+    ],
+    "fixed_singleton_order_status": "FIXED_SINGLETON_ORDER_ESCAPE_NOT_REALIZED",
+    "genuine_escape_status": "GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN",
+    "initial_enabled_centers": [
+      3
+    ],
+    "next_bridge_question": "Can a genuine rich-class catalogue add label 6 before center 3 without already forcing the connector, or can this pre-3 label-6 supply be ruled out under the minimal/rich-class hypotheses?",
+    "order_escape_gap_type": "FIXED_SINGLETON_ORDER_NOT_GENUINE_RICH_CLASS_ORDER",
+    "pre_3_label_6_supply_status": "NO_FIXED_SINGLETON_SUPPLY_BEFORE_CENTER_3",
+    "source_record_ids": [
+      81
+    ],
+    "target_row_center": 3,
+    "target_row_key": "81:3",
+    "target_witnesses": [
+      0,
+      1,
+      4,
+      6
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-order-escape.md
+++ b/docs/bootstrap-t12-81-3-order-escape.md
@@ -1,0 +1,98 @@
+# Bootstrap T12 81:3 Order Escape
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note records the order-resolved follow-up to the `81:3` rich-triple
+connector contract. The previous packet reduced the target to the pair
+`[0,1]`: any genuine rich class at center `3` containing witnesses `0` and
+`1` gives the T12/F16 connector `[1,3]=[0,3]`. A connector-avoiding activation
+through the fixed witness set `[0,1,4,6]` must therefore use `[0,4,6]` or
+`[1,4,6]`, so label `6` must be available before center `3` activates.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_order_escape.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_order_escape.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_order_escape.json`.
+
+## Scope
+
+This packet audits only the fixed singleton-rich model from source `81`, where
+each selected row is treated as the only rich class at its center. It does not
+prove that the row `81:3` is a genuine rich class, does not prove genuine
+rich-class closure order, and does not rule out additional rich classes.
+
+## Fixed-Row Order Audit
+
+From seed
+
+```text
+[0,1,4]
+```
+
+the fixed singleton-rich closure order is:
+
+```text
+[0,1,4,3,6]
+```
+
+The only initial activation is center `3`, using trigger:
+
+```text
+[0,1,4]
+```
+
+That trigger contains the connector pair `[0,1]`. Label `6` is not available
+before this step.
+
+The next fixed singleton-rich step adds label `6`, but only after center `3`
+has entered:
+
+```text
+center 6 trigger: [0,3,4]
+```
+
+So the fixed selected-row bookkeeping does not realize the connector-avoiding
+escape. In that model, label `6` is supplied only by a trigger that already
+uses center `3`.
+
+## Remaining Escape
+
+The remaining exact escape status is:
+
+```text
+GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN
+```
+
+A genuine escape now needs one of the following:
+
+```text
+a genuine rich class at some non-3 center that adds label 6 before center 3
+```
+
+or
+
+```text
+an exact proof that no such pre-3 label-6 supply exists under the
+minimal/rich-class hypotheses
+```
+
+with guardrails showing that any proposed supply does not already force the
+T12 connector by another route.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It only records that the fixed
+singleton-row closure order fails to supply label `6` before center `3`, so
+the next target must use genuine rich-class data rather than the current fixed
+selected-row packet alone.

--- a/docs/bootstrap-t12-81-3-rich-triple-contract.md
+++ b/docs/bootstrap-t12-81-3-rich-triple-contract.md
@@ -96,6 +96,13 @@ needed connector without proving the full fixed row. A negative result should
 be packaged as an exact escape packet explaining how label `6` becomes
 available first without already forcing the connector.
 
+The follow-up order audit is recorded in
+`docs/bootstrap-t12-81-3-order-escape.md`. It checks that the fixed
+singleton-rich closure does not realize the connector-avoiding path: center
+`3` is the only initial activation from `[0,1,4]`, and label `6` is supplied
+only afterward by a trigger containing center `3`. The remaining target is now
+genuine rich-class data, not fixed-row closure order.
+
 ## What This Does Not Prove
 
 This artifact does not prove row forcing, rich-class existence, `n=9`, the

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -555,6 +555,14 @@ exists. Its value is to isolate the exact escape: every rich class at center
 `3` must avoid the pair `[0,1]`, and any connector-avoiding activation through
 the fixed witness set must use label `6` before center `3` activates.
 
+The order-resolved `81:3` fixed-row escape audit in
+`docs/bootstrap-t12-81-3-order-escape.md` shows that the existing fixed
+singleton-rich packet does not itself supply that escape. From seed `[0,1,4]`,
+center `3` is the only initial fixed-row activation and fires through
+`[0,1,4]`; label `6` enters only afterward through trigger `[0,3,4]`, which
+already uses center `3`. This is a fixed-row diagnostic only, not a theorem
+about all genuine rich-class catalogues.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -76,9 +76,15 @@ Use this queue when no more specific issue is selected.
    The follow-up `81:3` rich-triple connector contract in
    `docs/bootstrap-t12-81-3-rich-triple-contract.md` reduces the next target:
    the stored T12 connector only needs witnesses `0` and `1` in one genuine
-   rich class at center `3`. The next useful PR should attack the
-   order-resolved escape: either force activation from `[0,1,4]`, or certify
-   how label `6` becomes available first without forcing the connector.
+   rich class at center `3`.
+   The order-resolved fixed-row escape audit in
+   `docs/bootstrap-t12-81-3-order-escape.md` shows the current singleton-rich
+   closure does not expose label `6` first: center `3` is the only initial
+   activation from `[0,1,4]`, and label `6` is added later by trigger
+   `[0,3,4]`. The next useful PR should leave fixed selected-row bookkeeping
+   and attack the genuine rich-class question directly: either exhibit a
+   pre-`3` rich-class supply of label `6` that avoids the connector, or prove
+   no such supply can satisfy the minimal/rich-class hypotheses.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -167,6 +167,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-rich-triple-contract.md`](bootstrap-t12-81-3-rich-triple-contract.md):
   follow-up packet reducing the `81:3` target to the connector pair `[0,1]`
   and recording the exact connector-avoiding escape through label `6`.
+- [`bootstrap-t12-81-3-order-escape.md`](bootstrap-t12-81-3-order-escape.md):
+  order-resolved fixed-row packet showing label `6` is not exposed before
+  center `3` in the current singleton-rich closure.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -366,6 +366,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   the connector pair `[0,1]`: any genuine rich class at center `3` containing
   that pair gives `[1,3]=[0,3]`, while a connector-avoiding activation must
   expose label `6` first.
+- bootstrap/T12 focused `81:3` order-escape evidence, as recorded in
+  `docs/bootstrap-t12-81-3-order-escape.md`, checking that the fixed
+  singleton-rich closure does not expose label `6` before center `3`; any
+  successful escape now needs genuine rich-class data that supplies label `6`
+  first, or a proof that no such supply exists.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -213,6 +213,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_rich_triple_contract.json"
       verifier: "scripts/check_bootstrap_t12_81_3_rich_triple_contract.py"
       claim_scope: "fixed selected-row proof-mining diagnostic only; proves only the local conditional from a genuine rich class at center 3 containing witnesses 0 and 1 to connector [1,3]=[0,3], but does not prove rich-class existence, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_order_escape"
+      status: "order-resolved fixed-row escape audit for the 81:3 T12/F16 target"
+      artifact: "data/certificates/bootstrap_t12_81_3_order_escape.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_order_escape.py"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; shows the current singleton-rich closure does not expose label 6 before center 3, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2420,6 +2420,117 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_order_escape
+    path: data/certificates/bootstrap_t12_81_3_order_escape.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_order_escape.py
+    command: python scripts/check_bootstrap_t12_81_3_order_escape.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_order_escape.py
+    check_command: python scripts/check_bootstrap_t12_81_3_order_escape.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused 81:3 order-resolved fixed-row escape diagnostic; shows only that the current singleton-rich closure from seed [0,1,4] activates center 3 before label 6 and later supplies label 6 using center 3, not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_order_escape.v1
+      status: BOOTSTRAP_T12_81_3_ORDER_ESCAPE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.target_row_center: 3
+      summary.target_witnesses:
+        - 0
+        - 1
+        - 4
+        - 6
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.exposed_core_vertex: 2
+      summary.closure_labels:
+        - 0
+        - 1
+        - 3
+        - 4
+        - 6
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.connector_forcing_triples:
+        - [0, 1, 4]
+        - [0, 1, 6]
+      summary.connector_avoiding_activation_triples:
+        - [0, 4, 6]
+        - [1, 4, 6]
+      summary.fixed_singleton_order:
+        - 0
+        - 1
+        - 4
+        - 3
+        - 6
+      summary.fixed_singleton_closure:
+        - 0
+        - 1
+        - 3
+        - 4
+        - 6
+      summary.initial_enabled_centers:
+        - 3
+      summary.fixed_singleton_center_3_step_index: 0
+      summary.fixed_singleton_label_6_step_index: 1
+      summary.fixed_singleton_label_6_before_center_3: false
+      summary.fixed_singleton_center_3_before_label_6: true
+      summary.fixed_singleton_center_3_trigger:
+        - 0
+        - 1
+        - 4
+      summary.fixed_singleton_center_3_trigger_forces_connector: true
+      summary.fixed_singleton_label_6_supply_trigger:
+        - 0
+        - 3
+        - 4
+      summary.fixed_singleton_label_6_supply_depends_on_center_3: true
+      summary.fixed_singleton_order_status: FIXED_SINGLETON_ORDER_ESCAPE_NOT_REALIZED
+      summary.pre_3_label_6_supply_status: NO_FIXED_SINGLETON_SUPPLY_BEFORE_CENTER_3
+      summary.genuine_escape_status: GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN
+      summary.order_escape_gap_type: FIXED_SINGLETON_ORDER_NOT_GENUINE_RICH_CLASS_ORDER
+      fixed_singleton_order_audit.center_3_trigger:
+        - 0
+        - 1
+        - 4
+      fixed_singleton_order_audit.label_6_supply_trigger:
+        - 0
+        - 3
+        - 4
+      fixed_singleton_order_audit.label_6_supply_depends_on_center_3: true
+      order_resolved_escape_contract.status: GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN
+      source_rich_triple_contract.source_schema: erdos97.bootstrap_t12_81_3_rich_triple_contract.v1
+      source_rich_triple_contract.escape_status: CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1
+      provenance.generator: scripts/check_bootstrap_t12_81_3_order_escape.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_order_escape.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - closure exposure proves row 81:3 is forced
+      - full-row containment proves a rich class
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the connector-pair contract proves rich-class existence
+      - the order-escape packet proves genuine rich-class order
+      - the order-escape packet proves no pre-3 label-6 supply exists
+      - the order-escape packet proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_order_escape.py
+++ b/scripts/check_bootstrap_t12_81_3_order_escape.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 order-resolved escape packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_order_escape import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_order_escape_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 order-resolved escape")
+    print(f"target row: {summary['target_row_key']}")
+    print(f"fixed singleton order: {summary['fixed_singleton_order']}")
+    print(f"initial enabled centers: {summary['initial_enabled_centers']}")
+    print(
+        "center 3 before label 6: "
+        f"{summary['fixed_singleton_center_3_before_label_6']}"
+    )
+    print(f"genuine escape status: {summary['genuine_escape_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_order_escape_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 order-escape artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 order-escape expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_order_escape.py
+++ b/src/erdos97/bootstrap_t12_81_3_order_escape.py
@@ -1,0 +1,551 @@
+"""Order-resolved fixed-row escape audit for bootstrap/T12 row 81:3.
+
+The preceding rich-triple packet shows that a genuine rich class at center
+``3`` containing witnesses ``0`` and ``1`` supplies the T12/F16 connector
+``[1,3]=[0,3]``.  This packet audits the narrower fixed singleton-row closure
+order from seed ``[0,1,4]``: in that bookkeeping model, center ``3`` activates
+before label ``6`` is available, and label ``6`` is added only after using
+center ``3``.
+
+This remains diagnostic bookkeeping.  It does not prove that the fixed row is
+geometrically forced, and it does not rule out a genuine rich-class catalogue
+that supplies label ``6`` before center ``3`` by additional rich classes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.adaptive_blockers import singleton_rich_classes_from_pattern
+from erdos97.bootstrap_cores import RichClasses, closure
+from erdos97.bootstrap_t12_81_3_closure_target import (
+    TARGET_CLASSIFICATION_ASSIGNMENT_ID,
+)
+from erdos97.bootstrap_t12_81_3_rich_triple_contract import (
+    CONNECTOR_AVOIDING_ACTIVATION_TRIPLES,
+    CONNECTOR_DISTANCE_PAIRS,
+    CONNECTOR_FORCING_TRIPLES,
+    CONNECTOR_PAIR,
+    DEFAULT_ARTIFACT as RICH_TRIPLE_ARTIFACT,
+    ESCAPE_STATUS as RICH_TRIPLE_ESCAPE_STATUS,
+    RICH_CLASS_EXISTENCE_STATUS,
+    SCHEMA as RICH_TRIPLE_SCHEMA,
+    STATUS as RICH_TRIPLE_STATUS,
+    TARGET_CLOSURE_LABELS,
+    TARGET_DELETION_SEED,
+    TARGET_EXPOSED_CORE_VERTEX,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+    TARGET_SOURCE_RECORD_ID,
+    TARGET_WITNESSES,
+    TRUST as RICH_TRIPLE_TRUST,
+    build_t12_81_3_rich_triple_contract_payload,
+)
+from erdos97.bootstrap_vertex_circle_overlay import (
+    SCHEMA as OVERLAY_SCHEMA,
+    STATUS as OVERLAY_STATUS,
+    TRUST as OVERLAY_TRUST,
+    build_overlay_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_order_escape.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ORDER_ESCAPE_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Fixed singleton-rich order diagnostic for source 81 row 3: in the fixed "
+    "selected-row closure from seed [0,1,4], center 3 activates before label "
+    "6 is available, and label 6 is then added using a trigger containing "
+    "center 3. This refines the remaining connector-avoiding escape target, "
+    "but does not prove genuine rich-class order, does not prove row forcing, "
+    "does not prove n=9, does not prove the bridge, and does not claim a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bootstrap_t12_81_3_order_escape.json"
+)
+
+FIXED_SINGLETON_ORDER_STATUS = "FIXED_SINGLETON_ORDER_ESCAPE_NOT_REALIZED"
+GENUINE_ESCAPE_STATUS = "GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN"
+PRE_3_LABEL_6_SUPPLY_STATUS = "NO_FIXED_SINGLETON_SUPPLY_BEFORE_CENTER_3"
+ORDER_ESCAPE_GAP = "FIXED_SINGLETON_ORDER_NOT_GENUINE_RICH_CLASS_ORDER"
+EXPECTED_FIXED_SINGLETON_ORDER = [0, 1, 4, 3, 6]
+EXPECTED_INITIAL_ENABLED_CENTERS = [3]
+EXPECTED_CENTER_3_TRIGGER = [0, 1, 4]
+EXPECTED_LABEL_6_TRIGGER = [0, 3, 4]
+EXPECTED_LABEL_6_SUPPLY_CENTER = 6
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _contains_connector_pair(values: Iterable[int]) -> bool:
+    value_set = {int(value) for value in values}
+    return all(label in value_set for label in CONNECTOR_PAIR)
+
+
+def _source_81_overlay_record() -> Mapping[str, Any]:
+    payload = build_overlay_payload()
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise AssertionError("overlay payload records must be a list")
+    matches = [
+        record
+        for record in records
+        if isinstance(record, Mapping)
+        and int(record.get("source_record_id", -1)) == TARGET_SOURCE_RECORD_ID
+    ]
+    if len(matches) != 1:
+        raise AssertionError("expected exactly one overlay record for source 81")
+    record = matches[0]
+    if record.get("classification_assignment_id") != TARGET_CLASSIFICATION_ASSIGNMENT_ID:
+        raise AssertionError("source 81 overlay assignment id drifted")
+    if record.get("selected_rows", [])[TARGET_ROW_CENTER] != TARGET_WITNESSES:
+        raise AssertionError("source 81 target row drifted")
+    return record
+
+
+def _enabled_entries(
+    rich_classes: RichClasses,
+    closure_vertices: Iterable[int],
+) -> list[dict[str, object]]:
+    closure_set = {int(label) for label in closure_vertices}
+    entries: list[dict[str, object]] = []
+    for center, classes in enumerate(rich_classes):
+        if center in closure_set:
+            continue
+        for class_index, row in enumerate(classes):
+            row_list = _int_list(row)
+            internal = sorted(set(row_list) & closure_set)
+            if len(internal) < 3:
+                continue
+            trigger = internal[:3]
+            entries.append(
+                {
+                    "enabled_center": center,
+                    "rich_class_index": class_index,
+                    "rich_class": row_list,
+                    "trigger_witnesses": trigger,
+                    "trigger_contains_connector_pair": _contains_connector_pair(
+                        trigger
+                    ),
+                    "trigger_uses_label_6": 6 in trigger,
+                }
+            )
+    return entries
+
+
+def _step_entries(result_steps: Sequence[Any]) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    for step_index, step in enumerate(result_steps):
+        trigger = _int_list(step.trigger_witnesses)
+        closure_before = _int_list(step.closure_before)
+        entries.append(
+            {
+                "step_index": step_index,
+                "added_center": int(step.added_center),
+                "rich_class_index": int(step.rich_class_index),
+                "rich_class": _int_list(step.rich_class),
+                "trigger_witnesses": trigger,
+                "closure_before": closure_before,
+                "target_center_step": int(step.added_center)
+                == TARGET_ROW_CENTER,
+                "label_6_supply_step": int(step.added_center)
+                == EXPECTED_LABEL_6_SUPPLY_CENTER,
+                "trigger_contains_connector_pair": _contains_connector_pair(
+                    trigger
+                ),
+                "trigger_uses_label_6": 6 in trigger,
+                "label_6_available_before_step": 6 in closure_before,
+                "trigger_depends_on_center_3": TARGET_ROW_CENTER in trigger,
+            }
+        )
+    return entries
+
+
+def _step_index_for(entries: Sequence[Mapping[str, Any]], center: int) -> int | None:
+    for entry in entries:
+        if int(entry["added_center"]) == center:
+            return int(entry["step_index"])
+    return None
+
+
+def _fixed_singleton_order_audit() -> dict[str, object]:
+    record = _source_81_overlay_record()
+    selected_rows = record["selected_rows"]
+    if not isinstance(selected_rows, list):
+        raise AssertionError("source selected rows must be a list")
+    rich_classes = singleton_rich_classes_from_pattern(selected_rows)
+    result = closure(TARGET_DELETION_SEED, rich_classes)
+    steps = _step_entries(result.steps)
+    center_3_step_index = _step_index_for(steps, TARGET_ROW_CENTER)
+    label_6_step_index = _step_index_for(steps, EXPECTED_LABEL_6_SUPPLY_CENTER)
+    if center_3_step_index is None:
+        raise AssertionError("fixed singleton closure did not activate center 3")
+    if label_6_step_index is None:
+        raise AssertionError("fixed singleton closure did not activate label 6")
+    center_3_step = steps[center_3_step_index]
+    label_6_step = steps[label_6_step_index]
+    initial_enabled = _enabled_entries(rich_classes, TARGET_DELETION_SEED)
+    seed_plus_3_enabled = _enabled_entries(
+        rich_classes,
+        sorted(set(TARGET_DELETION_SEED) | {TARGET_ROW_CENTER}),
+    )
+
+    return {
+        "source_record_id": TARGET_SOURCE_RECORD_ID,
+        "classification_assignment_id": record["classification_assignment_id"],
+        "target_row_key": TARGET_ROW_KEY,
+        "selected_rows": selected_rows,
+        "rich_class_model": "singleton_fixed_selected_rows",
+        "seed": result.seed,
+        "closure": result.closure,
+        "order": result.order,
+        "generates_all": result.generates_all,
+        "post_seed_steps": steps,
+        "initial_enabled_activations": initial_enabled,
+        "enabled_after_seed_plus_center_3": seed_plus_3_enabled,
+        "center_3_step_index": center_3_step_index,
+        "label_6_step_index": label_6_step_index,
+        "center_3_step": center_3_step,
+        "label_6_supply_step": label_6_step,
+        "label_6_before_center_3": label_6_step_index < center_3_step_index,
+        "center_3_before_label_6": center_3_step_index < label_6_step_index,
+        "center_3_trigger": center_3_step["trigger_witnesses"],
+        "center_3_trigger_forces_connector": center_3_step[
+            "trigger_contains_connector_pair"
+        ],
+        "label_6_supply_trigger": label_6_step["trigger_witnesses"],
+        "label_6_supply_depends_on_center_3": label_6_step[
+            "trigger_depends_on_center_3"
+        ],
+        "pre_3_label_6_supply_status": PRE_3_LABEL_6_SUPPLY_STATUS,
+    }
+
+
+def _rich_triple_source_summary() -> dict[str, object]:
+    payload = build_t12_81_3_rich_triple_contract_payload()
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("rich-triple source summary must be a mapping")
+    return {
+        "source_artifact": RICH_TRIPLE_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+        "source_schema": payload.get("schema"),
+        "source_status": payload.get("status"),
+        "source_trust": payload.get("trust"),
+        "target_row_key": summary.get("target_row_key"),
+        "target_row_center": summary.get("target_row_center"),
+        "target_witnesses": summary.get("target_witnesses"),
+        "deletion_seed": summary.get("deletion_seed"),
+        "connector_pair": summary.get("connector_pair"),
+        "connector_distance_pairs": summary.get("connector_distance_pairs"),
+        "connector_forcing_triples": summary.get("connector_forcing_triples"),
+        "connector_avoiding_activation_triples": summary.get(
+            "connector_avoiding_activation_triples"
+        ),
+        "rich_class_existence_status": summary.get(
+            "rich_class_existence_status"
+        ),
+        "escape_status": summary.get("escape_status"),
+    }
+
+
+def build_t12_81_3_order_escape_payload() -> dict[str, object]:
+    """Return the deterministic order-resolved fixed-row escape packet."""
+
+    order_audit = _fixed_singleton_order_audit()
+    rich_triple_summary = _rich_triple_source_summary()
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This packet audits only the fixed singleton-rich closure order for source 81.",
+            "It does not prove that the fixed selected row 81:3 is a genuine rich class.",
+            "It does not rule out extra genuine rich classes that add label 6 before center 3.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [TARGET_SOURCE_RECORD_ID],
+            "target_row_center": TARGET_ROW_CENTER,
+            "target_witnesses": TARGET_WITNESSES,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+            "closure_labels": TARGET_CLOSURE_LABELS,
+            "connector_pair": CONNECTOR_PAIR,
+            "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+            "connector_forcing_triples": CONNECTOR_FORCING_TRIPLES,
+            "connector_avoiding_activation_triples": (
+                CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+            ),
+            "fixed_singleton_order": order_audit["order"],
+            "fixed_singleton_closure": order_audit["closure"],
+            "initial_enabled_centers": [
+                entry["enabled_center"]
+                for entry in order_audit["initial_enabled_activations"]
+            ],
+            "fixed_singleton_center_3_step_index": order_audit[
+                "center_3_step_index"
+            ],
+            "fixed_singleton_label_6_step_index": order_audit[
+                "label_6_step_index"
+            ],
+            "fixed_singleton_label_6_before_center_3": order_audit[
+                "label_6_before_center_3"
+            ],
+            "fixed_singleton_center_3_before_label_6": order_audit[
+                "center_3_before_label_6"
+            ],
+            "fixed_singleton_center_3_trigger": order_audit[
+                "center_3_trigger"
+            ],
+            "fixed_singleton_center_3_trigger_forces_connector": order_audit[
+                "center_3_trigger_forces_connector"
+            ],
+            "fixed_singleton_label_6_supply_trigger": order_audit[
+                "label_6_supply_trigger"
+            ],
+            "fixed_singleton_label_6_supply_depends_on_center_3": order_audit[
+                "label_6_supply_depends_on_center_3"
+            ],
+            "fixed_singleton_order_status": FIXED_SINGLETON_ORDER_STATUS,
+            "pre_3_label_6_supply_status": PRE_3_LABEL_6_SUPPLY_STATUS,
+            "genuine_escape_status": GENUINE_ESCAPE_STATUS,
+            "order_escape_gap_type": ORDER_ESCAPE_GAP,
+            "next_bridge_question": (
+                "Can a genuine rich-class catalogue add label 6 before center "
+                "3 without already forcing the connector, or can this "
+                "pre-3 label-6 supply be ruled out under the minimal/rich-class "
+                "hypotheses?"
+            ),
+        },
+        "fixed_singleton_order_audit": order_audit,
+        "order_resolved_escape_contract": {
+            "status": GENUINE_ESCAPE_STATUS,
+            "fixed_singleton_status": FIXED_SINGLETON_ORDER_STATUS,
+            "required_for_connector_avoiding_activation": (
+                "Label 6 must be available before center 3 activates, because "
+                "the connector-avoiding triples from [0,1,4,6] are [0,4,6] "
+                "and [1,4,6]."
+            ),
+            "fixed_singleton_result": (
+                "The fixed singleton-rich closure does not realize that escape: "
+                "center 3 is the only initial activation from [0,1,4], and "
+                "label 6 is supplied only afterward by trigger [0,3,4]."
+            ),
+            "genuine_escape_certificate_needed": [
+                "a genuine rich class at some non-3 center that adds label 6 before center 3",
+                "or an exact proof that no such pre-3 label-6 supply exists",
+                "plus guardrails showing that any proposed supply does not already force the T12 connector",
+            ],
+        },
+        "source_rich_triple_contract": rich_triple_summary,
+        "source_artifacts": [
+            {
+                "path": RICH_TRIPLE_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+                "role": "source 81:3 connector-pair rich-triple contract",
+                "schema": RICH_TRIPLE_SCHEMA,
+                "status": RICH_TRIPLE_STATUS,
+                "trust": RICH_TRIPLE_TRUST,
+            },
+            {
+                "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+                "role": "source selected rows and deletion-closure audit for source 81",
+                "schema": OVERLAY_SCHEMA,
+                "status": OVERLAY_STATUS,
+                "trust": OVERLAY_TRUST,
+            },
+        ],
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_order_escape.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_order_escape.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline values for the order-escape packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [TARGET_SOURCE_RECORD_ID],
+        "target_row_center": TARGET_ROW_CENTER,
+        "target_witnesses": TARGET_WITNESSES,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "exposed_core_vertex": TARGET_EXPOSED_CORE_VERTEX,
+        "closure_labels": TARGET_CLOSURE_LABELS,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+        "connector_forcing_triples": CONNECTOR_FORCING_TRIPLES,
+        "connector_avoiding_activation_triples": (
+            CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+        ),
+        "fixed_singleton_order": EXPECTED_FIXED_SINGLETON_ORDER,
+        "fixed_singleton_closure": TARGET_CLOSURE_LABELS,
+        "initial_enabled_centers": EXPECTED_INITIAL_ENABLED_CENTERS,
+        "fixed_singleton_center_3_step_index": 0,
+        "fixed_singleton_label_6_step_index": 1,
+        "fixed_singleton_label_6_before_center_3": False,
+        "fixed_singleton_center_3_before_label_6": True,
+        "fixed_singleton_center_3_trigger": EXPECTED_CENTER_3_TRIGGER,
+        "fixed_singleton_center_3_trigger_forces_connector": True,
+        "fixed_singleton_label_6_supply_trigger": EXPECTED_LABEL_6_TRIGGER,
+        "fixed_singleton_label_6_supply_depends_on_center_3": True,
+        "fixed_singleton_order_status": FIXED_SINGLETON_ORDER_STATUS,
+        "pre_3_label_6_supply_status": PRE_3_LABEL_6_SUPPLY_STATUS,
+        "genuine_escape_status": GENUINE_ESCAPE_STATUS,
+        "order_escape_gap_type": ORDER_ESCAPE_GAP,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    warnings = payload.get("interpretation_warnings")
+    if not isinstance(warnings, Sequence):
+        raise AssertionError("interpretation_warnings must be a sequence")
+    if not any("fixed selected row 81:3" in str(warning) for warning in warnings):
+        raise AssertionError("warnings must preserve the row-forcing gap")
+    if not any("extra genuine rich classes" in str(warning) for warning in warnings):
+        raise AssertionError("warnings must preserve the genuine escape gap")
+
+    audit = payload.get("fixed_singleton_order_audit")
+    if not isinstance(audit, Mapping):
+        raise AssertionError("fixed_singleton_order_audit must be a mapping")
+    expected_audit = {
+        "source_record_id": TARGET_SOURCE_RECORD_ID,
+        "classification_assignment_id": TARGET_CLASSIFICATION_ASSIGNMENT_ID,
+        "target_row_key": TARGET_ROW_KEY,
+        "rich_class_model": "singleton_fixed_selected_rows",
+        "seed": TARGET_DELETION_SEED,
+        "closure": TARGET_CLOSURE_LABELS,
+        "order": EXPECTED_FIXED_SINGLETON_ORDER,
+        "generates_all": False,
+        "center_3_step_index": 0,
+        "label_6_step_index": 1,
+        "label_6_before_center_3": False,
+        "center_3_before_label_6": True,
+        "center_3_trigger": EXPECTED_CENTER_3_TRIGGER,
+        "center_3_trigger_forces_connector": True,
+        "label_6_supply_trigger": EXPECTED_LABEL_6_TRIGGER,
+        "label_6_supply_depends_on_center_3": True,
+        "pre_3_label_6_supply_status": PRE_3_LABEL_6_SUPPLY_STATUS,
+    }
+    for key, expected in expected_audit.items():
+        if audit.get(key) != expected:
+            raise AssertionError(
+                f"fixed_singleton_order_audit {key} is {audit.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+
+    initial_enabled = audit.get("initial_enabled_activations")
+    if not isinstance(initial_enabled, Sequence) or len(initial_enabled) != 1:
+        raise AssertionError("initial enabled activations must contain one entry")
+    initial = initial_enabled[0]
+    if not isinstance(initial, Mapping):
+        raise AssertionError("initial enabled activation must be a mapping")
+    if initial.get("enabled_center") != TARGET_ROW_CENTER:
+        raise AssertionError("center 3 must be the only initial activation")
+    if initial.get("trigger_witnesses") != EXPECTED_CENTER_3_TRIGGER:
+        raise AssertionError("initial center 3 trigger drifted")
+    if not initial.get("trigger_contains_connector_pair"):
+        raise AssertionError("initial center 3 trigger must contain connector pair")
+
+    steps = audit.get("post_seed_steps")
+    if not isinstance(steps, Sequence) or len(steps) != 2:
+        raise AssertionError("fixed singleton closure should have two post-seed steps")
+    center_3_step = steps[0]
+    label_6_step = steps[1]
+    if not isinstance(center_3_step, Mapping) or not isinstance(label_6_step, Mapping):
+        raise AssertionError("post-seed steps must be mappings")
+    if center_3_step.get("added_center") != TARGET_ROW_CENTER:
+        raise AssertionError("first post-seed step must add center 3")
+    if center_3_step.get("trigger_witnesses") != EXPECTED_CENTER_3_TRIGGER:
+        raise AssertionError("center 3 step trigger drifted")
+    if center_3_step.get("label_6_available_before_step"):
+        raise AssertionError("label 6 must not be available before center 3")
+    if label_6_step.get("added_center") != EXPECTED_LABEL_6_SUPPLY_CENTER:
+        raise AssertionError("second post-seed step must add label 6")
+    if label_6_step.get("trigger_witnesses") != EXPECTED_LABEL_6_TRIGGER:
+        raise AssertionError("label 6 supply trigger drifted")
+    if not label_6_step.get("trigger_depends_on_center_3"):
+        raise AssertionError("label 6 supply must depend on center 3")
+
+    contract = payload.get("order_resolved_escape_contract")
+    if not isinstance(contract, Mapping):
+        raise AssertionError("order_resolved_escape_contract must be a mapping")
+    if contract.get("status") != GENUINE_ESCAPE_STATUS:
+        raise AssertionError("genuine escape contract status drifted")
+    if contract.get("fixed_singleton_status") != FIXED_SINGLETON_ORDER_STATUS:
+        raise AssertionError("fixed singleton status drifted")
+
+    source = payload.get("source_rich_triple_contract")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_rich_triple_contract must be a mapping")
+    expected_source = {
+        "source_schema": RICH_TRIPLE_SCHEMA,
+        "source_status": RICH_TRIPLE_STATUS,
+        "source_trust": RICH_TRIPLE_TRUST,
+        "target_row_key": TARGET_ROW_KEY,
+        "target_row_center": TARGET_ROW_CENTER,
+        "target_witnesses": TARGET_WITNESSES,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+        "connector_forcing_triples": CONNECTOR_FORCING_TRIPLES,
+        "connector_avoiding_activation_triples": (
+            CONNECTOR_AVOIDING_ACTIVATION_TRIPLES
+        ),
+        "rich_class_existence_status": RICH_CLASS_EXISTENCE_STATUS,
+        "escape_status": RICH_TRIPLE_ESCAPE_STATUS,
+    }
+    for key, expected in expected_source.items():
+        if source.get(key) != expected:
+            raise AssertionError(
+                f"source_rich_triple_contract {key} is {source.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_order_escape.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_order_escape.py
+++ b/tests/test_bootstrap_t12_81_3_order_escape.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    DEFAULT_ARTIFACT,
+    FIXED_SINGLETON_ORDER_STATUS,
+    GENUINE_ESCAPE_STATUS,
+    ORDER_ESCAPE_GAP,
+    PRE_3_LABEL_6_SUPPLY_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_order_escape_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_81_3_order_escape_counts_and_scope() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_81_3_ORDER_ESCAPE_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Fixed singleton-rich order diagnostic" in claim_scope
+    assert "does not prove genuine rich-class order" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert "counterexample" in claim_scope
+
+
+def test_81_3_order_escape_summary_pins_order() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["target_row_center"] == 3
+    assert summary["target_witnesses"] == [0, 1, 4, 6]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["connector_forcing_triples"] == [[0, 1, 4], [0, 1, 6]]
+    assert summary["connector_avoiding_activation_triples"] == [
+        [0, 4, 6],
+        [1, 4, 6],
+    ]
+    assert summary["fixed_singleton_order"] == [0, 1, 4, 3, 6]
+    assert summary["fixed_singleton_closure"] == [0, 1, 3, 4, 6]
+    assert summary["initial_enabled_centers"] == [3]
+    assert summary["fixed_singleton_center_3_step_index"] == 0
+    assert summary["fixed_singleton_label_6_step_index"] == 1
+    assert not summary["fixed_singleton_label_6_before_center_3"]
+    assert summary["fixed_singleton_center_3_before_label_6"]
+    assert summary["fixed_singleton_center_3_trigger"] == [0, 1, 4]
+    assert summary["fixed_singleton_center_3_trigger_forces_connector"]
+    assert summary["fixed_singleton_label_6_supply_trigger"] == [0, 3, 4]
+    assert summary["fixed_singleton_label_6_supply_depends_on_center_3"]
+    assert summary["fixed_singleton_order_status"] == FIXED_SINGLETON_ORDER_STATUS
+    assert summary["pre_3_label_6_supply_status"] == PRE_3_LABEL_6_SUPPLY_STATUS
+    assert summary["genuine_escape_status"] == GENUINE_ESCAPE_STATUS
+    assert summary["order_escape_gap_type"] == ORDER_ESCAPE_GAP
+
+
+def test_81_3_order_escape_fixed_singleton_audit() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    audit = payload["fixed_singleton_order_audit"]
+
+    assert audit["source_record_id"] == 81
+    assert audit["classification_assignment_id"] == "A082"
+    assert audit["target_row_key"] == "81:3"
+    assert audit["rich_class_model"] == "singleton_fixed_selected_rows"
+    assert audit["seed"] == [0, 1, 4]
+    assert audit["closure"] == [0, 1, 3, 4, 6]
+    assert audit["order"] == [0, 1, 4, 3, 6]
+    assert not audit["generates_all"]
+    assert audit["center_3_step_index"] == 0
+    assert audit["label_6_step_index"] == 1
+    assert not audit["label_6_before_center_3"]
+    assert audit["center_3_before_label_6"]
+    assert audit["center_3_trigger"] == [0, 1, 4]
+    assert audit["center_3_trigger_forces_connector"]
+    assert audit["label_6_supply_trigger"] == [0, 3, 4]
+    assert audit["label_6_supply_depends_on_center_3"]
+    assert audit["pre_3_label_6_supply_status"] == PRE_3_LABEL_6_SUPPLY_STATUS
+
+    assert audit["selected_rows"][3] == [0, 1, 4, 6]
+    assert audit["selected_rows"][6] == [0, 3, 4, 7]
+    assert audit["initial_enabled_activations"] == [
+        {
+            "enabled_center": 3,
+            "rich_class_index": 0,
+            "rich_class": [0, 1, 4, 6],
+            "trigger_witnesses": [0, 1, 4],
+            "trigger_contains_connector_pair": True,
+            "trigger_uses_label_6": False,
+        }
+    ]
+
+
+def test_81_3_order_escape_steps_show_6_depends_on_3() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    steps = payload["fixed_singleton_order_audit"]["post_seed_steps"]
+
+    assert len(steps) == 2
+    center_3_step, label_6_step = steps
+    assert center_3_step["added_center"] == 3
+    assert center_3_step["closure_before"] == [0, 1, 4]
+    assert center_3_step["trigger_witnesses"] == [0, 1, 4]
+    assert center_3_step["trigger_contains_connector_pair"]
+    assert not center_3_step["label_6_available_before_step"]
+
+    assert label_6_step["added_center"] == 6
+    assert label_6_step["closure_before"] == [0, 1, 3, 4]
+    assert label_6_step["trigger_witnesses"] == [0, 3, 4]
+    assert not label_6_step["trigger_contains_connector_pair"]
+    assert label_6_step["trigger_depends_on_center_3"]
+
+
+def test_81_3_order_escape_contract_names_remaining_target() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    contract = payload["order_resolved_escape_contract"]
+
+    assert contract["status"] == GENUINE_ESCAPE_STATUS
+    assert contract["fixed_singleton_status"] == FIXED_SINGLETON_ORDER_STATUS
+    assert "Label 6 must be available before center 3" in contract[
+        "required_for_connector_avoiding_activation"
+    ]
+    assert "does not realize that escape" in contract["fixed_singleton_result"]
+    assert any(
+        "genuine rich class" in item
+        for item in contract["genuine_escape_certificate_needed"]
+    )
+
+
+def test_81_3_order_escape_source_rich_triple_contract_matches() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    source = payload["source_rich_triple_contract"]
+
+    assert source["source_schema"] == "erdos97.bootstrap_t12_81_3_rich_triple_contract.v1"
+    assert (
+        source["source_status"]
+        == "BOOTSTRAP_T12_81_3_RICH_TRIPLE_CONTRACT_DIAGNOSTIC_ONLY"
+    )
+    assert source["target_row_key"] == "81:3"
+    assert source["target_row_center"] == 3
+    assert source["target_witnesses"] == [0, 1, 4, 6]
+    assert source["connector_pair"] == [0, 1]
+    assert source["connector_forcing_triples"] == [[0, 1, 4], [0, 1, 6]]
+    assert source["connector_avoiding_activation_triples"] == [
+        [0, 4, 6],
+        [1, 4, 6],
+    ]
+    assert source["rich_class_existence_status"] == "OPEN_TARGET_NOT_PROVED"
+
+
+def test_81_3_order_escape_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_81_3_order_escape_payload()
+
+
+def test_81_3_order_escape_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_order_escape.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["target_row_key"] == "81:3"
+    assert payload["summary"]["genuine_escape_status"] == GENUINE_ESCAPE_STATUS
+
+
+def test_81_3_order_escape_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_81_3_order_escape.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_order_escape.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_order_escape.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_81_3_order_escape_expected_payload_rejects_drift() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["fixed_singleton_order"] = [0, 1, 4, 6, 3]
+
+    with pytest.raises(AssertionError, match="fixed_singleton_order"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

Adds a verifier-backed order-resolved diagnostic for the bootstrap/T12 `81:3` target. The new packet records that, in the fixed singleton-rich closure from seed `[0,1,4]`, center `3` is the only initial activation and label `6` appears only afterward via trigger `[0,3,4]`, which already uses center `3`.

This narrows the next bridge target without overclaiming: a genuine connector-avoiding escape now needs actual rich-class data that supplies label `6` before center `3`, or an exact proof that no such supply exists.

## Scope guardrails

- Diagnostic only; no general proof or counterexample is claimed.
- Does not prove row/rich-class forcing, genuine rich-class order, or `n=9`.
- Keeps metadata and source-of-truth docs aligned with the new artifact.

## Validation

- `python scripts/check_bootstrap_t12_81_3_order_escape.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_81_3_order_escape.py`
- `python -m ruff check src/erdos97/bootstrap_t12_81_3_order_escape.py scripts/check_bootstrap_t12_81_3_order_escape.py tests/test_bootstrap_t12_81_3_order_escape.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`