### PR TITLE
[codex] Register closure activation negative-control artifact

### DIFF
--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3006,6 +3006,35 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: closure_activation_negative_controls
+    path: data/certificates/closure_activation_negative_controls.json
+    kind: negative_control_artifact
+    generator: scripts/check_closure_activation_negative_controls.py
+    command: python scripts/check_closure_activation_negative_controls.py --write --assert-expected
+    checker: scripts/check_closure_activation_negative_controls.py
+    check_command: python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_PROVENANCE
+    claim_scope: Abstract rich-class closure activation negative controls only; not a Euclidean realization, not a proof of n=9, not a proof of the bootstrap bridge, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.closure_activation_negative_controls.v1
+      status: NEGATIVE_CONTROL_ABSTRACT_RICH_CLASS_ONLY
+      trust_label: NEGATIVE_CONTROL
+      claim_status: abstract_rich_class_closure_stress_tests_only
+      run_id: RS-2026-05-10-CE-A
+    forbidden_claims:
+      - closure activation proves row forcing
+      - rich-class closure proves row forcing
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap bridge is proved
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: n10_secondary_singleton_replay
     path: data/certificates/2026-05-05/n10_secondary.json
     kind: finite_case_draft_artifact

--- a/tests/test_closure_activation_negative_controls.py
+++ b/tests/test_closure_activation_negative_controls.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
 from copy import deepcopy
+from pathlib import Path
 
 from erdos97.closure_activation_negative_controls import (
     assert_full_row_anti_activation_expected,
@@ -20,6 +24,9 @@ from erdos97.closure_activation_negative_controls import (
     visibility_anti_activation_summary,
     wrong_fourth_negative_control_certificate,
 )
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_wrong_fourth_negative_control_replays_expected_status() -> None:
@@ -172,6 +179,26 @@ def test_rich_class_activation_controls_reject_crossing_loss() -> None:
 
     assert any("pair_checks" in error for error in errors)
     assert any("passes_intended_negative_control" in error for error in errors)
+
+
+def test_rich_class_activation_controls_default_artifact_cli_check() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_closure_activation_negative_controls.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["ok"] is True
+    assert summary["control_count"] == 4
 
 
 def test_visibility_anti_activation_control_replays_expected_status() -> None:


### PR DESCRIPTION
## Summary
- register the aggregate closure activation negative-control certificate in the generated-artifact provenance manifest
- add a regression test for the documented `--check --assert-expected --json` artifact command

## Claim status
- no general proof or counterexample is claimed
- no source-of-truth theorem status is changed
- artifact remains an abstract closure/rich-class negative control only

## Verification
- `python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json`
- `python -m pytest tests/test_closure_activation_negative_controls.py -q`
- `python -m ruff check tests/test_closure_activation_negative_controls.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`