### PR TITLE
[codex] Add 81:3 relaxed escape candidate scan

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -270,11 +270,24 @@ The order-resolved `81:3` fixed-row escape audit checks the current
 singleton-rich closure order for that same seed. In the fixed selected-row
 model, `[0,1,4]` enables only center `3`, with trigger `[0,1,4]`; label `6`
 enters later through center `6` with trigger `[0,3,4]`, depending on center
-`3`. Thus the fixed packet does not realize the connector-avoiding escape.
-This is still diagnostic bookkeeping only, not a proof about genuine rich
-classes; see `docs/bootstrap-t12-81-3-order-escape.md`,
+`3`. Thus the fixed packet does not realize the connector-avoiding escape. It
+also records that, if the source-`81` center-`6` row `[0,3,4,7]` is preserved
+as genuine, same-center disjointness blocks any additional center-`6` class
+from containing the seed triple `[0,1,4]`. This is still diagnostic
+bookkeeping only, not a proof about genuine rich classes; see
+`docs/bootstrap-t12-81-3-order-escape.md`,
 `scripts/check_bootstrap_t12_81_3_order_escape.py`, and
 `data/certificates/bootstrap_t12_81_3_order_escape.json`.
+
+The relaxed `81:3` escape-candidate scan then drops preservation of the
+source-`81` center-`3` and center-`6` rows while preserving the other seven
+rows. It enumerates the `40` one-class replacement candidates for pre-`3`
+label-`6` supply followed by connector-avoiding center-`3` activation. All
+`40` fail the basic row-pair, witness-pair, or crossing filters. This remains
+a fixed-row-neighborhood diagnostic only, not a proof of `n=9` or the
+bootstrap bridge; see `docs/bootstrap-t12-81-3-escape-candidates.md`,
+`scripts/check_bootstrap_t12_81_3_escape_candidates.py`, and
+`data/certificates/bootstrap_t12_81_3_escape_candidates.json`.
 
 ### Fixed-pattern exact obstructions
 

--- a/data/certificates/bootstrap_t12_81_3_escape_candidates.json
+++ b/data/certificates/bootstrap_t12_81_3_escape_candidates.json
@@ -1,0 +1,5348 @@
+{
+  "candidate_generation": {
+    "center_3_connector_avoiding_classes": [
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          0,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          0,
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          1,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          1,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          1,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          1,
+          4,
+          6,
+          8
+        ]
+      }
+    ],
+    "center_6_supply_classes": [
+      [
+        0,
+        1,
+        2,
+        4
+      ],
+      [
+        0,
+        1,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        8
+      ]
+    ]
+  },
+  "candidates": [
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            0,
+            2,
+            4
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            2,
+            6
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            2
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            6
+          ],
+          "pair": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            7
+          ],
+          "witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            5,
+            6
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            3,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            3
+          ],
+          "witness_chord": [
+            6,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "crossing",
+      "rejection_reasons": [
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": []
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "witness_pair+crossing",
+      "rejection_reasons": [
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            1,
+            2,
+            4
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            2
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            6
+          ],
+          "pair": [
+            2,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            8
+          ],
+          "witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            4,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            0,
+            3
+          ],
+          "intersection": [
+            1,
+            6,
+            7
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            3,
+            4
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            2,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "supply_fourth": 2,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            2,
+            6
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            7
+          ],
+          "witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            5,
+            6
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            3,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            3
+          ],
+          "witness_chord": [
+            6,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "crossing",
+      "rejection_reasons": [
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": []
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "witness_pair+crossing",
+      "rejection_reasons": [
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "witness_pair+crossing",
+      "rejection_reasons": [
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            8
+          ],
+          "witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            4,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            0,
+            3
+          ],
+          "intersection": [
+            1,
+            6,
+            7
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            3,
+            4
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "supply_fourth": 3,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            2,
+            6
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            7
+          ],
+          "witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            0,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            5,
+            6
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 4,
+          "centers": [
+            2,
+            3,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            3
+          ],
+          "witness_chord": [
+            6,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            8
+          ],
+          "witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 4,
+          "centers": [
+            3,
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            0,
+            3
+          ],
+          "intersection": [
+            1,
+            6,
+            7
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            3,
+            4
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "supply_fourth": 5,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            4,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            2,
+            6
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            7
+          ],
+          "witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            5,
+            6
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            3,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            3
+          ],
+          "witness_chord": [
+            6,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            0,
+            4,
+            7
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            6
+          ],
+          "pair": [
+            4,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "witness_pair+crossing",
+      "rejection_reasons": [
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "witness_pair+crossing",
+      "rejection_reasons": [
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            8
+          ],
+          "witness_chord": [
+            5,
+            6
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            4,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            0,
+            3
+          ],
+          "intersection": [
+            1,
+            6,
+            7
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            1,
+            4,
+            7
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 4,
+          "centers": [
+            0,
+            3,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            6
+          ],
+          "pair": [
+            4,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            1,
+            4
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "supply_fourth": 7,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            4,
+            6
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            3,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            2,
+            6
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            7
+          ],
+          "witness_chord": [
+            4,
+            5
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            8
+          ],
+          "intersection": [
+            0,
+            5,
+            6
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            3,
+            8
+          ],
+          "pair": [
+            0,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            3
+          ],
+          "witness_chord": [
+            6,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            3
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            0,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            3,
+            6
+          ],
+          "pair": [
+            0,
+            8
+          ]
+        },
+        {
+          "center_count": 4,
+          "centers": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            2,
+            6
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "target_center_fourth": 2,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            5,
+            8
+          ],
+          "pair": [
+            2,
+            6
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            8
+          ],
+          "witness_chord": [
+            5,
+            6
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            5
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "target_center_fourth": 5,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            4,
+            7
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            4
+          ],
+          "witness_chord": [
+            1,
+            7
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            0,
+            3
+          ],
+          "intersection": [
+            1,
+            6,
+            7
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "target_center_fourth": 7,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            3,
+            4
+          ],
+          "pair": [
+            1,
+            7
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            3
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            0,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            3,
+            5
+          ],
+          "witness_chord": [
+            6,
+            8
+          ]
+        }
+      ],
+      "passes_basic_incidence_crossing_filters": false,
+      "preserved_row_centers": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            3,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        },
+        {
+          "centers": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "supply_center": 6,
+      "supply_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "supply_fourth": 8,
+      "target_center": 3,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "target_center_fourth": 8,
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            1,
+            8
+          ]
+        },
+        {
+          "center_count": 4,
+          "centers": [
+            1,
+            3,
+            6,
+            7
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    }
+  ],
+  "claim_scope": "Relaxed 81:3 escape-candidate scan preserving the seven source-81 rows outside centers 3 and 6. It enumerates the 40 basic ways to supply label 6 before center 3 and then activate center 3 through a connector-avoiding triple; all fail row-pair, witness-pair, or crossing filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This scan preserves only the seven source-81 rows outside centers 3 and 6.",
+    "Rows 3 and 6 are replaced by one candidate rich class each.",
+    "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "preserved_source_rows": {
+    "0": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "1": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "2": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "4": [
+      1,
+      2,
+      5,
+      7
+    ],
+    "5": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "7": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "8": [
+      0,
+      2,
+      5,
+      6
+    ]
+  },
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_escape_candidates.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_escape_candidates.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_escape_candidates.v1",
+  "source_order_escape": {
+    "genuine_escape_status": "GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN",
+    "path": "data/certificates/bootstrap_t12_81_3_order_escape.json",
+    "schema": "erdos97.bootstrap_t12_81_3_order_escape.v1",
+    "status": "BOOTSTRAP_T12_81_3_ORDER_ESCAPE_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_ESCAPE_CANDIDATE_SCAN_DIAGNOSTIC_ONLY",
+  "summary": {
+    "candidate_count": 40,
+    "center_3_connector_avoiding_class_count": 8,
+    "center_6_supply_class_count": 5,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "preserved_row_centers": [
+      0,
+      1,
+      2,
+      4,
+      5,
+      7,
+      8
+    ],
+    "rejection_category_counts": {
+      "crossing": 2,
+      "row_pair+witness_pair+crossing": 33,
+      "witness_pair+crossing": 5
+    },
+    "remaining_gap": "This does not rule out escape mechanisms that fail to preserve the other source-81 rows, use richer catalogues than one replacement class at centers 3 and 6, or require additional minimal/rich-class hypotheses.",
+    "replaced_row_centers": [
+      3,
+      6
+    ],
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_UNDER_SOURCE81_OTHER_ROWS_PRESERVED",
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "surviving_candidate_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-escape-candidates.md
+++ b/docs/bootstrap-t12-81-3-escape-candidates.md
@@ -1,0 +1,98 @@
+# Bootstrap T12 81:3 Escape Candidates
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet is the next relaxation after the `81:3` order-escape guard. The
+guard in `docs/bootstrap-t12-81-3-order-escape.md` assumes the source-`81`
+center-`6` fixed row `[0,3,4,7]` is preserved. Here we drop that one row, and
+also allow the target center-`3` row to be replaced by a connector-avoiding
+class.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_candidates.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_candidates.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_escape_candidates.json`.
+
+## Scan Scope
+
+The scan preserves the seven source-`81` rows outside centers `3` and `6`:
+
+```text
+0,1,2,4,5,7,8
+```
+
+It then enumerates:
+
+```text
+5
+```
+
+possible center-`6` supply classes containing the deletion seed `[0,1,4]`, and
+
+```text
+8
+```
+
+possible connector-avoiding center-`3` classes using either `[0,4,6]` or
+`[1,4,6]`.
+
+So there are:
+
+```text
+5 * 8 = 40
+```
+
+relaxed escape candidates.
+
+## Result
+
+All `40` candidates fail the basic exact incidence/crossing filters:
+
+```text
+surviving candidates: 0
+```
+
+The rejection counts are:
+
+```text
+crossing: 2
+row_pair+witness_pair+crossing: 33
+witness_pair+crossing: 5
+```
+
+Thus the checked scan status is:
+
+```text
+NO_BASIC_FILTER_SURVIVORS_UNDER_SOURCE81_OTHER_ROWS_PRESERVED
+```
+
+## Remaining Gap
+
+This is still not a bridge proof. It only rules out this very specific relaxed
+escape model:
+
+```text
+preserve the seven non-3/non-6 source-81 rows,
+replace row 6 by one pre-3 supply class,
+replace row 3 by one connector-avoiding class.
+```
+
+It does not rule out richer catalogues that do not preserve those other rows,
+that use more than one replacement class at centers `3` or `6`, or that need
+additional minimal/rich-class hypotheses not included in this scan.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining diagnostic
+that narrows one concrete escape route.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -566,6 +566,15 @@ class, then no additional center-`6` class can contain the seed triple
 `[0,1,4]`. This is still a fixed-row-preservation diagnostic only, not a
 theorem about all genuine rich-class catalogues.
 
+The relaxed `81:3` escape-candidate scan in
+`docs/bootstrap-t12-81-3-escape-candidates.md` drops preservation of the
+center-`3` and center-`6` rows while preserving the other seven source-`81`
+rows. It enumerates all `40` one-class replacement candidates for pre-`3`
+label-`6` supply followed by connector-avoiding center-`3` activation, and all
+fail basic row-pair, witness-pair, or crossing filters. This is still a
+fixed-row-neighborhood diagnostic only, not a theorem about all genuine
+rich-class catalogues.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -89,6 +89,13 @@ Use this queue when no more specific issue is selected.
    pre-`3` rich-class supply of label `6` that avoids the connector without
    preserving that center-`6` row, or prove no such supply can satisfy the
    minimal/rich-class hypotheses.
+   The relaxed escape-candidate scan in
+   `docs/bootstrap-t12-81-3-escape-candidates.md` now drops preservation of
+   the source-`81` center-`3` and center-`6` rows while preserving the other
+   seven rows. All `40` one-class replacement candidates fail the basic
+   incidence/crossing filters. The next useful PR must either relax the
+   preservation of those seven rows or introduce an additional genuine
+   rich-class/minimality hypothesis that justifies preserving enough of them.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -217,7 +217,12 @@ local_repo:
       status: "order-resolved fixed-row escape audit for the 81:3 T12/F16 target"
       artifact: "data/certificates/bootstrap_t12_81_3_order_escape.json"
       verifier: "scripts/check_bootstrap_t12_81_3_order_escape.py"
-      claim_scope: "fixed selected-row proof-mining diagnostic only; shows the current singleton-rich closure does not expose label 6 before center 3, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+      claim_scope: "fixed selected-row proof-mining diagnostic only; shows the current singleton-rich closure does not expose label 6 before center 3 and records a same-center disjointness guard under center-6 row preservation, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_escape_candidates"
+      status: "relaxed one-class replacement scan for the 81:3 pre-3 label-6 escape"
+      artifact: "data/certificates/bootstrap_t12_81_3_escape_candidates.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_escape_candidates.py"
+      claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; preserves the seven source-81 rows outside centers 3 and 6 and rules out 40 one-class replacement escape candidates by basic incidence/crossing filters, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2811,6 +2811,84 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_escape_candidates
+    path: data/certificates/bootstrap_t12_81_3_escape_candidates.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_escape_candidates.py
+    command: python scripts/check_bootstrap_t12_81_3_escape_candidates.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_escape_candidates.py
+    check_command: python scripts/check_bootstrap_t12_81_3_escape_candidates.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Relaxed 81:3 escape-candidate scan preserving the seven source-81 rows outside centers 3 and 6; all 40 one-class replacement candidates fail basic incidence/crossing filters, but this is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_escape_candidates.v1
+      status: BOOTSTRAP_T12_81_3_ESCAPE_CANDIDATE_SCAN_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.preserved_row_centers:
+        - 0
+        - 1
+        - 2
+        - 4
+        - 5
+        - 7
+        - 8
+      summary.replaced_row_centers:
+        - 3
+        - 6
+      summary.center_6_supply_class_count: 5
+      summary.center_3_connector_avoiding_class_count: 8
+      summary.candidate_count: 40
+      summary.surviving_candidate_count: 0
+      summary.rejection_category_counts.crossing: 2
+      summary.rejection_category_counts.row_pair+witness_pair+crossing: 33
+      summary.rejection_category_counts.witness_pair+crossing: 5
+      summary.scan_status: NO_BASIC_FILTER_SURVIVORS_UNDER_SOURCE81_OTHER_ROWS_PRESERVED
+      source_order_escape.schema: erdos97.bootstrap_t12_81_3_order_escape.v1
+      source_order_escape.genuine_escape_status: GENUINE_RICH_CLASS_PRE_3_LABEL_6_SUPPLY_OPEN
+      provenance.generator: scripts/check_bootstrap_t12_81_3_escape_candidates.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_escape_candidates.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the escape-candidate scan proves genuine rich-class order
+      - the escape-candidate scan proves no pre-3 label-6 supply exists
+      - the escape-candidate scan proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_escape_candidates.py
+++ b/scripts/check_bootstrap_t12_81_3_escape_candidates.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check the relaxed bootstrap/T12 81:3 escape-candidate scan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_escape_candidate_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 relaxed escape candidates")
+    print(f"candidate count: {summary['candidate_count']}")
+    print(f"survivors: {summary['surviving_candidate_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_escape_candidate_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 escape-candidate artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 escape-candidate expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_escape_candidates.py
+++ b/src/erdos97/bootstrap_t12_81_3_escape_candidates.py
@@ -1,0 +1,351 @@
+"""Relaxed candidate scan for the bootstrap/T12 81:3 escape.
+
+This packet relaxes the fixed-row-preservation guard from the order-escape
+packet by allowing rows 3 and 6 of source 81 to be replaced:
+
+* row 6 must supply label 6 before center 3 from the deletion seed [0,1,4];
+* row 3 must then activate through a connector-avoiding triple using label 6.
+
+The other seven source-81 selected rows are preserved.  The scan is purely
+incidence/crossing bookkeeping; it is not a Euclidean realization theorem and
+does not prove the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    DEFAULT_ARTIFACT as ORDER_ESCAPE_ARTIFACT,
+    GENUINE_ESCAPE_STATUS,
+    SCHEMA as ORDER_ESCAPE_SCHEMA,
+    STATUS as ORDER_ESCAPE_STATUS,
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+    build_t12_81_3_order_escape_payload,
+)
+from erdos97.incidence_filters import crossing_bisector_violations
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_escape_candidates.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ESCAPE_CANDIDATE_SCAN_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_BASIC_FILTER_SURVIVORS_UNDER_SOURCE81_OTHER_ROWS_PRESERVED"
+CLAIM_SCOPE = (
+    "Relaxed 81:3 escape-candidate scan preserving the seven source-81 rows "
+    "outside centers 3 and 6. It enumerates the 40 basic ways to supply label "
+    "6 before center 3 and then activate center 3 through a connector-avoiding "
+    "triple; all fail row-pair, witness-pair, or crossing filters. This is not "
+    "a proof of genuine rich-class order, not a proof of row forcing, not a "
+    "proof of n=9, not a proof of the bridge, and not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT / "data" / "certificates" / "bootstrap_t12_81_3_escape_candidates.json"
+)
+
+N = 9
+CYCLIC_ORDER = list(range(N))
+SUPPLY_CENTER = 6
+PRESERVED_ROW_CENTERS = [0, 1, 2, 4, 5, 7, 8]
+REPLACED_ROW_CENTERS = [TARGET_ROW_CENTER, SUPPLY_CENTER]
+CONNECTOR_PAIR = [0, 1]
+CONNECTOR_AVOIDING_TRIPLES = [[0, 4, 6], [1, 4, 6]]
+EXPECTED_REJECTION_COUNTS = {
+    "crossing": 2,
+    "row_pair+witness_pair+crossing": 33,
+    "witness_pair+crossing": 5,
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _base_selected_rows() -> list[list[int]]:
+    payload = build_t12_81_3_order_escape_payload()
+    audit = payload["fixed_singleton_order_audit"]
+    if not isinstance(audit, Mapping):
+        raise AssertionError("order-escape audit must be a mapping")
+    rows = audit["selected_rows"]
+    if not isinstance(rows, Sequence):
+        raise AssertionError("selected_rows must be a sequence")
+    return [_int_list(row) for row in rows]
+
+
+def _row_pair_cap_violations(rows: Sequence[Sequence[int]]) -> list[dict[str, object]]:
+    violations: list[dict[str, object]] = []
+    row_sets = [set(row) for row in rows]
+    for i, j in combinations(range(len(rows)), 2):
+        intersection = sorted(row_sets[i] & row_sets[j])
+        if len(intersection) > 2:
+            violations.append(
+                {
+                    "centers": [i, j],
+                    "intersection": intersection,
+                    "intersection_size": len(intersection),
+                }
+            )
+    return violations
+
+
+def _witness_pair_cap_violations(
+    rows: Sequence[Sequence[int]],
+) -> list[dict[str, object]]:
+    pair_to_centers: dict[tuple[int, int], list[int]] = {}
+    for center, row in enumerate(rows):
+        for pair in combinations(sorted(row), 2):
+            pair_to_centers.setdefault(pair, []).append(center)
+    return [
+        {"pair": list(pair), "centers": centers, "center_count": len(centers)}
+        for pair, centers in sorted(pair_to_centers.items())
+        if len(centers) > 2
+    ]
+
+
+def _crossing_violations(rows: Sequence[Sequence[int]]) -> list[dict[str, object]]:
+    return [
+        {"source_chord": list(source), "witness_chord": list(target)}
+        for source, target in crossing_bisector_violations(rows, CYCLIC_ORDER)
+    ]
+
+
+def _supply_classes() -> list[list[int]]:
+    seed = set(TARGET_DELETION_SEED)
+    fourths = [
+        label for label in CYCLIC_ORDER if label not in seed and label != SUPPLY_CENTER
+    ]
+    return [sorted([*TARGET_DELETION_SEED, fourth]) for fourth in fourths]
+
+
+def _center_3_connector_avoiding_classes() -> list[dict[str, object]]:
+    classes: list[dict[str, object]] = []
+    for triple in CONNECTOR_AVOIDING_TRIPLES:
+        triple_set = set(triple)
+        fourths = [
+            label
+            for label in CYCLIC_ORDER
+            if label not in triple_set
+            and label != TARGET_ROW_CENTER
+            and set([*triple, label]) & set(CONNECTOR_PAIR) != set(CONNECTOR_PAIR)
+        ]
+        for fourth in fourths:
+            classes.append(
+                {
+                    "activation_triple": triple,
+                    "fourth": fourth,
+                    "rich_class": sorted([*triple, fourth]),
+                }
+            )
+    return classes
+
+
+def _candidate_records(base_rows: Sequence[Sequence[int]]) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for supply_class in _supply_classes():
+        supply_fourth = next(label for label in supply_class if label not in TARGET_DELETION_SEED)
+        for center_3_data in _center_3_connector_avoiding_classes():
+            center_3_class = _int_list(center_3_data["rich_class"])  # type: ignore[arg-type]
+            rows = [list(row) for row in base_rows]
+            rows[SUPPLY_CENTER] = supply_class
+            rows[TARGET_ROW_CENTER] = center_3_class
+
+            row_pair_violations = _row_pair_cap_violations(rows)
+            witness_pair_violations = _witness_pair_cap_violations(rows)
+            crossing_violations = _crossing_violations(rows)
+            rejection_reasons = []
+            if row_pair_violations:
+                rejection_reasons.append("row_pair")
+            if witness_pair_violations:
+                rejection_reasons.append("witness_pair")
+            if crossing_violations:
+                rejection_reasons.append("crossing")
+            category = "+".join(rejection_reasons) if rejection_reasons else "survive"
+
+            records.append(
+                {
+                    "supply_center": SUPPLY_CENTER,
+                    "supply_class": supply_class,
+                    "supply_fourth": supply_fourth,
+                    "target_center": TARGET_ROW_CENTER,
+                    "target_center_activation_triple": center_3_data[
+                        "activation_triple"
+                    ],
+                    "target_center_fourth": center_3_data["fourth"],
+                    "target_center_class": center_3_class,
+                    "preserved_row_centers": PRESERVED_ROW_CENTERS,
+                    "row_pair_cap_violations": row_pair_violations,
+                    "witness_pair_cap_violations": witness_pair_violations,
+                    "crossing_violations": crossing_violations,
+                    "rejection_reasons": rejection_reasons,
+                    "rejection_category": category,
+                    "passes_basic_incidence_crossing_filters": not rejection_reasons,
+                }
+            )
+    return records
+
+
+def build_t12_81_3_escape_candidate_payload() -> dict[str, object]:
+    """Return the deterministic relaxed 81:3 escape-candidate scan."""
+
+    base_rows = _base_selected_rows()
+    candidates = _candidate_records(base_rows)
+    rejection_counts = dict(sorted(Counter(c["rejection_category"] for c in candidates).items()))
+    survivors = [
+        candidate
+        for candidate in candidates
+        if candidate["passes_basic_incidence_crossing_filters"]
+    ]
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This scan preserves only the seven source-81 rows outside centers 3 and 6.",
+            "Rows 3 and 6 are replaced by one candidate rich class each.",
+            "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "preserved_row_centers": PRESERVED_ROW_CENTERS,
+            "replaced_row_centers": REPLACED_ROW_CENTERS,
+            "center_6_supply_class_count": len(_supply_classes()),
+            "center_3_connector_avoiding_class_count": len(
+                _center_3_connector_avoiding_classes()
+            ),
+            "candidate_count": len(candidates),
+            "surviving_candidate_count": len(survivors),
+            "rejection_category_counts": rejection_counts,
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not rule out escape mechanisms that fail to preserve "
+                "the other source-81 rows, use richer catalogues than one "
+                "replacement class at centers 3 and 6, or require additional "
+                "minimal/rich-class hypotheses."
+            ),
+        },
+        "preserved_source_rows": {
+            str(center): base_rows[center] for center in PRESERVED_ROW_CENTERS
+        },
+        "candidate_generation": {
+            "center_6_supply_classes": _supply_classes(),
+            "center_3_connector_avoiding_classes": _center_3_connector_avoiding_classes(),
+        },
+        "candidates": candidates,
+        "survivors": survivors,
+        "source_order_escape": {
+            "path": ORDER_ESCAPE_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": ORDER_ESCAPE_SCHEMA,
+            "status": ORDER_ESCAPE_STATUS,
+            "genuine_escape_status": GENUINE_ESCAPE_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_escape_candidates.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_escape_candidates.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "preserved_row_centers": PRESERVED_ROW_CENTERS,
+        "replaced_row_centers": REPLACED_ROW_CENTERS,
+        "center_6_supply_class_count": 5,
+        "center_3_connector_avoiding_class_count": 8,
+        "candidate_count": 40,
+        "surviving_candidate_count": 0,
+        "rejection_category_counts": EXPECTED_REJECTION_COUNTS,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    warnings = payload.get("interpretation_warnings")
+    if not isinstance(warnings, Sequence):
+        raise AssertionError("interpretation_warnings must be a sequence")
+    if not any("preserves only the seven source-81 rows" in str(w) for w in warnings):
+        raise AssertionError("warnings must preserve the row-preservation scope")
+    if not any("not Euclidean realizability" in str(w) for w in warnings):
+        raise AssertionError("warnings must preserve the non-realizability scope")
+
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, Sequence) or len(candidates) != 40:
+        raise AssertionError("expected exactly 40 escape candidates")
+    if any(
+        isinstance(candidate, Mapping)
+        and candidate.get("passes_basic_incidence_crossing_filters")
+        for candidate in candidates
+    ):
+        raise AssertionError("no candidate should pass the basic filters")
+
+    survivors = payload.get("survivors")
+    if survivors != []:
+        raise AssertionError("survivors must be empty")
+
+    source = payload.get("source_order_escape")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_order_escape must be a mapping")
+    if source.get("schema") != ORDER_ESCAPE_SCHEMA:
+        raise AssertionError("source order-escape schema drifted")
+    if source.get("genuine_escape_status") != GENUINE_ESCAPE_STATUS:
+        raise AssertionError("source genuine escape status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_escape_candidates.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_escape_candidates.py
+++ b/tests/test_bootstrap_t12_81_3_escape_candidates.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    DEFAULT_ARTIFACT,
+    EXPECTED_REJECTION_COUNTS,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_escape_candidate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_81_3_escape_candidate_scan_counts_and_scope() -> None:
+    payload = build_t12_81_3_escape_candidate_payload()
+
+    assert_expected_payload(payload)
+    assert (
+        payload["status"]
+        == "BOOTSTRAP_T12_81_3_ESCAPE_CANDIDATE_SCAN_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "preserving the seven source-81 rows" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_escape_candidate_scan_summary() -> None:
+    payload = build_t12_81_3_escape_candidate_payload()
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["preserved_row_centers"] == [0, 1, 2, 4, 5, 7, 8]
+    assert summary["replaced_row_centers"] == [3, 6]
+    assert summary["center_6_supply_class_count"] == 5
+    assert summary["center_3_connector_avoiding_class_count"] == 8
+    assert summary["candidate_count"] == 40
+    assert summary["surviving_candidate_count"] == 0
+    assert summary["rejection_category_counts"] == EXPECTED_REJECTION_COUNTS
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_escape_candidate_generation_space() -> None:
+    payload = build_t12_81_3_escape_candidate_payload()
+    generation = payload["candidate_generation"]
+
+    assert generation["center_6_supply_classes"] == [
+        [0, 1, 2, 4],
+        [0, 1, 3, 4],
+        [0, 1, 4, 5],
+        [0, 1, 4, 7],
+        [0, 1, 4, 8],
+    ]
+    assert generation["center_3_connector_avoiding_classes"] == [
+        {"activation_triple": [0, 4, 6], "fourth": 2, "rich_class": [0, 2, 4, 6]},
+        {"activation_triple": [0, 4, 6], "fourth": 5, "rich_class": [0, 4, 5, 6]},
+        {"activation_triple": [0, 4, 6], "fourth": 7, "rich_class": [0, 4, 6, 7]},
+        {"activation_triple": [0, 4, 6], "fourth": 8, "rich_class": [0, 4, 6, 8]},
+        {"activation_triple": [1, 4, 6], "fourth": 2, "rich_class": [1, 2, 4, 6]},
+        {"activation_triple": [1, 4, 6], "fourth": 5, "rich_class": [1, 4, 5, 6]},
+        {"activation_triple": [1, 4, 6], "fourth": 7, "rich_class": [1, 4, 6, 7]},
+        {"activation_triple": [1, 4, 6], "fourth": 8, "rich_class": [1, 4, 6, 8]},
+    ]
+
+
+def test_81_3_escape_candidate_records_have_no_survivors() -> None:
+    payload = build_t12_81_3_escape_candidate_payload()
+
+    assert payload["survivors"] == []
+    candidates = payload["candidates"]
+    assert len(candidates) == 40
+    assert all(not candidate["passes_basic_incidence_crossing_filters"] for candidate in candidates)
+    assert all(candidate["crossing_violations"] for candidate in candidates)
+    assert any(candidate["row_pair_cap_violations"] for candidate in candidates)
+    assert any(candidate["witness_pair_cap_violations"] for candidate in candidates)
+
+
+def test_81_3_escape_candidate_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_81_3_escape_candidate_payload()
+
+
+def test_81_3_escape_candidate_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_candidates.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_candidate_count"] == 0
+
+
+def test_81_3_escape_candidate_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_81_3_escape_candidates.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_candidates.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_candidates.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_81_3_escape_candidate_expected_payload_rejects_drift() -> None:
+    payload = build_t12_81_3_escape_candidate_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_candidate_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_candidate_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary
- add a checker and generated artifact for the relaxed `81:3` pre-3 label-6 escape scan
- enumerate all 40 one-class replacement candidates preserving the seven non-3/non-6 source-81 rows
- document that all candidates fail basic row-pair, witness-pair, or crossing filters, without promoting the result beyond proof-mining diagnostics

## Claim status
- no general proof or counterexample is claimed
- no `n=9` proof or bootstrap-bridge proof is claimed
- scan is scoped to preserving the seven source-81 rows outside centers 3 and 6, with one replacement class at each of centers 3 and 6

## Verification
- `python scripts/check_bootstrap_t12_81_3_escape_candidates.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_escape_candidates.py -q`
- `python -m ruff check src/erdos97/bootstrap_t12_81_3_escape_candidates.py scripts/check_bootstrap_t12_81_3_escape_candidates.py tests/test_bootstrap_t12_81_3_escape_candidates.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`