### PR TITLE
Wire n9 local lemma artifact into audit targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -231,6 +231,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_local_lemmas",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_local_lemmas.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Proof-mining scan for reusable n-independent n=9 vertex-circle "
+            "local lemmas; not a proof of n=9, counterexample, or "
+            "independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t01_self_edge_lemma_packet",
         command=(
             "python",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -184,6 +184,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_local_lemmas.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary

- add the new `check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json` replay to `verify-n9-review`
- include the local-lemma scan artifact in the scheduled/manual artifact audit command list
- update the audit-command test so the new replay remains wired in

## Verification

- `python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python -m pytest -q tests/test_run_artifact_audit.py`
- `python -m ruff check scripts/run_artifact_audit.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Scope discipline

This only wires an existing review-pending diagnostic artifact into verification paths. It does not claim an `n=9` proof, a general proof, or a counterexample.