### PR TITLE
Add block6 radius propagation audit

### DIFF
--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -351,6 +351,23 @@ This is still a local obstruction only: it does not show that every
 full-row extension of the two-block fragile rows has such a certificate, and
 it does not rule out minimal counterexamples.
 
+The same fixed survivor also passes the critical-radius propagation filter:
+
+```bash
+python scripts/check_block6_survivor_radius_propagation.py --assert-pass --json
+```
+
+There are `531441` formal choices of one short witness gap per row in the
+natural cyclic order. The replay uses the standard early-exit search and finds
+one acyclic choice after `13` nodes. This is a useful negative result for the
+critical-radius route: selected-distance quotienting, row-Ptolemy feasibility,
+and fixed-order radius-propagation all remain compatible for this survivor.
+The later Kalmanson certificate is genuinely stronger for this fixed order.
+This pass is not an exhaustive listing of radius-propagation choices, not a
+Euclidean realization certificate, not a counterexample, and not an
+obstruction for or against other full-row extensions of the two-block fragile
+rows.
+
 ## What This Does Not Prove
 
 The bridge is necessary, not sufficient. The checked block-6 family passes the

--- a/scripts/check_block6_survivor_kalmanson_certificate.py
+++ b/scripts/check_block6_survivor_kalmanson_certificate.py
@@ -13,23 +13,13 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from erdos97.fragile_benchmarks import (  # noqa: E402
+    block6_two_block_survivor_extension_3_rows,
+)
 from erdos97.quotient_cone import check_quotient_cone_certificate  # noqa: E402
 
 
-SURVIVOR_ROWS: list[list[int]] = [
-    [1, 2, 3, 4],
-    [3, 6, 9, 11],
-    [1, 3, 5, 10],
-    [0, 2, 4, 5],
-    [0, 3, 8, 11],
-    [0, 1, 6, 7],
-    [7, 8, 9, 10],
-    [1, 5, 6, 8],
-    [0, 5, 7, 9],
-    [6, 8, 10, 11],
-    [2, 5, 9, 11],
-    [0, 4, 6, 10],
-]
+SURVIVOR_ROWS: list[list[int]] = block6_two_block_survivor_extension_3_rows()
 
 STRICT_ROWS: list[dict[str, object]] = [
     {"source": "kalmanson", "kind": "K1_diag_gt_sides", "quad": [0, 1, 3, 9], "weight": 402},

--- a/scripts/check_block6_survivor_ptolemy_feasibility.py
+++ b/scripts/check_block6_survivor_ptolemy_feasibility.py
@@ -14,23 +14,13 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from erdos97.fragile_benchmarks import (  # noqa: E402
+    block6_two_block_survivor_extension_3_rows,
+)
 from erdos97.quotient_cone import pair, selected_distance_quotient  # noqa: E402
 
 
-SURVIVOR_ROWS: list[list[int]] = [
-    [1, 2, 3, 4],
-    [3, 6, 9, 11],
-    [1, 3, 5, 10],
-    [0, 2, 4, 5],
-    [0, 3, 8, 11],
-    [0, 1, 6, 7],
-    [7, 8, 9, 10],
-    [1, 5, 6, 8],
-    [0, 5, 7, 9],
-    [6, 8, 10, 11],
-    [2, 5, 9, 11],
-    [0, 4, 6, 10],
-]
+SURVIVOR_ROWS: list[list[int]] = block6_two_block_survivor_extension_3_rows()
 
 EXPECTED_CLASS_COUNT = 33
 

--- a/scripts/check_block6_survivor_radius_propagation.py
+++ b/scripts/check_block6_survivor_radius_propagation.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check radius-propagation on the fixed block-6 survivor extension."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.fragile_benchmarks import (  # noqa: E402
+    block6_two_block_survivor_extension_3_rows,
+)
+from erdos97.min_radius_filter import (  # noqa: E402
+    radius_propagation_order_obstruction,
+    radius_result_to_json,
+)
+
+PATTERN_NAME = "block6_two_block_survivor_extension_3"
+
+
+def audit(max_nodes: int | None = None) -> dict[str, object]:
+    """Return the fixed-order radius-propagation audit payload."""
+
+    rows = block6_two_block_survivor_extension_3_rows()
+    order = list(range(len(rows)))
+    result = radius_propagation_order_obstruction(
+        rows,
+        order=order,
+        pattern=PATTERN_NAME,
+        max_nodes=max_nodes,
+    )
+    payload = radius_result_to_json(result)
+    return {
+        "type": "block6_survivor_radius_propagation_audit",
+        "schema": "erdos97.block6_survivor_radius_propagation_audit.v1",
+        "claim_strength": (
+            "Fixed full selected-row extension and fixed natural cyclic order only."
+        ),
+        "selected_rows": {str(center): row for center, row in enumerate(rows)},
+        "radius_propagation": payload,
+        "status": payload["status"],
+        "obstructed": payload["obstructed"],
+        "acyclic_choice_found": payload["acyclic_choice"] is not None,
+        "interpretation": (
+            "PASS_RADIUS_PROPAGATION is a negative result for this filter only: "
+            "the fixed survivor escapes critical-radius propagation in this "
+            "order. It is not a Euclidean realization certificate and not a "
+            "counterexample."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--max-nodes", type=int)
+    parser.add_argument("--assert-pass", action="store_true")
+    args = parser.parse_args()
+
+    payload = audit(max_nodes=args.max_nodes)
+    if args.assert_pass:
+        if payload["status"] != "PASS_RADIUS_PROPAGATION":
+            raise AssertionError(f"expected PASS_RADIUS_PROPAGATION, got {payload['status']}")
+        if not payload["acyclic_choice_found"]:
+            raise AssertionError("expected an acyclic radius-propagation choice")
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        radius = payload["radius_propagation"]
+        print("block6 survivor radius-propagation audit")
+        print(f"status: {payload['status']}")
+        print(f"nodes visited: {radius['nodes_visited']}")
+        print(f"short-gap choices: {radius['short_gap_choice_count']}")
+        print(f"acyclic choice found: {payload['acyclic_choice_found']}")
+        if args.assert_pass:
+            print("OK: radius-propagation pass expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/fragile_benchmarks.py
+++ b/src/erdos97/fragile_benchmarks.py
@@ -1,0 +1,24 @@
+"""Shared fragile-cover benchmark selected-row systems."""
+
+from __future__ import annotations
+
+BLOCK6_TWO_BLOCK_SURVIVOR_EXTENSION_3: tuple[tuple[int, ...], ...] = (
+    (1, 2, 3, 4),
+    (3, 6, 9, 11),
+    (1, 3, 5, 10),
+    (0, 2, 4, 5),
+    (0, 3, 8, 11),
+    (0, 1, 6, 7),
+    (7, 8, 9, 10),
+    (1, 5, 6, 8),
+    (0, 5, 7, 9),
+    (6, 8, 10, 11),
+    (2, 5, 9, 11),
+    (0, 4, 6, 10),
+)
+
+
+def block6_two_block_survivor_extension_3_rows() -> list[list[int]]:
+    """Return a mutable copy of the fixed two-block block-6 survivor rows."""
+
+    return [list(row) for row in BLOCK6_TWO_BLOCK_SURVIVOR_EXTENSION_3]

--- a/tests/test_block6_survivor_radius_propagation.py
+++ b/tests/test_block6_survivor_radius_propagation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_block6_survivor_radius_propagation import audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_block6_survivor_passes_radius_propagation() -> None:
+    payload = audit()
+
+    assert payload["status"] == "PASS_RADIUS_PROPAGATION"
+    assert payload["obstructed"] is False
+    assert payload["acyclic_choice_found"] is True
+
+    radius = payload["radius_propagation"]
+    assert radius["n"] == 12
+    assert radius["nodes_visited"] == 13
+    assert radius["short_gap_choice_count"] == 531441
+    assert len(radius["acyclic_choice"]) == 12
+
+
+def test_block6_survivor_radius_propagation_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_survivor_radius_propagation.py",
+            "--assert-pass",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "status: PASS_RADIUS_PROPAGATION" in result.stdout
+    assert "short-gap choices: 531441" in result.stdout
+    assert "OK: radius-propagation pass expectation verified" in result.stdout


### PR DESCRIPTION
## Summary
- add a shared block6 two-block survivor benchmark used by the existing Ptolemy and Kalmanson scripts
- add a fixed-order radius-propagation replay for the same survivor
- document the result as a negative control for the critical-radius route, not as a realization or counterexample

## Verification
- `python scripts/check_block6_survivor_radius_propagation.py --assert-pass --json`
- `python scripts/check_block6_survivor_ptolemy_feasibility.py --assert-expected`
- `python scripts/check_block6_survivor_kalmanson_certificate.py --assert-expected`
- `python -m pytest tests/test_block6_survivor_radius_propagation.py tests/test_block6_survivor_ptolemy_feasibility.py tests/test_block6_survivor_kalmanson_certificate.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`