### PR TITLE
[codex] Add 81:3 same-center disjointness guard

### DIFF
--- a/data/certificates/bootstrap_t12_81_3_order_escape.json
+++ b/data/certificates/bootstrap_t12_81_3_order_escape.json
@@ -1,5 +1,5 @@
 {
-  "claim_scope": "Fixed singleton-rich order diagnostic for source 81 row 3: in the fixed selected-row closure from seed [0,1,4], center 3 activates before label 6 is available, and label 6 is then added using a trigger containing center 3. This refines the remaining connector-avoiding escape target, but does not prove genuine rich-class order, does not prove row forcing, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
+  "claim_scope": "Fixed singleton-rich order diagnostic for source 81 row 3: in the fixed selected-row closure from seed [0,1,4], center 3 activates before label 6 is available, and label 6 is then added using a trigger containing center 3. The packet also records the same-center disjointness guard showing that an extra center-6 class preserving the fixed center-6 row cannot trigger label 6 from the seed. This refines the remaining connector-avoiding escape target, but does not prove genuine rich-class order, does not prove row forcing, does not prove n=9, does not prove the bridge, and does not claim a counterexample.",
   "fixed_singleton_order_audit": {
     "center_3_before_label_6": true,
     "center_3_step": {
@@ -253,9 +253,11 @@
     "This packet audits only the fixed singleton-rich closure order for source 81.",
     "It does not prove that the fixed selected row 81:3 is a genuine rich class.",
     "It does not rule out extra genuine rich classes that add label 6 before center 3.",
+    "The same-center disjointness guard assumes the source-81 center-6 row is preserved as a genuine class.",
     "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
   ],
   "order_resolved_escape_contract": {
+    "fixed_row_preservation_guard": "If the source-81 center-6 row [0,3,4,7] is preserved as a genuine distance class, same-center disjointness prevents any additional center-6 class from containing the seed triple [0,1,4].",
     "fixed_singleton_result": "The fixed singleton-rich closure does not realize that escape: center 3 is the only initial activation from [0,1,4], and label 6 is supplied only afterward by trigger [0,3,4].",
     "fixed_singleton_status": "FIXED_SINGLETON_ORDER_ESCAPE_NOT_REALIZED",
     "genuine_escape_certificate_needed": [
@@ -264,11 +266,124 @@
       "plus guardrails showing that any proposed supply does not already force the T12 connector"
     ],
     "required_for_connector_avoiding_activation": "Label 6 must be available before center 3 activates, because the connector-avoiding triples from [0,1,4,6] are [0,4,6] and [1,4,6].",
+    "same_center_disjointness_guard_status": "NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS",
     "status": "GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN"
   },
   "provenance": {
     "command": "python scripts/check_bootstrap_t12_81_3_order_escape.py --write --assert-expected",
     "generator": "scripts/check_bootstrap_t12_81_3_order_escape.py"
+  },
+  "same_center_disjointness_guard": {
+    "can_additional_center_6_class_trigger_from_seed": false,
+    "candidate_pre_3_supply_classes": [
+      {
+        "candidate_center": 6,
+        "candidate_class": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "candidate_fourth": 2,
+        "fixed_center_6_class_overlap": [
+          0,
+          4
+        ],
+        "preserves_same_center_disjointness": false,
+        "rejection_reason": "overlaps the preserved center-6 fixed class"
+      },
+      {
+        "candidate_center": 6,
+        "candidate_class": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "candidate_fourth": 3,
+        "fixed_center_6_class_overlap": [
+          0,
+          3,
+          4
+        ],
+        "preserves_same_center_disjointness": false,
+        "rejection_reason": "overlaps the preserved center-6 fixed class"
+      },
+      {
+        "candidate_center": 6,
+        "candidate_class": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "candidate_fourth": 5,
+        "fixed_center_6_class_overlap": [
+          0,
+          4
+        ],
+        "preserves_same_center_disjointness": false,
+        "rejection_reason": "overlaps the preserved center-6 fixed class"
+      },
+      {
+        "candidate_center": 6,
+        "candidate_class": [
+          0,
+          1,
+          4,
+          7
+        ],
+        "candidate_fourth": 7,
+        "fixed_center_6_class_overlap": [
+          0,
+          4,
+          7
+        ],
+        "preserves_same_center_disjointness": false,
+        "rejection_reason": "overlaps the preserved center-6 fixed class"
+      },
+      {
+        "candidate_center": 6,
+        "candidate_class": [
+          0,
+          1,
+          4,
+          8
+        ],
+        "candidate_fourth": 8,
+        "fixed_center_6_class_overlap": [
+          0,
+          4
+        ],
+        "preserves_same_center_disjointness": false,
+        "rejection_reason": "overlaps the preserved center-6 fixed class"
+      }
+    ],
+    "center": 6,
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "fixed_center_6_class": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "fixed_class_seed_overlap": [
+      0,
+      4
+    ],
+    "max_seed_overlap_for_additional_center_6_class": 1,
+    "remaining_gap": "This guard does not prove center-3 rich-class activation and does not rule out hypotheses that do not preserve the center-6 fixed row as a genuine class.",
+    "same_center_disjointness_rule": "Distinct rich distance classes at the same center are disjoint, because each target vertex has a unique distance from that center.",
+    "scope": "Applies only if the source-81 center-6 fixed selected row is preserved as a genuine distance class.",
+    "seed_labels_available_to_additional_center_6_classes": [
+      1
+    ],
+    "status": "NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS",
+    "trigger_threshold": 3
   },
   "schema": "erdos97.bootstrap_t12_81_3_order_escape.v1",
   "source_artifacts": [
@@ -348,6 +463,7 @@
   },
   "status": "BOOTSTRAP_T12_81_3_ORDER_ESCAPE_DIAGNOSTIC_ONLY",
   "summary": {
+    "additional_center_6_class_can_trigger_from_seed": false,
     "closure_labels": [
       0,
       1,
@@ -399,6 +515,16 @@
       4
     ],
     "exposed_core_vertex": 2,
+    "fixed_center_6_class": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "fixed_center_6_class_seed_overlap": [
+      0,
+      4
+    ],
     "fixed_singleton_center_3_before_label_6": true,
     "fixed_singleton_center_3_step_index": 0,
     "fixed_singleton_center_3_trigger": [
@@ -434,9 +560,11 @@
     "initial_enabled_centers": [
       3
     ],
+    "max_seed_overlap_for_additional_center_6_class": 1,
     "next_bridge_question": "Can a genuine rich-class catalogue add label 6 before center 3 without already forcing the connector, or can this pre-3 label-6 supply be ruled out under the minimal/rich-class hypotheses?",
     "order_escape_gap_type": "FIXED_SINGLETON_ORDER_NOT_GENUINE_RICH_CLASS_ORDER",
     "pre_3_label_6_supply_status": "NO_FIXED_SINGLETON_SUPPLY_BEFORE_CENTER_3",
+    "same_center_disjointness_guard_status": "NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS",
     "source_record_ids": [
       81
     ],

--- a/docs/bootstrap-t12-81-3-order-escape.md
+++ b/docs/bootstrap-t12-81-3-order-escape.md
@@ -65,6 +65,36 @@ So the fixed selected-row bookkeeping does not realize the connector-avoiding
 escape. In that model, label `6` is supplied only by a trigger that already
 uses center `3`.
 
+## Same-Center Disjointness Guard
+
+There is one extra fixed-row-preservation guard. The source `81` fixed row at
+center `6` is:
+
+```text
+center 6: [0,3,4,7]
+```
+
+Distinct rich distance classes at a single center are disjoint, because each
+target vertex has a unique distance from that center. Therefore, if this
+center-`6` row is preserved as a genuine rich class, any additional center-`6`
+class must avoid `0`, `3`, `4`, and `7`.
+
+But a pre-`3` supply of label `6` from the deletion seed `[0,1,4]` would need
+an additional center-`6` rich class containing all three seed labels. This is
+impossible while preserving the fixed center-`6` row, since the seed labels
+`0` and `4` already lie in `[0,3,4,7]`.
+
+So the checked guard status is:
+
+```text
+NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS
+```
+
+This guard is conditional on preserving the fixed source-`81` center-`6` row.
+It does not prove that center `3` activates, does not prove that row `81:3` is
+genuine, and does not rule out bridge hypotheses that do not preserve the
+center-`6` fixed row as a genuine distance class.
+
 ## Remaining Escape
 
 The remaining exact escape status is:

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -560,8 +560,11 @@ The order-resolved `81:3` fixed-row escape audit in
 singleton-rich packet does not itself supply that escape. From seed `[0,1,4]`,
 center `3` is the only initial fixed-row activation and fires through
 `[0,1,4]`; label `6` enters only afterward through trigger `[0,3,4]`, which
-already uses center `3`. This is a fixed-row diagnostic only, not a theorem
-about all genuine rich-class catalogues.
+already uses center `3`. It also records a same-center disjointness guard:
+if the source-`81` center-`6` fixed row `[0,3,4,7]` is preserved as a genuine
+class, then no additional center-`6` class can contain the seed triple
+`[0,1,4]`. This is still a fixed-row-preservation diagnostic only, not a
+theorem about all genuine rich-class catalogues.
 
 ### n=8 witness indegree regularity
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -81,10 +81,14 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-order-escape.md` shows the current singleton-rich
    closure does not expose label `6` first: center `3` is the only initial
    activation from `[0,1,4]`, and label `6` is added later by trigger
-   `[0,3,4]`. The next useful PR should leave fixed selected-row bookkeeping
+   `[0,3,4]`. It now also records the same-center disjointness guard: if the
+   source-`81` center-`6` fixed row `[0,3,4,7]` is preserved as a genuine
+   class, no additional center-`6` class can contain the seed triple
+   `[0,1,4]`. The next useful PR should leave fixed selected-row preservation
    and attack the genuine rich-class question directly: either exhibit a
-   pre-`3` rich-class supply of label `6` that avoids the connector, or prove
-   no such supply can satisfy the minimal/rich-class hypotheses.
+   pre-`3` rich-class supply of label `6` that avoids the connector without
+   preserving that center-`6` row, or prove no such supply can satisfy the
+   minimal/rich-class hypotheses.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2685,7 +2685,7 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Focused 81:3 order-resolved fixed-row escape diagnostic; shows only that the current singleton-rich closure from seed [0,1,4] activates center 3 before label 6 and later supplies label 6 using center 3, not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    claim_scope: Focused 81:3 order-resolved fixed-row escape diagnostic; shows only that the current singleton-rich closure from seed [0,1,4] activates center 3 before label 6, later supplies label 6 using center 3, and blocks extra center-6 seed activation only under the fixed-row-preservation same-center disjointness guard. It is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
     json_top_level_type: object
     expected_json:
       schema: erdos97.bootstrap_t12_81_3_order_escape.v1
@@ -2748,6 +2748,17 @@ artifacts:
         - 3
         - 4
       summary.fixed_singleton_label_6_supply_depends_on_center_3: true
+      summary.fixed_center_6_class:
+        - 0
+        - 3
+        - 4
+        - 7
+      summary.fixed_center_6_class_seed_overlap:
+        - 0
+        - 4
+      summary.max_seed_overlap_for_additional_center_6_class: 1
+      summary.additional_center_6_class_can_trigger_from_seed: false
+      summary.same_center_disjointness_guard_status: NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS
       summary.fixed_singleton_order_status: FIXED_SINGLETON_ORDER_ESCAPE_NOT_REALIZED
       summary.pre_3_label_6_supply_status: NO_FIXED_SINGLETON_SUPPLY_BEFORE_CENTER_3
       summary.genuine_escape_status: GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN
@@ -2761,7 +2772,19 @@ artifacts:
         - 3
         - 4
       fixed_singleton_order_audit.label_6_supply_depends_on_center_3: true
+      same_center_disjointness_guard.status: NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS
+      same_center_disjointness_guard.fixed_center_6_class:
+        - 0
+        - 3
+        - 4
+        - 7
+      same_center_disjointness_guard.fixed_class_seed_overlap:
+        - 0
+        - 4
+      same_center_disjointness_guard.max_seed_overlap_for_additional_center_6_class: 1
+      same_center_disjointness_guard.can_additional_center_6_class_trigger_from_seed: false
       order_resolved_escape_contract.status: GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN
+      order_resolved_escape_contract.same_center_disjointness_guard_status: NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS
       source_rich_triple_contract.source_schema: erdos97.bootstrap_t12_81_3_rich_triple_contract.v1
       source_rich_triple_contract.escape_status: CONNECTOR_ESCAPE_REQUIRES_RICH_CLASSES_AVOID_PAIR_0_1
       provenance.generator: scripts/check_bootstrap_t12_81_3_order_escape.py
@@ -2780,6 +2803,8 @@ artifacts:
       - the connector-pair contract proves rich-class existence
       - the order-escape packet proves genuine rich-class order
       - the order-escape packet proves no pre-3 label-6 supply exists
+      - the same-center disjointness guard proves row forcing
+      - the same-center disjointness guard proves the bridge
       - the order-escape packet proves the bridge
       - official/global status update
       - source-of-truth strongest result

--- a/src/erdos97/bootstrap_t12_81_3_order_escape.py
+++ b/src/erdos97/bootstrap_t12_81_3_order_escape.py
@@ -58,10 +58,12 @@ CLAIM_SCOPE = (
     "Fixed singleton-rich order diagnostic for source 81 row 3: in the fixed "
     "selected-row closure from seed [0,1,4], center 3 activates before label "
     "6 is available, and label 6 is then added using a trigger containing "
-    "center 3. This refines the remaining connector-avoiding escape target, "
-    "but does not prove genuine rich-class order, does not prove row forcing, "
-    "does not prove n=9, does not prove the bridge, and does not claim a "
-    "counterexample."
+    "center 3. The packet also records the same-center disjointness guard "
+    "showing that an extra center-6 class preserving the fixed center-6 row "
+    "cannot trigger label 6 from the seed. This refines the remaining "
+    "connector-avoiding escape target, but does not prove genuine rich-class "
+    "order, does not prove row forcing, does not prove n=9, does not prove the "
+    "bridge, and does not claim a counterexample."
 )
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_ARTIFACT = (
@@ -77,6 +79,10 @@ EXPECTED_INITIAL_ENABLED_CENTERS = [3]
 EXPECTED_CENTER_3_TRIGGER = [0, 1, 4]
 EXPECTED_LABEL_6_TRIGGER = [0, 3, 4]
 EXPECTED_LABEL_6_SUPPLY_CENTER = 6
+EXPECTED_LABEL_6_FIXED_CLASS = [0, 3, 4, 7]
+SAME_CENTER_DISJOINTNESS_GUARD_STATUS = (
+    "NO_PRE_3_LABEL_6_SUPPLY_PRESERVING_CENTER_6_FIXED_CLASS"
+)
 
 
 def _int_list(values: Iterable[Any]) -> list[int]:
@@ -234,6 +240,75 @@ def _fixed_singleton_order_audit() -> dict[str, object]:
     }
 
 
+def _same_center_disjointness_guard(
+    selected_rows: Sequence[Any],
+) -> dict[str, object]:
+    """Audit extra center-6 classes under same-center disjointness.
+
+    Distinct distance classes at one center are disjoint: a target vertex has
+    one distance from that center.  Thus, if the fixed source-81 row at center
+    6 is preserved as a genuine rich class, any additional center-6 rich class
+    is disjoint from it.
+    """
+
+    fixed_class = _int_list(selected_rows[EXPECTED_LABEL_6_SUPPLY_CENTER])
+    if fixed_class != EXPECTED_LABEL_6_FIXED_CLASS:
+        raise AssertionError("source 81 center-6 fixed class drifted")
+
+    seed = set(TARGET_DELETION_SEED)
+    fixed_class_set = set(fixed_class)
+    available_seed_labels = sorted(seed - fixed_class_set)
+    candidate_fourths = [
+        label
+        for label in range(9)
+        if label not in seed and label != EXPECTED_LABEL_6_SUPPLY_CENTER
+    ]
+    candidates: list[dict[str, object]] = []
+    for fourth in candidate_fourths:
+        candidate = sorted([*TARGET_DELETION_SEED, fourth])
+        fixed_overlap = sorted(set(candidate) & fixed_class_set)
+        candidates.append(
+            {
+                "candidate_center": EXPECTED_LABEL_6_SUPPLY_CENTER,
+                "candidate_class": candidate,
+                "candidate_fourth": fourth,
+                "fixed_center_6_class_overlap": fixed_overlap,
+                "preserves_same_center_disjointness": not fixed_overlap,
+                "rejection_reason": (
+                    "overlaps the preserved center-6 fixed class"
+                    if fixed_overlap
+                    else None
+                ),
+            }
+        )
+
+    return {
+        "status": SAME_CENTER_DISJOINTNESS_GUARD_STATUS,
+        "scope": (
+            "Applies only if the source-81 center-6 fixed selected row is "
+            "preserved as a genuine distance class."
+        ),
+        "same_center_disjointness_rule": (
+            "Distinct rich distance classes at the same center are disjoint, "
+            "because each target vertex has a unique distance from that center."
+        ),
+        "center": EXPECTED_LABEL_6_SUPPLY_CENTER,
+        "fixed_center_6_class": fixed_class,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "fixed_class_seed_overlap": sorted(seed & fixed_class_set),
+        "seed_labels_available_to_additional_center_6_classes": available_seed_labels,
+        "max_seed_overlap_for_additional_center_6_class": len(available_seed_labels),
+        "trigger_threshold": 3,
+        "can_additional_center_6_class_trigger_from_seed": False,
+        "candidate_pre_3_supply_classes": candidates,
+        "remaining_gap": (
+            "This guard does not prove center-3 rich-class activation and does "
+            "not rule out hypotheses that do not preserve the center-6 fixed "
+            "row as a genuine class."
+        ),
+    }
+
+
 def _rich_triple_source_summary() -> dict[str, object]:
     payload = build_t12_81_3_rich_triple_contract_payload()
     summary = payload.get("summary")
@@ -265,6 +340,10 @@ def build_t12_81_3_order_escape_payload() -> dict[str, object]:
     """Return the deterministic order-resolved fixed-row escape packet."""
 
     order_audit = _fixed_singleton_order_audit()
+    selected_rows = order_audit.get("selected_rows")
+    if not isinstance(selected_rows, Sequence):
+        raise AssertionError("selected_rows must be a sequence")
+    disjointness_guard = _same_center_disjointness_guard(selected_rows)
     rich_triple_summary = _rich_triple_source_summary()
     payload: dict[str, object] = {
         "schema": SCHEMA,
@@ -275,6 +354,7 @@ def build_t12_81_3_order_escape_payload() -> dict[str, object]:
             "This packet audits only the fixed singleton-rich closure order for source 81.",
             "It does not prove that the fixed selected row 81:3 is a genuine rich class.",
             "It does not rule out extra genuine rich classes that add label 6 before center 3.",
+            "The same-center disjointness guard assumes the source-81 center-6 row is preserved as a genuine class.",
             "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
         ],
         "summary": {
@@ -321,6 +401,19 @@ def build_t12_81_3_order_escape_payload() -> dict[str, object]:
             "fixed_singleton_label_6_supply_depends_on_center_3": order_audit[
                 "label_6_supply_depends_on_center_3"
             ],
+            "fixed_center_6_class": disjointness_guard["fixed_center_6_class"],
+            "fixed_center_6_class_seed_overlap": disjointness_guard[
+                "fixed_class_seed_overlap"
+            ],
+            "max_seed_overlap_for_additional_center_6_class": disjointness_guard[
+                "max_seed_overlap_for_additional_center_6_class"
+            ],
+            "additional_center_6_class_can_trigger_from_seed": disjointness_guard[
+                "can_additional_center_6_class_trigger_from_seed"
+            ],
+            "same_center_disjointness_guard_status": disjointness_guard[
+                "status"
+            ],
             "fixed_singleton_order_status": FIXED_SINGLETON_ORDER_STATUS,
             "pre_3_label_6_supply_status": PRE_3_LABEL_6_SUPPLY_STATUS,
             "genuine_escape_status": GENUINE_ESCAPE_STATUS,
@@ -333,13 +426,23 @@ def build_t12_81_3_order_escape_payload() -> dict[str, object]:
             ),
         },
         "fixed_singleton_order_audit": order_audit,
+        "same_center_disjointness_guard": disjointness_guard,
         "order_resolved_escape_contract": {
             "status": GENUINE_ESCAPE_STATUS,
             "fixed_singleton_status": FIXED_SINGLETON_ORDER_STATUS,
+            "same_center_disjointness_guard_status": disjointness_guard[
+                "status"
+            ],
             "required_for_connector_avoiding_activation": (
                 "Label 6 must be available before center 3 activates, because "
                 "the connector-avoiding triples from [0,1,4,6] are [0,4,6] "
                 "and [1,4,6]."
+            ),
+            "fixed_row_preservation_guard": (
+                "If the source-81 center-6 row [0,3,4,7] is preserved as a "
+                "genuine distance class, same-center disjointness prevents any "
+                "additional center-6 class from containing the seed triple "
+                "[0,1,4]."
             ),
             "fixed_singleton_result": (
                 "The fixed singleton-rich closure does not realize that escape: "
@@ -426,6 +529,13 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
         "fixed_singleton_center_3_trigger_forces_connector": True,
         "fixed_singleton_label_6_supply_trigger": EXPECTED_LABEL_6_TRIGGER,
         "fixed_singleton_label_6_supply_depends_on_center_3": True,
+        "fixed_center_6_class": EXPECTED_LABEL_6_FIXED_CLASS,
+        "fixed_center_6_class_seed_overlap": [0, 4],
+        "max_seed_overlap_for_additional_center_6_class": 1,
+        "additional_center_6_class_can_trigger_from_seed": False,
+        "same_center_disjointness_guard_status": (
+            SAME_CENTER_DISJOINTNESS_GUARD_STATUS
+        ),
         "fixed_singleton_order_status": FIXED_SINGLETON_ORDER_STATUS,
         "pre_3_label_6_supply_status": PRE_3_LABEL_6_SUPPLY_STATUS,
         "genuine_escape_status": GENUINE_ESCAPE_STATUS,
@@ -444,6 +554,8 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
         raise AssertionError("warnings must preserve the row-forcing gap")
     if not any("extra genuine rich classes" in str(warning) for warning in warnings):
         raise AssertionError("warnings must preserve the genuine escape gap")
+    if not any("center-6 row is preserved" in str(warning) for warning in warnings):
+        raise AssertionError("warnings must preserve the disjointness guard scope")
 
     audit = payload.get("fixed_singleton_order_audit")
     if not isinstance(audit, Mapping):
@@ -507,6 +619,40 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
     if not label_6_step.get("trigger_depends_on_center_3"):
         raise AssertionError("label 6 supply must depend on center 3")
 
+    guard = payload.get("same_center_disjointness_guard")
+    if not isinstance(guard, Mapping):
+        raise AssertionError("same_center_disjointness_guard must be a mapping")
+    expected_guard = {
+        "status": SAME_CENTER_DISJOINTNESS_GUARD_STATUS,
+        "center": EXPECTED_LABEL_6_SUPPLY_CENTER,
+        "fixed_center_6_class": EXPECTED_LABEL_6_FIXED_CLASS,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "fixed_class_seed_overlap": [0, 4],
+        "seed_labels_available_to_additional_center_6_classes": [1],
+        "max_seed_overlap_for_additional_center_6_class": 1,
+        "trigger_threshold": 3,
+        "can_additional_center_6_class_trigger_from_seed": False,
+    }
+    for key, expected in expected_guard.items():
+        if guard.get(key) != expected:
+            raise AssertionError(
+                f"same_center_disjointness_guard {key} is {guard.get(key)!r}, "
+                f"expected {expected!r}"
+            )
+    candidates = guard.get("candidate_pre_3_supply_classes")
+    if not isinstance(candidates, Sequence) or len(candidates) != 5:
+        raise AssertionError("expected five candidate pre-3 supply classes")
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            raise AssertionError("candidate pre-3 supply classes must be mappings")
+        if candidate.get("preserves_same_center_disjointness"):
+            raise AssertionError("candidate unexpectedly preserves disjointness")
+        overlap = candidate.get("fixed_center_6_class_overlap")
+        if not isinstance(overlap, Sequence) or not {0, 4}.issubset(
+            set(_int_list(overlap))
+        ):
+            raise AssertionError("candidate must overlap fixed class in seed labels")
+
     contract = payload.get("order_resolved_escape_contract")
     if not isinstance(contract, Mapping):
         raise AssertionError("order_resolved_escape_contract must be a mapping")
@@ -514,6 +660,11 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
         raise AssertionError("genuine escape contract status drifted")
     if contract.get("fixed_singleton_status") != FIXED_SINGLETON_ORDER_STATUS:
         raise AssertionError("fixed singleton status drifted")
+    if (
+        contract.get("same_center_disjointness_guard_status")
+        != SAME_CENTER_DISJOINTNESS_GUARD_STATUS
+    ):
+        raise AssertionError("same-center disjointness guard status drifted")
 
     source = payload.get("source_rich_triple_contract")
     if not isinstance(source, Mapping):

--- a/tests/test_bootstrap_t12_81_3_order_escape.py
+++ b/tests/test_bootstrap_t12_81_3_order_escape.py
@@ -10,10 +10,12 @@ import pytest
 
 from erdos97.bootstrap_t12_81_3_order_escape import (
     DEFAULT_ARTIFACT,
+    EXPECTED_LABEL_6_FIXED_CLASS,
     FIXED_SINGLETON_ORDER_STATUS,
     GENUINE_ESCAPE_STATUS,
     ORDER_ESCAPE_GAP,
     PRE_3_LABEL_6_SUPPLY_STATUS,
+    SAME_CENTER_DISJOINTNESS_GUARD_STATUS,
     assert_expected_payload,
     build_t12_81_3_order_escape_payload,
 )
@@ -61,6 +63,14 @@ def test_81_3_order_escape_summary_pins_order() -> None:
     assert summary["fixed_singleton_center_3_trigger_forces_connector"]
     assert summary["fixed_singleton_label_6_supply_trigger"] == [0, 3, 4]
     assert summary["fixed_singleton_label_6_supply_depends_on_center_3"]
+    assert summary["fixed_center_6_class"] == EXPECTED_LABEL_6_FIXED_CLASS
+    assert summary["fixed_center_6_class_seed_overlap"] == [0, 4]
+    assert summary["max_seed_overlap_for_additional_center_6_class"] == 1
+    assert not summary["additional_center_6_class_can_trigger_from_seed"]
+    assert (
+        summary["same_center_disjointness_guard_status"]
+        == SAME_CENTER_DISJOINTNESS_GUARD_STATUS
+    )
     assert summary["fixed_singleton_order_status"] == FIXED_SINGLETON_ORDER_STATUS
     assert summary["pre_3_label_6_supply_status"] == PRE_3_LABEL_6_SUPPLY_STATUS
     assert summary["genuine_escape_status"] == GENUINE_ESCAPE_STATUS
@@ -122,14 +132,51 @@ def test_81_3_order_escape_steps_show_6_depends_on_3() -> None:
     assert label_6_step["trigger_depends_on_center_3"]
 
 
+def test_81_3_order_escape_same_center_disjointness_guard() -> None:
+    payload = build_t12_81_3_order_escape_payload()
+    guard = payload["same_center_disjointness_guard"]
+
+    assert guard["status"] == SAME_CENTER_DISJOINTNESS_GUARD_STATUS
+    assert guard["center"] == 6
+    assert guard["fixed_center_6_class"] == EXPECTED_LABEL_6_FIXED_CLASS
+    assert guard["deletion_seed"] == [0, 1, 4]
+    assert guard["fixed_class_seed_overlap"] == [0, 4]
+    assert guard["seed_labels_available_to_additional_center_6_classes"] == [1]
+    assert guard["max_seed_overlap_for_additional_center_6_class"] == 1
+    assert guard["trigger_threshold"] == 3
+    assert not guard["can_additional_center_6_class_trigger_from_seed"]
+
+    candidates = guard["candidate_pre_3_supply_classes"]
+    assert [candidate["candidate_fourth"] for candidate in candidates] == [
+        2,
+        3,
+        5,
+        7,
+        8,
+    ]
+    for candidate in candidates:
+        assert not candidate["preserves_same_center_disjointness"]
+        assert {0, 4}.issubset(candidate["fixed_center_6_class_overlap"])
+        assert candidate["rejection_reason"] == (
+            "overlaps the preserved center-6 fixed class"
+        )
+
+
 def test_81_3_order_escape_contract_names_remaining_target() -> None:
     payload = build_t12_81_3_order_escape_payload()
     contract = payload["order_resolved_escape_contract"]
 
     assert contract["status"] == GENUINE_ESCAPE_STATUS
     assert contract["fixed_singleton_status"] == FIXED_SINGLETON_ORDER_STATUS
+    assert (
+        contract["same_center_disjointness_guard_status"]
+        == SAME_CENTER_DISJOINTNESS_GUARD_STATUS
+    )
     assert "Label 6 must be available before center 3" in contract[
         "required_for_connector_avoiding_activation"
+    ]
+    assert "same-center disjointness prevents" in contract[
+        "fixed_row_preservation_guard"
     ]
     assert "does not realize that escape" in contract["fixed_singleton_result"]
     assert any(


### PR DESCRIPTION
## Summary
- extend the `81:3` order-escape packet with a same-center disjointness guard for the source-81 center-6 fixed row
- regenerate the checked packet artifact and pin the new guard in manifest expectations and tests
- update the order-escape note, claims ledger, and Codex backlog with the narrowed remaining gap

## Claim status
- no general proof or counterexample is claimed
- no `n=9` proof or bootstrap-bridge proof is claimed
- the new guard is conditional on preserving the source-81 center-6 fixed row as a genuine distance class

## Verification
- `python scripts/check_bootstrap_t12_81_3_order_escape.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_order_escape.py -q`
- `python -m ruff check src/erdos97/bootstrap_t12_81_3_order_escape.py tests/test_bootstrap_t12_81_3_order_escape.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`