### PR TITLE
Add turn frontier certificates

### DIFF
--- a/data/certificates/n10_turn_row0_pilot.json
+++ b/data/certificates/n10_turn_row0_pilot.json
@@ -1,0 +1,15463 @@
+{
+  "assignment_sha256": "ec0fa48ec4db8a4a133bffbd86647ade7f33444a1ccb7eea098aae04df4d42b7",
+  "assignments": [
+    {
+      "assignment_index_1based": 1,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 1,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          60,
+          72,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 2,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 2,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          60,
+          72,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 3,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          8,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 3,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          83,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 4,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 4,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          60,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 5,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 5,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          60,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 6,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 6,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 7,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 7,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 8,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          7,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 8,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 9,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 9,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          12,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 10,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 10,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          12,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 11,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 11,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          72,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 12,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 12,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          72,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 13,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          7,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 13,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 14,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          7,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 14,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 15,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 15,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 16,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 16,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 17,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          8,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 17,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          83,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 18,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 18,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          83,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 19,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 19,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          83,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 20,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          7,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 20,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 21,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 21,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 22,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 22,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 23,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 23,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 24,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 24,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 25,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 25,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          72,
+          84,
+          95
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 26,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          7,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 26,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 27,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 27,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          84,
+          96,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 28,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 28,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          107,
+          108,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 29,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 29,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 30,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 30,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 31,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 31,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 32,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 32,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 33,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 33,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          12,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 34,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 34,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          60,
+          72,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 35,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 35,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          60,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 36,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          7,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 36,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 37,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          7,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 37,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          60,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 38,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 38,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          60,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 39,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 39,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          83,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 40,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 40,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 41,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          7,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 41,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          60,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 42,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 42,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 43,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          7,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 43,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 44,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 44,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 45,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 45,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 46,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 46,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 47,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          7,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 47,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          95,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 48,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 48,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 49,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 49,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          72,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 50,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 50,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 51,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 51,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 52,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 52,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          72,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 53,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 53,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 54,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 54,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 55,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 55,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 56,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 56,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 57,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 57,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 58,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          4,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 58,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 59,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 59,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          84,
+          96,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 60,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 60,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 61,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 61,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 62,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 62,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 63,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 63,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          84,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 64,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 64,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          84,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 65,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 65,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 66,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 66,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 67,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 67,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 68,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 68,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 69,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 69,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          84,
+          96,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 70,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 70,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          95,
+          96,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 71,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          8,
+          9
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 71,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          12,
+          23,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 72,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          8,
+          9
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 72,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          84,
+          107,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 73,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 73,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 74,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_model": [
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "1",
+        "0"
+      ],
+      "turn_status": "sat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 75,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 75,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          107,
+          108,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 76,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 76,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          95,
+          107,
+          108,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 77,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 77,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          95,
+          107,
+          108,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 78,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 78,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          96,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 79,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 79,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          96,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 80,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 80,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 81,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 81,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          72,
+          95
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 82,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 82,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 83,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 83,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 84,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 84,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          95,
+          107,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 85,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 85,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          72,
+          95
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 86,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 86,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 87,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 87,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 88,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 88,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          48,
+          72,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 89,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 89,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 90,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 90,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 91,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 91,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 92,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 92,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 93,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 93,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 94,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 94,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 95,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 95,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 96,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 96,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 97,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 97,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 98,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 98,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 99,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 99,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 100,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          4,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 100,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 101,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 101,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 102,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 102,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 103,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          9
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          4,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_model": [
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "0",
+        "1",
+        "0",
+        "1",
+        "0"
+      ],
+      "turn_status": "sat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 104,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 104,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 105,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 105,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          83,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 106,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 106,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          83,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 107,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 107,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 108,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 108,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 109,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 109,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 110,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          4,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 110,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 111,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 111,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 112,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 112,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 113,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 113,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 114,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 114,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 115,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 115,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 116,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          9
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 116,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 117,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          3,
+          7,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 117,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          83,
+          95
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 118,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          3,
+          7,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 118,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          83,
+          95
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 119,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          3,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 119,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 120,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 120,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          96,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 121,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 121,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          48,
+          60,
+          72,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 122,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 122,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          60,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 123,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 123,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 124,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 124,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          84,
+          96
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 125,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 125,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 126,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 126,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 127,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 127,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          60,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 128,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 128,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 129,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 129,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          12,
+          60,
+          83,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 130,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 130,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 131,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 131,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 132,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 132,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 133,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 133,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 134,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          8,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          1,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 134,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          83,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 135,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 135,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          48,
+          60,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 136,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 136,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 137,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 137,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 138,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          3,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          6
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 138,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 139,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 139,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 140,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 140,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          60,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 141,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 141,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          60,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 142,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 142,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          48,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 143,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 143,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 144,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 144,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 145,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          6
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 145,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          96,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 146,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 146,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 147,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          3,
+          9
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 147,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          83,
+          95,
+          107,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          0,
+          0,
+          1,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 148,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          3,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 148,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 149,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 149,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          107
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 150,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          0,
+          1,
+          3,
+          5
+        ],
+        [
+          0,
+          2,
+          4,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          6,
+          9
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 150,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          48,
+          72,
+          84
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 151,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 151,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          95,
+          107,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 152,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          7,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          1,
+          6,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 152,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          24,
+          95,
+          107,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 153,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 153,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 154,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          7,
+          9
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 154,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 155,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 155,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 156,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_model": [
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "0",
+        "1"
+      ],
+      "turn_status": "sat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 157,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          6,
+          8
+        ],
+        [
+          1,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ]
+      ],
+      "turn_model": [
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "0",
+        "0",
+        "1",
+        "0",
+        "1"
+      ],
+      "turn_status": "sat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 158,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          7,
+          9
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          3,
+          5,
+          6
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 158,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          24,
+          48,
+          72
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0,
+          1,
+          0,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 159,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          7,
+          9
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          3,
+          5,
+          9
+        ],
+        [
+          4,
+          6,
+          8,
+          9
+        ],
+        [
+          3,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 159,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          36,
+          72,
+          84,
+          108
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+          1,
+          1,
+          1
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index_1based": 160,
+      "rows": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        [
+          0,
+          2,
+          6,
+          9
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          9
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          4,
+          7,
+          8,
+          9
+        ],
+        [
+          0,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          9
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ]
+      ],
+      "turn_certificate": {
+        "assignment_index_1based": 160,
+        "deficit": 1,
+        "lambda": 1,
+        "max_variable_coefficient": 1,
+        "rhs_sum": 5,
+        "term_count": 5,
+        "term_indices": [
+          0,
+          23,
+          36,
+          95,
+          119
+        ],
+        "term_weight": 1,
+        "variable_coefficients": [
+          1,
+          1,
+          0,
+          0,
+          1,
+          0,
+          1,
+          1,
+          1,
+          0
+        ]
+      },
+      "turn_status": "farkas_unsat",
+      "vertex_circle_status": "self_edge"
+    }
+  ],
+  "claim_scope": "Bounded n=10 row0-index-0 turn-frontier pilot; not a proof of n=10, not a counterexample, not a completeness result, and not a global status update.",
+  "full_assignment_count": 160,
+  "interpretation": "The candidate turn inequalities kill most, but not all, raw assignments in this bounded n=10 slice. The four weak-turn SAT escapes are all killed by the existing vertex-circle self-edge filter.",
+  "n": 10,
+  "provenance": {
+    "command": "python scripts/check_n10_turn_row0_pilot.py --assert-expected --write",
+    "generator": "scripts/check_n10_turn_row0_pilot.py"
+  },
+  "row0_index": 0,
+  "row_size": 4,
+  "schema": "erdos97.n10_turn_row0_pilot.v1",
+  "status": "EXPLORATORY_ROW0_TURN_FRONTIER_PILOT",
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF",
+  "turn_farkas_certificate_count": 156,
+  "turn_farkas_certificate_sha256": "c55eb78466233cc7c9c379ffd1d8d555304349e4bc4eaf588c79be5638ee4a55",
+  "turn_sat_escape_count": 4,
+  "turn_sat_escape_self_edges": [
+    {
+      "assignment_index_1based": 74,
+      "self_edge": {
+        "distance_equality_path": [
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              4,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "shared_endpoint_count": 1,
+        "witness_order": [
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+    },
+    {
+      "assignment_index_1based": 103,
+      "self_edge": {
+        "distance_equality_path": [
+          {
+            "next_pair": [
+              0,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "shared_endpoint_count": 1,
+        "witness_order": [
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+    },
+    {
+      "assignment_index_1based": 156,
+      "self_edge": {
+        "distance_equality_path": [
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "shared_endpoint_count": 1,
+        "witness_order": [
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+    },
+    {
+      "assignment_index_1based": 157,
+      "self_edge": {
+        "distance_equality_path": [
+          {
+            "next_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              0,
+              4
+            ],
+            "row": 0
+          },
+          {
+            "next_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "next_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          }
+        ],
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "shared_endpoint_count": 1,
+        "witness_order": [
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+    }
+  ],
+  "turn_status_counts": {
+    "farkas_unsat": 156,
+    "sat": 4
+  },
+  "vertex_circle_status_counts": {
+    "self_edge": 160
+  }
+}

--- a/data/certificates/n9_turn_inequality_frontier.json
+++ b/data/certificates/n9_turn_inequality_frontier.json
@@ -1,0 +1,5155 @@
+{
+  "benchmarks": [
+    {
+      "frontier_assignment_index_1based": 4,
+      "indegrees": [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "name": "gpt_pro_output_10_side_cap_pattern",
+      "natural_order_classify_status": "accepted_frontier",
+      "natural_order_phi_edges": 18,
+      "natural_order_rectangle_trap_4_cycles": 0,
+      "natural_order_row_ptolemy_product_cancellation_count": 0,
+      "rows": [
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ],
+        [
+          4,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ]
+      ],
+      "side_sensitive_pair_cap_violation_count": 0,
+      "turn_inequality_count": 108,
+      "turn_z3_status": "unsat",
+      "vertex_circle_status": "self_edge"
+    }
+  ],
+  "claim_scope": "Candidate n=9 selected-witness turn-inequality frontier replay; not a proof of Erdos Problem #97, not a counterexample, not an independent review, and not a source-of-truth status update.",
+  "conclusion": "All 184 regenerated n=9 pair/crossing/count frontier assignments have stored integer dual certificates proving infeasibility of the candidate weak turn inequalities.",
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "farkas_certificates": [
+    {
+      "assignment_index_1based": 1,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        48,
+        60,
+        71,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 2,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        60,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 3,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        36,
+        60,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 4,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 5,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        48,
+        84,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 6,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 7,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        23,
+        36,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 8,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 9,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 10,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 11,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 12,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        72,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 13,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        83,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 14,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        36,
+        59,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 15,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        36,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 16,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        71,
+        72,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 17,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        36,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 18,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        84,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 19,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        60,
+        72,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 20,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        84,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 21,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        36,
+        59,
+        60,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 22,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        23,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 23,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 24,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        36,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 25,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        23,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 26,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        36,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 27,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        48,
+        71,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 28,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        23,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 29,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 30,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        59,
+        71,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 31,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 32,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        36,
+        59,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 33,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 34,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 35,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 36,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        72,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 37,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 38,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        59,
+        71,
+        72,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 39,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        59,
+        71,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 40,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        23,
+        36,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 41,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        36,
+        59,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 42,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        59,
+        83,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 43,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 44,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        36,
+        60,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 45,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 46,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        72,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 47,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        23,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 48,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        24,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 49,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 50,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        48,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 51,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 52,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        36,
+        48,
+        59,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 53,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        36,
+        59,
+        60,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 54,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        60,
+        83,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 55,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        60,
+        72,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 56,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        36,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 57,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        60,
+        83,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 58,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 59,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        12,
+        36,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 60,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        12,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 61,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        12,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 62,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        12,
+        24,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 63,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        23,
+        59,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 64,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        23,
+        24,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 65,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        23,
+        71,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 66,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        23,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 67,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        36,
+        48,
+        60,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 68,
+      "deficit": 1,
+      "lambda": 2,
+      "max_variable_coefficient": 2,
+      "rhs_sum": 9,
+      "term_count": 9,
+      "term_indices": [
+        0,
+        12,
+        24,
+        36,
+        48,
+        60,
+        72,
+        84,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    },
+    {
+      "assignment_index_1based": 69,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        36,
+        59,
+        60,
+        72,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 70,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        24,
+        35,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 71,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        36,
+        59,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 72,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        36,
+        47,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 73,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        36,
+        59,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 74,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        47,
+        48,
+        71,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 75,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        36,
+        48,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 76,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        47,
+        59,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 77,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        35,
+        59,
+        83,
+        84,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 78,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        24,
+        36,
+        47,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 79,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        24,
+        47,
+        48,
+        72,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 80,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        72,
+        95,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 81,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        24,
+        35,
+        47,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 82,
+      "deficit": 1,
+      "lambda": 2,
+      "max_variable_coefficient": 2,
+      "rhs_sum": 9,
+      "term_count": 9,
+      "term_indices": [
+        0,
+        11,
+        12,
+        23,
+        24,
+        35,
+        36,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    },
+    {
+      "assignment_index_1based": 83,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        48,
+        71,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 84,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        59,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 85,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        59,
+        71,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 86,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        24,
+        48,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 87,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        36,
+        48,
+        59,
+        60,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 88,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        47,
+        59,
+        60,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 89,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        47,
+        59,
+        60,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 90,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        24,
+        47,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 91,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        24,
+        36,
+        47,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 92,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        47,
+        59,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 93,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        36,
+        48,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 94,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        35,
+        36,
+        59,
+        72,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 95,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        60,
+        83,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 96,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        47,
+        71,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 97,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        24,
+        47,
+        48,
+        60,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 98,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 99,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 100,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        35,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 101,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        35,
+        47
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 102,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        36,
+        47
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 103,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 104,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        36,
+        59,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 105,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        48,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 106,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        48,
+        71,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 107,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        71,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 108,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        35,
+        59,
+        71,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 109,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        36,
+        59,
+        95,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 110,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        36,
+        72,
+        95,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 111,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 112,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        35,
+        36,
+        48,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 113,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        48,
+        60,
+        71,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 114,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        35,
+        47,
+        59,
+        71,
+        72
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 115,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        24,
+        36,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 116,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        48,
+        71,
+        72,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 117,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        35,
+        36,
+        60,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 118,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        23,
+        35,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 119,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        23,
+        35,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 120,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        23,
+        24,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 121,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        35,
+        47
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 122,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        24,
+        47,
+        83,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 123,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        47,
+        59,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 124,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        36,
+        60,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 125,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        35,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 126,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        48,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 127,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        60,
+        83,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 128,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        35,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 129,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        36,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 130,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        71,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 131,
+      "deficit": 1,
+      "lambda": 2,
+      "max_variable_coefficient": 2,
+      "rhs_sum": 9,
+      "term_count": 9,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        59,
+        71,
+        83,
+        95,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    },
+    {
+      "assignment_index_1based": 132,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        35,
+        71,
+        83,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 133,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        23,
+        24,
+        36
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 134,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        47,
+        60,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 135,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        47,
+        59,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 136,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 137,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        47,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 138,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 139,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        48,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 140,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 141,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        48,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 142,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        48,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 143,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        59,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 144,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        47,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 145,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 146,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        47,
+        48,
+        71,
+        84,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 147,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        71,
+        83,
+        84,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 148,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        24,
+        47,
+        83,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 149,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        48,
+        60,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 150,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        24,
+        60,
+        84,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 151,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        48,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 152,
+      "deficit": 1,
+      "lambda": 2,
+      "max_variable_coefficient": 2,
+      "rhs_sum": 9,
+      "term_count": 9,
+      "term_indices": [
+        0,
+        11,
+        12,
+        23,
+        24,
+        35,
+        36,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    },
+    {
+      "assignment_index_1based": 153,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        23,
+        71,
+        72,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 154,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        36,
+        47
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 155,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        47,
+        71,
+        72,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 156,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        47,
+        71,
+        95,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 157,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        0,
+        11,
+        24,
+        95,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 158,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        47,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 159,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        24,
+        36,
+        60,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 160,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        24,
+        48,
+        60,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 161,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        24,
+        48,
+        60,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 162,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        12,
+        48,
+        71,
+        72,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 163,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        47,
+        59,
+        71,
+        83,
+        84
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 164,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        59,
+        60,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 165,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        23,
+        24,
+        47,
+        60,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "assignment_index_1based": 166,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        48,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 167,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 168,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        48,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 169,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        48,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 170,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        71,
+        83,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 171,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        71,
+        83,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 172,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        59,
+        60,
+        83,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 173,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        59,
+        71,
+        83,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 174,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        47,
+        59
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 175,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        24,
+        47,
+        60
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 176,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        47,
+        59,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 177,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        48,
+        96
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 178,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        47,
+        59,
+        71
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 179,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        83,
+        107
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 180,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        24,
+        35,
+        48
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 181,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        35,
+        59,
+        60,
+        83
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 182,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        36,
+        47
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 183,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        12,
+        35,
+        71,
+        95
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        0,
+        1,
+        1,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1
+      ]
+    },
+    {
+      "assignment_index_1based": 184,
+      "deficit": 1,
+      "lambda": 1,
+      "max_variable_coefficient": 1,
+      "rhs_sum": 5,
+      "term_count": 5,
+      "term_indices": [
+        11,
+        23,
+        35,
+        36,
+        47
+      ],
+      "term_weight": 1,
+      "variable_coefficients": [
+        1,
+        1,
+        1,
+        0,
+        1,
+        0,
+        0,
+        0,
+        1
+      ]
+    }
+  ],
+  "farkas_replay": {
+    "arithmetic": "integer coefficient check; no solver needed for replay",
+    "certificate_count": 184,
+    "certificate_explanation": "For each assignment, summing the listed interval inequalities gives RHS > 4*lambda while every turn variable has coefficient at most lambda. Since t_i >= 0 and sum_i t_i = 4, the same left-hand side is at most 4*lambda, a contradiction.",
+    "certificate_sha256": "1aed1b1f78178b967f93a3894e67cf9a0c314441a94423c8f24f2e0b8cb9bf89",
+    "certificate_type": "unit_weight_interval_dual",
+    "deficit_histogram": {
+      "1": 184
+    },
+    "lambda_histogram": {
+      "1": 180,
+      "2": 4
+    },
+    "max_variable_coefficient_histogram": {
+      "1": 180,
+      "2": 4
+    },
+    "term_count_histogram": {
+      "5": 180,
+      "9": 4
+    }
+  },
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write",
+    "generator": "scripts/check_n9_turn_inequality_frontier.py"
+  },
+  "review_requirements": [
+    "Review the geometric turn lemma and indexing conventions.",
+    "Review the regenerated n=9 source frontier and lack of hidden symmetry quotienting.",
+    "Review the stored integer dual certificates and their arithmetic verifier.",
+    "Keep this scoped as review-pending n=9 finite-case evidence only."
+  ],
+  "row_size": 4,
+  "schema": "erdos97.n9_turn_inequality_frontier.v1",
+  "source_frontier": {
+    "assignment_count": 184,
+    "assignment_sha256": "d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01",
+    "description": "Complete selected-witness assignments surviving pair/crossing/count filters before vertex-circle pruning.",
+    "generator": "GenericVertexSearch(n=9).valid_options_for_center",
+    "indegree_distribution": {
+      "(4, 4, 4, 4, 4, 4, 4, 4, 4)": 184
+    },
+    "side_sensitive_pair_cap_violation_count_histogram": {
+      "0": 184
+    }
+  },
+  "status": "REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY",
+  "trust": "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING",
+  "turn_system": {
+    "inequality_count_histogram": {
+      "108": 184
+    },
+    "nonnegativity": "t_i >= 0",
+    "normalized_variables": "t_i = 2*tau_i/pi",
+    "strict_geometry_note": "The geometric lemma gives strict inequalities; this replay uses weak rational inequalities, so UNSAT is stronger than needed.",
+    "sum_constraint": "sum_i t_i = 4",
+    "weak_inequality_template": [
+      "sum_{h=1}^{b-1} t_{i+h} >= 1",
+      "sum_{h=a+1}^{8} t_{i+h} >= 1"
+    ]
+  },
+  "z3_replay": {
+    "arithmetic": "exact rational linear real arithmetic",
+    "role": "cross-check; stored Farkas certificates are verified by integer arithmetic",
+    "sat_count": 0,
+    "solver": "z3",
+    "status_counts": {
+      "unsat": 184
+    },
+    "unknown_count": 0,
+    "unsat_count": 184
+  }
+}

--- a/docs/gpt-pro-followup-triage-2026-05-11.md
+++ b/docs/gpt-pro-followup-triage-2026-05-11.md
@@ -1,0 +1,361 @@
+# GPT Pro follow-up triage, 2026-05-11
+
+Status: provenance and task-selection guidance only; not mathematical evidence.
+
+This note triages ten additional GPT Pro outputs supplied in chat. It does not
+promote any claim, alter the source-of-truth status, or replace the checked
+finite-case and exact-obstruction artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Decision
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this batch. The useful parts are either already in
+the repo or should remain as negative-control/provenance leads until converted
+into small checked artifacts.
+
+Highest-value salvage:
+
+- a standalone parabola model-case write-up, if promoted from the existing
+  synthesis artifact;
+- the exact nonconvex eight-point all-bad model as a possible convexity-check
+  negative control;
+- the reminder that diameter-endpoint shortcuts are unsafe.
+
+## Outputs 1 and 2: small-case incidence obstruction
+
+Triage: already covered, with stronger repo-local machinery.
+
+The side-pair/diagonal-pair capacity proof in Output 1 is the same geometric
+base-apex count recorded in `docs/n8-geometric-proof.md`, and its selected-row
+version is the sharpened incidence count in `docs/claims.md`. The conclusion
+`n >= 8` and the saturated `n=8` constraints are already source-tracked.
+
+Output 2's Fano/perpendicularity proof for `n=7` matches the proof-facing
+summary in `docs/claims.md` and the reproducible enumeration in
+`docs/n7-fano-enumeration.md`. Its lower bound on the number of row-pairs with
+two common witnesses is a useful sanity check, but it is not a new source claim.
+
+Recommended current action: no source-of-truth update.
+
+## Outputs 3 and 4: parabola model case and failed shortcuts
+
+Triage: the parabola proof is valid as a model-case theorem; keep it separate
+from the global problem.
+
+The proof for points on the standard parabola
+
+```text
+p(t) = (t, t^2)
+```
+
+is the same argument already recorded in
+`data/llm_runs/ten_prompt_review_2026-04-29/corrected_synthesis.md`: if four
+parameters `u_1,...,u_4` are at the same distance from `p(t)`, Vieta's formulas
+for
+
+```text
+(u-t)^2 * (1 + (u+t)^2) = R
+```
+
+give
+
+```text
+u_1 + u_2 + u_3 + u_4 = 0
+u_1^2 + u_2^2 + u_3^2 + u_4^2 = 4*t^2 - 2.
+```
+
+Choosing a point with minimal `|t|` gives a contradiction. This is a clean
+subcase obstruction and is worth a standalone proof note if it is promoted into
+the proof-facing docs. It is not evidence of a general theorem beyond that
+subcase.
+
+The alternating-radius octagon/regular two-orbit discussion is already
+subsumed by `docs/two-orbit-radius-propagation.md`, which records the exact
+convexity obstruction for the relevant ansatz and a broader alternating
+two-radius regular-family check.
+
+The diameter-endpoint shortcut should remain rejected. A diameter endpoint can
+still have four other vertices at the same smaller distance, so proof routes
+that try to choose a diameter endpoint and bound all smaller distance layers by
+three need an additional argument.
+
+Recommended current action: if this branch is revived, add
+`docs/parabola-model-case.md` as a compact standalone proof and link it from
+the proof-facing index. Do not promote it to a global result.
+
+## Output 5: exact nonconvex eight-point all-bad model
+
+Triage: useful negative control; not a counterexample.
+
+The pasted coordinates with `a = 2 - sqrt(3)` were sanity-checked locally with
+exact SymPy arithmetic. For the supplied rows, every selected squared radius is
+exactly equal; rows alternate between squared radii `2 - sqrt(3)` and `1`.
+The convex hull of the eight points has labels `[5, 3, 1, 7]`, so only four of
+the eight points are hull vertices.
+
+This is therefore an exact all-bad point set outside strict convex position. It
+is a good trap for weak convexity checks, especially checks that only inspect a
+claimed cyclic label order and miss self-intersection or interior points. It is
+not a counterexample to Erdos Problem #97.
+
+Recommended current action: optionally add a small JSON artifact and verifier
+later, for example `data/certificates/nonconvex_all_bad_octagon_control.json`
+plus a script that checks exact row distances and hull size. This is lower
+priority than the current `n=9` local-lemma and finite-artifact audit tasks.
+
+## Existing exact nonconvex ten-point control
+
+Output 2's pentagon-plus-inner-pentagon near miss is already represented by
+`golden_decagon_example()` in `src/erdos97/affine_circuit_certificates.py` and
+checked by:
+
+```bash
+python scripts/check_affine_circuit_certificates.py --example golden-decagon --assert-expected --json
+```
+
+This remains a negative control showing that the equal-distance equations are
+not inherently contradictory once strict convexity is dropped.
+
+## Output 6: compact n=8 saturation proof
+
+Triage: already covered by the octagon proof-note draft.
+
+The follow-up proof excluding bad convex octagons is essentially the same route
+as `docs/n8-geometric-proof.md`: the base-apex capacity count saturates at
+`n=8`; length-2 diagonals force all side lengths equal; length-3 diagonals
+force the set of exterior turns equal to `2*pi/3` to hit every adjacent pair in
+the 8-cycle; at least four such turns contradict total exterior turn `2*pi`.
+
+This is a useful reviewer-facing phrasing because it keeps the slack at `n=9`
+visible: the same capacity bound is `63`, while the forced lower count is only
+`54`. That explains exactly where the saturation argument stops.
+
+Recommended current action: no new source-of-truth update. If the octagon
+proof note is revised for external review, consider borrowing this output's
+explicit `m(a,b)` notation and final `n=9` slack calculation as explanatory
+text. Keep the note's current status as a proof-note draft pending independent
+review.
+
+## Output 7: alternate n=8 middle-target enumeration
+
+Triage: partly known, partly unverified. Do not promote.
+
+The initial incidence ingredients are already source-tracked:
+
+- the two-circle cap `|S_i cap S_j| <= 2`;
+- the target-pair cap that a pair `{a,b}` can occur in at most two selected
+  rows;
+- the `n=8` witness indegree regularity proof `d_x = 4`, recorded in
+  `docs/claims.md` and `docs/n8-incidence-enumeration.md`.
+
+The new proposed ingredient is a middle-target rule: if `j in S_i` and
+`|S_i cap S_j| = 2`, then `j` must be one of the two middle targets of `S_i`
+in angular order around `p_i`. The geometric intuition is plausible: the line
+`p_i p_j` is the perpendicular bisector of a chord of the selected circle
+centered at `p_i`, so its direction is an angle-bisector direction for that
+chord. But to be usable in this repo it needs a precise lemma covering:
+
+- the boundary-order-to-angular-order hypothesis at a hull vertex;
+- the exclusion of the opposite angle-bisector ray;
+- the case where the two common witnesses are not adjacent among the four
+  selected targets;
+- why an extreme selected target cannot be such a bisector point.
+
+The output then says an exact enumeration leaves nine labelled incidence
+patterns, three fail by a wrong-midpoint-direction condition, and the remaining
+six force a single distance class containing a `K_{2,3}`. This is not currently
+a checked repo artifact, and the count does not match the existing
+`n=8` incidence pipeline, which leaves 15 canonical survivor classes before
+exact geometric obstruction. The proposed enumeration may simply be using a
+stronger middle-target filter, but that filter and the nine-pattern count would
+need a replayable script or JSON certificate before they can be cited.
+
+The final `K_{2,3}` obstruction is valid only with its exact equality scope
+made explicit: two centers sharing the same three targets at one common radius
+would force three intersections of two distinct equal-radius circles. A checker
+would need to verify that the selected-distance quotient really puts all six
+edges of the alleged `K_{2,3}` into one distance class, not just into two
+separate row-radius classes.
+
+Recommended current action: preserve this as an alternate n=8 proof route to
+benchmark against the existing 15-class checker. A useful follow-up artifact
+would be a small script that implements the middle-target rule, emits the nine
+patterns, and verifies the wrong-bisector or single-distance-`K_{2,3}` kill for
+each pattern. Until then, keep `docs/n8-geometric-proof.md`,
+`docs/n8-incidence-enumeration.md`, and `docs/n8-exact-survivors.md` as the
+source-tracked n=8 routes.
+
+## Output 8: two-pattern n=8 collapse and explicit n=9 slack pattern
+
+Triage: useful cross-reference, but still not a source-of-truth update.
+
+The `n <= 8` conclusion is already covered by the repository's existing
+routes. The proof's first three lemmas match the current incidence/crossing
+toolkit. Its n=8 counting phase is a good compact derivation of the saturated
+octagon structure:
+
+- all nonadjacent row-pairs have two common witnesses;
+- all adjacent row-pairs have exactly one common witness;
+- all target indegrees are four;
+- the length-2 source chord condition forces adjacent labels into each row.
+
+The output then says the remaining n=8 crossing possibilities reduce to the
+two cyclic patterns
+
+```text
+S_i = {i-1,i+1,i+2,i+5}
+S_i = {i-1,i+1,i+3,i+6}
+```
+
+and each pattern forces every consecutive triple to be equilateral. This would
+be a nice short proof if the finite reduction to exactly those two patterns is
+replayed by a checker. It should not replace the current
+`docs/n8-geometric-proof.md` argument or the 15-class incidence/exact pipeline
+until that tiny enumeration is made reproducible.
+
+The explicit n=9 pattern displayed at the end is already tracked in
+`docs/n9-incidence-frontier.md` as the row-Ptolemy frontier pattern:
+
+```text
+S0 = {1,2,3,8}
+S1 = {0,3,4,7}
+S2 = {1,3,5,6}
+S3 = {2,4,5,8}
+S4 = {0,3,6,8}
+S5 = {2,4,6,7}
+S6 = {1,5,7,8}
+S7 = {0,1,4,6}
+S8 = {0,2,5,7}
+```
+
+It does satisfy the early pair/crossing/count filters in the natural cyclic
+order and has balanced indegrees. In the fixed natural order, the repo classifies
+it by six exact row-Ptolemy product-cancellation certificates. That obstruction
+is order-sensitive: `tests/test_n9_incidence_frontier.py` records a scrambled
+order where the row-Ptolemy certificates disappear. Separately, the
+review-pending exhaustive n=9 vertex-circle checker kills all 184 complete
+patterns surviving the pair/crossing/count filters, including this kind of
+slack-frontier behavior, but that n=9 artifact remains review-pending.
+
+Recommended current action: no metadata/status update. If this branch is
+continued, the best artifact would be a script that proves the n=8 two-pattern
+reduction from the saturated row constraints. For n=9, use the displayed
+pattern as a benchmark already connected to row-Ptolemy and vertex-circle
+review artifacts, not as a new live candidate.
+
+## Output 9: candidate n=9 turn-inequality LP obstruction
+
+Triage: promising review-pending route; not a source-of-truth update.
+
+The side-aware pair-cap sharpening gives a compact n=9 indegree argument: if a
+vertex `x` appears in `r_x` selected rows, then the `3*r_x` witness-pair
+occurrences involving `x` have capacity
+
+```text
+2 side-neighbor pairs * 1 + 6 diagonal pairs * 2 = 14,
+```
+
+so `r_x <= 4`. Since total selected appearances are `36`, every `r_x` must be
+4. This is stronger than the generic n=9 checker bound `r_x <= 5`, although an
+ad hoc replay over the existing 184 pair/crossing/count frontier assignments
+also found all 184 to be 4-regular.
+
+The proposed turn lemma is also plausible and useful: if a row centered at `i`
+contains selected offsets `a < b`, then equal distances from `i` force the
+edge-direction turn along the arc from `i` to `i+b` to exceed `pi/2`, and the
+reverse complementary arc to exceed `pi/2`. In normalized variables
+`t_i = 2*tau_i/pi`, the weak constraints are:
+
+```text
+sum_i t_i = 4,   t_i >= 0,
+sum_{h=1}^{b-1} t_{i+h} >= 1,
+sum_{h=a+1}^{8} t_{i+h} >= 1.
+```
+
+I ran an ad hoc exact-rational Z3 replay over the 184 complete n=9 assignments
+that survive the existing pair/crossing/count filters in
+`GenericVertexSearch(use_vertex_circle=False)`. All 184 were `unsat` under
+these weak turn constraints. A SciPy `linprog` replay gave the same result.
+
+This is not yet a claim-bearing artifact. Before this can change the local
+finite-case status, the repo needs:
+
+- a proof-facing write-up of the turn lemma, including the reverse-arc
+  inequality and indexing conventions;
+- a small checker that treats the 184 frontier assignments, or a regenerated
+  equivalent frontier, as input;
+- exact infeasibility certificates or a trusted replay route for the rational
+  linear systems;
+- documentation that keeps this as a candidate n=9 finite-case extension,
+  still independent-review pending and not a general proof.
+
+Recommended current action: turn this into a Codex backlog task or a compact
+checker artifact. It may be a cleaner second route to the review-pending n=9
+finite case than the vertex-circle exhaustive checker, but it should not update
+`README.md`, `STATE.md`, `RESULTS.md`, or `metadata/erdos97.yaml` until it is
+implemented and reviewed.
+
+## Output 10: side-sensitive n<=8 proof and new side-cap n=9 pattern
+
+Triage: the n<=8 proof is already covered; the n=9 pattern is a useful
+frontier example.
+
+The side-sensitive perpendicular-bisector count and the saturated octagon
+argument duplicate the proof-note route in `docs/n8-geometric-proof.md` and
+Output 6 above. The displayed angle-sum contradiction is the same obstruction
+phrased with interior angles rather than exterior turns: at least four
+interior angles would be `60` degrees, while the other four are strictly below
+`180` degrees, giving total angle sum below `960` degrees instead of the
+required `1080` degrees.
+
+The new n=9 incidence pattern is different from the row-Ptolemy frontier
+pattern in Output 8:
+
+```text
+S0 = {1,2,4,6}
+S1 = {0,2,3,5}
+S2 = {1,3,4,8}
+S3 = {0,2,4,7}
+S4 = {2,5,6,8}
+S5 = {1,3,6,7}
+S6 = {4,5,7,8}
+S7 = {0,3,6,8}
+S8 = {0,1,5,7}
+```
+
+Ad hoc checks showed:
+
+- balanced selected indegrees `[4,4,4,4,4,4,4,4,4]`;
+- no row-pair cap, adjacent two-overlap, crossing-bisector, column-pair cap,
+  phi4, or natural-order row-Ptolemy obstruction under
+  `classify_pattern`;
+- no side-sensitive pair-cap violation;
+- `GenericVertexSearch.vertex_circle_status` reports `self_edge`;
+- in the existing full n=9 pair/crossing/count frontier enumeration order, it
+  is assignment 4;
+- the candidate weak turn-inequality Z3 system from Output 9 is `unsat`.
+
+So this is a good witness that the side-sensitive capacity obstruction really
+does have slack at n=9. It is not a geometric candidate after the stronger
+review-pending filters are applied.
+
+Recommended current action: keep this pattern as a regression/benchmark if the
+turn-inequality LP checker is promoted into a real artifact. It is a compact
+example that passes the first incidence/crossing layer but is killed by both
+vertex-circle self-edge and the candidate turn LP.
+
+## Prompting guidance
+
+Further GPT Pro prompts are most useful if they ask for machine-checkable
+objects:
+
+1. exact coordinates plus selected rows for negative controls;
+2. a verifier snippet or JSON artifact schema;
+3. an explicit diff against `docs/claims.md`, `RESULTS.md`, and existing
+   failed-route docs;
+4. a trust label for every claim.
+
+Avoid prompts that ask for a narrative proof first. In this repo, the useful
+unit of progress is a small exact lemma, a replayable certificate, or a
+well-labelled failed route.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,9 @@ put detailed reconciliation in the canonical synthesis.
   crossing CSP for two-overlap patterns.
 - [`vertex-circle-order-filter.md`](vertex-circle-order-filter.md): exact
   row-wise convexity-distance filter for cyclic orders.
+- [`turn-inequality-lemma.md`](turn-inequality-lemma.md): proof-facing note for
+  the candidate exterior-turn inequalities used in the review-pending `n=9`
+  turn-frontier replay.
 - [`relation-skeleton-catalog.md`](relation-skeleton-catalog.md): first
   review-pending relation-skeleton extraction for T01 self-edge and T10
   strict-cycle vertex-circle quotient motifs; proof-mining aid only.
@@ -194,6 +197,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-exhaustive.md`](n9-vertex-circle-exhaustive.md):
   review-pending exhaustive `n=9` selected-witness checker using the
   vertex-circle strict-chord filter.
+- [`n9-turn-inequality-frontier.md`](n9-turn-inequality-frontier.md):
+  review-pending replay of 184 `n=9` selected-witness assignments killed by
+  candidate exterior-turn Farkas certificates; not a proof of `n=9`.
 - [`n9-vertex-circle-row0-root-audit.md`](n9-vertex-circle-row0-root-audit.md):
   row0-root enumeration audit for the exhaustive `n=9` vertex-circle checker.
 - [`n9-vertex-circle-mro-branching-audit.md`](n9-vertex-circle-mro-branching-audit.md):
@@ -270,6 +276,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n10-vertex-circle-singleton-slices.md`](n10-vertex-circle-singleton-slices.md):
   review-pending `n=10` singleton-slice finite-case draft, including the
   secondary first-five replay cross-check.
+- [`n10-turn-row0-pilot.md`](n10-turn-row0-pilot.md): bounded `n=10`
+  row0-index-0 turn-frontier pilot; finite bookkeeping only, not a proof of
+  `n=10`.
 - [`octagon-trap.html`](octagon-trap.html): interactive visualization of the
   isosceles-triangle count and octagon equality trap.
 - [`reproduction-log.md`](reproduction-log.md): fast, artifact, and exhaustive
@@ -316,6 +325,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt-pro-output-triage-2026-05-10.md`](gpt-pro-output-triage-2026-05-10.md):
   triage of three GPT Pro reconstructed-output notes; provenance and
   task-selection guidance only.
+- [`gpt-pro-followup-triage-2026-05-11.md`](gpt-pro-followup-triage-2026-05-11.md):
+  triage of later GPT Pro follow-up notes; provenance and task-selection
+  guidance only.
 - [`n9-base-apex-frontier.md`](n9-base-apex-frontier.md): corrected exploratory
   slack ledger for the first `n=9` base-apex workstream; not a proof.
 - [`repo-roadmap.md`](repo-roadmap.md): staged repository plan.

--- a/docs/n10-turn-row0-pilot.md
+++ b/docs/n10-turn-row0-pilot.md
@@ -1,0 +1,59 @@
+# n=10 Turn Row0 Pilot
+
+Status: `FINITE_BOOKKEEPING_NOT_A_PROOF`.
+
+This bounded pilot tests the candidate turn inequalities on the first raw
+`n=10` row0 slice, before vertex-circle pruning. It is not a proof of `n=10`,
+not a counterexample, not a completeness result, and not a source-of-truth
+status update.
+
+## Scope
+
+The pilot fixes row0 choice index `0` in the natural cyclic order and enumerates
+all full assignments satisfying the pair/crossing/count filters for that slice.
+It then checks the candidate weak turn inequalities and the existing
+vertex-circle filter.
+
+Artifact:
+
+```bash
+data/certificates/n10_turn_row0_pilot.json
+```
+
+Commands:
+
+```bash
+python scripts/check_n10_turn_row0_pilot.py --assert-expected --write
+python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
+```
+
+## Result
+
+The row0-index-0 slice has:
+
+- raw full assignments: `160`;
+- assignment SHA-256:
+  `ec0fa48ec4db8a4a133bffbd86647ade7f33444a1ccb7eea098aae04df4d42b7`;
+- turn Farkas/dual certificate kills: `156`;
+- weak-turn SAT escapes: `4`;
+- vertex-circle status: all `160` are `self_edge`;
+- turn-certificate SHA-256:
+  `c55eb78466233cc7c9c379ffd1d8d555304349e4bc4eaf588c79be5638ee4a55`.
+
+The four weak-turn escapes are assignments `74`, `103`, `156`, and `157` in
+the stored row0 slice. All four are killed already in row `0`, whose witness
+order is `[1,2,3,4]`; the first stored self-edge conflict always identifies
+the outer and inner distance classes as `[0,1]`. This is a compact target for a
+row0-local vertex-circle self-edge template.
+
+## Interpretation
+
+This is useful negative information about the turn route. The turn inequalities
+kill most assignments in this bounded `n=10` slice, but they do not close the
+slice by themselves: four assignments satisfy the weak turn system. Those four
+are still killed by the existing vertex-circle self-edge filter.
+
+So the next proof-facing move should not be "turn inequalities alone scale to
+`n=10`." A realistic next step is to combine turn certificates with a compact
+vertex-circle self-edge template, or to mine the four weak-turn escapes for a
+small reusable obstruction.

--- a/docs/n9-turn-inequality-frontier.md
+++ b/docs/n9-turn-inequality-frontier.md
@@ -1,0 +1,107 @@
+# n=9 Turn-Inequality Frontier Replay
+
+Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.
+
+This note records a replayable check of the latest GPT Pro n=9 route. It is
+not a proof of Erdos Problem #97, not a counterexample, not an official/global
+status update, and not an independently reviewed theorem. The geometric turn
+lemma below is the review bottleneck.
+
+## Scope
+
+The checker regenerates the 184 complete selected-witness assignments that
+survive the existing n=9 pair/crossing/count filters before vertex-circle
+pruning, in the natural cyclic order. For each assignment it builds the weak
+linear turn system suggested by the proposed geometry argument and stores an
+integer dual certificate. Z3 is still replayed as a cross-check, but the stored
+certificate layer is verified by arithmetic alone.
+
+The generated artifact is:
+
+```bash
+data/certificates/n9_turn_inequality_frontier.json
+```
+
+The generator and checker are:
+
+```bash
+python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+```
+
+## Candidate Turn Lemma
+
+Let `tau_i` be exterior turns and set `t_i = 2*tau_i/pi`, so
+`sum_i t_i = 4`. If center `i` selects two targets with cyclic offsets
+`1 <= a < b <= 8`, the proposed lemma gives the strict inequalities
+
+```text
+sum_{h=1}^{b-1} t_{i+h} > 1
+sum_{h=a+1}^{8} t_{i+h} > 1
+```
+
+The replay uses the weaker rational inequalities with `>= 1`. Therefore an
+`unsat` result for the weak system is stronger than what the geometric argument
+would need, assuming the lemma and indexing are correct.
+
+## Current Replay Counts
+
+The artifact currently records:
+
+- regenerated source-frontier assignments: `184`;
+- source-frontier SHA-256:
+  `d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01`;
+- indegree distribution: all assignments have indegrees `(4,4,4,4,4,4,4,4,4)`;
+- side-sensitive pair-cap violation count: `0` for all 184 assignments;
+- turn inequalities per assignment: `108`;
+- Farkas/dual certificates: `184`;
+- Farkas certificate SHA-256:
+  `1aed1b1f78178b967f93a3894e67cf9a0c314441a94423c8f24f2e0b8cb9bf89`;
+- Farkas lambda histogram: `lambda=1` for 180 assignments and `lambda=2`
+  for 4 assignments;
+- Farkas term-count histogram: 5 selected interval inequalities for 180
+  assignments and 9 selected interval inequalities for 4 assignments;
+- Z3 exact linear-arithmetic status: `unsat` for all 184 assignments.
+
+Each stored certificate lists interval-inequality indices. If its bound is
+`lambda`, every normalized turn variable has total coefficient at most
+`lambda`, while the number of selected inequalities is greater than
+`4*lambda`. Summing the selected weak inequalities gives
+
+```text
+left side >= rhs_sum > 4*lambda,
+```
+
+but nonnegativity and `sum_i t_i = 4` give
+
+```text
+left side <= lambda * sum_i t_i = 4*lambda.
+```
+
+That is the recorded arithmetic contradiction.
+
+The side-cap benchmark pattern from the GPT Pro continuation is included as a
+negative-control-style benchmark. It is assignment `4` in the regenerated
+frontier, has natural-order status `accepted_frontier`, has vertex-circle
+status `self_edge`, and is also `unsat` under the weak turn system.
+
+## Review Requirements
+
+Before this can support a theorem-style n=9 claim, reviewers should check:
+
+- the geometric turn lemma and all offset/index conventions;
+- that the regenerated 184-assignment frontier is the intended source frontier
+  and is not hiding symmetry quotient assumptions;
+- the stored integer dual certificates and their arithmetic verifier;
+- the Z3 linear-arithmetic replay as an independent cross-check, not as the
+  primary stored certificate;
+- that no source-of-truth status file is promoted until the above review is
+  complete.
+
+## Fast Reproduction
+
+```bash
+python scripts/check_n9_turn_inequality_frontier.py --assert-expected --json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+python -m pytest tests/test_n9_turn_inequality_frontier.py -q
+```

--- a/docs/turn-inequality-lemma.md
+++ b/docs/turn-inequality-lemma.md
@@ -1,0 +1,118 @@
+# Turn-Inequality Lemma
+
+Status: proof-facing lemma note; independent review requested.
+
+This note isolates the geometric lemma used by
+`docs/n9-turn-inequality-frontier.md`. It does not prove Erdos Problem #97, does
+not claim a counterexample, and does not promote any source-of-truth finite-case
+status.
+
+## Statement
+
+Let
+
+```text
+p_0,p_1,...,p_{n-1}
+```
+
+be the vertices of a strictly convex polygon in counterclockwise cyclic order.
+Let `tau_i > 0` be the exterior turn at vertex `p_i`, so
+`sum_i tau_i = 2*pi`.
+
+Fix a center `p_i`. Suppose two selected witnesses have cyclic offsets
+
+```text
+1 <= a < b <= n-1
+```
+
+and equal distance from the center:
+
+```text
+|p_{i+a} - p_i| = |p_{i+b} - p_i|.
+```
+
+Then
+
+```text
+tau_{i+1} + tau_{i+2} + ... + tau_{i+b-1} > pi/2
+```
+
+and
+
+```text
+tau_{i+a+1} + tau_{i+a+2} + ... + tau_{i+n-1} > pi/2,
+```
+
+with indices read modulo `n`.
+
+Equivalently, after normalizing `t_i = 2*tau_i/pi`, the weak inequalities
+used in the n=9 replay are
+
+```text
+sum_{h=1}^{b-1} t_{i+h} >= 1
+sum_{h=a+1}^{n-1} t_{i+h} >= 1.
+```
+
+The actual geometry gives strict inequalities; the machine replay intentionally
+uses the weaker closed halfspaces.
+
+## Proof Sketch
+
+Let
+
+```text
+u = p_{i+a} - p_i,
+v = p_{i+b} - p_{i+a}.
+```
+
+The equality of distances gives
+
+```text
+|u+v| = |u|.
+```
+
+After squaring and cancelling `|u|^2`,
+
+```text
+2 u.v + |v|^2 = 0,
+```
+
+so
+
+```text
+u.v = -|v|^2/2 < 0.
+```
+
+Now write `u` as the positive sum of edge vectors along the arc from `p_i` to
+`p_{i+a}`, and write `v` as the positive sum of edge vectors along the arc from
+`p_{i+a}` to `p_{i+b}`. If the total exterior turn from `p_i` through
+`p_{i+b}` were at most `pi/2`, all those edge directions would lie in a closed
+cone of angle at most `pi/2`. Every pairwise dot product between an edge vector
+from the first sum and an edge vector from the second sum would then be
+nonnegative, forcing `u.v >= 0`, contradiction.
+
+Therefore the turn along that arc is strictly greater than `pi/2`, proving the
+first inequality.
+
+For the second inequality, apply the same argument to the opposite arc from
+`p_{i+a}` back to `p_i`, using
+
+```text
+u' = p_i - p_{i+a},
+v' = p_{i+b} - p_i.
+```
+
+Again `|u'+v'| = |u'|`, so the total turn along the complementary arc must
+exceed `pi/2`.
+
+## Review Points
+
+The lemma is short, but it is now the main bottleneck for the review-pending
+n=9 turn-frontier artifact. Reviewers should check:
+
+- the indexing of both arcs;
+- the use of a closed cone when the turn is exactly `pi/2`;
+- that strict convexity gives positive edge lengths and strictly positive
+  exterior turns;
+- that the normalized weak inequalities used by the checker are legitimate
+  consequences of the strict geometric inequalities.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -261,6 +261,47 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_turn_inequality_frontier
+    path: data/certificates/n9_turn_inequality_frontier.json
+    kind: finite_case_artifact
+    generator: scripts/check_n9_turn_inequality_frontier.py
+    command: python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
+    checker: scripts/check_n9_turn_inequality_frontier.py
+    check_command: python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING
+    claim_scope: Candidate n=9 selected-witness turn-inequality frontier replay; not a proof of n=9, not an independent review of the exhaustive checker, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_turn_inequality_frontier.v1
+      status: REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY
+      trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING
+      n: 9
+      row_size: 4
+      source_frontier.assignment_count: 184
+      source_frontier.assignment_sha256: d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01
+      source_frontier.side_sensitive_pair_cap_violation_count_histogram.0: 184
+      turn_system.inequality_count_histogram.108: 184
+      farkas_replay.certificate_count: 184
+      farkas_replay.certificate_sha256: 1aed1b1f78178b967f93a3894e67cf9a0c314441a94423c8f24f2e0b8cb9bf89
+      farkas_replay.lambda_histogram.1: 180
+      farkas_replay.lambda_histogram.2: 4
+      farkas_replay.term_count_histogram.5: 180
+      farkas_replay.term_count_histogram.9: 4
+      farkas_replay.deficit_histogram.1: 184
+      z3_replay.unsat_count: 184
+      z3_replay.sat_count: 0
+      z3_replay.unknown_count: 0
+      provenance.command: python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review complete
+      - source-of-truth strongest result
+      - official/global status update
+      - counterexample to Erdos Problem #97
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_local_core_packet
     path: data/certificates/n9_vertex_circle_local_core_packet.json
     kind: certificate_diagnostic_artifact
@@ -1857,6 +1898,43 @@ artifacts:
       - n=10 is proved
       - official/global status update
       - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+
+  - id: n10_turn_row0_pilot
+    path: data/certificates/n10_turn_row0_pilot.json
+    kind: exploratory_ledger_artifact
+    generator: scripts/check_n10_turn_row0_pilot.py
+    command: python scripts/check_n10_turn_row0_pilot.py --assert-expected --write
+    checker: scripts/check_n10_turn_row0_pilot.py
+    check_command: python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Bounded n=10 row0-index-0 turn-frontier pilot; not a proof of n=10, not a complete n=10 search, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n10_turn_row0_pilot.v1
+      status: EXPLORATORY_ROW0_TURN_FRONTIER_PILOT
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      n: 10
+      row_size: 4
+      row0_index: 0
+      full_assignment_count: 160
+      assignment_sha256: ec0fa48ec4db8a4a133bffbd86647ade7f33444a1ccb7eea098aae04df4d42b7
+      turn_status_counts.farkas_unsat: 156
+      turn_status_counts.sat: 4
+      vertex_circle_status_counts.self_edge: 160
+      turn_farkas_certificate_count: 156
+      turn_farkas_certificate_sha256: c55eb78466233cc7c9c379ffd1d8d555304349e4bc4eaf588c79be5638ee4a55
+      turn_sat_escape_count: 4
+      provenance.command: python scripts/check_n10_turn_row0_pilot.py --assert-expected --write
+    forbidden_claims:
+      - n=10 is proved
+      - turn inequalities close n=10
+      - row0 pilot is a completeness result
+      - source-of-truth strongest result
+      - official/global status update
+      - counterexample to Erdos Problem #97
       - general proof of Erdos Problem #97
 
   - id: bootstrap_core_crosswalk

--- a/scripts/check_n10_turn_row0_pilot.py
+++ b/scripts/check_n10_turn_row0_pilot.py
@@ -59,11 +59,12 @@ def main() -> int:
 
     start = perf_counter()
     payload = _load(artifact) if args.check else summary_payload()
-    errors = validate_payload(payload)
-    if errors:
-        raise SystemExit("; ".join(errors[:5]))
     if args.assert_expected:
         assert_expected_payload(payload)
+    else:
+        errors = validate_payload(payload)
+        if errors:
+            raise SystemExit("; ".join(errors[:5]))
     elapsed = perf_counter() - start
 
     if args.write:

--- a/scripts/check_n10_turn_row0_pilot.py
+++ b/scripts/check_n10_turn_row0_pilot.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate or check the bounded n=10 row0 turn-inequality pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from time import perf_counter
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n10_turn_row0_pilot import (  # noqa: E402
+    assert_expected_payload,
+    summary_payload,
+    validate_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n10_turn_row0_pilot.json"
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("expected object payload")
+    return payload
+
+
+def _write(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="validate stored artifact")
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    artifact = _resolve(args.artifact)
+    out = _resolve(args.out)
+    if args.write and args.check and artifact != out:
+        parser.error("--write --check requires --artifact and --out to match")
+
+    start = perf_counter()
+    payload = _load(artifact) if args.check else summary_payload()
+    errors = validate_payload(payload)
+    if errors:
+        raise SystemExit("; ".join(errors[:5]))
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    elapsed = perf_counter() - start
+
+    if args.write:
+        _write(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("bounded n=10 row0 turn-inequality pilot")
+        print(f"full assignments: {payload['full_assignment_count']}")
+        print(f"turn status counts: {payload['turn_status_counts']}")
+        print(f"vertex-circle counts: {payload['vertex_circle_status_counts']}")
+        print(f"elapsed_seconds: {elapsed:.6f}")
+        if args.assert_expected:
+            print("OK: bounded n=10 row0 pilot matches expected data")
+        if args.check:
+            print(f"checked {display_path(artifact, ROOT)}")
+        if args.write:
+            print(f"wrote {display_path(out, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_n9_turn_inequality_frontier.py
+++ b/scripts/check_n9_turn_inequality_frontier.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Generate or check the review-pending n=9 turn-inequality frontier replay."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from time import perf_counter
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_turn_inequality_frontier import (  # noqa: E402
+    assert_expected_payload,
+    summary_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_turn_inequality_frontier.json"
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected object payload in {display_path(path, ROOT)}")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _print_summary(payload: dict[str, object], elapsed: float | None = None) -> None:
+    source = payload["source_frontier"]
+    turn_system = payload["turn_system"]
+    z3_replay = payload["z3_replay"]
+    farkas_replay = payload["farkas_replay"]
+    benchmark = payload["benchmarks"][0]
+    assert isinstance(source, dict)
+    assert isinstance(turn_system, dict)
+    assert isinstance(z3_replay, dict)
+    assert isinstance(farkas_replay, dict)
+    assert isinstance(benchmark, dict)
+
+    print("review-pending n=9 turn-inequality frontier replay")
+    print(f"assignments: {source['assignment_count']}")
+    print(f"frontier_sha256: {source['assignment_sha256']}")
+    print(f"turn inequality counts: {turn_system['inequality_count_histogram']}")
+    print(f"z3 status counts: {z3_replay['status_counts']}")
+    print(f"farkas certificate hash: {farkas_replay['certificate_sha256']}")
+    print(f"farkas lambda counts: {farkas_replay['lambda_histogram']}")
+    print(
+        "benchmark: "
+        f"index={benchmark['frontier_assignment_index_1based']}, "
+        f"frontier={benchmark['natural_order_classify_status']}, "
+        f"vertex_circle={benchmark['vertex_circle_status']}, "
+        f"turn={benchmark['turn_z3_status']}"
+    )
+    if elapsed is not None:
+        print(f"elapsed_seconds: {elapsed:.6f}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact = _resolve(args.artifact)
+    out = _resolve(args.out)
+    if args.write and args.check and artifact != out:
+        raise SystemExit("--write --check requires --artifact and --out to match")
+
+    start = perf_counter()
+    payload = _load_json(artifact) if args.check else summary_payload()
+    elapsed = perf_counter() - start
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        _write_json(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_summary(payload, elapsed)
+        if args.assert_expected:
+            print("OK: n=9 turn-inequality frontier replay matches expected data")
+        if args.check:
+            print(f"checked {display_path(artifact, ROOT)}")
+        if args.write:
+            print(f"wrote {display_path(out, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_n9_turn_inequality_frontier.py
+++ b/scripts/check_n9_turn_inequality_frontier.py
@@ -17,6 +17,7 @@ if str(SRC) not in sys.path:
 from erdos97.n9_turn_inequality_frontier import (  # noqa: E402
     assert_expected_payload,
     summary_payload,
+    validate_payload,
 )
 from erdos97.path_display import display_path  # noqa: E402
 
@@ -91,9 +92,13 @@ def main(argv: list[str] | None = None) -> int:
 
     start = perf_counter()
     payload = _load_json(artifact) if args.check else summary_payload()
-    elapsed = perf_counter() - start
     if args.assert_expected:
         assert_expected_payload(payload)
+    else:
+        errors = validate_payload(payload)
+        if errors:
+            raise SystemExit("; ".join(errors[:5]))
+    elapsed = perf_counter() - start
 
     if args.write:
         _write_json(out, payload)

--- a/src/erdos97/n10_turn_row0_pilot.py
+++ b/src/erdos97/n10_turn_row0_pilot.py
@@ -380,7 +380,10 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
             errors.append(f"assignment {expected_index} has no rows")
             continue
         try:
-            _validate_full_assignment(rows)
+            normalized_rows = normalize_pattern(rows)
+            _validate_full_assignment(normalized_rows)
+            if rows != normalized_rows:
+                raise ValueError("rows are not stored in normalized order")
             if record.get("assignment_index_1based") != expected_index:
                 raise ValueError("assignment index mismatch")
             turn_status = record.get("turn_status")
@@ -388,15 +391,15 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
                 certificate = record.get("turn_certificate")
                 if not isinstance(certificate, dict):
                     raise ValueError("missing turn certificate")
-                verify_turn_farkas_certificate(rows, certificate, n=N)
+                verify_turn_farkas_certificate(normalized_rows, certificate, n=N)
             elif turn_status == "sat":
                 model = record.get("turn_model")
                 if not isinstance(model, list):
                     raise ValueError("missing turn model")
-                _verify_turn_model(rows, [str(value) for value in model])
+                _verify_turn_model(normalized_rows, [str(value) for value in model])
             else:
                 raise ValueError(f"unexpected turn status {turn_status!r}")
-            vertex_status = _vertex_circle_status(rows)
+            vertex_status = _vertex_circle_status(normalized_rows)
             if record.get("vertex_circle_status") != vertex_status:
                 raise ValueError("vertex-circle status mismatch")
         except ValueError as exc:
@@ -409,6 +412,28 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
         for record in records
         if isinstance(record, dict) and record.get("turn_status") == "farkas_unsat"
     ]
+    turn_sat_self_edges = []
+    for record in records:
+        if not isinstance(record, dict) or record.get("turn_status") != "sat":
+            continue
+        rows = record.get("rows")
+        if not isinstance(rows, list):
+            continue
+        try:
+            turn_sat_self_edges.append(
+                {
+                    "assignment_index_1based": record.get(
+                        "assignment_index_1based"
+                    ),
+                    "self_edge": first_self_edge_conflict(rows),
+                }
+            )
+        except ValueError as exc:
+            errors.append(
+                "assignment "
+                f"{record.get('assignment_index_1based')}: SAT escape self-edge "
+                f"mismatch: {exc}"
+            )
     expected_fields = {
         "full_assignment_count": len(records),
         "assignment_sha256": _stable_sha256([record.get("rows") for record in records]),
@@ -416,6 +441,8 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
         "vertex_circle_status_counts": dict(sorted(vertex_counts.items())),
         "turn_farkas_certificate_count": len(certificates),
         "turn_farkas_certificate_sha256": _stable_sha256(certificates),
+        "turn_sat_escape_count": len(turn_sat_self_edges),
+        "turn_sat_escape_self_edges": turn_sat_self_edges,
     }
     for key, expected in expected_fields.items():
         if payload.get(key) != expected:
@@ -442,6 +469,7 @@ def assert_expected_payload(payload: dict[str, object] | None = None) -> None:
         },
         "turn_farkas_certificate_count": EXPECTED_TURN_FARKAS_UNSAT,
         "turn_farkas_certificate_sha256": EXPECTED_CERTIFICATE_SHA256,
+        "turn_sat_escape_count": EXPECTED_TURN_SAT_VERTEX_SELF_EDGE,
     }
     for key, expected_value in expected.items():
         if payload.get(key) != expected_value:

--- a/src/erdos97/n10_turn_row0_pilot.py
+++ b/src/erdos97/n10_turn_row0_pilot.py
@@ -1,0 +1,450 @@
+"""Bounded n=10 turn-inequality pilot for the first row0 slice.
+
+This module is exploratory and review-pending. It checks the row0-index-0
+slice of the n=10 pair/crossing/count frontier against the candidate turn
+inequalities. It does not prove n=10, does not produce a counterexample, and
+does not change the repository source-of-truth status.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict, deque
+from fractions import Fraction
+from functools import lru_cache
+from hashlib import sha256
+from typing import Sequence
+import json
+
+import z3
+
+from erdos97.generic_vertex_search import GenericVertexSearch
+from erdos97.n9_turn_inequality_frontier import (
+    find_turn_farkas_certificate,
+    turn_inequality_terms_for_pattern,
+    turn_z3_status,
+    verify_turn_farkas_certificate,
+)
+from erdos97.vertex_circle_order_filter import (
+    Pair,
+    StrictInequality,
+    pair,
+    vertex_circle_order_obstruction,
+)
+
+N = 10
+ROW_SIZE = 4
+PAIR_CAP = 2
+ROW0_INDEX = 0
+SCHEMA = "erdos97.n10_turn_row0_pilot.v1"
+STATUS = "EXPLORATORY_ROW0_TURN_FRONTIER_PILOT"
+TRUST = "FINITE_BOOKKEEPING_NOT_A_PROOF"
+EXPECTED_FULL_ASSIGNMENTS = 160
+EXPECTED_TURN_FARKAS_UNSAT = 156
+EXPECTED_TURN_SAT_VERTEX_SELF_EDGE = 4
+EXPECTED_ASSIGNMENT_SHA256 = (
+    "ec0fa48ec4db8a4a133bffbd86647ade7f33444a1ccb7eea098aae04df4d42b7"
+)
+EXPECTED_CERTIFICATE_SHA256 = (
+    "c55eb78466233cc7c9c379ffd1d8d555304349e4bc4eaf588c79be5638ee4a55"
+)
+
+
+@lru_cache(maxsize=1)
+def _searcher() -> GenericVertexSearch:
+    return GenericVertexSearch(N, row_size=ROW_SIZE, pair_cap=PAIR_CAP)
+
+
+def _mask_from_row(row: Sequence[int]) -> int:
+    mask = 0
+    for value in row:
+        mask |= 1 << int(value)
+    return mask
+
+
+def normalize_pattern(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    """Return sorted JSON-friendly rows."""
+    return [sorted(int(value) for value in row) for row in rows]
+
+
+def _stable_sha256(value: object) -> str:
+    blob = json.dumps(value, separators=(",", ":"), sort_keys=True)
+    return sha256(blob.encode("utf-8")).hexdigest()
+
+
+def enumerate_row0_full_assignments(row0_index: int = ROW0_INDEX) -> list[list[list[int]]]:
+    """Enumerate raw full assignments in one n=10 row0 slice."""
+    searcher = _searcher()
+    row0 = searcher.options[0][row0_index]
+    frontier: list[list[list[int]]] = []
+
+    def search(
+        assign: dict[int, int],
+        column_counts: list[int],
+        witness_pair_counts: list[int],
+    ) -> None:
+        if len(assign) == N:
+            frontier.append(
+                [list(searcher.mask_bits[assign[center]]) for center in range(N)]
+            )
+            return
+        best_center = None
+        best_options = None
+        for center in range(N):
+            if center in assign:
+                continue
+            opts = searcher.valid_options_for_center(
+                center,
+                assign,
+                column_counts,
+                witness_pair_counts,
+            )
+            if best_options is None or len(opts) < len(best_options):
+                best_center = center
+                best_options = opts
+                if not opts:
+                    break
+        if not best_options:
+            return
+        assert best_center is not None
+        for mask in best_options:
+            assign[best_center] = mask
+            for target in searcher.mask_bits[mask]:
+                column_counts[target] += 1
+            for pair_index in searcher.row_pair_indices[mask]:
+                witness_pair_counts[pair_index] += 1
+            search(assign, column_counts, witness_pair_counts)
+            for pair_index in searcher.row_pair_indices[mask]:
+                witness_pair_counts[pair_index] -= 1
+            for target in searcher.mask_bits[mask]:
+                column_counts[target] -= 1
+            del assign[best_center]
+
+    assign = {0: row0}
+    column_counts = [0] * N
+    witness_pair_counts = [0] * len(searcher.pairs)
+    for target in searcher.mask_bits[row0]:
+        column_counts[target] += 1
+    for pair_index in searcher.row_pair_indices[row0]:
+        witness_pair_counts[pair_index] += 1
+    search(assign, column_counts, witness_pair_counts)
+    return [normalize_pattern(rows) for rows in frontier]
+
+
+def _z3_turn_model(rows: Sequence[Sequence[int]]) -> list[str] | None:
+    variables = [z3.Real(f"t_{idx}") for idx in range(N)]
+    solver = z3.Solver()
+    solver.add(z3.Sum(variables) == 4)
+    for variable in variables:
+        solver.add(variable >= 0)
+    for term in turn_inequality_terms_for_pattern(rows, n=N):
+        solver.add(z3.Sum([variables[idx] for idx in term["support"]]) >= 1)
+    if str(solver.check()) != "sat":
+        return None
+    model = solver.model()
+    return [str(model.evaluate(variable, model_completion=True)) for variable in variables]
+
+
+def _verify_turn_model(rows: Sequence[Sequence[int]], model: Sequence[str]) -> None:
+    values = [Fraction(value) for value in model]
+    if len(values) != N:
+        raise ValueError("turn model has wrong length")
+    if any(value < 0 for value in values):
+        raise ValueError("turn model has negative entry")
+    if sum(values) != 4:
+        raise ValueError("turn model does not sum to 4")
+    for term in turn_inequality_terms_for_pattern(rows, n=N):
+        lhs = sum(values[int(index)] for index in term["support"])
+        if lhs < 1:
+            raise ValueError(f"turn model violates term {term}")
+
+
+def _vertex_circle_status(rows: Sequence[Sequence[int]]) -> str:
+    searcher = _searcher()
+    assign = {center: _mask_from_row(row) for center, row in enumerate(rows)}
+    return searcher.vertex_circle_status(assign)
+
+
+def _json_self_edge(edge: StrictInequality) -> dict[str, object]:
+    return {
+        "row": int(edge.row),
+        "witness_order": [int(value) for value in edge.witness_order],
+        "outer_interval": [int(value) for value in edge.outer_interval],
+        "inner_interval": [int(value) for value in edge.inner_interval],
+        "outer_pair": [int(value) for value in edge.outer_pair],
+        "inner_pair": [int(value) for value in edge.inner_pair],
+        "outer_class": [int(value) for value in edge.outer_class],
+        "inner_class": [int(value) for value in edge.inner_class],
+        "outer_span": int(edge.outer_interval[1] - edge.outer_interval[0]),
+        "inner_span": int(edge.inner_interval[1] - edge.inner_interval[0]),
+        "shared_endpoint_count": len(set(edge.outer_pair) & set(edge.inner_pair)),
+    }
+
+
+def _distance_equality_graph(
+    rows: Sequence[Sequence[int]],
+) -> dict[Pair, list[tuple[Pair, int]]]:
+    graph: dict[Pair, list[tuple[Pair, int]]] = defaultdict(list)
+    for center, row in enumerate(rows):
+        selected_pairs = [pair(center, witness) for witness in row]
+        for left_index, left_pair in enumerate(selected_pairs):
+            for right_pair in selected_pairs[left_index + 1 :]:
+                graph[left_pair].append((right_pair, center))
+                graph[right_pair].append((left_pair, center))
+    for item in graph:
+        graph[item].sort()
+    return graph
+
+
+def _distance_equality_path(
+    rows: Sequence[Sequence[int]],
+    start: Pair,
+    end: Pair,
+) -> list[dict[str, object]]:
+    graph = _distance_equality_graph(rows)
+    queue: deque[tuple[Pair, list[dict[str, object]]]] = deque([(start, [])])
+    seen = {start}
+    while queue:
+        current, path = queue.popleft()
+        if current == end:
+            return path
+        for next_pair, row in graph.get(current, []):
+            if next_pair in seen:
+                continue
+            seen.add(next_pair)
+            queue.append(
+                (
+                    next_pair,
+                    path
+                    + [
+                        {
+                            "row": int(row),
+                            "next_pair": [int(value) for value in next_pair],
+                        }
+                    ],
+                )
+            )
+    raise ValueError(f"no equality path from {start} to {end}")
+
+
+def first_self_edge_conflict(rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    """Return the first vertex-circle self-edge conflict for rows."""
+    result = vertex_circle_order_obstruction(
+        rows,
+        list(range(N)),
+        pattern="n10_turn_row0_pilot",
+    )
+    if not result.self_edge_conflicts:
+        raise ValueError("rows do not have a self-edge conflict")
+    edge = result.self_edge_conflicts[0]
+    out = _json_self_edge(edge)
+    out["distance_equality_path"] = _distance_equality_path(
+        rows,
+        edge.outer_pair,
+        edge.inner_pair,
+    )
+    return out
+
+
+def _validate_full_assignment(rows: Sequence[Sequence[int]]) -> None:
+    searcher = _searcher()
+    normalized = normalize_pattern(rows)
+    if len(normalized) != N:
+        raise ValueError("wrong row count")
+    if normalized[0] != list(searcher.mask_bits[searcher.options[0][ROW0_INDEX]]):
+        raise ValueError("row0 does not match pilot slice")
+    masks = [_mask_from_row(row) for row in normalized]
+    for center, row in enumerate(normalized):
+        if center in row or len(row) != ROW_SIZE:
+            raise ValueError(f"invalid row {center}: {row}")
+        if masks[center] not in searcher.options[center]:
+            raise ValueError(f"unknown row option {center}: {row}")
+    for left in range(N):
+        for right in range(left + 1, N):
+            if not searcher.rows_compatible(left, masks[left], right, masks[right]):
+                raise ValueError(f"incompatible rows {left}, {right}")
+    indegrees = [sum(1 for row in normalized if target in row) for target in range(N)]
+    if any(value > searcher.max_indegree for value in indegrees):
+        raise ValueError(f"indegree cap violation: {indegrees}")
+
+
+def classify_assignment(
+    rows: Sequence[Sequence[int]],
+    assignment_index_1based: int,
+) -> dict[str, object]:
+    """Classify one row0-pilot assignment by turn and vertex-circle checks."""
+    normalized = normalize_pattern(rows)
+    _validate_full_assignment(normalized)
+    try:
+        certificate = find_turn_farkas_certificate(
+            normalized,
+            assignment_index_1based=assignment_index_1based,
+            n=N,
+        )
+        verify_turn_farkas_certificate(normalized, certificate, n=N)
+        return {
+            "assignment_index_1based": assignment_index_1based,
+            "rows": normalized,
+            "turn_status": "farkas_unsat",
+            "turn_certificate": certificate,
+            "vertex_circle_status": _vertex_circle_status(normalized),
+        }
+    except ValueError:
+        turn_status = turn_z3_status(normalized, n=N)
+        record: dict[str, object] = {
+            "assignment_index_1based": assignment_index_1based,
+            "rows": normalized,
+            "turn_status": turn_status,
+            "vertex_circle_status": _vertex_circle_status(normalized),
+        }
+        if turn_status == "sat":
+            model = _z3_turn_model(normalized)
+            if model is None:
+                raise ValueError("Z3 reported sat but no model was extracted")
+            _verify_turn_model(normalized, model)
+            record["turn_model"] = model
+        return record
+
+
+def summary_payload() -> dict[str, object]:
+    """Generate the n=10 row0-index-0 turn pilot artifact."""
+    assignments = enumerate_row0_full_assignments(ROW0_INDEX)
+    records = [
+        classify_assignment(rows, index)
+        for index, rows in enumerate(assignments, start=1)
+    ]
+    status_counts = Counter(str(record["turn_status"]) for record in records)
+    vertex_counts = Counter(str(record["vertex_circle_status"]) for record in records)
+    certificates = [
+        record["turn_certificate"]
+        for record in records
+        if record.get("turn_status") == "farkas_unsat"
+    ]
+    turn_sat_self_edges = [
+        {
+            "assignment_index_1based": record["assignment_index_1based"],
+            "self_edge": first_self_edge_conflict(record["rows"]),
+        }
+        for record in records
+        if record.get("turn_status") == "sat"
+    ]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Bounded n=10 row0-index-0 turn-frontier pilot; not a proof of n=10, "
+            "not a counterexample, not a completeness result, and not a global "
+            "status update."
+        ),
+        "n": N,
+        "row_size": ROW_SIZE,
+        "row0_index": ROW0_INDEX,
+        "full_assignment_count": len(records),
+        "assignment_sha256": _stable_sha256(
+            [record["rows"] for record in records]
+        ),
+        "turn_status_counts": dict(sorted(status_counts.items())),
+        "vertex_circle_status_counts": dict(sorted(vertex_counts.items())),
+        "turn_farkas_certificate_count": len(certificates),
+        "turn_farkas_certificate_sha256": _stable_sha256(certificates),
+        "turn_sat_escape_count": len(turn_sat_self_edges),
+        "turn_sat_escape_self_edges": turn_sat_self_edges,
+        "interpretation": (
+            "The candidate turn inequalities kill most, but not all, raw "
+            "assignments in this bounded n=10 slice. The four weak-turn SAT "
+            "escapes are all killed by the existing vertex-circle self-edge "
+            "filter."
+        ),
+        "assignments": records,
+        "provenance": {
+            "generator": "scripts/check_n10_turn_row0_pilot.py",
+            "command": "python scripts/check_n10_turn_row0_pilot.py --assert-expected --write",
+        },
+    }
+
+
+def validate_payload(payload: dict[str, object]) -> list[str]:
+    """Validate a stored n=10 row0 pilot payload."""
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append("unexpected schema")
+    records = payload.get("assignments")
+    if not isinstance(records, list):
+        return errors + ["missing assignments list"]
+    for expected_index, record in enumerate(records, start=1):
+        if not isinstance(record, dict):
+            errors.append(f"assignment {expected_index} is not an object")
+            continue
+        rows = record.get("rows")
+        if not isinstance(rows, list):
+            errors.append(f"assignment {expected_index} has no rows")
+            continue
+        try:
+            _validate_full_assignment(rows)
+            if record.get("assignment_index_1based") != expected_index:
+                raise ValueError("assignment index mismatch")
+            turn_status = record.get("turn_status")
+            if turn_status == "farkas_unsat":
+                certificate = record.get("turn_certificate")
+                if not isinstance(certificate, dict):
+                    raise ValueError("missing turn certificate")
+                verify_turn_farkas_certificate(rows, certificate, n=N)
+            elif turn_status == "sat":
+                model = record.get("turn_model")
+                if not isinstance(model, list):
+                    raise ValueError("missing turn model")
+                _verify_turn_model(rows, [str(value) for value in model])
+            else:
+                raise ValueError(f"unexpected turn status {turn_status!r}")
+            vertex_status = _vertex_circle_status(rows)
+            if record.get("vertex_circle_status") != vertex_status:
+                raise ValueError("vertex-circle status mismatch")
+        except ValueError as exc:
+            errors.append(f"assignment {expected_index}: {exc}")
+
+    status_counts = Counter(str(record.get("turn_status")) for record in records)
+    vertex_counts = Counter(str(record.get("vertex_circle_status")) for record in records)
+    certificates = [
+        record["turn_certificate"]
+        for record in records
+        if isinstance(record, dict) and record.get("turn_status") == "farkas_unsat"
+    ]
+    expected_fields = {
+        "full_assignment_count": len(records),
+        "assignment_sha256": _stable_sha256([record.get("rows") for record in records]),
+        "turn_status_counts": dict(sorted(status_counts.items())),
+        "vertex_circle_status_counts": dict(sorted(vertex_counts.items())),
+        "turn_farkas_certificate_count": len(certificates),
+        "turn_farkas_certificate_sha256": _stable_sha256(certificates),
+    }
+    for key, expected in expected_fields.items():
+        if payload.get(key) != expected:
+            errors.append(f"{key} mismatch: {payload.get(key)!r} != {expected!r}")
+    return errors
+
+
+def assert_expected_payload(payload: dict[str, object] | None = None) -> None:
+    """Assert stable expected counts for the bounded pilot."""
+    if payload is None:
+        payload = summary_payload()
+    errors = validate_payload(payload)
+    if errors:
+        raise AssertionError(errors[:5])
+    expected = {
+        "full_assignment_count": EXPECTED_FULL_ASSIGNMENTS,
+        "assignment_sha256": EXPECTED_ASSIGNMENT_SHA256,
+        "turn_status_counts": {
+            "farkas_unsat": EXPECTED_TURN_FARKAS_UNSAT,
+            "sat": EXPECTED_TURN_SAT_VERTEX_SELF_EDGE,
+        },
+        "vertex_circle_status_counts": {
+            "self_edge": EXPECTED_FULL_ASSIGNMENTS,
+        },
+        "turn_farkas_certificate_count": EXPECTED_TURN_FARKAS_UNSAT,
+        "turn_farkas_certificate_sha256": EXPECTED_CERTIFICATE_SHA256,
+    }
+    for key, expected_value in expected.items():
+        if payload.get(key) != expected_value:
+            raise AssertionError(
+                f"unexpected {key}: {payload.get(key)!r} != {expected_value!r}"
+            )

--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -589,10 +589,161 @@ def summary_payload() -> dict[str, object]:
     }
 
 
+def _compare_expected_fields(
+    errors: list[str],
+    section_name: str,
+    section: dict[str, object],
+    expected_fields: dict[str, object],
+) -> None:
+    for key, expected in expected_fields.items():
+        if section.get(key) != expected:
+            errors.append(
+                f"{section_name}.{key} mismatch: "
+                f"{section.get(key)!r} != {expected!r}"
+            )
+
+
+def validate_payload(payload: dict[str, object]) -> list[str]:
+    """Validate a stored n=9 turn-inequality frontier payload."""
+    errors: list[str] = []
+    if payload.get("schema") != "erdos97.n9_turn_inequality_frontier.v1":
+        errors.append("unexpected schema")
+    if payload.get("n") != N:
+        errors.append(f"unexpected n: {payload.get('n')!r}")
+    if payload.get("row_size") != ROW_SIZE:
+        errors.append(f"unexpected row_size: {payload.get('row_size')!r}")
+
+    source = payload.get("source_frontier")
+    turn_system = payload.get("turn_system")
+    z3_replay = payload.get("z3_replay")
+    farkas_replay = payload.get("farkas_replay")
+    farkas_certificates = payload.get("farkas_certificates")
+    benchmarks = payload.get("benchmarks")
+    if not isinstance(source, dict):
+        errors.append("missing source_frontier object")
+    if not isinstance(turn_system, dict):
+        errors.append("missing turn_system object")
+    if not isinstance(z3_replay, dict):
+        errors.append("missing z3_replay object")
+    if not isinstance(farkas_replay, dict):
+        errors.append("missing farkas_replay object")
+    if not isinstance(farkas_certificates, list):
+        errors.append("missing farkas_certificates list")
+    if not isinstance(benchmarks, list):
+        errors.append("missing benchmarks list")
+    if errors:
+        return errors
+
+    assert isinstance(source, dict)
+    assert isinstance(turn_system, dict)
+    assert isinstance(z3_replay, dict)
+    assert isinstance(farkas_replay, dict)
+    assert isinstance(farkas_certificates, list)
+    assert isinstance(benchmarks, list)
+
+    frontier = normalize_pattern_list(enumerate_pair_crossing_count_frontier())
+    indegree_rows = [tuple(indegrees(rows)) for rows in frontier]
+    side_cap_violations = [
+        len(side_sensitive_pair_cap_violations(rows)) for rows in frontier
+    ]
+    turn_counts = [len(turn_inequality_terms_for_pattern(rows)) for rows in frontier]
+
+    _compare_expected_fields(
+        errors,
+        "source_frontier",
+        source,
+        {
+            "assignment_count": len(frontier),
+            "assignment_sha256": frontier_sha256(frontier),
+            "indegree_distribution": _histogram(indegree_rows),
+            "side_sensitive_pair_cap_violation_count_histogram": _histogram(
+                side_cap_violations
+            ),
+        },
+    )
+    _compare_expected_fields(
+        errors,
+        "turn_system",
+        turn_system,
+        {"inequality_count_histogram": _histogram(turn_counts)},
+    )
+
+    certificate_errors: list[str] = []
+    certificate_summaries: list[dict[str, object]] = []
+    if len(farkas_certificates) != len(frontier):
+        certificate_errors.append(
+            "certificate count mismatch: "
+            f"{len(farkas_certificates)} stored vs {len(frontier)} frontier assignments"
+        )
+    for index, (rows, certificate) in enumerate(
+        zip(frontier, farkas_certificates), start=1
+    ):
+        if not isinstance(certificate, dict):
+            certificate_errors.append(f"certificate {index} is not an object")
+            continue
+        if certificate.get("assignment_index_1based") != index:
+            certificate_errors.append(
+                f"certificate {index} has assignment index "
+                f"{certificate.get('assignment_index_1based')!r}"
+            )
+            continue
+        try:
+            certificate_summaries.append(
+                verify_turn_farkas_certificate(rows, certificate)
+            )
+        except ValueError as exc:
+            certificate_errors.append(f"certificate {index}: {exc}")
+    errors.extend(certificate_errors)
+
+    _compare_expected_fields(
+        errors,
+        "z3_replay",
+        z3_replay,
+        {
+            "status_counts": {"unsat": len(frontier)},
+            "sat_count": 0,
+            "unsat_count": len(frontier),
+            "unknown_count": 0,
+        },
+    )
+    _compare_expected_fields(
+        errors,
+        "farkas_replay",
+        farkas_replay,
+        {
+            "certificate_count": len(farkas_certificates),
+            "certificate_sha256": farkas_certificate_sha256(farkas_certificates),
+            "lambda_histogram": _histogram(
+                [summary["lambda"] for summary in certificate_summaries]
+            ),
+            "term_count_histogram": _histogram(
+                [summary["term_count"] for summary in certificate_summaries]
+            ),
+            "deficit_histogram": _histogram(
+                [summary["deficit"] for summary in certificate_summaries]
+            ),
+            "max_variable_coefficient_histogram": _histogram(
+                [
+                    summary["max_variable_coefficient"]
+                    for summary in certificate_summaries
+                ]
+            ),
+        },
+    )
+
+    expected_benchmark = side_cap_benchmark_summary(frontier)
+    if benchmarks != [expected_benchmark]:
+        errors.append("benchmarks mismatch")
+    return errors
+
+
 def assert_expected_payload(payload: dict[str, object] | None = None) -> None:
     """Assert stable counts and benchmark fields for the replay artifact."""
     if payload is None:
         payload = summary_payload()
+    validation_errors = validate_payload(payload)
+    if validation_errors:
+        raise AssertionError(validation_errors[:5])
     if payload.get("schema") != "erdos97.n9_turn_inequality_frontier.v1":
         raise AssertionError("unexpected schema")
     source = payload.get("source_frontier")
@@ -654,9 +805,6 @@ def assert_expected_payload(payload: dict[str, object] | None = None) -> None:
         != EXPECTED_FARKAS_CERTIFICATE_SHA256
     ):
         raise AssertionError("stored Farkas certificates do not match expected hash")
-    farkas_errors = validate_farkas_certificates(payload)
-    if farkas_errors:
-        raise AssertionError(f"invalid Farkas certificates: {farkas_errors[:3]}")
     benchmark = benchmarks[0]
     if not isinstance(benchmark, dict):
         raise AssertionError("malformed benchmark")

--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -1,0 +1,676 @@
+"""Review-pending n=9 turn-inequality frontier replay.
+
+This module checks a candidate finite-case obstruction for the 184 complete
+selected-witness assignments that survive the n=9 pair/crossing/count filters.
+It does not prove Erdos Problem #97 and does not promote the n=9 source-of-truth
+status. The geometric turn lemma behind these inequalities still needs
+independent review.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from hashlib import sha256
+from itertools import combinations
+import json
+from typing import Sequence
+
+from erdos97.generic_vertex_search import GenericVertexSearch
+from erdos97.incidence_filters import normalize_chord
+from erdos97.n9_incidence_frontier import classify_pattern
+
+N = 9
+ROW_SIZE = 4
+PAIR_CAP = 2
+EXPECTED_FRONTIER_ASSIGNMENTS = 184
+EXPECTED_TURN_UNSAT = 184
+EXPECTED_TURN_INEQUALITY_COUNT = 108
+EXPECTED_SIDE_CAP_PATTERN_INDEX = 4
+EXPECTED_FRONTIER_SHA256 = (
+    "d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01"
+)
+EXPECTED_FARKAS_CERTIFICATE_SHA256 = (
+    "1aed1b1f78178b967f93a3894e67cf9a0c314441a94423c8f24f2e0b8cb9bf89"
+)
+EXPECTED_FARKAS_LAMBDA_HISTOGRAM = {"1": 180, "2": 4}
+EXPECTED_FARKAS_TERM_COUNT_HISTOGRAM = {"5": 180, "9": 4}
+EXPECTED_FARKAS_DEFICIT_HISTOGRAM = {"1": 184}
+
+SIDE_CAP_BENCHMARK_PATTERN: list[list[int]] = [
+    [1, 2, 4, 6],
+    [0, 2, 3, 5],
+    [1, 3, 4, 8],
+    [0, 2, 4, 7],
+    [2, 5, 6, 8],
+    [1, 3, 6, 7],
+    [4, 5, 7, 8],
+    [0, 3, 6, 8],
+    [0, 1, 5, 7],
+]
+
+
+def _mask_from_row(row: Sequence[int]) -> int:
+    mask = 0
+    for value in row:
+        mask |= 1 << int(value)
+    return mask
+
+
+def normalize_pattern(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    """Return a selected-row pattern as sorted JSON-friendly rows."""
+    return [sorted(int(value) for value in row) for row in rows]
+
+
+def _pattern_key(rows: Sequence[Sequence[int]]) -> tuple[tuple[int, ...], ...]:
+    return tuple(tuple(row) for row in normalize_pattern(rows))
+
+
+def enumerate_pair_crossing_count_frontier() -> list[list[list[int]]]:
+    """Regenerate the 184 n=9 assignments before vertex-circle pruning."""
+    searcher = GenericVertexSearch(N, row_size=ROW_SIZE, pair_cap=PAIR_CAP)
+    frontier: list[list[list[int]]] = []
+
+    def collect(
+        assign: dict[int, int],
+        column_counts: list[int],
+        witness_pair_counts: list[int],
+    ) -> None:
+        if len(assign) == searcher.n:
+            frontier.append(
+                [list(searcher.mask_bits[assign[center]]) for center in range(searcher.n)]
+            )
+            return
+
+        best_center = None
+        best_options = None
+        for center in range(searcher.n):
+            if center in assign:
+                continue
+            opts = searcher.valid_options_for_center(
+                center,
+                assign,
+                column_counts,
+                witness_pair_counts,
+            )
+            if best_options is None or len(opts) < len(best_options):
+                best_center = center
+                best_options = opts
+                if not opts:
+                    break
+        if not best_options:
+            return
+
+        center = best_center
+        assert center is not None
+        for mask in best_options:
+            assign[center] = mask
+            for target in searcher.mask_bits[mask]:
+                column_counts[target] += 1
+            for pair_index in searcher.row_pair_indices[mask]:
+                witness_pair_counts[pair_index] += 1
+
+            collect(assign, column_counts, witness_pair_counts)
+
+            for pair_index in searcher.row_pair_indices[mask]:
+                witness_pair_counts[pair_index] -= 1
+            for target in searcher.mask_bits[mask]:
+                column_counts[target] -= 1
+            del assign[center]
+
+    for row0 in searcher.options[0]:
+        assign = {0: row0}
+        column_counts = [0] * searcher.n
+        witness_pair_counts = [0] * len(searcher.pairs)
+        for target in searcher.mask_bits[row0]:
+            column_counts[target] += 1
+        for pair_index in searcher.row_pair_indices[row0]:
+            witness_pair_counts[pair_index] += 1
+        collect(assign, column_counts, witness_pair_counts)
+
+    return frontier
+
+
+def frontier_sha256(frontier: Sequence[Sequence[Sequence[int]]]) -> str:
+    """Return a stable SHA-256 hash for a frontier row list."""
+    blob = json.dumps(normalize_pattern_list(frontier), separators=(",", ":"), sort_keys=True)
+    return sha256(blob.encode("utf-8")).hexdigest()
+
+
+def normalize_pattern_list(
+    frontier: Sequence[Sequence[Sequence[int]]],
+) -> list[list[list[int]]]:
+    """Return a stable JSON-friendly copy of a frontier pattern list."""
+    return [normalize_pattern(rows) for rows in frontier]
+
+
+def indegrees(rows: Sequence[Sequence[int]], n: int = N) -> list[int]:
+    """Return selected indegrees for a row system."""
+    return [sum(1 for row in rows if target in row) for target in range(n)]
+
+
+def _in_open_arc(a: int, b: int, x: int, n: int = N) -> bool:
+    return ((x - a) % n) < ((b - a) % n) and x not in (a, b)
+
+
+def side_sensitive_pair_cap_violations(
+    rows: Sequence[Sequence[int]],
+    n: int = N,
+) -> list[dict[str, object]]:
+    """Return side-sensitive pair-cap violations for a cyclic row system."""
+    pair_to_centers: dict[tuple[int, int], list[int]] = defaultdict(list)
+    for center, row in enumerate(rows):
+        for a, b in combinations(sorted(row), 2):
+            pair_to_centers[normalize_chord(a, b)].append(center)
+
+    violations: list[dict[str, object]] = []
+    for (a, b), centers in sorted(pair_to_centers.items()):
+        arc_ab = [center for center in centers if _in_open_arc(a, b, center, n=n)]
+        arc_ba = [center for center in centers if _in_open_arc(b, a, center, n=n)]
+        if len(arc_ab) > 1 or len(arc_ba) > 1:
+            violations.append(
+                {
+                    "witness_pair": [a, b],
+                    "source_centers": centers,
+                    "arc_ab_centers": arc_ab,
+                    "arc_ba_centers": arc_ba,
+                }
+            )
+    return violations
+
+
+def turn_inequality_terms_for_pattern(
+    rows: Sequence[Sequence[int]],
+    n: int = N,
+) -> list[dict[str, object]]:
+    """Return normalized weak turn inequalities for one row system.
+
+    For each selected offset pair ``a < b`` in a row centered at ``i``, the
+    candidate turn lemma gives:
+
+    ``sum_{h=1}^{b-1} t_{i+h} >= 1``
+    ``sum_{h=a+1}^{n-1} t_{i+h} >= 1``.
+    """
+    terms: list[dict[str, object]] = []
+    for center, row in enumerate(rows):
+        offsets = sorted((target - center) % n for target in row)
+        if len(offsets) != ROW_SIZE or any(offset <= 0 for offset in offsets):
+            raise ValueError(f"invalid row {center}: {row}")
+        for left_index, right_index in combinations(range(ROW_SIZE), 2):
+            a = offsets[left_index]
+            b = offsets[right_index]
+            forward = sorted((center + h) % n for h in range(1, b))
+            reverse = sorted((center + h) % n for h in range(a + 1, n))
+            terms.append(
+                {
+                    "center": center,
+                    "selected_offsets": [a, b],
+                    "support": forward,
+                    "bound": 1,
+                    "orientation": "forward",
+                }
+            )
+            terms.append(
+                {
+                    "center": center,
+                    "selected_offsets": [a, b],
+                    "support": reverse,
+                    "bound": 1,
+                    "orientation": "reverse",
+                }
+            )
+    return terms
+
+
+def turn_z3_status(rows: Sequence[Sequence[int]], n: int = N) -> str:
+    """Check weak turn-inequality feasibility with exact Z3 rationals."""
+    import z3
+
+    variables = [z3.Real(f"t_{idx}") for idx in range(n)]
+    solver = z3.Solver()
+    solver.add(z3.Sum(variables) == 4)
+    for variable in variables:
+        solver.add(variable >= 0)
+    for term in turn_inequality_terms_for_pattern(rows, n=n):
+        support = [int(value) for value in term["support"]]
+        solver.add(z3.Sum([variables[index] for index in support]) >= int(term["bound"]))
+    return str(solver.check())
+
+
+def _support_mask(term: dict[str, object]) -> int:
+    mask = 0
+    for value in term["support"]:
+        mask |= 1 << int(value)
+    return mask
+
+
+def _certificate_summary_from_indices(
+    term_indices: Sequence[int],
+    masks: Sequence[int],
+    lambda_bound: int,
+    n: int = N,
+) -> dict[str, object]:
+    coefficients = [0] * n
+    for term_index in term_indices:
+        mask = masks[term_index]
+        for variable_index in range(n):
+            if (mask >> variable_index) & 1:
+                coefficients[variable_index] += 1
+    rhs_sum = len(term_indices)
+    return {
+        "lambda": lambda_bound,
+        "term_count": rhs_sum,
+        "rhs_sum": rhs_sum,
+        "max_variable_coefficient": max(coefficients, default=0),
+        "deficit": rhs_sum - 4 * lambda_bound,
+        "variable_coefficients": coefficients,
+    }
+
+
+def find_turn_farkas_certificate(
+    rows: Sequence[Sequence[int]],
+    assignment_index_1based: int | None = None,
+    n: int = N,
+) -> dict[str, object]:
+    """Find a compact integer dual certificate for one turn LP.
+
+    A certificate consists of unit weights on selected interval inequalities and
+    an integer ``lambda`` such that each turn variable is used at most
+    ``lambda`` times, while the number of selected inequalities is greater than
+    ``4*lambda``. Summing those inequalities gives a lower bound larger than
+    the upper bound forced by ``sum_i t_i = 4`` and ``t_i >= 0``.
+    """
+    terms = turn_inequality_terms_for_pattern(rows, n=n)
+    masks = [_support_mask(term) for term in terms]
+    items = [
+        (term_index, mask, mask.bit_count())
+        for term_index, mask in enumerate(masks)
+        if mask
+    ]
+    items.sort(key=lambda item: (item[2], item[0]))
+
+    for lambda_bound in (1, 2):
+        target_count = 4 * lambda_bound + 1
+        chosen: list[int] = []
+        coefficients = [0] * n
+
+        def search(start: int) -> bool:
+            if len(chosen) == target_count:
+                return True
+            if len(chosen) + (len(items) - start) < target_count:
+                return False
+            for item_pos in range(start, len(items)):
+                term_index, mask, _support_size = items[item_pos]
+                changed: list[int] = []
+                for variable_index in range(n):
+                    if (mask >> variable_index) & 1:
+                        if coefficients[variable_index] >= lambda_bound:
+                            break
+                        changed.append(variable_index)
+                else:
+                    for variable_index in changed:
+                        coefficients[variable_index] += 1
+                    chosen.append(term_index)
+                    if search(item_pos + 1):
+                        return True
+                    chosen.pop()
+                    for variable_index in changed:
+                        coefficients[variable_index] -= 1
+            return False
+
+        if search(0):
+            term_indices = sorted(chosen)
+            summary = _certificate_summary_from_indices(
+                term_indices,
+                masks,
+                lambda_bound,
+                n=n,
+            )
+            certificate: dict[str, object] = {
+                "lambda": lambda_bound,
+                "term_weight": 1,
+                "term_indices": term_indices,
+                **summary,
+            }
+            if assignment_index_1based is not None:
+                certificate["assignment_index_1based"] = assignment_index_1based
+            return certificate
+
+    raise ValueError("no bounded unit-weight turn Farkas certificate found")
+
+
+def verify_turn_farkas_certificate(
+    rows: Sequence[Sequence[int]],
+    certificate: dict[str, object],
+    n: int = N,
+) -> dict[str, object]:
+    """Verify one stored turn dual certificate by integer arithmetic only."""
+    terms = turn_inequality_terms_for_pattern(rows, n=n)
+    masks = [_support_mask(term) for term in terms]
+    lambda_bound = certificate.get("lambda")
+    term_weight = certificate.get("term_weight", 1)
+    term_indices = certificate.get("term_indices")
+    if not isinstance(lambda_bound, int) or lambda_bound <= 0:
+        raise ValueError(f"invalid lambda: {lambda_bound!r}")
+    if term_weight != 1:
+        raise ValueError(f"unsupported term weight: {term_weight!r}")
+    if not isinstance(term_indices, list) or not term_indices:
+        raise ValueError("term_indices must be a nonempty list")
+    if len(set(term_indices)) != len(term_indices):
+        raise ValueError(f"duplicate term index in certificate: {term_indices!r}")
+    if any(
+        not isinstance(term_index, int)
+        or term_index < 0
+        or term_index >= len(terms)
+        for term_index in term_indices
+    ):
+        raise ValueError(f"term index out of range: {term_indices!r}")
+
+    summary = _certificate_summary_from_indices(term_indices, masks, lambda_bound, n=n)
+    if summary["rhs_sum"] <= 4 * lambda_bound:
+        raise ValueError("certificate has no positive Farkas deficit")
+    if summary["max_variable_coefficient"] > lambda_bound:
+        raise ValueError("certificate exceeds its variable coefficient bound")
+    for key in (
+        "term_count",
+        "rhs_sum",
+        "max_variable_coefficient",
+        "deficit",
+        "variable_coefficients",
+    ):
+        if key in certificate and certificate[key] != summary[key]:
+            raise ValueError(
+                f"stored certificate field {key}={certificate[key]!r} "
+                f"does not match recomputed {summary[key]!r}"
+            )
+    return summary
+
+
+def farkas_certificate_sha256(certificates: Sequence[dict[str, object]]) -> str:
+    """Return a stable SHA-256 hash for stored Farkas certificates."""
+    blob = json.dumps(certificates, separators=(",", ":"), sort_keys=True)
+    return sha256(blob.encode("utf-8")).hexdigest()
+
+
+def validate_farkas_certificates(
+    payload: dict[str, object],
+    frontier: Sequence[Sequence[Sequence[int]]] | None = None,
+) -> list[str]:
+    """Validate stored Farkas certificates against the regenerated frontier."""
+    if frontier is None:
+        frontier = normalize_pattern_list(enumerate_pair_crossing_count_frontier())
+    certificates = payload.get("farkas_certificates")
+    if not isinstance(certificates, list):
+        return ["missing farkas_certificates list"]
+    if len(certificates) != len(frontier):
+        return [
+            "certificate count mismatch: "
+            f"{len(certificates)} stored vs {len(frontier)} frontier assignments"
+        ]
+
+    errors: list[str] = []
+    for index, (rows, certificate) in enumerate(zip(frontier, certificates), start=1):
+        if not isinstance(certificate, dict):
+            errors.append(f"certificate {index} is not an object")
+            continue
+        if certificate.get("assignment_index_1based") != index:
+            errors.append(
+                f"certificate {index} has assignment index "
+                f"{certificate.get('assignment_index_1based')!r}"
+            )
+            continue
+        try:
+            verify_turn_farkas_certificate(rows, certificate)
+        except ValueError as exc:
+            errors.append(f"certificate {index}: {exc}")
+    return errors
+
+
+def vertex_circle_status_for_pattern(rows: Sequence[Sequence[int]]) -> str:
+    """Replay GenericVertexSearch's vertex-circle status for a complete pattern."""
+    searcher = GenericVertexSearch(N, row_size=ROW_SIZE, pair_cap=PAIR_CAP)
+    assign = {center: _mask_from_row(row) for center, row in enumerate(rows)}
+    return searcher.vertex_circle_status(assign)
+
+
+def _histogram(values: Sequence[object]) -> dict[str, int]:
+    return {str(key): int(value) for key, value in sorted(Counter(values).items())}
+
+
+def _find_pattern_index(
+    frontier: Sequence[Sequence[Sequence[int]]],
+    pattern: Sequence[Sequence[int]],
+) -> int | None:
+    target = _pattern_key(pattern)
+    for index, rows in enumerate(frontier, start=1):
+        if _pattern_key(rows) == target:
+            return index
+    return None
+
+
+def side_cap_benchmark_summary(frontier: Sequence[Sequence[Sequence[int]]]) -> dict[str, object]:
+    """Return replay data for the side-cap benchmark from GPT Pro output 10."""
+    rows = normalize_pattern(SIDE_CAP_BENCHMARK_PATTERN)
+    classification = classify_pattern(rows, order=list(range(N)), max_details=3)
+    turn_status = turn_z3_status(rows)
+    return {
+        "name": "gpt_pro_output_10_side_cap_pattern",
+        "rows": rows,
+        "frontier_assignment_index_1based": _find_pattern_index(frontier, rows),
+        "indegrees": indegrees(rows),
+        "side_sensitive_pair_cap_violation_count": len(side_sensitive_pair_cap_violations(rows)),
+        "natural_order_classify_status": classification["status"],
+        "natural_order_phi_edges": classification["phi_edges"],
+        "natural_order_row_ptolemy_product_cancellation_count": classification[
+            "row_ptolemy_product_cancellation_count"
+        ],
+        "natural_order_rectangle_trap_4_cycles": classification["rectangle_trap_4_cycles"],
+        "vertex_circle_status": vertex_circle_status_for_pattern(rows),
+        "turn_z3_status": turn_status,
+        "turn_inequality_count": len(turn_inequality_terms_for_pattern(rows)),
+    }
+
+
+def summary_payload() -> dict[str, object]:
+    """Return the stable JSON payload for the turn-inequality frontier replay."""
+    frontier = enumerate_pair_crossing_count_frontier()
+    normalized_frontier = normalize_pattern_list(frontier)
+    farkas_certificates = [
+        find_turn_farkas_certificate(rows, assignment_index_1based=index)
+        for index, rows in enumerate(normalized_frontier, start=1)
+    ]
+    farkas_summaries = [
+        verify_turn_farkas_certificate(rows, certificate)
+        for rows, certificate in zip(normalized_frontier, farkas_certificates)
+    ]
+    z3_statuses = [turn_z3_status(rows) for rows in normalized_frontier]
+    indegree_rows = [tuple(indegrees(rows)) for rows in normalized_frontier]
+    turn_counts = [
+        len(turn_inequality_terms_for_pattern(rows)) for rows in normalized_frontier
+    ]
+    side_cap_violations = [
+        len(side_sensitive_pair_cap_violations(rows)) for rows in normalized_frontier
+    ]
+
+    return {
+        "schema": "erdos97.n9_turn_inequality_frontier.v1",
+        "status": "REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY",
+        "trust": "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING",
+        "claim_scope": (
+            "Candidate n=9 selected-witness turn-inequality frontier replay; "
+            "not a proof of Erdos Problem #97, not a counterexample, not an "
+            "independent review, and not a source-of-truth status update."
+        ),
+        "n": N,
+        "row_size": ROW_SIZE,
+        "cyclic_order": list(range(N)),
+        "source_frontier": {
+            "description": (
+                "Complete selected-witness assignments surviving pair/crossing/count "
+                "filters before vertex-circle pruning."
+            ),
+            "generator": "GenericVertexSearch(n=9).valid_options_for_center",
+            "assignment_count": len(normalized_frontier),
+            "assignment_sha256": frontier_sha256(normalized_frontier),
+            "indegree_distribution": _histogram(indegree_rows),
+            "side_sensitive_pair_cap_violation_count_histogram": _histogram(
+                side_cap_violations
+            ),
+        },
+        "turn_system": {
+            "normalized_variables": "t_i = 2*tau_i/pi",
+            "sum_constraint": "sum_i t_i = 4",
+            "nonnegativity": "t_i >= 0",
+            "weak_inequality_template": [
+                "sum_{h=1}^{b-1} t_{i+h} >= 1",
+                "sum_{h=a+1}^{8} t_{i+h} >= 1",
+            ],
+            "strict_geometry_note": (
+                "The geometric lemma gives strict inequalities; this replay uses "
+                "weak rational inequalities, so UNSAT is stronger than needed."
+            ),
+            "inequality_count_histogram": _histogram(turn_counts),
+        },
+        "z3_replay": {
+            "solver": "z3",
+            "arithmetic": "exact rational linear real arithmetic",
+            "role": "cross-check; stored Farkas certificates are verified by integer arithmetic",
+            "status_counts": _histogram(z3_statuses),
+            "sat_count": z3_statuses.count("sat"),
+            "unsat_count": z3_statuses.count("unsat"),
+            "unknown_count": z3_statuses.count("unknown"),
+        },
+        "farkas_replay": {
+            "certificate_type": "unit_weight_interval_dual",
+            "certificate_count": len(farkas_certificates),
+            "certificate_sha256": farkas_certificate_sha256(farkas_certificates),
+            "arithmetic": "integer coefficient check; no solver needed for replay",
+            "lambda_histogram": _histogram(
+                [summary["lambda"] for summary in farkas_summaries]
+            ),
+            "term_count_histogram": _histogram(
+                [summary["term_count"] for summary in farkas_summaries]
+            ),
+            "deficit_histogram": _histogram(
+                [summary["deficit"] for summary in farkas_summaries]
+            ),
+            "max_variable_coefficient_histogram": _histogram(
+                [
+                    summary["max_variable_coefficient"]
+                    for summary in farkas_summaries
+                ]
+            ),
+            "certificate_explanation": (
+                "For each assignment, summing the listed interval inequalities "
+                "gives RHS > 4*lambda while every turn variable has coefficient "
+                "at most lambda. Since t_i >= 0 and sum_i t_i = 4, the same "
+                "left-hand side is at most 4*lambda, a contradiction."
+            ),
+        },
+        "farkas_certificates": farkas_certificates,
+        "benchmarks": [side_cap_benchmark_summary(normalized_frontier)],
+        "conclusion": (
+            "All 184 regenerated n=9 pair/crossing/count frontier assignments "
+            "have stored integer dual certificates proving infeasibility of "
+            "the candidate weak turn inequalities."
+        ),
+        "review_requirements": [
+            "Review the geometric turn lemma and indexing conventions.",
+            "Review the regenerated n=9 source frontier and lack of hidden symmetry quotienting.",
+            "Review the stored integer dual certificates and their arithmetic verifier.",
+            "Keep this scoped as review-pending n=9 finite-case evidence only.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_turn_inequality_frontier.py",
+            "command": (
+                "python scripts/check_n9_turn_inequality_frontier.py "
+                "--assert-expected --write"
+            ),
+        },
+    }
+
+
+def assert_expected_payload(payload: dict[str, object] | None = None) -> None:
+    """Assert stable counts and benchmark fields for the replay artifact."""
+    if payload is None:
+        payload = summary_payload()
+    if payload.get("schema") != "erdos97.n9_turn_inequality_frontier.v1":
+        raise AssertionError("unexpected schema")
+    source = payload.get("source_frontier")
+    turn_system = payload.get("turn_system")
+    z3_replay = payload.get("z3_replay")
+    farkas_replay = payload.get("farkas_replay")
+    farkas_certificates = payload.get("farkas_certificates")
+    benchmarks = payload.get("benchmarks")
+    if not isinstance(source, dict) or not isinstance(turn_system, dict):
+        raise AssertionError("malformed source or turn-system summary")
+    if (
+        not isinstance(z3_replay, dict)
+        or not isinstance(farkas_replay, dict)
+        or not isinstance(farkas_certificates, list)
+        or not isinstance(benchmarks, list)
+    ):
+        raise AssertionError("malformed z3, Farkas, or benchmark summary")
+    if source.get("assignment_count") != EXPECTED_FRONTIER_ASSIGNMENTS:
+        raise AssertionError(f"unexpected frontier count: {source.get('assignment_count')}")
+    if source.get("assignment_sha256") != EXPECTED_FRONTIER_SHA256:
+        raise AssertionError(f"unexpected frontier hash: {source.get('assignment_sha256')}")
+    if source.get("indegree_distribution") != {
+        "(4, 4, 4, 4, 4, 4, 4, 4, 4)": EXPECTED_FRONTIER_ASSIGNMENTS
+    }:
+        raise AssertionError(f"unexpected indegree distribution: {source.get('indegree_distribution')}")
+    if source.get("side_sensitive_pair_cap_violation_count_histogram") != {
+        "0": EXPECTED_FRONTIER_ASSIGNMENTS
+    }:
+        raise AssertionError("unexpected side-sensitive pair-cap histogram")
+    if turn_system.get("inequality_count_histogram") != {
+        str(EXPECTED_TURN_INEQUALITY_COUNT): EXPECTED_FRONTIER_ASSIGNMENTS
+    }:
+        raise AssertionError("unexpected turn inequality count histogram")
+    if z3_replay.get("unsat_count") != EXPECTED_TURN_UNSAT:
+        raise AssertionError(f"unexpected unsat count: {z3_replay.get('unsat_count')}")
+    if z3_replay.get("sat_count") != 0 or z3_replay.get("unknown_count") != 0:
+        raise AssertionError(f"unexpected z3 status counts: {z3_replay}")
+    if farkas_replay.get("certificate_count") != EXPECTED_FRONTIER_ASSIGNMENTS:
+        raise AssertionError("unexpected Farkas certificate count")
+    if (
+        farkas_replay.get("certificate_sha256")
+        != EXPECTED_FARKAS_CERTIFICATE_SHA256
+    ):
+        raise AssertionError(
+            "unexpected Farkas certificate hash: "
+            f"{farkas_replay.get('certificate_sha256')}"
+        )
+    if farkas_replay.get("lambda_histogram") != EXPECTED_FARKAS_LAMBDA_HISTOGRAM:
+        raise AssertionError("unexpected Farkas lambda histogram")
+    if (
+        farkas_replay.get("term_count_histogram")
+        != EXPECTED_FARKAS_TERM_COUNT_HISTOGRAM
+    ):
+        raise AssertionError("unexpected Farkas term-count histogram")
+    if farkas_replay.get("deficit_histogram") != EXPECTED_FARKAS_DEFICIT_HISTOGRAM:
+        raise AssertionError("unexpected Farkas deficit histogram")
+    if (
+        farkas_certificate_sha256(farkas_certificates)
+        != EXPECTED_FARKAS_CERTIFICATE_SHA256
+    ):
+        raise AssertionError("stored Farkas certificates do not match expected hash")
+    farkas_errors = validate_farkas_certificates(payload)
+    if farkas_errors:
+        raise AssertionError(f"invalid Farkas certificates: {farkas_errors[:3]}")
+    benchmark = benchmarks[0]
+    if not isinstance(benchmark, dict):
+        raise AssertionError("malformed benchmark")
+    expected_benchmark = {
+        "frontier_assignment_index_1based": EXPECTED_SIDE_CAP_PATTERN_INDEX,
+        "natural_order_classify_status": "accepted_frontier",
+        "vertex_circle_status": "self_edge",
+        "turn_z3_status": "unsat",
+        "side_sensitive_pair_cap_violation_count": 0,
+        "natural_order_row_ptolemy_product_cancellation_count": 0,
+        "natural_order_rectangle_trap_4_cycles": 0,
+    }
+    for key, expected in expected_benchmark.items():
+        if benchmark.get(key) != expected:
+            raise AssertionError(
+                f"unexpected benchmark {key}: {benchmark.get(key)!r}, expected {expected!r}"
+            )

--- a/tests/test_n10_turn_row0_pilot.py
+++ b/tests/test_n10_turn_row0_pilot.py
@@ -80,3 +80,5 @@ def test_tiny_payload_validation_checks_stored_fields() -> None:
     errors = validate_payload(payload)
 
     assert any("assignment_sha256 mismatch" in error for error in errors)
+    assert any("turn_sat_escape_count mismatch" in error for error in errors)
+    assert any("turn_sat_escape_self_edges mismatch" in error for error in errors)

--- a/tests/test_n10_turn_row0_pilot.py
+++ b/tests/test_n10_turn_row0_pilot.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from erdos97.n10_turn_row0_pilot import (
+    ROW0_INDEX,
+    classify_assignment,
+    first_self_edge_conflict,
+    validate_payload,
+)
+
+
+def test_known_turn_sat_escape_is_vertex_circle_self_edge() -> None:
+    rows = [
+        [1, 2, 3, 4],
+        [0, 4, 5, 7],
+        [1, 3, 5, 6],
+        [2, 4, 6, 8],
+        [3, 5, 8, 9],
+        [0, 4, 6, 9],
+        [1, 5, 7, 9],
+        [0, 1, 6, 8],
+        [2, 6, 7, 9],
+        [0, 3, 7, 8],
+    ]
+
+    record = classify_assignment(rows, assignment_index_1based=1)
+
+    assert ROW0_INDEX == 0
+    assert record["turn_status"] == "sat"
+    assert record["vertex_circle_status"] == "self_edge"
+    assert record["turn_model"] == ["0", "1", "0", "0", "1", "0", "0", "1", "1", "0"]
+    assert first_self_edge_conflict(rows) == {
+        "row": 0,
+        "witness_order": [1, 2, 3, 4],
+        "outer_interval": [0, 3],
+        "inner_interval": [0, 1],
+        "outer_pair": [1, 4],
+        "inner_pair": [1, 2],
+        "outer_class": [0, 1],
+        "inner_class": [0, 1],
+        "outer_span": 3,
+        "inner_span": 1,
+        "shared_endpoint_count": 1,
+        "distance_equality_path": [
+            {"row": 1, "next_pair": [1, 7]},
+            {"row": 7, "next_pair": [6, 7]},
+            {"row": 6, "next_pair": [5, 6]},
+            {"row": 5, "next_pair": [4, 5]},
+            {"row": 4, "next_pair": [3, 4]},
+            {"row": 3, "next_pair": [2, 3]},
+            {"row": 2, "next_pair": [1, 2]},
+        ],
+    }
+
+
+def test_tiny_payload_validation_checks_stored_fields() -> None:
+    rows = [
+        [1, 2, 3, 4],
+        [0, 4, 5, 7],
+        [1, 3, 5, 6],
+        [2, 4, 6, 8],
+        [3, 5, 8, 9],
+        [0, 4, 6, 9],
+        [1, 5, 7, 9],
+        [0, 1, 6, 8],
+        [2, 6, 7, 9],
+        [0, 3, 7, 8],
+    ]
+    record = classify_assignment(rows, assignment_index_1based=1)
+    payload = {
+        "schema": "erdos97.n10_turn_row0_pilot.v1",
+        "assignments": [record],
+        "full_assignment_count": 1,
+        "assignment_sha256": "wrong",
+        "turn_status_counts": {"sat": 1},
+        "vertex_circle_status_counts": {"self_edge": 1},
+        "turn_farkas_certificate_count": 0,
+        "turn_farkas_certificate_sha256": "wrong",
+    }
+
+    errors = validate_payload(payload)
+
+    assert any("assignment_sha256 mismatch" in error for error in errors)

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -7,6 +7,7 @@ from erdos97.n9_turn_inequality_frontier import (
     side_sensitive_pair_cap_violations,
     turn_inequality_terms_for_pattern,
     turn_z3_status,
+    validate_payload,
     verify_turn_farkas_certificate,
     vertex_circle_status_for_pattern,
 )
@@ -49,3 +50,16 @@ def test_side_cap_benchmark_has_integer_farkas_certificate() -> None:
     assert summary["deficit"] == 1
     assert summary["rhs_sum"] > 4 * summary["lambda"]
     assert summary["max_variable_coefficient"] <= summary["lambda"]
+
+
+def test_payload_validation_rejects_malformed_check_payload() -> None:
+    errors = validate_payload(
+        {
+            "schema": "erdos97.n9_turn_inequality_frontier.v1",
+            "n": 9,
+            "row_size": 4,
+        }
+    )
+
+    assert "missing source_frontier object" in errors
+    assert "missing farkas_certificates list" in errors

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from erdos97.n9_turn_inequality_frontier import (
+    EXPECTED_TURN_INEQUALITY_COUNT,
+    SIDE_CAP_BENCHMARK_PATTERN,
+    find_turn_farkas_certificate,
+    side_sensitive_pair_cap_violations,
+    turn_inequality_terms_for_pattern,
+    turn_z3_status,
+    verify_turn_farkas_certificate,
+    vertex_circle_status_for_pattern,
+)
+
+
+def test_side_cap_benchmark_has_expected_turn_system() -> None:
+    terms = turn_inequality_terms_for_pattern(SIDE_CAP_BENCHMARK_PATTERN)
+
+    assert len(terms) == EXPECTED_TURN_INEQUALITY_COUNT
+    assert terms[0] == {
+        "center": 0,
+        "selected_offsets": [1, 2],
+        "support": [1],
+        "bound": 1,
+        "orientation": "forward",
+    }
+    assert terms[1] == {
+        "center": 0,
+        "selected_offsets": [1, 2],
+        "support": [2, 3, 4, 5, 6, 7, 8],
+        "bound": 1,
+        "orientation": "reverse",
+    }
+
+
+def test_side_cap_benchmark_replays_known_obstructions() -> None:
+    assert side_sensitive_pair_cap_violations(SIDE_CAP_BENCHMARK_PATTERN) == []
+    assert vertex_circle_status_for_pattern(SIDE_CAP_BENCHMARK_PATTERN) == "self_edge"
+    assert turn_z3_status(SIDE_CAP_BENCHMARK_PATTERN) == "unsat"
+
+
+def test_side_cap_benchmark_has_integer_farkas_certificate() -> None:
+    certificate = find_turn_farkas_certificate(
+        SIDE_CAP_BENCHMARK_PATTERN,
+        assignment_index_1based=4,
+    )
+    summary = verify_turn_farkas_certificate(SIDE_CAP_BENCHMARK_PATTERN, certificate)
+
+    assert certificate["assignment_index_1based"] == 4
+    assert summary["deficit"] == 1
+    assert summary["rhs_sum"] > 4 * summary["lambda"]
+    assert summary["max_variable_coefficient"] <= summary["lambda"]


### PR DESCRIPTION
## Summary

- add a review-pending `n=9` turn-inequality frontier replay with 184 integer Farkas certificates
- add a bounded `n=10` row0-index-0 turn-frontier pilot ledger
- add proof-facing/provenance docs and register both generated artifacts in the manifest
- tighten artifact `--check` validation after automated review feedback

## Claim discipline

This PR does not claim a general proof, a counterexample, or a public theorem. The `n=9` material is review-pending finite-case replay; the `n=10` material is bounded finite bookkeeping only.

## Verification

- `python scripts/check_n9_turn_inequality_frontier.py --check`
- `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected`
- `python scripts/check_n10_turn_row0_pilot.py --check --assert-expected`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`727 passed, 281 deselected`)
- artifact tier run manually because `make` is not installed in this shell: n8, Kalmanson, n9 review, bridge-frontier, and n10 review commands all passed