### PR TITLE
Add 81:3 one-row-drop escape scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the order-resolved `81:3` fixed-row escape audit, where label `6`
   appears only after center `3` in the fixed singleton-rich closure, read
   [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
+- For the relaxed `81:3` escape-candidate scans, which replace centers `3`
+  and `6` and then allow one other source-`81` row to move, read
+  [`docs/bootstrap-t12-81-3-escape-candidates.md`](docs/bootstrap-t12-81-3-escape-candidates.md)
+  and
+  [`docs/bootstrap-t12-81-3-escape-one-row-drop.md`](docs/bootstrap-t12-81-3-escape-one-row-drop.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -289,6 +289,17 @@ bootstrap bridge; see `docs/bootstrap-t12-81-3-escape-candidates.md`,
 `scripts/check_bootstrap_t12_81_3_escape_candidates.py`, and
 `data/certificates/bootstrap_t12_81_3_escape_candidates.json`.
 
+The one-row-drop follow-up relaxes that fixed-row-neighborhood guard one step
+further. For each of the seven source-`81` rows outside centers `3` and `6`,
+it drops that one row and enumerates all `70` replacement 4-sets while keeping
+the same center-`6` supply and center-`3` connector-avoiding replacement
+space. All `19600` candidates fail the same basic row-pair, witness-pair, or
+crossing filters. This is still a finite diagnostic only, not a proof of
+genuine rich-class order, `n=9`, or the bootstrap bridge; see
+`docs/bootstrap-t12-81-3-escape-one-row-drop.md`,
+`scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py`, and
+`data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -156,6 +156,16 @@ genuine rich-class data: either find a pre-`3` supply of label `6` that avoids
 the connector, or prove such a supply impossible under the minimal/rich-class
 hypotheses. See `docs/bootstrap-t12-81-3-order-escape.md`.
 
+The relaxed `81:3` escape-candidate scans probe that remaining target under
+fixed-row-neighborhood hypotheses. The first scan replaces centers `3` and `6`
+while preserving the other seven source-`81` rows and finds no surviving
+basic incidence/crossing candidate. The one-row-drop scan then allows any one
+of those seven preserved rows to move as an arbitrary 4-set; all `19600`
+candidates again fail the basic filters. This is still proof-mining
+bookkeeping only, not a theorem about all genuine rich-class catalogues. See
+`docs/bootstrap-t12-81-3-escape-candidates.md` and
+`docs/bootstrap-t12-81-3-escape-one-row-drop.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json
+++ b/data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json
@@ -1,0 +1,418 @@
+{
+  "candidate_generation": {
+    "center_3_connector_avoiding_classes": [
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          0,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          0,
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          1,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          1,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          1,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          1,
+          4,
+          6,
+          8
+        ]
+      }
+    ],
+    "center_6_supply_classes": [
+      [
+        0,
+        1,
+        2,
+        4
+      ],
+      [
+        0,
+        1,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        8
+      ]
+    ],
+    "dropped_row_choice_count_per_center": {
+      "0": 70,
+      "1": 70,
+      "2": 70,
+      "4": 70,
+      "5": 70,
+      "7": 70,
+      "8": 70
+    }
+  },
+  "claim_scope": "One-row-drop relaxation of the 81:3 escape-candidate scan. For each of the seven source-81 rows outside centers 3 and 6, it allows that one row to be replaced by an arbitrary 4-set while also replacing centers 3 and 6 by one candidate class each. All 19,600 candidates fail row-pair, witness-pair, or crossing filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This scan drops exactly one of the seven source-81 rows that were preserved in the previous escape-candidate scan.",
+    "Rows 3 and 6 are also replaced by one candidate rich class each, as in the previous scan.",
+    "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "per_dropped_center": [
+    {
+      "candidate_count": 2800,
+      "dropped_center": 0,
+      "rejection_category_counts": {
+        "crossing": 8,
+        "row_pair+witness_pair+crossing": 2702,
+        "witness_pair+crossing": 90
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        1,
+        3,
+        6,
+        7
+      ],
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 2800,
+      "dropped_center": 1,
+      "rejection_category_counts": {
+        "crossing": 13,
+        "row_pair+crossing": 3,
+        "row_pair+witness_pair+crossing": 2706,
+        "witness_pair+crossing": 78
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 2800,
+      "dropped_center": 2,
+      "rejection_category_counts": {
+        "crossing": 11,
+        "row_pair+crossing": 5,
+        "row_pair+witness_pair+crossing": 2701,
+        "witness_pair+crossing": 83
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 2800,
+      "dropped_center": 4,
+      "rejection_category_counts": {
+        "crossing": 8,
+        "row_pair+crossing": 3,
+        "row_pair+witness_pair+crossing": 2736,
+        "witness_pair+crossing": 53
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        1,
+        2,
+        5,
+        7
+      ],
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 2800,
+      "dropped_center": 5,
+      "rejection_category_counts": {
+        "crossing": 5,
+        "row_pair+crossing": 5,
+        "row_pair+witness_pair+crossing": 2731,
+        "witness_pair+crossing": 59
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        2,
+        3,
+        6,
+        8
+      ],
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 2800,
+      "dropped_center": 7,
+      "rejection_category_counts": {
+        "crossing": 23,
+        "row_pair+witness_pair+crossing": 2638,
+        "witness_pair+crossing": 139
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        1,
+        4,
+        5,
+        8
+      ],
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 2800,
+      "dropped_center": 8,
+      "rejection_category_counts": {
+        "crossing": 9,
+        "row_pair+crossing": 2,
+        "row_pair+witness_pair+crossing": 2675,
+        "witness_pair+crossing": 114
+      },
+      "replacement_row_count": 70,
+      "source_row": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "surviving_candidate_count": 0
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_escape_one_row_drop.v1",
+  "source_escape_candidate_scan": {
+    "claim_scope": "Relaxed 81:3 escape-candidate scan preserving the seven source-81 rows outside centers 3 and 6. It enumerates the 40 basic ways to supply label 6 before center 3 and then activate center 3 through a connector-avoiding triple; all fail row-pair, witness-pair, or crossing filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+    "path": "data/certificates/bootstrap_t12_81_3_escape_candidates.json",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_UNDER_SOURCE81_OTHER_ROWS_PRESERVED",
+    "schema": "erdos97.bootstrap_t12_81_3_escape_candidates.v1",
+    "status": "BOOTSTRAP_T12_81_3_ESCAPE_CANDIDATE_SCAN_DIAGNOSTIC_ONLY"
+  },
+  "source_rows": {
+    "0": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "1": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "2": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "3": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "4": [
+      1,
+      2,
+      5,
+      7
+    ],
+    "5": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "6": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "7": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "8": [
+      0,
+      2,
+      5,
+      6
+    ]
+  },
+  "status": "BOOTSTRAP_T12_81_3_ESCAPE_ONE_ROW_DROP_SCAN_DIAGNOSTIC_ONLY",
+  "summary": {
+    "also_replaced_row_centers": [
+      3,
+      6
+    ],
+    "candidate_count": 19600,
+    "center_3_connector_avoiding_class_count": 8,
+    "center_6_supply_class_count": 5,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "dropped_center_count": 7,
+    "dropped_row_replacement_count_per_center": 70,
+    "one_row_drop_centers": [
+      0,
+      1,
+      2,
+      4,
+      5,
+      7,
+      8
+    ],
+    "rejection_category_counts": {
+      "crossing": 77,
+      "row_pair+crossing": 18,
+      "row_pair+witness_pair+crossing": 18889,
+      "witness_pair+crossing": 616
+    },
+    "remaining_gap": "This does not rule out escape mechanisms that move two or more of the other source-81 rows, use richer catalogues than one replacement class at centers 3 and 6, or require additional minimal/rich-class hypotheses.",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_ONE_OTHER_SOURCE81_ROW_DROPS",
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "surviving_candidate_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-escape-one-row-drop.md
+++ b/docs/bootstrap-t12-81-3-escape-one-row-drop.md
@@ -1,0 +1,105 @@
+# Bootstrap T12 81:3 One-Row-Drop Escape Scan
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet is the next relaxation after
+`docs/bootstrap-t12-81-3-escape-candidates.md`. That previous scan preserved
+the seven source-`81` rows outside centers `3` and `6`. Here we allow any one
+of those seven rows to move, one dropped center at a time.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json`.
+
+## Scan Scope
+
+For each dropped center in
+
+```text
+0,1,2,4,5,7,8
+```
+
+the scan enumerates all
+
+```text
+70
+```
+
+possible replacement selected rows for that center. It also uses the same
+replacement space as the previous escape-candidate scan:
+
+```text
+5
+```
+
+possible center-`6` supply classes containing deletion seed `[0,1,4]`, and
+
+```text
+8
+```
+
+possible connector-avoiding center-`3` classes using either `[0,4,6]` or
+`[1,4,6]`.
+
+So there are:
+
+```text
+7 * 70 * 5 * 8 = 19600
+```
+
+one-row-drop candidates.
+
+## Result
+
+All `19600` candidates fail the basic exact incidence/crossing filters:
+
+```text
+surviving candidates: 0
+```
+
+The aggregate rejection counts are:
+
+```text
+crossing: 77
+row_pair+crossing: 18
+row_pair+witness_pair+crossing: 18889
+witness_pair+crossing: 616
+```
+
+Thus the checked scan status is:
+
+```text
+NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_ONE_OTHER_SOURCE81_ROW_DROPS
+```
+
+## Remaining Gap
+
+This is still not a bridge proof. It only rules out this finite relaxed
+escape model:
+
+```text
+drop exactly one preserved non-3/non-6 source-81 row,
+replace row 6 by one pre-3 supply class,
+replace row 3 by one connector-avoiding class.
+```
+
+It does not rule out escape mechanisms that move two or more of the other
+source-`81` rows, use more than one replacement class at centers `3` or `6`, or
+depend on additional minimal/rich-class hypotheses not included in this scan.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining diagnostic
+that narrows one concrete escape route.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -575,6 +575,14 @@ fail basic row-pair, witness-pair, or crossing filters. This is still a
 fixed-row-neighborhood diagnostic only, not a theorem about all genuine
 rich-class catalogues.
 
+The one-row-drop follow-up in
+`docs/bootstrap-t12-81-3-escape-one-row-drop.md` allows any one of those seven
+preserved rows to move as an arbitrary 4-set while also replacing centers `3`
+and `6` as above. It checks `19600` candidates and again finds no survivor
+under the basic row-pair, witness-pair, and crossing filters. This remains a
+finite proof-mining diagnostic only, not a proof of row forcing, `n=9`, the
+bootstrap bridge, or Erdos Problem #97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -93,9 +93,14 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-escape-candidates.md` now drops preservation of
    the source-`81` center-`3` and center-`6` rows while preserving the other
    seven rows. All `40` one-class replacement candidates fail the basic
-   incidence/crossing filters. The next useful PR must either relax the
-   preservation of those seven rows or introduce an additional genuine
-   rich-class/minimality hypothesis that justifies preserving enough of them.
+   incidence/crossing filters.
+   The one-row-drop follow-up in
+   `docs/bootstrap-t12-81-3-escape-one-row-drop.md` then allows any one of
+   those seven preserved rows to move as an arbitrary 4-set. All `19600`
+   candidates still fail the basic row-pair, witness-pair, or crossing
+   filters. The next useful PR must either relax two or more of those seven
+   rows at once, introduce a stronger genuine rich-class/minimality hypothesis
+   that justifies preserving enough rows, or move to a different bridge target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,12 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-order-escape.md`](bootstrap-t12-81-3-order-escape.md):
   order-resolved fixed-row packet showing label `6` is not exposed before
   center `3` in the current singleton-rich closure.
+- [`bootstrap-t12-81-3-escape-candidates.md`](bootstrap-t12-81-3-escape-candidates.md):
+  relaxed fixed-row-neighborhood scan replacing centers `3` and `6` for the
+  `81:3` pre-`3` label-`6` escape.
+- [`bootstrap-t12-81-3-escape-one-row-drop.md`](bootstrap-t12-81-3-escape-one-row-drop.md):
+  one-row-drop relaxation allowing one additional source-`81` row to move
+  while checking the same escape route.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -223,6 +223,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_escape_candidates.json"
       verifier: "scripts/check_bootstrap_t12_81_3_escape_candidates.py"
       claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; preserves the seven source-81 rows outside centers 3 and 6 and rules out 40 one-class replacement escape candidates by basic incidence/crossing filters, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_escape_one_row_drop"
+      status: "one-row-drop replacement scan for the 81:3 pre-3 label-6 escape"
+      artifact: "data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py"
+      claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; for each of the seven source-81 rows outside centers 3 and 6, allows that one row to move as an arbitrary 4-set and rules out 19600 candidates by basic incidence/crossing filters, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2889,6 +2889,87 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_escape_one_row_drop
+    path: data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py
+    command: python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py
+    check_command: python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: One-row-drop relaxation of the 81:3 escape-candidate scan; all 19600 candidates fail basic incidence/crossing filters, but this is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_escape_one_row_drop.v1
+      status: BOOTSTRAP_T12_81_3_ESCAPE_ONE_ROW_DROP_SCAN_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.one_row_drop_centers:
+        - 0
+        - 1
+        - 2
+        - 4
+        - 5
+        - 7
+        - 8
+      summary.also_replaced_row_centers:
+        - 3
+        - 6
+      summary.center_6_supply_class_count: 5
+      summary.center_3_connector_avoiding_class_count: 8
+      summary.dropped_row_replacement_count_per_center: 70
+      summary.dropped_center_count: 7
+      summary.candidate_count: 19600
+      summary.surviving_candidate_count: 0
+      summary.rejection_category_counts.crossing: 77
+      summary.rejection_category_counts.row_pair+crossing: 18
+      summary.rejection_category_counts.row_pair+witness_pair+crossing: 18889
+      summary.rejection_category_counts.witness_pair+crossing: 616
+      summary.scan_status: NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_ONE_OTHER_SOURCE81_ROW_DROPS
+      source_escape_candidate_scan.schema: erdos97.bootstrap_t12_81_3_escape_candidates.v1
+      source_escape_candidate_scan.scan_status: NO_BASIC_FILTER_SURVIVORS_UNDER_SOURCE81_OTHER_ROWS_PRESERVED
+      provenance.generator: scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the one-row-drop scan proves genuine rich-class order
+      - the one-row-drop scan proves no pre-3 label-6 supply exists
+      - the one-row-drop scan proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py
+++ b/scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 one-row-drop escape scan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_escape_one_row_drop import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_escape_one_row_drop_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 one-row-drop escape scan")
+    print(f"candidate count: {summary['candidate_count']}")
+    print(f"survivors: {summary['surviving_candidate_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_escape_one_row_drop_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 one-row-drop artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 one-row-drop expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_escape_one_row_drop.py
+++ b/src/erdos97/bootstrap_t12_81_3_escape_one_row_drop.py
@@ -1,0 +1,360 @@
+"""One-row-drop scan for the bootstrap/T12 81:3 escape.
+
+The previous relaxed escape-candidate packet preserves the seven source-81
+rows outside centers 3 and 6.  This packet relaxes that guard one step further:
+for each of those seven rows, drop that single preserved row and enumerate all
+70 possible replacement 4-sets for its center while also replacing centers 3
+and 6 as in the escape-candidate scan.
+
+The scan uses only selected-row incidence and cyclic crossing filters.  It is a
+proof-mining diagnostic, not a Euclidean realizability theorem and not a proof
+of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CLAIM_SCOPE as ESCAPE_CANDIDATE_CLAIM_SCOPE,
+    DEFAULT_ARTIFACT as ESCAPE_CANDIDATE_ARTIFACT,
+    SCAN_STATUS as ESCAPE_CANDIDATE_SCAN_STATUS,
+    SCHEMA as ESCAPE_CANDIDATE_SCHEMA,
+    STATUS as ESCAPE_CANDIDATE_STATUS,
+    _base_selected_rows,
+    _center_3_connector_avoiding_classes,
+    _crossing_violations,
+    _row_pair_cap_violations,
+    _supply_classes,
+    _witness_pair_cap_violations,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    PRESERVED_ROW_CENTERS,
+    SUPPLY_CENTER,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_escape_one_row_drop.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ESCAPE_ONE_ROW_DROP_SCAN_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_ONE_OTHER_SOURCE81_ROW_DROPS"
+CLAIM_SCOPE = (
+    "One-row-drop relaxation of the 81:3 escape-candidate scan. For each of "
+    "the seven source-81 rows outside centers 3 and 6, it allows that one row "
+    "to be replaced by an arbitrary 4-set while also replacing centers 3 and "
+    "6 by one candidate class each. All 19,600 candidates fail row-pair, "
+    "witness-pair, or crossing filters. This is not a proof of genuine "
+    "rich-class order, not a proof of row forcing, not a proof of n=9, not a "
+    "proof of the bridge, and not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_escape_one_row_drop.json"
+)
+
+REPLACED_ROW_CENTERS = [TARGET_ROW_CENTER, SUPPLY_CENTER]
+EXPECTED_REJECTION_COUNTS = {
+    "crossing": 77,
+    "row_pair+crossing": 18,
+    "row_pair+witness_pair+crossing": 18889,
+    "witness_pair+crossing": 616,
+}
+EXPECTED_PER_DROPPED_REJECTION_COUNTS = {
+    0: {
+        "crossing": 8,
+        "row_pair+witness_pair+crossing": 2702,
+        "witness_pair+crossing": 90,
+    },
+    1: {
+        "crossing": 13,
+        "row_pair+crossing": 3,
+        "row_pair+witness_pair+crossing": 2706,
+        "witness_pair+crossing": 78,
+    },
+    2: {
+        "crossing": 11,
+        "row_pair+crossing": 5,
+        "row_pair+witness_pair+crossing": 2701,
+        "witness_pair+crossing": 83,
+    },
+    4: {
+        "crossing": 8,
+        "row_pair+crossing": 3,
+        "row_pair+witness_pair+crossing": 2736,
+        "witness_pair+crossing": 53,
+    },
+    5: {
+        "crossing": 5,
+        "row_pair+crossing": 5,
+        "row_pair+witness_pair+crossing": 2731,
+        "witness_pair+crossing": 59,
+    },
+    7: {
+        "crossing": 23,
+        "row_pair+witness_pair+crossing": 2638,
+        "witness_pair+crossing": 139,
+    },
+    8: {
+        "crossing": 9,
+        "row_pair+crossing": 2,
+        "row_pair+witness_pair+crossing": 2675,
+        "witness_pair+crossing": 114,
+    },
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _all_replacement_rows(center: int) -> list[list[int]]:
+    labels = [label for label in CYCLIC_ORDER if label != center]
+    return [list(row) for row in combinations(labels, 4)]
+
+
+def _rejection_category(rows: Sequence[Sequence[int]]) -> str:
+    rejection_reasons = []
+    if _row_pair_cap_violations(rows):
+        rejection_reasons.append("row_pair")
+    if _witness_pair_cap_violations(rows):
+        rejection_reasons.append("witness_pair")
+    if _crossing_violations(rows):
+        rejection_reasons.append("crossing")
+    return "+".join(rejection_reasons) if rejection_reasons else "survive"
+
+
+def _scan_candidates(base_rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    total_counts: Counter[str] = Counter()
+    dropped_summaries: list[dict[str, object]] = []
+    survivors: list[dict[str, object]] = []
+
+    supply_classes = _supply_classes()
+    center_3_classes = _center_3_connector_avoiding_classes()
+    for dropped_center in PRESERVED_ROW_CENTERS:
+        dropped_counts: Counter[str] = Counter()
+        replacement_rows = _all_replacement_rows(dropped_center)
+        for supply_class in supply_classes:
+            for center_3_data in center_3_classes:
+                center_3_class = _int_list(center_3_data["rich_class"])
+                for dropped_row in replacement_rows:
+                    rows = [list(row) for row in base_rows]
+                    rows[SUPPLY_CENTER] = list(supply_class)
+                    rows[TARGET_ROW_CENTER] = center_3_class
+                    rows[dropped_center] = dropped_row
+
+                    category = _rejection_category(rows)
+                    dropped_counts[category] += 1
+                    total_counts[category] += 1
+                    if category == "survive":
+                        survivors.append(
+                            {
+                                "dropped_center": dropped_center,
+                                "dropped_center_class": dropped_row,
+                                "supply_center_class": list(supply_class),
+                                "target_center_class": center_3_class,
+                                "target_center_activation_triple": center_3_data[
+                                    "activation_triple"
+                                ],
+                            }
+                        )
+
+        dropped_summaries.append(
+            {
+                "dropped_center": dropped_center,
+                "source_row": list(base_rows[dropped_center]),
+                "replacement_row_count": len(replacement_rows),
+                "candidate_count": sum(dropped_counts.values()),
+                "surviving_candidate_count": dropped_counts.get("survive", 0),
+                "rejection_category_counts": dict(sorted(dropped_counts.items())),
+            }
+        )
+
+    return {
+        "candidate_count": sum(total_counts.values()),
+        "survivors": survivors,
+        "rejection_category_counts": dict(sorted(total_counts.items())),
+        "per_dropped_center": dropped_summaries,
+    }
+
+
+def build_t12_81_3_escape_one_row_drop_payload() -> dict[str, object]:
+    """Return the deterministic one-row-drop escape scan."""
+
+    base_rows = _base_selected_rows()
+    scan = _scan_candidates(base_rows)
+    survivors = scan["survivors"]
+    if not isinstance(survivors, Sequence):
+        raise AssertionError("survivors must be a sequence")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This scan drops exactly one of the seven source-81 rows that were preserved in the previous escape-candidate scan.",
+            "Rows 3 and 6 are also replaced by one candidate rich class each, as in the previous scan.",
+            "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "one_row_drop_centers": PRESERVED_ROW_CENTERS,
+            "also_replaced_row_centers": REPLACED_ROW_CENTERS,
+            "center_6_supply_class_count": len(_supply_classes()),
+            "center_3_connector_avoiding_class_count": len(
+                _center_3_connector_avoiding_classes()
+            ),
+            "dropped_row_replacement_count_per_center": 70,
+            "dropped_center_count": len(PRESERVED_ROW_CENTERS),
+            "candidate_count": scan["candidate_count"],
+            "surviving_candidate_count": len(survivors),
+            "rejection_category_counts": scan["rejection_category_counts"],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not rule out escape mechanisms that move two or "
+                "more of the other source-81 rows, use richer catalogues than "
+                "one replacement class at centers 3 and 6, or require "
+                "additional minimal/rich-class hypotheses."
+            ),
+        },
+        "source_rows": {str(center): base_rows[center] for center in CYCLIC_ORDER},
+        "candidate_generation": {
+            "center_6_supply_classes": _supply_classes(),
+            "center_3_connector_avoiding_classes": _center_3_connector_avoiding_classes(),
+            "dropped_row_choice_count_per_center": {
+                str(center): len(_all_replacement_rows(center))
+                for center in PRESERVED_ROW_CENTERS
+            },
+        },
+        "per_dropped_center": scan["per_dropped_center"],
+        "survivors": survivors,
+        "source_escape_candidate_scan": {
+            "path": ESCAPE_CANDIDATE_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": ESCAPE_CANDIDATE_SCHEMA,
+            "status": ESCAPE_CANDIDATE_STATUS,
+            "scan_status": ESCAPE_CANDIDATE_SCAN_STATUS,
+            "claim_scope": ESCAPE_CANDIDATE_CLAIM_SCOPE,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "one_row_drop_centers": PRESERVED_ROW_CENTERS,
+        "also_replaced_row_centers": REPLACED_ROW_CENTERS,
+        "center_6_supply_class_count": 5,
+        "center_3_connector_avoiding_class_count": 8,
+        "dropped_row_replacement_count_per_center": 70,
+        "dropped_center_count": 7,
+        "candidate_count": 19600,
+        "surviving_candidate_count": 0,
+        "rejection_category_counts": EXPECTED_REJECTION_COUNTS,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    per_dropped = payload.get("per_dropped_center")
+    if not isinstance(per_dropped, Sequence) or len(per_dropped) != 7:
+        raise AssertionError("expected seven dropped-center summaries")
+    for record in per_dropped:
+        if not isinstance(record, Mapping):
+            raise AssertionError("dropped-center summaries must be mappings")
+        center = record.get("dropped_center")
+        if center not in EXPECTED_PER_DROPPED_REJECTION_COUNTS:
+            raise AssertionError(f"unexpected dropped center {center!r}")
+        if record.get("replacement_row_count") != 70:
+            raise AssertionError(f"dropped center {center!r} has bad row count")
+        if record.get("candidate_count") != 2800:
+            raise AssertionError(f"dropped center {center!r} has bad candidate count")
+        if record.get("surviving_candidate_count") != 0:
+            raise AssertionError(f"dropped center {center!r} should have no survivors")
+        expected_counts = EXPECTED_PER_DROPPED_REJECTION_COUNTS[int(center)]
+        if record.get("rejection_category_counts") != expected_counts:
+            raise AssertionError(
+                f"dropped center {center!r} rejection counts drifted"
+            )
+
+    survivors = payload.get("survivors")
+    if survivors != []:
+        raise AssertionError("survivors must be empty")
+
+    source = payload.get("source_escape_candidate_scan")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_escape_candidate_scan must be a mapping")
+    if source.get("schema") != ESCAPE_CANDIDATE_SCHEMA:
+        raise AssertionError("source escape-candidate schema drifted")
+    if source.get("scan_status") != ESCAPE_CANDIDATE_SCAN_STATUS:
+        raise AssertionError("source escape-candidate scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_escape_one_row_drop.py
+++ b/tests/test_bootstrap_t12_81_3_escape_one_row_drop.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_escape_one_row_drop import (
+    DEFAULT_ARTIFACT,
+    EXPECTED_PER_DROPPED_REJECTION_COUNTS,
+    EXPECTED_REJECTION_COUNTS,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_escape_one_row_drop_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_81_3_one_row_drop_counts_and_scope() -> None:
+    payload = build_t12_81_3_escape_one_row_drop_payload()
+
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_ESCAPE_ONE_ROW_DROP_SCAN_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "one row" in claim_scope
+    assert "All 19,600 candidates fail" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_one_row_drop_summary() -> None:
+    payload = build_t12_81_3_escape_one_row_drop_payload()
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["one_row_drop_centers"] == [0, 1, 2, 4, 5, 7, 8]
+    assert summary["also_replaced_row_centers"] == [3, 6]
+    assert summary["center_6_supply_class_count"] == 5
+    assert summary["center_3_connector_avoiding_class_count"] == 8
+    assert summary["dropped_row_replacement_count_per_center"] == 70
+    assert summary["dropped_center_count"] == 7
+    assert summary["candidate_count"] == 19600
+    assert summary["surviving_candidate_count"] == 0
+    assert summary["rejection_category_counts"] == EXPECTED_REJECTION_COUNTS
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_one_row_drop_per_center_counts() -> None:
+    payload = build_t12_81_3_escape_one_row_drop_payload()
+    per_dropped = payload["per_dropped_center"]
+
+    assert len(per_dropped) == 7
+    for record in per_dropped:
+        center = record["dropped_center"]
+        assert record["replacement_row_count"] == 70
+        assert record["candidate_count"] == 2800
+        assert record["surviving_candidate_count"] == 0
+        assert (
+            record["rejection_category_counts"]
+            == EXPECTED_PER_DROPPED_REJECTION_COUNTS[center]
+        )
+
+
+def test_81_3_one_row_drop_generation_space() -> None:
+    payload = build_t12_81_3_escape_one_row_drop_payload()
+    generation = payload["candidate_generation"]
+
+    assert generation["center_6_supply_classes"] == [
+        [0, 1, 2, 4],
+        [0, 1, 3, 4],
+        [0, 1, 4, 5],
+        [0, 1, 4, 7],
+        [0, 1, 4, 8],
+    ]
+    assert generation["dropped_row_choice_count_per_center"] == {
+        "0": 70,
+        "1": 70,
+        "2": 70,
+        "4": 70,
+        "5": 70,
+        "7": 70,
+        "8": 70,
+    }
+
+
+def test_81_3_one_row_drop_artifact_matches_generator() -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == build_t12_81_3_escape_one_row_drop_payload()
+
+
+def test_81_3_one_row_drop_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_candidate_count"] == 0
+
+
+def test_81_3_one_row_drop_write_check_out(tmp_path: Path) -> None:
+    out = tmp_path / "bootstrap_t12_81_3_escape_one_row_drop.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py",
+            "--write",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py",
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(out),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_81_3_one_row_drop_expected_payload_rejects_drift() -> None:
+    payload = build_t12_81_3_escape_one_row_drop_payload()
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_candidate_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_candidate_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a generator-backed one-row-drop relaxation for the `81:3` pre-3 label-6 escape scan
- enumerate `7 * 70 * 5 * 8 = 19600` candidates while allowing one additional source-81 row to move
- record zero basic row-pair, witness-pair, or crossing survivors as a review-pending diagnostic only
- update the ledgers, manifest, and docs without changing the global/open or strongest local finite-case status

## Verification

- `python scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_escape_one_row_drop.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`