### PR TITLE
Add T01 self-edge mini replay

### DIFF
--- a/data/certificates/n9_t01_self_edge_minireplay.json
+++ b/data/certificates/n9_t01_self_edge_minireplay.json
@@ -1,0 +1,107 @@
+{
+  "claim_scope": "Minimal input-data replay of the focused T01/F09 self-edge local lemma packet; not a proof of n=9, not an independent review of the full checker, not a counterexample, and not a global status update.",
+  "interpretation": "The selected rows identify the strict outer and inner chord pairs, while the row-0 vertex-circle order makes the outer chord strictly longer than the inner chord.",
+  "ok": true,
+  "provenance": {
+    "command": "python scripts/check_n9_t01_self_edge_minireplay.py --write --assert-expected",
+    "generator": "scripts/check_n9_t01_self_edge_minireplay.py"
+  },
+  "replay": {
+    "core_centers": [
+      0,
+      1,
+      2
+    ],
+    "core_row_count": 3,
+    "equality_chain": [
+      [
+        1,
+        8
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        2
+      ],
+      [
+        1,
+        2
+      ]
+    ],
+    "equality_step_count": 3,
+    "equality_steps": [
+      {
+        "left_pair": [
+          1,
+          8
+        ],
+        "right_pair": [
+          0,
+          1
+        ],
+        "row": 1
+      },
+      {
+        "left_pair": [
+          0,
+          1
+        ],
+        "right_pair": [
+          0,
+          2
+        ],
+        "row": 0
+      },
+      {
+        "left_pair": [
+          0,
+          2
+        ],
+        "right_pair": [
+          1,
+          2
+        ],
+        "row": 2
+      }
+    ],
+    "self_edge_contradiction": true,
+    "source_family_id": "F09",
+    "source_template_id": "T01",
+    "strict_inequality": {
+      "inner_interval": [
+        0,
+        1
+      ],
+      "inner_pair": [
+        1,
+        2
+      ],
+      "inner_span": 1,
+      "outer_interval": [
+        0,
+        3
+      ],
+      "outer_pair": [
+        1,
+        8
+      ],
+      "outer_span": 3,
+      "row": 0,
+      "witness_order": [
+        1,
+        2,
+        4,
+        8
+      ]
+    }
+  },
+  "schema": "erdos97.n9_t01_self_edge_minireplay.v1",
+  "source_packet": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+  "source_packet_schema": "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1",
+  "status": "REVIEW_PENDING_T01_SELF_EDGE_MINIREPLAY",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": []
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -240,6 +240,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t01-self-edge-lemma.md`](n9-vertex-circle-t01-self-edge-lemma.md):
   focused review-pending T01/F09 self-edge local lemma packet for proof
   mining.
+- [`n9-t01-self-edge-minireplay.md`](n9-t01-self-edge-minireplay.md):
+  minimal input-data replay of the T01/F09 local self-edge equality chain and
+  strict chord containment; proof-mining scaffolding only.
 - [`n9-vertex-circle-t02-self-edge-lemma.md`](n9-vertex-circle-t02-self-edge-lemma.md):
   focused review-pending T02 multi-family self-edge local lemma packet for
   proof mining.

--- a/docs/n9-t01-self-edge-minireplay.md
+++ b/docs/n9-t01-self-edge-minireplay.md
@@ -1,0 +1,62 @@
+# n=9 T01 Self-edge Mini-replay
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This mini-replay is a deliberately small verifier for the focused T01/F09
+self-edge local lemma packet. It does not enumerate `n=9` selected-witness
+systems, does not review the full vertex-circle checker, does not prove `n=9`,
+does not claim a counterexample, and does not update the global status of
+Erdos Problem #97.
+
+## Scope
+
+The source packet is:
+
+```bash
+data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
+```
+
+The mini-replay reads that packet as input data and checks only:
+
+- the three local selected rows for centers `0`, `1`, and `2`;
+- the selected-distance equality chain
+  `[1,8] = [0,1] = [0,2] = [1,2]`;
+- the row-0 witness order `[1,2,4,8]`;
+- that chord `[1,8]` strictly contains chord `[1,2]` in that row order;
+- that the strict outer and inner chord pairs are the endpoints of the same
+  selected-distance equality chain.
+
+This is intentionally independent of the larger quotient-replay helper and the
+full exhaustive brancher. It is a second, smaller input-data replay of one
+local lemma candidate.
+
+## Artifact
+
+```bash
+data/certificates/n9_t01_self_edge_minireplay.json
+```
+
+Generate and check:
+
+```bash
+python scripts/check_n9_t01_self_edge_minireplay.py --write --assert-expected
+python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
+```
+
+Targeted test:
+
+```bash
+python -m pytest tests/test_n9_t01_self_edge_minireplay.py -q
+```
+
+## Interpretation
+
+The replay confirms that the packet data supports the local contradiction:
+
+```text
+[1,8] = [1,2]
+[1,8] > [1,2]
+```
+
+This rules out only the exact local T01/F09 hypothesis packet. It is proof
+mining scaffolding, not a finite-case completeness result.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -755,6 +755,44 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_t01_self_edge_minireplay
+    path: data/certificates/n9_t01_self_edge_minireplay.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_t01_self_edge_minireplay.py
+    command: python scripts/check_n9_t01_self_edge_minireplay.py --write --assert-expected
+    checker: scripts/check_n9_t01_self_edge_minireplay.py
+    check_command: python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Minimal input-data replay of the focused T01/F09 self-edge local lemma packet; not a proof of n=9, not an independent review of the full checker, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_t01_self_edge_minireplay.v1
+      status: REVIEW_PENDING_T01_SELF_EDGE_MINIREPLAY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      ok: true
+      source_packet: data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
+      source_packet_schema: erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1
+      replay.source_template_id: T01
+      replay.source_family_id: F09
+      replay.core_row_count: 3
+      replay.equality_step_count: 3
+      replay.self_edge_contradiction: true
+      replay.strict_inequality.row: 0
+      replay.strict_inequality.outer_span: 3
+      replay.strict_inequality.inner_span: 1
+      provenance.command: python scripts/check_n9_t01_self_edge_minireplay.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - T01 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the mini-replay is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t02_self_edge_lemma_packet
     path: data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_t01_self_edge_minireplay.py
+++ b/scripts/check_n9_t01_self_edge_minireplay.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate or check the minimal T01/F09 self-edge mini-replay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_t01_self_edge_minireplay import (  # noqa: E402
+    assert_expected_payload,
+    minireplay_payload,
+    validate_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_SOURCE = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t01_self_edge_lemma_packet.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_t01_self_edge_minireplay.json"
+)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected object payload in {display_path(path, ROOT)}")
+    return payload
+
+
+def _write(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="validate stored artifact")
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    source = _resolve(args.source)
+    artifact = _resolve(args.artifact)
+    out = _resolve(args.out)
+    if args.write and args.check and artifact != out:
+        raise SystemExit("--write --check requires --artifact and --out to match")
+
+    source_packet = _load(source)
+    payload = _load(artifact) if args.check else minireplay_payload(source_packet)
+    errors = validate_payload(payload, source_packet)
+    if errors:
+        raise SystemExit("; ".join(errors[:5]))
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        _write(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        replay = payload["replay"]
+        assert isinstance(replay, dict)
+        print("n=9 T01/F09 self-edge mini-replay")
+        print(f"ok: {payload['ok']}")
+        print(f"core rows: {replay['core_centers']}")
+        print(f"equality chain: {replay['equality_chain']}")
+        print(f"self-edge contradiction: {replay['self_edge_contradiction']}")
+        if args.assert_expected:
+            print("OK: T01/F09 mini-replay matches expected data")
+        if args.check:
+            print(f"checked {display_path(artifact, ROOT)}")
+        if args.write:
+            print(f"wrote {display_path(out, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_t01_self_edge_minireplay.py
+++ b/src/erdos97/n9_t01_self_edge_minireplay.py
@@ -57,6 +57,8 @@ def _rows(packet: dict[str, Any], errors: list[str]) -> dict[int, list[int]]:
 
 
 def _other_endpoint(pair_value: list[int], center: int) -> int | None:
+    if len(pair_value) != 2:
+        return None
     if center == pair_value[0]:
         return pair_value[1]
     if center == pair_value[1]:

--- a/src/erdos97/n9_t01_self_edge_minireplay.py
+++ b/src/erdos97/n9_t01_self_edge_minireplay.py
@@ -1,0 +1,310 @@
+"""Minimal replay for the n=9 T01 self-edge local lemma packet.
+
+This module treats the focused T01 packet as input data and checks only the
+small local proof skeleton: selected-distance equality steps plus one strict
+vertex-circle chord containment. It is proof-mining scaffolding only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SCHEMA = "erdos97.n9_t01_self_edge_minireplay.v1"
+STATUS = "REVIEW_PENDING_T01_SELF_EDGE_MINIREPLAY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SOURCE_PACKET_SCHEMA = "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1"
+SOURCE_PACKET = "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json"
+
+
+def _pair(value: Any, label: str, errors: list[str]) -> list[int]:
+    if not isinstance(value, list) or len(value) != 2:
+        errors.append(f"{label} must be a two-element list")
+        return []
+    try:
+        left, right = sorted(int(item) for item in value)
+    except (TypeError, ValueError):
+        errors.append(f"{label} must contain integer labels")
+        return []
+    if left == right:
+        errors.append(f"{label} must contain two distinct labels")
+    return [left, right]
+
+
+def _rows(packet: dict[str, Any], errors: list[str]) -> dict[int, list[int]]:
+    raw_rows = packet.get("core_selected_rows")
+    if not isinstance(raw_rows, list):
+        errors.append("core_selected_rows must be a list")
+        return {}
+    rows: dict[int, list[int]] = {}
+    for index, raw_row in enumerate(raw_rows):
+        if not isinstance(raw_row, list) or len(raw_row) != 5:
+            errors.append(f"core_selected_rows[{index}] must have center plus four witnesses")
+            continue
+        try:
+            center = int(raw_row[0])
+            witnesses = [int(value) for value in raw_row[1:]]
+        except (TypeError, ValueError):
+            errors.append(f"core_selected_rows[{index}] must contain integer labels")
+            continue
+        if center in rows:
+            errors.append(f"duplicate core row for center {center}")
+        if center in witnesses:
+            errors.append(f"core row {center} contains its own center")
+        if len(set(witnesses)) != 4:
+            errors.append(f"core row {center} has duplicate witnesses")
+        rows[center] = witnesses
+    return rows
+
+
+def _other_endpoint(pair_value: list[int], center: int) -> int | None:
+    if center == pair_value[0]:
+        return pair_value[1]
+    if center == pair_value[1]:
+        return pair_value[0]
+    return None
+
+
+def _replay_equality_chain(
+    packet: dict[str, Any],
+    rows: dict[int, list[int]],
+    errors: list[str],
+) -> tuple[list[list[int]], list[dict[str, object]]]:
+    equality = packet.get("distance_equality")
+    if not isinstance(equality, dict):
+        errors.append("distance_equality must be an object")
+        return [], []
+    current = _pair(equality.get("start_pair"), "distance_equality.start_pair", errors)
+    end_pair = _pair(equality.get("end_pair"), "distance_equality.end_pair", errors)
+    path = equality.get("path")
+    if not isinstance(path, list):
+        errors.append("distance_equality.path must be a list")
+        return [], []
+
+    chain = [current]
+    steps: list[dict[str, object]] = []
+    for step_index, step in enumerate(path):
+        if not isinstance(step, dict):
+            errors.append(f"distance_equality.path[{step_index}] must be an object")
+            continue
+        try:
+            row = int(step["row"])
+        except (KeyError, TypeError, ValueError):
+            errors.append(f"distance_equality.path[{step_index}].row must be an integer")
+            continue
+        next_pair = _pair(
+            step.get("next_pair"),
+            f"distance_equality.path[{step_index}].next_pair",
+            errors,
+        )
+        witnesses = rows.get(row)
+        if witnesses is None:
+            errors.append(f"equality step {step_index} uses missing row {row}")
+            continue
+        current_other = _other_endpoint(current, row)
+        next_other = _other_endpoint(next_pair, row)
+        if current_other is None:
+            errors.append(f"equality step {step_index} does not start at row center {row}")
+        elif current_other not in witnesses:
+            errors.append(
+                f"equality step {step_index} current endpoint {current_other} "
+                f"is not selected by row {row}"
+            )
+        if next_other is None:
+            errors.append(f"equality step {step_index} does not end at row center {row}")
+        elif next_other not in witnesses:
+            errors.append(
+                f"equality step {step_index} next endpoint {next_other} "
+                f"is not selected by row {row}"
+            )
+        steps.append(
+            {
+                "row": row,
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+        chain.append(current)
+
+    if current != end_pair:
+        errors.append(f"equality chain ends at {current}, not {end_pair}")
+    stored_chain = packet.get("equality_chain")
+    if stored_chain != chain:
+        errors.append(f"stored equality_chain mismatch: {stored_chain!r} != {chain!r}")
+    return chain, steps
+
+
+def _interval_for_pair(witness_order: list[int], pair_value: list[int]) -> list[int]:
+    positions = sorted(witness_order.index(endpoint) for endpoint in pair_value)
+    return [int(positions[0]), int(positions[1])]
+
+
+def _replay_strict_inequality(
+    packet: dict[str, Any],
+    rows: dict[int, list[int]],
+    equality_chain: list[list[int]],
+    errors: list[str],
+) -> dict[str, object]:
+    strict = packet.get("strict_inequality")
+    if not isinstance(strict, dict):
+        errors.append("strict_inequality must be an object")
+        return {}
+    try:
+        row = int(strict["row"])
+        witness_order = [int(value) for value in strict["witness_order"]]
+    except (KeyError, TypeError, ValueError):
+        errors.append("strict_inequality row and witness_order must be present")
+        return {}
+    row_witnesses = rows.get(row)
+    if row_witnesses is None:
+        errors.append(f"strict_inequality uses missing row {row}")
+    elif sorted(row_witnesses) != sorted(witness_order):
+        errors.append("strict_inequality witness_order must list the row witnesses")
+
+    outer_pair = _pair(strict.get("outer_pair"), "strict_inequality.outer_pair", errors)
+    inner_pair = _pair(strict.get("inner_pair"), "strict_inequality.inner_pair", errors)
+    for label, pair_value in (("outer", outer_pair), ("inner", inner_pair)):
+        for endpoint in pair_value:
+            if endpoint not in witness_order:
+                errors.append(f"strict_inequality {label}_pair endpoint {endpoint} is not a witness")
+    if errors:
+        return {}
+
+    outer_interval = _interval_for_pair(witness_order, outer_pair)
+    inner_interval = _interval_for_pair(witness_order, inner_pair)
+    if strict.get("outer_interval") != outer_interval:
+        errors.append("strict_inequality outer_interval mismatch")
+    if strict.get("inner_interval") != inner_interval:
+        errors.append("strict_inequality inner_interval mismatch")
+    if not (
+        outer_interval[0] <= inner_interval[0]
+        and inner_interval[1] <= outer_interval[1]
+        and outer_interval != inner_interval
+    ):
+        errors.append("strict outer interval must properly contain inner interval")
+    if strict.get("outer_span") != outer_interval[1] - outer_interval[0]:
+        errors.append("strict_inequality outer_span mismatch")
+    if strict.get("inner_span") != inner_interval[1] - inner_interval[0]:
+        errors.append("strict_inequality inner_span mismatch")
+    if equality_chain and (equality_chain[0] != outer_pair or equality_chain[-1] != inner_pair):
+        errors.append("equality chain endpoints must match strict outer and inner pairs")
+
+    return {
+        "row": row,
+        "witness_order": witness_order,
+        "outer_pair": outer_pair,
+        "inner_pair": inner_pair,
+        "outer_interval": outer_interval,
+        "inner_interval": inner_interval,
+        "outer_span": outer_interval[1] - outer_interval[0],
+        "inner_span": inner_interval[1] - inner_interval[0],
+    }
+
+
+def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]:
+    """Replay the local T01 packet and return a compact summary plus errors."""
+    errors: list[str] = []
+    if packet.get("schema") != SOURCE_PACKET_SCHEMA:
+        errors.append(f"unexpected source schema: {packet.get('schema')!r}")
+    if packet.get("template_id") != "T01":
+        errors.append(f"unexpected template_id: {packet.get('template_id')!r}")
+    if packet.get("family_id") != "F09":
+        errors.append(f"unexpected family_id: {packet.get('family_id')!r}")
+    if packet.get("cyclic_order") != list(range(9)):
+        errors.append("cyclic_order must be the natural nonagon order")
+
+    rows = _rows(packet, errors)
+    equality_chain, equality_steps = _replay_equality_chain(packet, rows, errors)
+    strict_summary = _replay_strict_inequality(packet, rows, equality_chain, errors)
+    summary = {
+        "source_template_id": packet.get("template_id"),
+        "source_family_id": packet.get("family_id"),
+        "core_row_count": len(rows),
+        "core_centers": sorted(rows),
+        "equality_chain": equality_chain,
+        "equality_step_count": len(equality_steps),
+        "equality_steps": equality_steps,
+        "strict_inequality": strict_summary,
+        "self_edge_contradiction": bool(
+            equality_chain
+            and strict_summary
+            and equality_chain[0] == strict_summary.get("outer_pair")
+            and equality_chain[-1] == strict_summary.get("inner_pair")
+        ),
+    }
+    if not summary["self_edge_contradiction"]:
+        errors.append("strict inequality does not close on an equality-chain self-edge")
+    return summary, errors
+
+
+def minireplay_payload(packet: dict[str, Any]) -> dict[str, object]:
+    """Build the stable mini-replay artifact payload."""
+    replay, errors = replay_packet(packet)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Minimal input-data replay of the focused T01/F09 self-edge local "
+            "lemma packet; not a proof of n=9, not an independent review of the "
+            "full checker, not a counterexample, and not a global status update."
+        ),
+        "source_packet": SOURCE_PACKET,
+        "source_packet_schema": SOURCE_PACKET_SCHEMA,
+        "ok": not errors,
+        "validation_errors": errors,
+        "replay": replay,
+        "interpretation": (
+            "The selected rows identify the strict outer and inner chord pairs, "
+            "while the row-0 vertex-circle order makes the outer chord strictly "
+            "longer than the inner chord."
+        ),
+        "provenance": {
+            "generator": "scripts/check_n9_t01_self_edge_minireplay.py",
+            "command": "python scripts/check_n9_t01_self_edge_minireplay.py --write --assert-expected",
+        },
+    }
+
+
+def validate_payload(payload: dict[str, Any], source_packet: dict[str, Any]) -> list[str]:
+    """Validate a stored mini-replay payload against the source packet."""
+    errors: list[str] = []
+    expected = minireplay_payload(source_packet)
+    for key in ("schema", "status", "trust", "source_packet", "source_packet_schema", "ok"):
+        if payload.get(key) != expected.get(key):
+            errors.append(f"{key} mismatch: {payload.get(key)!r} != {expected.get(key)!r}")
+    if payload.get("validation_errors") != expected["validation_errors"]:
+        errors.append("validation_errors mismatch")
+    if payload.get("replay") != expected["replay"]:
+        errors.append("replay mismatch")
+    return errors
+
+
+def assert_expected_payload(payload: dict[str, Any]) -> None:
+    """Assert the stable expected T01 mini-replay facts."""
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected schema")
+    if payload.get("ok") is not True:
+        raise AssertionError(f"mini-replay is not ok: {payload.get('validation_errors')!r}")
+    replay = payload.get("replay")
+    if not isinstance(replay, dict):
+        raise AssertionError("missing replay object")
+    expected = {
+        "source_template_id": "T01",
+        "source_family_id": "F09",
+        "core_row_count": 3,
+        "core_centers": [0, 1, 2],
+        "equality_chain": [[1, 8], [0, 1], [0, 2], [1, 2]],
+        "equality_step_count": 3,
+        "self_edge_contradiction": True,
+    }
+    for key, expected_value in expected.items():
+        if replay.get(key) != expected_value:
+            raise AssertionError(
+                f"unexpected replay {key}: {replay.get(key)!r} != {expected_value!r}"
+            )
+    strict = replay.get("strict_inequality")
+    if not isinstance(strict, dict):
+        raise AssertionError("missing strict_inequality summary")
+    if strict.get("outer_pair") != [1, 8] or strict.get("inner_pair") != [1, 2]:
+        raise AssertionError("unexpected strict chord pairs")

--- a/tests/test_n9_t01_self_edge_minireplay.py
+++ b/tests/test_n9_t01_self_edge_minireplay.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_t01_self_edge_minireplay import (
+    assert_expected_payload,
+    minireplay_payload,
+    replay_packet,
+    validate_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "data" / "certificates" / "n9_vertex_circle_t01_self_edge_lemma_packet.json"
+
+
+def _source_packet() -> dict[str, object]:
+    payload = json.loads(SOURCE.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_t01_minireplay_replays_local_self_edge() -> None:
+    packet = _source_packet()
+    replay, errors = replay_packet(packet)
+
+    assert errors == []
+    assert replay["equality_chain"] == [[1, 8], [0, 1], [0, 2], [1, 2]]
+    assert replay["self_edge_contradiction"] is True
+    assert replay["strict_inequality"] == {
+        "row": 0,
+        "witness_order": [1, 2, 4, 8],
+        "outer_pair": [1, 8],
+        "inner_pair": [1, 2],
+        "outer_interval": [0, 3],
+        "inner_interval": [0, 1],
+        "outer_span": 3,
+        "inner_span": 1,
+    }
+
+
+def test_t01_minireplay_rejects_broken_equality_step() -> None:
+    packet = _source_packet()
+    equality = packet["distance_equality"]
+    assert isinstance(equality, dict)
+    path = equality["path"]
+    assert isinstance(path, list)
+    bad_step = dict(path[0])
+    bad_step["next_pair"] = [3, 5]
+    path[0] = bad_step
+
+    _, errors = replay_packet(packet)
+
+    assert any("does not end at row center 1" in error for error in errors)
+    assert any("stored equality_chain mismatch" in error for error in errors)
+
+
+@pytest.mark.artifact
+def test_t01_minireplay_payload_validates_against_source() -> None:
+    packet = _source_packet()
+    payload = minireplay_payload(packet)
+
+    assert validate_payload(payload, packet) == []
+    assert_expected_payload(payload)

--- a/tests/test_n9_t01_self_edge_minireplay.py
+++ b/tests/test_n9_t01_self_edge_minireplay.py
@@ -57,6 +57,18 @@ def test_t01_minireplay_rejects_broken_equality_step() -> None:
     assert any("stored equality_chain mismatch" in error for error in errors)
 
 
+def test_t01_minireplay_reports_malformed_pairs_without_crashing() -> None:
+    packet = _source_packet()
+    equality = packet["distance_equality"]
+    assert isinstance(equality, dict)
+    equality["start_pair"] = [1]
+
+    _, errors = replay_packet(packet)
+
+    assert "distance_equality.start_pair must be a two-element list" in errors
+    assert any("does not start at row center" in error for error in errors)
+
+
 @pytest.mark.artifact
 def test_t01_minireplay_payload_validates_against_source() -> None:
     packet = _source_packet()


### PR DESCRIPTION
## Summary

- add a minimal input-data replay for the focused T01/F09 self-edge local lemma packet
- verify the local equality chain `[1,8] = [0,1] = [0,2] = [1,2]` directly from selected rows
- verify the row-0 strict chord containment `[1,8] > [1,2]` from the packet witness order
- register the generated mini-replay artifact and add a short doc note
- harden malformed-pair validation after automated review feedback

## Claim discipline

This is proof-mining scaffolding only. It does not prove `n=9`, does not independently review the full exhaustive checker, does not claim a counterexample, and does not update global status.

## Verification

- `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected`
- `python -m pytest -q tests/test_n9_t01_self_edge_minireplay.py`
- `python -m pytest -q tests/test_n9_t01_self_edge_minireplay.py -m artifact`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`730 passed, 282 deselected`)
- source packet checks: `check_n9_vertex_circle_t01_self_edge_lemma_packet`, `check_n9_vertex_circle_template_lemma_catalog`, and `check_n9_vertex_circle_exhaustive` all passed