### PR TITLE
Add n9 local lemma scan artifact

### DIFF
--- a/data/certificates/n9_vertex_circle_local_lemmas.json
+++ b/data/certificates/n9_vertex_circle_local_lemmas.json
@@ -1,0 +1,3339 @@
+{
+  "claim_scope": "Proof-mining scan for reusable n-independent vertex-circle local lemmas. This is not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "coverage_summary": {
+    "covered_assignment_count": 184,
+    "covered_family_count": 16,
+    "covered_family_ids": [
+      "F01",
+      "F02",
+      "F03",
+      "F04",
+      "F05",
+      "F06",
+      "F07",
+      "F08",
+      "F09",
+      "F10",
+      "F11",
+      "F12",
+      "F13",
+      "F14",
+      "F15",
+      "F16"
+    ],
+    "family_to_lemmas": {
+      "F01": [
+        "shared_endpoint_nested_self_edge"
+      ],
+      "F02": [
+        "nested_spoke_quotient_self_edge"
+      ],
+      "F03": [
+        "nested_spoke_quotient_self_edge"
+      ],
+      "F04": [
+        "shared_endpoint_nested_self_edge"
+      ],
+      "F05": [
+        "t03_selected_path_self_edge"
+      ],
+      "F06": [
+        "nested_spoke_quotient_self_edge"
+      ],
+      "F07": [
+        "t11_three_edge_strict_cycle"
+      ],
+      "F08": [
+        "shared_endpoint_nested_self_edge"
+      ],
+      "F09": [
+        "nested_spoke_quotient_self_edge"
+      ],
+      "F10": [
+        "nested_spoke_quotient_self_edge"
+      ],
+      "F11": [
+        "nested_spoke_quotient_self_edge"
+      ],
+      "F12": [
+        "t10_two_edge_strict_cycle"
+      ],
+      "F13": [
+        "t04_selected_path_self_edge"
+      ],
+      "F14": [
+        "shared_endpoint_nested_self_edge"
+      ],
+      "F15": [
+        "t03_selected_path_self_edge"
+      ],
+      "F16": [
+        "t12_three_edge_strict_cycle"
+      ]
+    },
+    "source_assignment_count": 184,
+    "source_family_count": 16,
+    "uncovered_assignment_count": 0,
+    "uncovered_family_count": 0,
+    "uncovered_family_ids": []
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "direct_two_row_nested_spoke_special_case": {
+    "instance_count": 0,
+    "instances": [],
+    "interpretation": "The two-row special case proposed in solver output 3 is a valid proof pattern, but this scan finds no exact direct instances in the current n=9 template packets.  The packet instances use the more general selected-distance quotient version instead.",
+    "lemma_id": "nested_spoke_direct_two_row_special_case"
+  },
+  "focused_note_crosscheck": [
+    {
+      "check_status": "checked",
+      "covered_assignment_count": 20,
+      "families_checked": [
+        {
+          "assignment_count": 18,
+          "family_id": "F05",
+          "orbit_size": 18
+        },
+        {
+          "assignment_count": 2,
+          "family_id": "F15",
+          "orbit_size": 2
+        }
+      ],
+      "family_ids": [
+        "F05",
+        "F15"
+      ],
+      "interpretation": "Aggregate scan instance matches the focused packet used by the proof-facing note; this is a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "t03_selected_path_self_edge",
+      "packet_key": "T03",
+      "packet_path": "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t03-self-edge-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T03"
+    },
+    {
+      "check_status": "checked",
+      "covered_assignment_count": 2,
+      "families_checked": [
+        {
+          "assignment_count": 2,
+          "family_id": "F13",
+          "orbit_size": 2
+        }
+      ],
+      "family_ids": [
+        "F13"
+      ],
+      "interpretation": "The T04 proof note is backed directly by the self-edge template packet; the aggregate scan matches that source family record.",
+      "lemma_id": "t04_selected_path_self_edge",
+      "packet_key": null,
+      "packet_path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t04-self-edge-lemma.md",
+      "source_kind": "template_packet",
+      "template_id": "T04"
+    },
+    {
+      "check_status": "checked",
+      "covered_assignment_count": 18,
+      "families_checked": [
+        {
+          "assignment_count": 18,
+          "family_id": "F12",
+          "orbit_size": 18
+        }
+      ],
+      "family_ids": [
+        "F12"
+      ],
+      "interpretation": "Aggregate scan instance matches the focused packet used by the proof-facing note; this is a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "t10_two_edge_strict_cycle",
+      "packet_key": "T10",
+      "packet_path": "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t10-strict-cycle-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T10"
+    },
+    {
+      "check_status": "checked",
+      "covered_assignment_count": 6,
+      "families_checked": [
+        {
+          "assignment_count": 6,
+          "family_id": "F07",
+          "orbit_size": 6
+        }
+      ],
+      "family_ids": [
+        "F07"
+      ],
+      "interpretation": "Aggregate scan instance matches the focused packet used by the proof-facing note; this is a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "t11_three_edge_strict_cycle",
+      "packet_key": "T11",
+      "packet_path": "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t11-strict-cycle-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T11"
+    },
+    {
+      "check_status": "checked",
+      "covered_assignment_count": 2,
+      "families_checked": [
+        {
+          "assignment_count": 2,
+          "family_id": "F16",
+          "orbit_size": 2
+        }
+      ],
+      "family_ids": [
+        "F16"
+      ],
+      "interpretation": "Aggregate scan instance matches the focused packet used by the proof-facing note; this is a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "t12_three_edge_strict_cycle",
+      "packet_key": "T12",
+      "packet_path": "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t12-strict-cycle-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T12"
+    }
+  ],
+  "interpretation": "The listed local shapes are reusable obstruction candidates: each one produces either a reflexive strict edge or a directed strict cycle after selected-distance quotienting.  The scan only uses stored template-packet local cores and does not enumerate all n=9 selected-witness assignments.",
+  "lemmas": [
+    {
+      "covered_assignment_count": 40,
+      "family_ids": [
+        "F01",
+        "F04",
+        "F08",
+        "F14"
+      ],
+      "instance_count": 4,
+      "instances": [
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              4,
+              7
+            ],
+            [
+              8,
+              0,
+              1,
+              4,
+              5
+            ]
+          ],
+          "direct_conditions": {
+            "holds": true,
+            "labels": {
+              "a": 1,
+              "b": 2,
+              "center": 0,
+              "d": 8
+            },
+            "row_a_condition": true,
+            "row_a_witnesses": [
+              0,
+              2,
+              4,
+              7
+            ],
+            "row_d_condition": true,
+            "row_d_witnesses": [
+              0,
+              1,
+              4,
+              5
+            ],
+            "variant": "row_d_contains_center_and_a__row_a_contains_center_and_b"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F01",
+          "lemma_id": "shared_endpoint_nested_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "template_id": "T02",
+          "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              6
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              5
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              8
+            ]
+          ],
+          "direct_conditions": {
+            "holds": true,
+            "labels": {
+              "a": 2,
+              "b": 3,
+              "center": 1,
+              "d": 0
+            },
+            "row_a_condition": true,
+            "row_a_witnesses": [
+              1,
+              3,
+              4,
+              8
+            ],
+            "row_d_condition": true,
+            "row_d_witnesses": [
+              1,
+              2,
+              4,
+              6
+            ],
+            "variant": "row_d_contains_center_and_a__row_a_contains_center_and_b"
+          },
+          "distance_equality": {
+            "end_pair": [
+              2,
+              3
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              0,
+              2
+            ]
+          },
+          "family_id": "F04",
+          "lemma_id": "shared_endpoint_nested_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          },
+          "template_id": "T02",
+          "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+        },
+        {
+          "assignment_count": 2,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              5
+            ],
+            [
+              8,
+              0,
+              1,
+              3,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": true,
+            "labels": {
+              "a": 1,
+              "b": 2,
+              "center": 0,
+              "d": 8
+            },
+            "row_a_condition": true,
+            "row_a_witnesses": [
+              0,
+              2,
+              3,
+              5
+            ],
+            "row_d_condition": true,
+            "row_d_witnesses": [
+              0,
+              1,
+              3,
+              7
+            ],
+            "variant": "row_d_contains_center_and_a__row_a_contains_center_and_b"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F08",
+          "lemma_id": "shared_endpoint_nested_self_edge",
+          "orbit_size": 2,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "template_id": "T02",
+          "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+        },
+        {
+          "assignment_count": 2,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              6,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              7
+            ],
+            [
+              8,
+              0,
+              1,
+              5,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": true,
+            "labels": {
+              "a": 1,
+              "b": 2,
+              "center": 0,
+              "d": 8
+            },
+            "row_a_condition": true,
+            "row_a_witnesses": [
+              0,
+              2,
+              3,
+              7
+            ],
+            "row_d_condition": true,
+            "row_d_witnesses": [
+              0,
+              1,
+              5,
+              7
+            ],
+            "variant": "row_d_contains_center_and_a__row_a_contains_center_and_b"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F14",
+          "lemma_id": "shared_endpoint_nested_self_edge",
+          "orbit_size": 2,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              6,
+              8
+            ]
+          },
+          "template_id": "T02",
+          "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+        }
+      ],
+      "lemma_id": "shared_endpoint_nested_self_edge",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T02"
+      ]
+    },
+    {
+      "covered_assignment_count": 96,
+      "family_ids": [
+        "F02",
+        "F03",
+        "F06",
+        "F09",
+        "F10",
+        "F11"
+      ],
+      "instance_count": 8,
+      "instances": [
+        {
+          "assignment_count": 6,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              2,
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 1,
+              "b": 2,
+              "c": 4,
+              "d": 8
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "row_b_condition": true,
+            "row_b_witnesses": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  2
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F09",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 6,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "template_id": "T01",
+          "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              7
+            ],
+            [
+              7,
+              2,
+              5,
+              6,
+              8
+            ],
+            [
+              8,
+              0,
+              1,
+              6,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 1,
+              "b": 2,
+              "c": 4,
+              "d": 8
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [],
+            "row_b_condition": true,
+            "row_b_witnesses": [
+              1,
+              3,
+              4,
+              7
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  7,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  2,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              8
+            ]
+          },
+          "family_id": "F10",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          "template_id": "T05",
+          "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              1,
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              5,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              6,
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              7,
+              0,
+              1,
+              5,
+              6
+            ],
+            [
+              8,
+              2,
+              3,
+              6,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 7,
+              "b": 8,
+              "c": 2,
+              "d": 5
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [
+              0,
+              1,
+              5,
+              6
+            ],
+            "row_b_condition": true,
+            "row_b_witnesses": [
+              2,
+              3,
+              6,
+              7
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              3,
+              5
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  6,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  6,
+                  7
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  5,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 5
+              }
+            ],
+            "start_pair": [
+              3,
+              8
+            ]
+          },
+          "family_id": "F11",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              5,
+              7
+            ],
+            "outer_span": 3,
+            "row": 6,
+            "witness_order": [
+              7,
+              8,
+              2,
+              5
+            ]
+          },
+          "template_id": "T06",
+          "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x1,3:1:0x1,3:1:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              7
+            ],
+            [
+              2,
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              4,
+              1,
+              3,
+              5,
+              7
+            ],
+            [
+              5,
+              3,
+              4,
+              6,
+              8
+            ],
+            [
+              6,
+              0,
+              2,
+              5,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 4,
+              "b": 6,
+              "c": 0,
+              "d": 1
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [
+              1,
+              3,
+              5,
+              7
+            ],
+            "row_b_condition": false,
+            "row_b_witnesses": [
+              0,
+              2,
+              5,
+              7
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  4,
+                  5
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  5,
+                  6
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  2,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              4
+            ]
+          },
+          "family_id": "F06",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              0,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 3,
+            "row": 2,
+            "witness_order": [
+              4,
+              6,
+              0,
+              1
+            ]
+          },
+          "template_id": "T07",
+          "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x3,3:1:0x1,3:1:1x1,3:2:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              2,
+              1,
+              3,
+              5,
+              6
+            ],
+            [
+              5,
+              2,
+              4,
+              6,
+              7
+            ],
+            [
+              6,
+              1,
+              5,
+              7,
+              8
+            ],
+            [
+              7,
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 3,
+              "b": 4,
+              "c": 7,
+              "d": 0
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [],
+            "row_b_condition": false,
+            "row_b_witnesses": [],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  6,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  5,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "family_id": "F02",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              4,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "witness_order": [
+              3,
+              4,
+              7,
+              0
+            ]
+          },
+          "template_id": "T08",
+          "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              2,
+              1,
+              3,
+              5,
+              6
+            ],
+            [
+              5,
+              2,
+              4,
+              6,
+              7
+            ],
+            [
+              6,
+              1,
+              5,
+              7,
+              8
+            ],
+            [
+              7,
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 3,
+              "b": 5,
+              "c": 6,
+              "d": 1
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [],
+            "row_b_condition": false,
+            "row_b_witnesses": [
+              2,
+              4,
+              6,
+              7
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  6,
+                  7
+                ],
+                "row": 7
+              },
+              {
+                "next_pair": [
+                  5,
+                  6
+                ],
+                "row": 6
+              },
+              {
+                "next_pair": [
+                  2,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "family_id": "F02",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              5,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 3,
+            "row": 2,
+            "witness_order": [
+              3,
+              5,
+              6,
+              1
+            ]
+          },
+          "template_id": "T08",
+          "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              5,
+              7
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              6
+            ],
+            [
+              3,
+              2,
+              4,
+              5,
+              8
+            ],
+            [
+              4,
+              0,
+              3,
+              6,
+              8
+            ],
+            [
+              8,
+              0,
+              1,
+              4,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 1,
+              "b": 2,
+              "c": 3,
+              "d": 8
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "row_b_condition": true,
+            "row_b_witnesses": [
+              1,
+              3,
+              4,
+              6
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  4,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  3,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "family_id": "F03",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          "template_id": "T09",
+          "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x5,3:1:0x2,3:1:1x4,3:2:1x2"
+        },
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              3,
+              8
+            ],
+            [
+              1,
+              0,
+              3,
+              5,
+              7
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              6
+            ],
+            [
+              3,
+              2,
+              4,
+              5,
+              8
+            ],
+            [
+              4,
+              0,
+              3,
+              6,
+              8
+            ],
+            [
+              8,
+              0,
+              1,
+              4,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "holds": false,
+            "labels": {
+              "a": 3,
+              "b": 4,
+              "c": 6,
+              "d": 1
+            },
+            "row_a_condition": false,
+            "row_a_witnesses": [
+              2,
+              4,
+              5,
+              8
+            ],
+            "row_b_condition": true,
+            "row_b_witnesses": [
+              0,
+              3,
+              6,
+              8
+            ],
+            "variant": "output3_direct_two_row_special_case"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  0,
+                  8
+                ],
+                "row": 0
+              },
+              {
+                "next_pair": [
+                  4,
+                  8
+                ],
+                "row": 8
+              },
+              {
+                "next_pair": [
+                  3,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              }
+            ],
+            "start_pair": [
+              1,
+              3
+            ]
+          },
+          "family_id": "F03",
+          "lemma_id": "nested_spoke_quotient_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              4,
+              6
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 3,
+            "row": 2,
+            "witness_order": [
+              3,
+              4,
+              6,
+              1
+            ]
+          },
+          "template_id": "T09",
+          "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x5,3:1:0x2,3:1:1x4,3:2:1x2"
+        }
+      ],
+      "lemma_id": "nested_spoke_quotient_self_edge",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T01",
+        "T05",
+        "T06",
+        "T07",
+        "T08",
+        "T09"
+      ]
+    },
+    {
+      "covered_assignment_count": 20,
+      "family_ids": [
+        "F05",
+        "F15"
+      ],
+      "instance_count": 2,
+      "instances": [
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              1,
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              2,
+              1,
+              3,
+              4,
+              8
+            ],
+            [
+              3,
+              0,
+              2,
+              4,
+              7
+            ],
+            [
+              6,
+              1,
+              3,
+              5,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "holds": true,
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "path_length": 3,
+            "start_pair": [
+              3,
+              7
+            ],
+            "variant": "selected_path_self_edge"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              7
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              3,
+              7
+            ]
+          },
+          "family_id": "F05",
+          "lemma_id": "t03_selected_path_self_edge",
+          "orbit_size": 18,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "witness_order": [
+              7,
+              1,
+              3,
+              5
+            ]
+          },
+          "template_id": "T03",
+          "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+        },
+        {
+          "assignment_count": 2,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              3,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              4,
+              5
+            ],
+            [
+              2,
+              1,
+              3,
+              5,
+              6
+            ],
+            [
+              3,
+              2,
+              4,
+              6,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "end_pair": [
+              3,
+              4
+            ],
+            "holds": true,
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  3,
+                  4
+                ],
+                "row": 3
+              }
+            ],
+            "path_length": 3,
+            "start_pair": [
+              1,
+              4
+            ],
+            "variant": "selected_path_self_edge"
+          },
+          "distance_equality": {
+            "end_pair": [
+              3,
+              4
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              },
+              {
+                "next_pair": [
+                  2,
+                  3
+                ],
+                "row": 2
+              },
+              {
+                "next_pair": [
+                  3,
+                  4
+                ],
+                "row": 3
+              }
+            ],
+            "start_pair": [
+              1,
+              4
+            ]
+          },
+          "family_id": "F15",
+          "lemma_id": "t03_selected_path_self_edge",
+          "orbit_size": 2,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              3,
+              4,
+              8
+            ]
+          },
+          "template_id": "T03",
+          "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+        }
+      ],
+      "lemma_id": "t03_selected_path_self_edge",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T03"
+      ]
+    },
+    {
+      "covered_assignment_count": 2,
+      "family_ids": [
+        "F13"
+      ],
+      "instance_count": 1,
+      "instances": [
+        {
+          "assignment_count": 2,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              5,
+              7
+            ],
+            [
+              1,
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              3,
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              5,
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "direct_conditions": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "holds": true,
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  1,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "path_length": 3,
+            "start_pair": [
+              1,
+              5
+            ],
+            "variant": "selected_path_self_edge"
+          },
+          "distance_equality": {
+            "end_pair": [
+              1,
+              2
+            ],
+            "path": [
+              {
+                "next_pair": [
+                  3,
+                  5
+                ],
+                "row": 5
+              },
+              {
+                "next_pair": [
+                  1,
+                  3
+                ],
+                "row": 3
+              },
+              {
+                "next_pair": [
+                  1,
+                  2
+                ],
+                "row": 1
+              }
+            ],
+            "start_pair": [
+              1,
+              5
+            ]
+          },
+          "family_id": "F13",
+          "lemma_id": "t04_selected_path_self_edge",
+          "orbit_size": 2,
+          "simple_filter_violations": [],
+          "strict_inequality": {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              5
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              5,
+              7
+            ]
+          },
+          "template_id": "T04",
+          "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2"
+        }
+      ],
+      "lemma_id": "t04_selected_path_self_edge",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T04"
+      ]
+    },
+    {
+      "covered_assignment_count": 18,
+      "family_ids": [
+        "F12"
+      ],
+      "instance_count": 1,
+      "instances": [
+        {
+          "assignment_count": 18,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              5,
+              6
+            ],
+            [
+              3,
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              6,
+              1,
+              3,
+              4,
+              7
+            ],
+            [
+              8,
+              0,
+              3,
+              6,
+              7
+            ]
+          ],
+          "cycle_edges": [
+            {
+              "inner_class": [
+                0,
+                3
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                0,
+                3
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                2
+              ],
+              "outer_pair": [
+                0,
+                6
+              ],
+              "outer_span": 2,
+              "row": 8,
+              "witness_order": [
+                0,
+                3,
+                6,
+                7
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                1
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                3
+              ],
+              "outer_interval": [
+                1,
+                3
+              ],
+              "outer_pair": [
+                1,
+                6
+              ],
+              "outer_span": 2,
+              "row": 3,
+              "witness_order": [
+                4,
+                6,
+                0,
+                1
+              ]
+            }
+          ],
+          "cycle_length": 2,
+          "cycle_steps": [
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  1,
+                  6
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      3,
+                      6
+                    ],
+                    "row": 3
+                  },
+                  {
+                    "next_pair": [
+                      1,
+                      6
+                    ],
+                    "row": 6
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  3
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  0,
+                  3
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  6
+                ],
+                "outer_span": 2,
+                "row": 8,
+                "witness_order": [
+                  0,
+                  3,
+                  6,
+                  7
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  6
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      0,
+                      6
+                    ],
+                    "row": 0
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  1
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  1
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  6
+                ],
+                "outer_span": 2,
+                "row": 3,
+                "witness_order": [
+                  4,
+                  6,
+                  0,
+                  1
+                ]
+              }
+            }
+          ],
+          "family_id": "F12",
+          "lemma_id": "t10_two_edge_strict_cycle",
+          "orbit_size": 18,
+          "replay_status": "strict_cycle",
+          "simple_filter_violations": [],
+          "template_id": "T10",
+          "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+        }
+      ],
+      "lemma_id": "t10_two_edge_strict_cycle",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T10"
+      ]
+    },
+    {
+      "covered_assignment_count": 6,
+      "family_ids": [
+        "F07"
+      ],
+      "instance_count": 1,
+      "instances": [
+        {
+          "assignment_count": 6,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              1,
+              0,
+              2,
+              3,
+              5
+            ],
+            [
+              5,
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              6,
+              1,
+              5,
+              7,
+              8
+            ]
+          ],
+          "cycle_edges": [
+            {
+              "inner_class": [
+                0,
+                3
+              ],
+              "inner_interval": [
+                1,
+                3
+              ],
+              "inner_pair": [
+                0,
+                3
+              ],
+              "inner_span": 2,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                0,
+                2
+              ],
+              "outer_span": 3,
+              "row": 1,
+              "witness_order": [
+                2,
+                3,
+                5,
+                0
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                5
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                5
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                3
+              ],
+              "outer_interval": [
+                1,
+                3
+              ],
+              "outer_pair": [
+                0,
+                3
+              ],
+              "outer_span": 2,
+              "row": 1,
+              "witness_order": [
+                2,
+                3,
+                5,
+                0
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                1,
+                5
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                5
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                5,
+                7
+              ],
+              "outer_span": 3,
+              "row": 6,
+              "witness_order": [
+                7,
+                8,
+                1,
+                5
+              ]
+            }
+          ],
+          "cycle_length": 3,
+          "cycle_steps": [
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  3
+                ],
+                "path": [],
+                "start_pair": [
+                  0,
+                  3
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  3
+                ],
+                "inner_span": 2,
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  2
+                ],
+                "outer_span": 3,
+                "row": 1,
+                "witness_order": [
+                  2,
+                  3,
+                  5,
+                  0
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  5,
+                  7
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      5,
+                      7
+                    ],
+                    "row": 5
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  5
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  5
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  5
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  3
+                ],
+                "outer_span": 2,
+                "row": 1,
+                "witness_order": [
+                  2,
+                  3,
+                  5,
+                  0
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  2
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      0,
+                      1
+                    ],
+                    "row": 1
+                  },
+                  {
+                    "next_pair": [
+                      0,
+                      2
+                    ],
+                    "row": 0
+                  }
+                ],
+                "start_pair": [
+                  1,
+                  5
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  5
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  5
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  5,
+                  7
+                ],
+                "outer_span": 3,
+                "row": 6,
+                "witness_order": [
+                  7,
+                  8,
+                  1,
+                  5
+                ]
+              }
+            }
+          ],
+          "family_id": "F07",
+          "lemma_id": "t11_three_edge_strict_cycle",
+          "orbit_size": 6,
+          "replay_status": "strict_cycle",
+          "simple_filter_violations": [],
+          "template_id": "T11",
+          "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=3|spans=2:1x1,3:1x1,3:2x1"
+        }
+      ],
+      "lemma_id": "t11_three_edge_strict_cycle",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T11"
+      ]
+    },
+    {
+      "covered_assignment_count": 2,
+      "family_ids": [
+        "F16"
+      ],
+      "instance_count": 1,
+      "instances": [
+        {
+          "assignment_count": 2,
+          "core_selected_rows": [
+            [
+              0,
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              1,
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              2,
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              3,
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              4,
+              1,
+              2,
+              5,
+              7
+            ],
+            [
+              8,
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "cycle_edges": [
+            {
+              "inner_class": [
+                0,
+                2
+              ],
+              "inner_interval": [
+                2,
+                3
+              ],
+              "inner_pair": [
+                0,
+                8
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                1
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                0,
+                3
+              ],
+              "outer_span": 3,
+              "row": 2,
+              "witness_order": [
+                3,
+                5,
+                8,
+                0
+              ]
+            },
+            {
+              "inner_class": [
+                1,
+                2
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                2,
+                4
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                0,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                2,
+                8
+              ],
+              "outer_span": 3,
+              "row": 1,
+              "witness_order": [
+                2,
+                4,
+                7,
+                8
+              ]
+            },
+            {
+              "inner_class": [
+                0,
+                1
+              ],
+              "inner_interval": [
+                0,
+                1
+              ],
+              "inner_pair": [
+                1,
+                3
+              ],
+              "inner_span": 1,
+              "outer_class": [
+                1,
+                2
+              ],
+              "outer_interval": [
+                0,
+                3
+              ],
+              "outer_pair": [
+                1,
+                7
+              ],
+              "outer_span": 3,
+              "row": 0,
+              "witness_order": [
+                1,
+                3,
+                6,
+                7
+              ]
+            }
+          ],
+          "cycle_length": 3,
+          "cycle_steps": [
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  2,
+                  8
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      2,
+                      8
+                    ],
+                    "row": 8
+                  }
+                ],
+                "start_pair": [
+                  0,
+                  8
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  2
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  3
+                ],
+                "outer_span": 3,
+                "row": 2,
+                "witness_order": [
+                  3,
+                  5,
+                  8,
+                  0
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  1,
+                  7
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      1,
+                      4
+                    ],
+                    "row": 4
+                  },
+                  {
+                    "next_pair": [
+                      1,
+                      7
+                    ],
+                    "row": 1
+                  }
+                ],
+                "start_pair": [
+                  2,
+                  4
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  1,
+                  2
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  2,
+                  4
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  0,
+                  2
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  2,
+                  8
+                ],
+                "outer_span": 3,
+                "row": 1,
+                "witness_order": [
+                  2,
+                  4,
+                  7,
+                  8
+                ]
+              }
+            },
+            {
+              "equality_to_next_outer_pair": {
+                "end_pair": [
+                  0,
+                  3
+                ],
+                "path": [
+                  {
+                    "next_pair": [
+                      0,
+                      3
+                    ],
+                    "row": 3
+                  }
+                ],
+                "start_pair": [
+                  1,
+                  3
+                ]
+              },
+              "strict_inequality": {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  1,
+                  3
+                ],
+                "inner_span": 1,
+                "outer_class": [
+                  1,
+                  2
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  7
+                ],
+                "outer_span": 3,
+                "row": 0,
+                "witness_order": [
+                  1,
+                  3,
+                  6,
+                  7
+                ]
+              }
+            }
+          ],
+          "family_id": "F16",
+          "lemma_id": "t12_three_edge_strict_cycle",
+          "orbit_size": 2,
+          "replay_status": "strict_cycle",
+          "simple_filter_violations": [],
+          "template_id": "T12",
+          "template_key": "strict_cycle|rows=6|strict_edges=54|cycle=3|spans=3:1x3"
+        }
+      ],
+      "lemma_id": "t12_three_edge_strict_cycle",
+      "review_status": "review_pending",
+      "template_ids": [
+        "T12"
+      ]
+    }
+  ],
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_local_lemmas.py"
+  },
+  "schema": "erdos97.n9_vertex_circle_local_lemmas.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "source self-edge template packet",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+      "role": "source strict-cycle template packet",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -13,6 +13,17 @@ The companion checker is:
 python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --json
 ```
 
+The stored artifact form is:
+
+```bash
+python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write
+python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+```
+
+It writes `data/certificates/n9_vertex_circle_local_lemmas.json`. The artifact
+is a replayable proof-mining summary of the local template packets, not an
+independent `n=9` proof artifact.
+
 It scans only the stored local-core template packets:
 
 - `data/certificates/n9_vertex_circle_self_edge_template_packet.json`

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -688,6 +688,40 @@ artifacts:
       - the lemma catalog is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_local_lemmas
+    path: data/certificates/n9_vertex_circle_local_lemmas.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_local_lemmas.py
+    command: python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_local_lemmas.py
+    check_command: python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Proof-mining scan for reusable n-independent vertex-circle local lemmas; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_local_lemmas.v1
+      status: REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      n: 9
+      coverage_summary.source_family_count: 16
+      coverage_summary.source_assignment_count: 184
+      coverage_summary.covered_family_count: 16
+      coverage_summary.covered_assignment_count: 184
+      coverage_summary.uncovered_family_count: 0
+      coverage_summary.uncovered_assignment_count: 0
+      direct_two_row_nested_spoke_special_case.instance_count: 0
+      provenance.command: python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the local-lemma scan is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t01_self_edge_lemma_packet
     path: data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -15,9 +15,15 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.n9_vertex_circle_local_lemmas import (  # noqa: E402
+    CLAIM_SCOPE,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
     assert_expected_local_lemma_scan,
     local_lemma_scan_payload,
 )
+from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_SELF_EDGE_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_self_edge_template_packet.json"
@@ -37,12 +43,28 @@ DEFAULT_T11_PACKET = (
 DEFAULT_T12_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t12_strict_cycle_lemma_packet.json"
 )
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_local_lemmas.json"
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
 
 
 def load_artifact(path: Path) -> Any:
     """Load a JSON artifact."""
 
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
 
 
 def scan_payload(
@@ -66,6 +88,61 @@ def scan_payload(
             "T12": load_artifact(t12_packet_path),
         },
     )
+
+
+def validate_payload(payload: Any, expected_payload: dict[str, Any]) -> list[str]:
+    """Return validation errors for a stored local-lemma scan artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    errors: list[str] = []
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "cyclic_order": list(range(9)),
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        if payload.get(key) != expected:
+            errors.append(f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}")
+
+    try:
+        assert_expected_local_lemma_scan(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected local-lemma scan failed: {exc}")
+
+    if payload != expected_payload:
+        errors.append("local-lemma scan payload mismatch")
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: list[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    coverage = object_payload.get("coverage_summary", {})
+    if not isinstance(coverage, dict):
+        coverage = {}
+    lemmas = object_payload.get("lemmas", [])
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "lemma_count": len(lemmas) if isinstance(lemmas, list) else None,
+        "source_family_count": coverage.get("source_family_count"),
+        "source_assignment_count": coverage.get("source_assignment_count"),
+        "covered_family_count": coverage.get("covered_family_count"),
+        "covered_assignment_count": coverage.get("covered_assignment_count"),
+        "uncovered_family_count": coverage.get("uncovered_family_count"),
+        "uncovered_assignment_count": coverage.get("uncovered_assignment_count"),
+        "validation_errors": errors,
+    }
 
 
 def summary_lines(payload: dict[str, Any]) -> list[str]:
@@ -105,6 +182,10 @@ def summary_lines(payload: dict[str, Any]) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
     parser.add_argument(
         "--self-edge-packet",
         type=Path,
@@ -149,16 +230,60 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Print JSON output.")
     args = parser.parse_args(argv)
 
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
     payload = scan_payload(
-        self_edge_packet_path=args.self_edge_packet,
-        strict_cycle_packet_path=args.strict_cycle_packet,
-        t03_packet_path=args.t03_packet,
-        t10_packet_path=args.t10_packet,
-        t11_packet_path=args.t11_packet,
-        t12_packet_path=args.t12_packet,
+        self_edge_packet_path=_resolve(args.self_edge_packet),
+        strict_cycle_packet_path=_resolve(args.strict_cycle_packet),
+        t03_packet_path=_resolve(args.t03_packet),
+        t10_packet_path=_resolve(args.t10_packet),
+        t11_packet_path=_resolve(args.t11_packet),
+        t12_packet_path=_resolve(args.t12_packet),
     )
     if args.assert_expected:
         assert_expected_local_lemma_scan(payload)
+
+    if args.write:
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    if args.check:
+        try:
+            stored_payload = load_artifact(artifact)
+            errors = validate_payload(stored_payload, payload)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            stored_payload = {}
+            errors = [str(exc)]
+
+        summary = summary_payload(artifact, stored_payload, errors)
+        if args.json:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        elif errors:
+            print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+            for error in errors:
+                print(f"- {error}", file=sys.stderr)
+        else:
+            print("n=9 vertex-circle local-lemma scan artifact")
+            print(f"artifact: {summary['artifact']}")
+            print(f"covered assignments: {summary['covered_assignment_count']}")
+            print(f"covered families: {summary['covered_family_count']}")
+            print(f"lemmas: {summary['lemma_count']}")
+            print("OK: local-lemma scan artifact checks passed")
+        return 1 if errors else 0
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -26,6 +26,10 @@ CLAIM_SCOPE = (
     "This is not a proof of n=9, not a counterexample, not an independent "
     "review of the exhaustive checker, and not a global status update."
 )
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_local_lemmas.py",
+    "command": "python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write",
+}
 
 SHARED_ENDPOINT_LEMMA = "shared_endpoint_nested_self_edge"
 NESTED_SPOKE_LEMMA = "nested_spoke_quotient_self_edge"
@@ -295,6 +299,7 @@ def local_lemma_scan_payload(
             "stored template-packet local cores and does not enumerate all n=9 "
             "selected-witness assignments."
         ),
+        "provenance": dict(PROVENANCE),
     }
 
 
@@ -580,6 +585,8 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         raise AssertionError(f"status mismatch: {payload.get('status')!r}")
     if payload.get("trust") != TRUST:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
     claim_scope = str(payload.get("claim_scope", ""))
     for forbidden in ("proof of n=9", "counterexample", "global status update"):
         if f"not a {forbidden}" not in claim_scope and f"not an {forbidden}" not in claim_scope:

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -27,6 +27,7 @@ from scripts.check_n9_vertex_circle_local_lemmas import (
     DEFAULT_T12_PACKET,
     load_artifact,
     scan_payload,
+    validate_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -428,6 +429,29 @@ def test_assert_expected_rejects_count_drift(payload: dict[str, object]) -> None
         assert_expected_local_lemma_scan(tampered)
 
 
+def test_validate_payload_rejects_provenance_drift(payload: dict[str, object]) -> None:
+    tampered = json.loads(json.dumps(payload))
+    tampered["provenance"]["command"] = "python changed.py"
+
+    errors = validate_payload(tampered, payload)
+
+    assert any("provenance mismatch" in error for error in errors)
+    assert "local-lemma scan payload mismatch" in errors
+
+
+def test_payload_provenance_is_not_shared_mutable_state() -> None:
+    payload = scan_payload()
+    payload["provenance"]["command"] = "python changed.py"  # type: ignore[index]
+
+    with pytest.raises(AssertionError, match="provenance mismatch"):
+        assert_expected_local_lemma_scan(payload)
+
+    fresh_payload = scan_payload()
+    assert fresh_payload["provenance"]["command"] == (  # type: ignore[index]
+        "python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write"
+    )
+
+
 def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
     self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
     strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
@@ -488,3 +512,54 @@ def test_local_lemma_scan_cli_json() -> None:
     assert parsed["schema"] == "erdos97.n9_vertex_circle_local_lemmas.v1"
     assert parsed["coverage_summary"]["covered_assignment_count"] == 184
     assert parsed["coverage_summary"]["uncovered_family_ids"] == []
+
+
+def test_local_lemma_scan_cli_write_and_check(tmp_path: Path) -> None:
+    artifact = tmp_path / "n9_vertex_circle_local_lemmas.json"
+    write_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_lemmas.py",
+            "--write",
+            "--out",
+            str(artifact),
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    write_summary = json.loads(write_result.stdout)
+    assert write_summary["ok"] is True
+    assert write_summary["covered_assignment_count"] == 184
+    stored = json.loads(artifact.read_text(encoding="utf-8"))
+    assert stored["provenance"] == {
+        "generator": "scripts/check_n9_vertex_circle_local_lemmas.py",
+        "command": (
+            "python scripts/check_n9_vertex_circle_local_lemmas.py "
+            "--assert-expected --write"
+        ),
+    }
+
+    check_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_lemmas.py",
+            "--check",
+            "--artifact",
+            str(artifact),
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    check_summary = json.loads(check_result.stdout)
+    assert check_summary["ok"] is True
+    assert check_summary["lemma_count"] == 7


### PR DESCRIPTION
## Summary

- add a generated `n9_vertex_circle_local_lemmas.json` artifact for the review-pending local-lemma scan
- teach the local-lemma checker `--write` and `--check` modes with provenance validation
- register the artifact in `metadata/generated_artifacts.yaml` and document the replay commands

## Verification

- `python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python -m pytest -q tests/test_n9_vertex_circle_local_lemmas.py`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check src/erdos97/n9_vertex_circle_local_lemmas.py scripts/check_n9_vertex_circle_local_lemmas.py tests/test_n9_vertex_circle_local_lemmas.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Scope discipline

This PR records a replayable proof-mining summary of the local template packets. It remains review-pending and does not claim an `n=9` proof, a general proof, or a counterexample.