### PR TITLE
Add 81:3 two-row-drop escape scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,12 @@ This repository is a public research log and reproducibility workspace for Erdő
   appears only after center `3` in the fixed singleton-rich closure, read
   [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
 - For the relaxed `81:3` escape-candidate scans, which replace centers `3`
-  and `6` and then allow one other source-`81` row to move, read
+  and `6` and then allow one or two other source-`81` rows to move, read
   [`docs/bootstrap-t12-81-3-escape-candidates.md`](docs/bootstrap-t12-81-3-escape-candidates.md)
   and
-  [`docs/bootstrap-t12-81-3-escape-one-row-drop.md`](docs/bootstrap-t12-81-3-escape-one-row-drop.md).
+  [`docs/bootstrap-t12-81-3-escape-one-row-drop.md`](docs/bootstrap-t12-81-3-escape-one-row-drop.md),
+  then
+  [`docs/bootstrap-t12-81-3-escape-two-row-drop.md`](docs/bootstrap-t12-81-3-escape-two-row-drop.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -300,6 +300,16 @@ genuine rich-class order, `n=9`, or the bootstrap bridge; see
 `scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py`, and
 `data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json`.
 
+The two-row-drop follow-up repeats the same finite stress test while allowing
+any pair of the seven source-`81` rows outside centers `3` and `6` to move.
+For each dropped pair it checks all `70 * 70` replacement-row choices, for a
+total of `4116000` candidates. All candidates fail the same basic row-pair,
+witness-pair, or crossing filters. This is still a finite diagnostic only, not
+a proof of genuine rich-class order, `n=9`, or the bootstrap bridge; see
+`docs/bootstrap-t12-81-3-escape-two-row-drop.md`,
+`scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py`, and
+`data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -161,10 +161,13 @@ fixed-row-neighborhood hypotheses. The first scan replaces centers `3` and `6`
 while preserving the other seven source-`81` rows and finds no surviving
 basic incidence/crossing candidate. The one-row-drop scan then allows any one
 of those seven preserved rows to move as an arbitrary 4-set; all `19600`
-candidates again fail the basic filters. This is still proof-mining
-bookkeeping only, not a theorem about all genuine rich-class catalogues. See
+candidates again fail the basic filters. The two-row-drop scan allows any pair
+of those seven rows to move and all `4116000` candidates fail as well. This is
+still proof-mining bookkeeping only, not a theorem about all genuine
+rich-class catalogues. See
 `docs/bootstrap-t12-81-3-escape-candidates.md` and
-`docs/bootstrap-t12-81-3-escape-one-row-drop.md`.
+`docs/bootstrap-t12-81-3-escape-one-row-drop.md`, plus
+`docs/bootstrap-t12-81-3-escape-two-row-drop.md`.
 
 ## New exact fixed-pattern obstructions
 

--- a/data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json
+++ b/data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json
@@ -1,0 +1,907 @@
+{
+  "candidate_generation": {
+    "center_3_connector_avoiding_classes": [
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          0,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          0,
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          1,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          1,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          1,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          1,
+          4,
+          6,
+          8
+        ]
+      }
+    ],
+    "center_6_supply_classes": [
+      [
+        0,
+        1,
+        2,
+        4
+      ],
+      [
+        0,
+        1,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        8
+      ]
+    ],
+    "dropped_row_choice_count_per_center": {
+      "0": 70,
+      "1": 70,
+      "2": 70,
+      "4": 70,
+      "5": 70,
+      "7": 70,
+      "8": 70
+    }
+  },
+  "claim_scope": "Two-row-drop relaxation of the 81:3 escape-candidate scan. For each pair of the seven source-81 rows outside centers 3 and 6, it allows both rows to be replaced by arbitrary 4-sets while also replacing centers 3 and 6 by one candidate class each. All 4,116,000 candidates fail row-pair, witness-pair, or crossing filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This scan drops exactly two of the seven source-81 rows that were preserved in the original escape-candidate scan.",
+    "Rows 3 and 6 are also replaced by one candidate rich class each, as in the previous scans.",
+    "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "per_dropped_pair": [
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        0,
+        1
+      ],
+      "rejection_category_counts": {
+        "crossing": 58,
+        "row_pair+crossing": 48,
+        "row_pair+witness_pair+crossing": 194506,
+        "witness_pair+crossing": 1388
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        0,
+        2
+      ],
+      "rejection_category_counts": {
+        "crossing": 58,
+        "row_pair+crossing": 54,
+        "row_pair+witness_pair+crossing": 194287,
+        "witness_pair+crossing": 1601
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        0,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 99,
+        "row_pair+crossing": 9,
+        "row_pair+witness_pair+crossing": 193975,
+        "witness_pair+crossing": 1917
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        0,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 71,
+        "row_pair+crossing": 62,
+        "row_pair+witness_pair+crossing": 193649,
+        "witness_pair+crossing": 2218
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        0,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 150,
+        "row_pair+crossing": 68,
+        "row_pair+witness_pair+crossing": 193416,
+        "witness_pair+crossing": 2366
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        0,
+        8
+      ],
+      "rejection_category_counts": {
+        "crossing": 65,
+        "row_pair+crossing": 37,
+        "row_pair+witness_pair+crossing": 193911,
+        "witness_pair+crossing": 1987
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        1,
+        2
+      ],
+      "rejection_category_counts": {
+        "crossing": 59,
+        "row_pair+crossing": 84,
+        "row_pair+witness_pair+crossing": 194566,
+        "witness_pair+crossing": 1291
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        1,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 83,
+        "row_pair+crossing": 41,
+        "row_pair+witness_pair+crossing": 194919,
+        "witness_pair+crossing": 957
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        1,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 103,
+        "row_pair+crossing": 71,
+        "row_pair+witness_pair+crossing": 194332,
+        "witness_pair+crossing": 1494
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        1,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 131,
+        "row_pair+crossing": 14,
+        "row_pair+witness_pair+crossing": 193330,
+        "witness_pair+crossing": 2525
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        1,
+        8
+      ],
+      "rejection_category_counts": {
+        "crossing": 111,
+        "row_pair+crossing": 118,
+        "row_pair+witness_pair+crossing": 194223,
+        "witness_pair+crossing": 1548
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        2,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 45,
+        "row_pair+crossing": 86,
+        "row_pair+witness_pair+crossing": 194912,
+        "witness_pair+crossing": 957
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        2,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 43,
+        "row_pair+crossing": 44,
+        "row_pair+witness_pair": 9,
+        "row_pair+witness_pair+crossing": 194869,
+        "witness_pair+crossing": 1035
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        2,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 374,
+        "row_pair+crossing": 95,
+        "row_pair+witness_pair": 10,
+        "row_pair+witness_pair+crossing": 191823,
+        "witness_pair+crossing": 3698
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        2,
+        8
+      ],
+      "rejection_category_counts": {
+        "crossing": 88,
+        "row_pair+crossing": 11,
+        "row_pair+witness_pair+crossing": 193986,
+        "witness_pair+crossing": 1915
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        4,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 27,
+        "row_pair+crossing": 77,
+        "row_pair+witness_pair+crossing": 195359,
+        "witness_pair+crossing": 537
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        4,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 151,
+        "row_pair+crossing": 43,
+        "row_pair+witness_pair+crossing": 194071,
+        "witness_pair+crossing": 1735
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        4,
+        8
+      ],
+      "rejection_category_counts": {
+        "crossing": 215,
+        "row_pair+crossing": 133,
+        "row_pair+witness_pair": 31,
+        "row_pair+witness_pair+crossing": 193524,
+        "witness_pair+crossing": 2097
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        5,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 114,
+        "row_pair+crossing": 163,
+        "row_pair+witness_pair+crossing": 193914,
+        "witness_pair+crossing": 1809
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        5,
+        8
+      ],
+      "rejection_category_counts": {
+        "crossing": 74,
+        "row_pair+crossing": 59,
+        "row_pair+witness_pair": 9,
+        "row_pair+witness_pair+crossing": 194476,
+        "witness_pair+crossing": 1382
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "surviving_candidate_count": 0
+    },
+    {
+      "candidate_count": 196000,
+      "dropped_centers": [
+        7,
+        8
+      ],
+      "rejection_category_counts": {
+        "crossing": 274,
+        "row_pair+crossing": 159,
+        "row_pair+witness_pair+crossing": 192889,
+        "witness_pair+crossing": 2678
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "surviving_candidate_count": 0
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_escape_two_row_drop.v1",
+  "source_one_row_drop_scan": {
+    "path": "data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_ONE_OTHER_SOURCE81_ROW_DROPS",
+    "schema": "erdos97.bootstrap_t12_81_3_escape_one_row_drop.v1",
+    "status": "BOOTSTRAP_T12_81_3_ESCAPE_ONE_ROW_DROP_SCAN_DIAGNOSTIC_ONLY"
+  },
+  "source_rows": {
+    "0": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "1": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "2": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "3": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "4": [
+      1,
+      2,
+      5,
+      7
+    ],
+    "5": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "6": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "7": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "8": [
+      0,
+      2,
+      5,
+      6
+    ]
+  },
+  "status": "BOOTSTRAP_T12_81_3_ESCAPE_TWO_ROW_DROP_SCAN_DIAGNOSTIC_ONLY",
+  "summary": {
+    "also_replaced_row_centers": [
+      3,
+      6
+    ],
+    "candidate_count": 4116000,
+    "center_3_connector_avoiding_class_count": 8,
+    "center_6_supply_class_count": 5,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "dropped_pair_count": 21,
+    "dropped_row_replacement_count_per_center": 70,
+    "rejection_category_counts": {
+      "crossing": 2393,
+      "row_pair+crossing": 1476,
+      "row_pair+witness_pair": 59,
+      "row_pair+witness_pair+crossing": 4074937,
+      "witness_pair+crossing": 37135
+    },
+    "remaining_gap": "This does not rule out escape mechanisms that move three or more of the other source-81 rows, use richer catalogues than one replacement class at centers 3 and 6, or require additional minimal/rich-class hypotheses.",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP",
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "surviving_candidate_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3",
+    "two_row_drop_centers": [
+      0,
+      1,
+      2,
+      4,
+      5,
+      7,
+      8
+    ]
+  },
+  "survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-escape-two-row-drop.md
+++ b/docs/bootstrap-t12-81-3-escape-two-row-drop.md
@@ -1,0 +1,106 @@
+# Bootstrap T12 81:3 Two-Row-Drop Escape Scan
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet is the next relaxation after
+`docs/bootstrap-t12-81-3-escape-one-row-drop.md`. That scan allowed any one of
+the seven source-`81` rows outside centers `3` and `6` to move. Here we allow
+any two of those seven rows to move, one dropped pair at a time.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json`.
+
+## Scan Scope
+
+For each dropped pair from
+
+```text
+0,1,2,4,5,7,8
+```
+
+the scan enumerates all
+
+```text
+70 * 70
+```
+
+possible replacement selected-row pairs. It also uses the same replacement
+space as the previous escape-candidate scans:
+
+```text
+5
+```
+
+possible center-`6` supply classes containing deletion seed `[0,1,4]`, and
+
+```text
+8
+```
+
+possible connector-avoiding center-`3` classes using either `[0,4,6]` or
+`[1,4,6]`.
+
+So there are:
+
+```text
+21 * 70 * 70 * 5 * 8 = 4116000
+```
+
+two-row-drop candidates.
+
+## Result
+
+All `4116000` candidates fail the basic exact incidence/crossing filters:
+
+```text
+surviving candidates: 0
+```
+
+The aggregate rejection counts are:
+
+```text
+crossing: 2393
+row_pair+crossing: 1476
+row_pair+witness_pair: 59
+row_pair+witness_pair+crossing: 4074937
+witness_pair+crossing: 37135
+```
+
+Thus the checked scan status is:
+
+```text
+NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP
+```
+
+## Remaining Gap
+
+This is still not a bridge proof. It only rules out this finite relaxed escape
+model:
+
+```text
+drop exactly two preserved non-3/non-6 source-81 rows,
+replace row 6 by one pre-3 supply class,
+replace row 3 by one connector-avoiding class.
+```
+
+It does not rule out escape mechanisms that move three or more of the other
+source-`81` rows, use more than one replacement class at centers `3` or `6`, or
+depend on additional minimal/rich-class hypotheses not included in this scan.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining diagnostic
+that narrows one concrete escape route.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -583,6 +583,14 @@ under the basic row-pair, witness-pair, and crossing filters. This remains a
 finite proof-mining diagnostic only, not a proof of row forcing, `n=9`, the
 bootstrap bridge, or Erdos Problem #97.
 
+The two-row-drop follow-up in
+`docs/bootstrap-t12-81-3-escape-two-row-drop.md` allows any pair of those seven
+preserved rows to move as arbitrary 4-sets while also replacing centers `3`
+and `6` as above. It checks `4116000` candidates and again finds no survivor
+under the same basic filters. This remains a finite proof-mining diagnostic
+only, not a proof of row forcing, `n=9`, the bootstrap bridge, or Erdos
+Problem #97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -98,7 +98,11 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-escape-one-row-drop.md` then allows any one of
    those seven preserved rows to move as an arbitrary 4-set. All `19600`
    candidates still fail the basic row-pair, witness-pair, or crossing
-   filters. The next useful PR must either relax two or more of those seven
+   filters.
+   The two-row-drop scan in
+   `docs/bootstrap-t12-81-3-escape-two-row-drop.md` allows any pair of those
+   seven rows to move. All `4116000` candidates still fail the same basic
+   filters. The next useful PR must either relax three or more of those seven
    rows at once, introduce a stronger genuine rich-class/minimality hypothesis
    that justifies preserving enough rows, or move to a different bridge target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,6 +179,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-escape-one-row-drop.md`](bootstrap-t12-81-3-escape-one-row-drop.md):
   one-row-drop relaxation allowing one additional source-`81` row to move
   while checking the same escape route.
+- [`bootstrap-t12-81-3-escape-two-row-drop.md`](bootstrap-t12-81-3-escape-two-row-drop.md):
+  two-row-drop relaxation allowing a pair of additional source-`81` rows to
+  move while checking the same escape route.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -228,6 +228,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_escape_one_row_drop.json"
       verifier: "scripts/check_bootstrap_t12_81_3_escape_one_row_drop.py"
       claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; for each of the seven source-81 rows outside centers 3 and 6, allows that one row to move as an arbitrary 4-set and rules out 19600 candidates by basic incidence/crossing filters, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_escape_two_row_drop"
+      status: "two-row-drop replacement scan for the 81:3 pre-3 label-6 escape"
+      artifact: "data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py"
+      claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; for each pair of the seven source-81 rows outside centers 3 and 6, allows both rows to move as arbitrary 4-sets and rules out 4116000 candidates by basic incidence/crossing filters, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2970,6 +2970,88 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_escape_two_row_drop
+    path: data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py
+    command: python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py
+    check_command: python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Two-row-drop relaxation of the 81:3 escape-candidate scan; all 4116000 candidates fail basic incidence/crossing filters, but this is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_escape_two_row_drop.v1
+      status: BOOTSTRAP_T12_81_3_ESCAPE_TWO_ROW_DROP_SCAN_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.two_row_drop_centers:
+        - 0
+        - 1
+        - 2
+        - 4
+        - 5
+        - 7
+        - 8
+      summary.also_replaced_row_centers:
+        - 3
+        - 6
+      summary.center_6_supply_class_count: 5
+      summary.center_3_connector_avoiding_class_count: 8
+      summary.dropped_pair_count: 21
+      summary.dropped_row_replacement_count_per_center: 70
+      summary.candidate_count: 4116000
+      summary.surviving_candidate_count: 0
+      summary.rejection_category_counts.crossing: 2393
+      summary.rejection_category_counts.row_pair+crossing: 1476
+      summary.rejection_category_counts.row_pair+witness_pair: 59
+      summary.rejection_category_counts.row_pair+witness_pair+crossing: 4074937
+      summary.rejection_category_counts.witness_pair+crossing: 37135
+      summary.scan_status: NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP
+      source_one_row_drop_scan.schema: erdos97.bootstrap_t12_81_3_escape_one_row_drop.v1
+      source_one_row_drop_scan.scan_status: NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_ONE_OTHER_SOURCE81_ROW_DROPS
+      provenance.generator: scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the two-row-drop scan proves genuine rich-class order
+      - the two-row-drop scan proves no pre-3 label-6 supply exists
+      - the two-row-drop scan proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py
+++ b/scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 two-row-drop escape scan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_escape_two_row_drop_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 two-row-drop escape scan")
+    print(f"candidate count: {summary['candidate_count']}")
+    print(f"survivors: {summary['surviving_candidate_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_escape_two_row_drop_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 two-row-drop artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 two-row-drop expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_escape_two_row_drop.py
+++ b/src/erdos97/bootstrap_t12_81_3_escape_two_row_drop.py
@@ -1,0 +1,527 @@
+"""Two-row-drop scan for the bootstrap/T12 81:3 escape.
+
+This packet relaxes the 81:3 escape-candidate neighborhood one step beyond the
+one-row-drop scan.  For each pair of source-81 rows outside centers 3 and 6, it
+allows both rows to be replaced by arbitrary 4-sets while also replacing
+centers 3 and 6 as in the escape-candidate scan.
+
+The scan uses only selected-row incidence and cyclic crossing filters.  It is a
+proof-mining diagnostic, not a Euclidean realizability theorem and not a proof
+of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    _base_selected_rows,
+    _center_3_connector_avoiding_classes,
+    _supply_classes,
+)
+from erdos97.bootstrap_t12_81_3_escape_one_row_drop import (
+    DEFAULT_ARTIFACT as ONE_ROW_DROP_ARTIFACT,
+    SCAN_STATUS as ONE_ROW_DROP_SCAN_STATUS,
+    SCHEMA as ONE_ROW_DROP_SCHEMA,
+    STATUS as ONE_ROW_DROP_STATUS,
+)
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    PRESERVED_ROW_CENTERS,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_escape_two_row_drop.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ESCAPE_TWO_ROW_DROP_SCAN_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP"
+CLAIM_SCOPE = (
+    "Two-row-drop relaxation of the 81:3 escape-candidate scan. For each pair "
+    "of the seven source-81 rows outside centers 3 and 6, it allows both rows "
+    "to be replaced by arbitrary 4-sets while also replacing centers 3 and 6 "
+    "by one candidate class each. All 4,116,000 candidates fail row-pair, "
+    "witness-pair, or crossing filters. This is not a proof of genuine "
+    "rich-class order, not a proof of row forcing, not a proof of n=9, not a "
+    "proof of the bridge, and not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_escape_two_row_drop.json"
+)
+
+N = len(CYCLIC_ORDER)
+LABELS = list(CYCLIC_ORDER)
+ALL_PAIRS = list(combinations(LABELS, 2))
+REPLACED_ROW_CENTERS = [TARGET_ROW_CENTER, SUPPLY_CENTER]
+EXPECTED_REJECTION_COUNTS = {
+    "crossing": 2393,
+    "row_pair+crossing": 1476,
+    "row_pair+witness_pair": 59,
+    "row_pair+witness_pair+crossing": 4074937,
+    "witness_pair+crossing": 37135,
+}
+EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS = {
+    "0,1": {
+        "crossing": 58,
+        "row_pair+crossing": 48,
+        "row_pair+witness_pair+crossing": 194506,
+        "witness_pair+crossing": 1388,
+    },
+    "0,2": {
+        "crossing": 58,
+        "row_pair+crossing": 54,
+        "row_pair+witness_pair+crossing": 194287,
+        "witness_pair+crossing": 1601,
+    },
+    "0,4": {
+        "crossing": 99,
+        "row_pair+crossing": 9,
+        "row_pair+witness_pair+crossing": 193975,
+        "witness_pair+crossing": 1917,
+    },
+    "0,5": {
+        "crossing": 71,
+        "row_pair+crossing": 62,
+        "row_pair+witness_pair+crossing": 193649,
+        "witness_pair+crossing": 2218,
+    },
+    "0,7": {
+        "crossing": 150,
+        "row_pair+crossing": 68,
+        "row_pair+witness_pair+crossing": 193416,
+        "witness_pair+crossing": 2366,
+    },
+    "0,8": {
+        "crossing": 65,
+        "row_pair+crossing": 37,
+        "row_pair+witness_pair+crossing": 193911,
+        "witness_pair+crossing": 1987,
+    },
+    "1,2": {
+        "crossing": 59,
+        "row_pair+crossing": 84,
+        "row_pair+witness_pair+crossing": 194566,
+        "witness_pair+crossing": 1291,
+    },
+    "1,4": {
+        "crossing": 83,
+        "row_pair+crossing": 41,
+        "row_pair+witness_pair+crossing": 194919,
+        "witness_pair+crossing": 957,
+    },
+    "1,5": {
+        "crossing": 103,
+        "row_pair+crossing": 71,
+        "row_pair+witness_pair+crossing": 194332,
+        "witness_pair+crossing": 1494,
+    },
+    "1,7": {
+        "crossing": 131,
+        "row_pair+crossing": 14,
+        "row_pair+witness_pair+crossing": 193330,
+        "witness_pair+crossing": 2525,
+    },
+    "1,8": {
+        "crossing": 111,
+        "row_pair+crossing": 118,
+        "row_pair+witness_pair+crossing": 194223,
+        "witness_pair+crossing": 1548,
+    },
+    "2,4": {
+        "crossing": 45,
+        "row_pair+crossing": 86,
+        "row_pair+witness_pair+crossing": 194912,
+        "witness_pair+crossing": 957,
+    },
+    "2,5": {
+        "crossing": 43,
+        "row_pair+crossing": 44,
+        "row_pair+witness_pair": 9,
+        "row_pair+witness_pair+crossing": 194869,
+        "witness_pair+crossing": 1035,
+    },
+    "2,7": {
+        "crossing": 374,
+        "row_pair+crossing": 95,
+        "row_pair+witness_pair": 10,
+        "row_pair+witness_pair+crossing": 191823,
+        "witness_pair+crossing": 3698,
+    },
+    "2,8": {
+        "crossing": 88,
+        "row_pair+crossing": 11,
+        "row_pair+witness_pair+crossing": 193986,
+        "witness_pair+crossing": 1915,
+    },
+    "4,5": {
+        "crossing": 27,
+        "row_pair+crossing": 77,
+        "row_pair+witness_pair+crossing": 195359,
+        "witness_pair+crossing": 537,
+    },
+    "4,7": {
+        "crossing": 151,
+        "row_pair+crossing": 43,
+        "row_pair+witness_pair+crossing": 194071,
+        "witness_pair+crossing": 1735,
+    },
+    "4,8": {
+        "crossing": 215,
+        "row_pair+crossing": 133,
+        "row_pair+witness_pair": 31,
+        "row_pair+witness_pair+crossing": 193524,
+        "witness_pair+crossing": 2097,
+    },
+    "5,7": {
+        "crossing": 114,
+        "row_pair+crossing": 163,
+        "row_pair+witness_pair+crossing": 193914,
+        "witness_pair+crossing": 1809,
+    },
+    "5,8": {
+        "crossing": 74,
+        "row_pair+crossing": 59,
+        "row_pair+witness_pair": 9,
+        "row_pair+witness_pair+crossing": 194476,
+        "witness_pair+crossing": 1382,
+    },
+    "7,8": {
+        "crossing": 274,
+        "row_pair+crossing": 159,
+        "row_pair+witness_pair+crossing": 192889,
+        "witness_pair+crossing": 2678,
+    },
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _row_mask(row: Iterable[int]) -> int:
+    mask = 0
+    for label in row:
+        mask |= 1 << int(label)
+    return mask
+
+
+def _mask_to_row(mask: int) -> list[int]:
+    return [label for label in LABELS if (mask >> label) & 1]
+
+
+def _all_replacement_row_masks(center: int) -> list[int]:
+    labels = [label for label in LABELS if label != center]
+    return [_row_mask(row) for row in combinations(labels, 4)]
+
+
+def _between_cyclic(a: int, x: int, b: int) -> bool:
+    if a < b:
+        return a < x < b
+    return x > a or x < b
+
+
+def _crosses_pair(i: int, j: int, a: int, b: int) -> bool:
+    if len({i, j, a, b}) < 4:
+        return False
+    return (
+        _between_cyclic(i, a, j) != _between_cyclic(i, b, j)
+        and _between_cyclic(a, i, b) != _between_cyclic(a, j, b)
+    )
+
+
+PAIR_INDEX = {pair: index for index, pair in enumerate(ALL_PAIRS)}
+MASK_TO_PAIR_INDEX = {
+    (1 << a) | (1 << b): PAIR_INDEX[(a, b)] for a, b in ALL_PAIRS
+}
+CROSS_OK = {
+    (i, j, PAIR_INDEX[(a, b)]): _crosses_pair(i, j, a, b)
+    for i, j in ALL_PAIRS
+    for a, b in ALL_PAIRS
+}
+ROW_PAIR_INDICES = {
+    row_mask: [
+        PAIR_INDEX[(a, b)]
+        for a, b in combinations(_mask_to_row(row_mask), 2)
+    ]
+    for row_mask in [_row_mask(row) for row in combinations(LABELS, 4)]
+}
+
+
+def _scan_candidate_category(row_masks: Sequence[int]) -> str:
+    row_pair_violation = False
+    crossing_violation = False
+    for i, j in ALL_PAIRS:
+        intersection = row_masks[i] & row_masks[j]
+        intersection_size = intersection.bit_count()
+        if intersection_size > 2:
+            row_pair_violation = True
+        elif intersection_size == 2:
+            pair_index = MASK_TO_PAIR_INDEX[intersection]
+            if not CROSS_OK[(i, j, pair_index)]:
+                crossing_violation = True
+
+    witness_pair_violation = False
+    pair_counts = [0] * len(ALL_PAIRS)
+    for row_mask in row_masks:
+        for pair_index in ROW_PAIR_INDICES[row_mask]:
+            pair_counts[pair_index] += 1
+            if pair_counts[pair_index] > 2:
+                witness_pair_violation = True
+
+    rejection_reasons = []
+    if row_pair_violation:
+        rejection_reasons.append("row_pair")
+    if witness_pair_violation:
+        rejection_reasons.append("witness_pair")
+    if crossing_violation:
+        rejection_reasons.append("crossing")
+    return "+".join(rejection_reasons) if rejection_reasons else "survive"
+
+
+def _scan_candidates(base_rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    base_masks = [_row_mask(row) for row in base_rows]
+    supply_masks = [_row_mask(row) for row in _supply_classes()]
+    center_3_masks = [
+        _row_mask(_int_list(record["rich_class"]))
+        for record in _center_3_connector_avoiding_classes()
+    ]
+    replacement_masks = {
+        center: _all_replacement_row_masks(center) for center in PRESERVED_ROW_CENTERS
+    }
+
+    total_counts: Counter[str] = Counter()
+    dropped_pair_summaries: list[dict[str, object]] = []
+    survivors: list[dict[str, object]] = []
+
+    for dropped_a, dropped_b in combinations(PRESERVED_ROW_CENTERS, 2):
+        dropped_counts: Counter[str] = Counter()
+        for supply_mask in supply_masks:
+            for center_3_mask in center_3_masks:
+                base_candidate = list(base_masks)
+                base_candidate[SUPPLY_CENTER] = supply_mask
+                base_candidate[TARGET_ROW_CENTER] = center_3_mask
+                for row_a in replacement_masks[dropped_a]:
+                    candidate_a = list(base_candidate)
+                    candidate_a[dropped_a] = row_a
+                    for row_b in replacement_masks[dropped_b]:
+                        row_masks = list(candidate_a)
+                        row_masks[dropped_b] = row_b
+                        category = _scan_candidate_category(row_masks)
+                        dropped_counts[category] += 1
+                        total_counts[category] += 1
+                        if category == "survive":
+                            survivors.append(
+                                {
+                                    "dropped_centers": [dropped_a, dropped_b],
+                                    "dropped_center_classes": {
+                                        str(dropped_a): _mask_to_row(row_a),
+                                        str(dropped_b): _mask_to_row(row_b),
+                                    },
+                                    "supply_center_class": _mask_to_row(supply_mask),
+                                    "target_center_class": _mask_to_row(center_3_mask),
+                                }
+                            )
+
+        dropped_pair_summaries.append(
+            {
+                "dropped_centers": [dropped_a, dropped_b],
+                "source_rows": {
+                    str(dropped_a): list(base_rows[dropped_a]),
+                    str(dropped_b): list(base_rows[dropped_b]),
+                },
+                "replacement_row_count_per_center": 70,
+                "candidate_count": sum(dropped_counts.values()),
+                "surviving_candidate_count": dropped_counts.get("survive", 0),
+                "rejection_category_counts": dict(sorted(dropped_counts.items())),
+            }
+        )
+
+    return {
+        "candidate_count": sum(total_counts.values()),
+        "survivors": survivors,
+        "rejection_category_counts": dict(sorted(total_counts.items())),
+        "per_dropped_pair": dropped_pair_summaries,
+    }
+
+
+def build_t12_81_3_escape_two_row_drop_payload() -> dict[str, object]:
+    """Return the deterministic two-row-drop escape scan."""
+
+    base_rows = _base_selected_rows()
+    scan = _scan_candidates(base_rows)
+    survivors = scan["survivors"]
+    if not isinstance(survivors, Sequence):
+        raise AssertionError("survivors must be a sequence")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This scan drops exactly two of the seven source-81 rows that were preserved in the original escape-candidate scan.",
+            "Rows 3 and 6 are also replaced by one candidate rich class each, as in the previous scans.",
+            "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "two_row_drop_centers": PRESERVED_ROW_CENTERS,
+            "also_replaced_row_centers": REPLACED_ROW_CENTERS,
+            "center_6_supply_class_count": len(_supply_classes()),
+            "center_3_connector_avoiding_class_count": len(
+                _center_3_connector_avoiding_classes()
+            ),
+            "dropped_pair_count": len(list(combinations(PRESERVED_ROW_CENTERS, 2))),
+            "dropped_row_replacement_count_per_center": 70,
+            "candidate_count": scan["candidate_count"],
+            "surviving_candidate_count": len(survivors),
+            "rejection_category_counts": scan["rejection_category_counts"],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not rule out escape mechanisms that move three or "
+                "more of the other source-81 rows, use richer catalogues than "
+                "one replacement class at centers 3 and 6, or require "
+                "additional minimal/rich-class hypotheses."
+            ),
+        },
+        "source_rows": {str(center): base_rows[center] for center in CYCLIC_ORDER},
+        "candidate_generation": {
+            "center_6_supply_classes": _supply_classes(),
+            "center_3_connector_avoiding_classes": _center_3_connector_avoiding_classes(),
+            "dropped_row_choice_count_per_center": {
+                str(center): len(_all_replacement_row_masks(center))
+                for center in PRESERVED_ROW_CENTERS
+            },
+        },
+        "per_dropped_pair": scan["per_dropped_pair"],
+        "survivors": survivors,
+        "source_one_row_drop_scan": {
+            "path": ONE_ROW_DROP_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": ONE_ROW_DROP_SCHEMA,
+            "status": ONE_ROW_DROP_STATUS,
+            "scan_status": ONE_ROW_DROP_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "two_row_drop_centers": PRESERVED_ROW_CENTERS,
+        "also_replaced_row_centers": REPLACED_ROW_CENTERS,
+        "center_6_supply_class_count": 5,
+        "center_3_connector_avoiding_class_count": 8,
+        "dropped_pair_count": 21,
+        "dropped_row_replacement_count_per_center": 70,
+        "candidate_count": 4116000,
+        "surviving_candidate_count": 0,
+        "rejection_category_counts": EXPECTED_REJECTION_COUNTS,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    per_dropped = payload.get("per_dropped_pair")
+    if not isinstance(per_dropped, Sequence) or len(per_dropped) != 21:
+        raise AssertionError("expected 21 dropped-pair summaries")
+    for record in per_dropped:
+        if not isinstance(record, Mapping):
+            raise AssertionError("dropped-pair summaries must be mappings")
+        centers = record.get("dropped_centers")
+        if not isinstance(centers, Sequence) or len(centers) != 2:
+            raise AssertionError("dropped_centers must be a pair")
+        key = f"{centers[0]},{centers[1]}"
+        if key not in EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS:
+            raise AssertionError(f"unexpected dropped pair {key!r}")
+        if record.get("replacement_row_count_per_center") != 70:
+            raise AssertionError(f"dropped pair {key!r} has bad row count")
+        if record.get("candidate_count") != 196000:
+            raise AssertionError(f"dropped pair {key!r} has bad candidate count")
+        if record.get("surviving_candidate_count") != 0:
+            raise AssertionError(f"dropped pair {key!r} should have no survivors")
+        expected_counts = EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS[key]
+        if record.get("rejection_category_counts") != expected_counts:
+            raise AssertionError(f"dropped pair {key!r} rejection counts drifted")
+
+    survivors = payload.get("survivors")
+    if survivors != []:
+        raise AssertionError("survivors must be empty")
+
+    source = payload.get("source_one_row_drop_scan")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_one_row_drop_scan must be a mapping")
+    if source.get("schema") != ONE_ROW_DROP_SCHEMA:
+        raise AssertionError("source one-row-drop schema drifted")
+    if source.get("scan_status") != ONE_ROW_DROP_SCAN_STATUS:
+        raise AssertionError("source one-row-drop scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_escape_two_row_drop.py
+++ b/tests/test_bootstrap_t12_81_3_escape_two_row_drop.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    _base_selected_rows,
+    _candidate_records,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import (
+    DEFAULT_ARTIFACT,
+    EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS,
+    EXPECTED_REJECTION_COUNTS,
+    SCAN_STATUS,
+    SUPPLY_CENTER,
+    TARGET_ROW_CENTER,
+    _row_mask,
+    _scan_candidate_category,
+    assert_expected_payload,
+    build_t12_81_3_escape_two_row_drop_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_escape_two_row_drop_payload()
+
+
+def test_81_3_two_row_drop_counts_and_scope(payload: dict[str, object]) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_ESCAPE_TWO_ROW_DROP_SCAN_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Two-row-drop" in claim_scope
+    assert "All 4,116,000 candidates fail" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_two_row_drop_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["two_row_drop_centers"] == [0, 1, 2, 4, 5, 7, 8]
+    assert summary["also_replaced_row_centers"] == [3, 6]
+    assert summary["center_6_supply_class_count"] == 5
+    assert summary["center_3_connector_avoiding_class_count"] == 8
+    assert summary["dropped_pair_count"] == 21
+    assert summary["dropped_row_replacement_count_per_center"] == 70
+    assert summary["candidate_count"] == 4116000
+    assert summary["surviving_candidate_count"] == 0
+    assert summary["rejection_category_counts"] == EXPECTED_REJECTION_COUNTS
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_two_row_drop_per_pair_counts(payload: dict[str, object]) -> None:
+    per_dropped = payload["per_dropped_pair"]
+
+    assert len(per_dropped) == 21
+    for record in per_dropped:
+        key = ",".join(str(center) for center in record["dropped_centers"])
+        assert record["replacement_row_count_per_center"] == 70
+        assert record["candidate_count"] == 196000
+        assert record["surviving_candidate_count"] == 0
+        assert (
+            record["rejection_category_counts"]
+            == EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS[key]
+        )
+
+
+def test_81_3_two_row_drop_fast_filter_matches_reference_one_row_scan() -> None:
+    base_rows = _base_selected_rows()
+    records = _candidate_records(base_rows)
+
+    for record in records:
+        rows = [list(row) for row in base_rows]
+        rows[SUPPLY_CENTER] = record["supply_class"]
+        rows[TARGET_ROW_CENTER] = record["target_center_class"]
+        category = _scan_candidate_category([_row_mask(row) for row in rows])
+        assert category == record["rejection_category"]
+
+
+def test_81_3_two_row_drop_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_two_row_drop_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_candidate_count"] == 0
+
+
+def test_81_3_two_row_drop_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_candidate_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_candidate_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add an optimized generator-backed two-row-drop relaxation for the `81:3` pre-3 label-6 escape scan
- enumerate `21 * 70 * 70 * 5 * 8 = 4,116,000` candidates while allowing any pair of the seven non-3/non-6 source-81 rows to move
- record zero basic row-pair, witness-pair, or crossing survivors as a review-pending diagnostic only
- update the ledgers, manifest, and docs without changing the global/open or strongest local finite-case status

## Verification

- `python scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_escape_two_row_drop.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`782 passed, 285 deselected`)