### PR TITLE
Add 81:3 full-neighborhood escape CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ This repository is a public research log and reproducibility workspace for Erdő
   appears only after center `3` in the fixed singleton-rich closure, read
   [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
 - For the relaxed `81:3` escape-candidate scans, which replace centers `3`
-  and `6` and then allow one or two other source-`81` rows to move, read
+  and `6` and then allow one, two, or all other source-`81` rows to move, read
   [`docs/bootstrap-t12-81-3-escape-candidates.md`](docs/bootstrap-t12-81-3-escape-candidates.md)
   and
   [`docs/bootstrap-t12-81-3-escape-one-row-drop.md`](docs/bootstrap-t12-81-3-escape-one-row-drop.md),
   then
-  [`docs/bootstrap-t12-81-3-escape-two-row-drop.md`](docs/bootstrap-t12-81-3-escape-two-row-drop.md).
+  [`docs/bootstrap-t12-81-3-escape-two-row-drop.md`](docs/bootstrap-t12-81-3-escape-two-row-drop.md)
+  and
+  [`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`](docs/bootstrap-t12-81-3-escape-full-neighborhood.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -310,6 +310,17 @@ a proof of genuine rich-class order, `n=9`, or the bootstrap bridge; see
 `scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py`, and
 `data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json`.
 
+The full-neighborhood CSP then lets all seven source-`81` rows outside centers
+`3` and `6` move at once, while keeping the same one-class replacement spaces
+at centers `3` and `6`. The implicit space has `329417200000000` assignments.
+Exact backtracking with the basic row-pair, witness-pair, and crossing filters
+visits `1177` search nodes and finds no complete assignment. This subsumes the
+one- and two-row fixed-neighborhood stress tests, but remains a diagnostic
+only: it is not a proof of genuine rich-class order, `n=9`, or the bootstrap
+bridge; see `docs/bootstrap-t12-81-3-escape-full-neighborhood.md`,
+`scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py`, and
+`data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -163,11 +163,16 @@ basic incidence/crossing candidate. The one-row-drop scan then allows any one
 of those seven preserved rows to move as an arbitrary 4-set; all `19600`
 candidates again fail the basic filters. The two-row-drop scan allows any pair
 of those seven rows to move and all `4116000` candidates fail as well. This is
-still proof-mining bookkeeping only, not a theorem about all genuine
-rich-class catalogues. See
+now subsumed by a full-neighborhood CSP: with centers `3` and `6` still using
+the same one-class replacement spaces, all seven other source-`81` rows may be
+arbitrary 4-sets, and the exact backtracker finds no complete basic-filter
+assignment in the implicit `329417200000000`-assignment space. This is still
+proof-mining bookkeeping only, not a theorem about all genuine rich-class
+catalogues. See
 `docs/bootstrap-t12-81-3-escape-candidates.md` and
 `docs/bootstrap-t12-81-3-escape-one-row-drop.md`, plus
-`docs/bootstrap-t12-81-3-escape-two-row-drop.md`.
+`docs/bootstrap-t12-81-3-escape-two-row-drop.md` and
+`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`.
 
 ## New exact fixed-pattern obstructions
 

--- a/data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json
+++ b/data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json
@@ -1,0 +1,1367 @@
+{
+  "candidate_generation": {
+    "center_3_connector_avoiding_classes": [
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          0,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          0,
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          1,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          1,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          1,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          1,
+          4,
+          6,
+          8
+        ]
+      }
+    ],
+    "center_6_supply_classes": [
+      [
+        0,
+        1,
+        2,
+        4
+      ],
+      [
+        0,
+        1,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        8
+      ]
+    ],
+    "free_row_choice_count_per_center": {
+      "0": 70,
+      "1": 70,
+      "2": 70,
+      "4": 70,
+      "5": 70,
+      "7": 70,
+      "8": 70
+    }
+  },
+  "claim_scope": "Full-neighborhood CSP relaxation of the 81:3 escape-candidate scan. The search keeps the one-class replacement spaces at centers 3 and 6, but allows all seven source-81 rows outside centers 3 and 6 to be arbitrary 4-sets. The implicit space has 329,417,200,000,000 assignments, and exact backtracking proves none satisfy the row-pair, witness-pair, and crossing filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "fixed_pair_summaries": [
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 12,
+      "empty_domain_depth_histogram": {
+        "2": 10,
+        "3": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 21,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 10,
+        "3": 6,
+        "4": 1,
+        "5": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 10,
+        "3": 6,
+        "4": 1,
+        "5": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 12,
+      "empty_domain_depth_histogram": {
+        "2": 10,
+        "3": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 21,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 17,
+      "empty_domain_depth_histogram": {
+        "2": 10,
+        "3": 7
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 30,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "2": 10,
+        "3": 9,
+        "4": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 34,
+      "supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 8,
+        "3": 10
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 33,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 12,
+      "empty_domain_depth_histogram": {
+        "2": 9,
+        "3": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 22,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 17,
+      "empty_domain_depth_histogram": {
+        "2": 11,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 29,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 17,
+      "empty_domain_depth_histogram": {
+        "2": 11,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 29,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 16,
+      "empty_domain_depth_histogram": {
+        "2": 8,
+        "3": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 31,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 12,
+      "empty_domain_depth_histogram": {
+        "2": 9,
+        "3": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 22,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 17,
+      "empty_domain_depth_histogram": {
+        "2": 11,
+        "3": 3,
+        "4": 2,
+        "5": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 11,
+        "3": 3,
+        "4": 3,
+        "5": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 35,
+      "supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 42,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 14,
+        "3": 13,
+        "4": 12
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 75,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 10,
+      "empty_domain_depth_histogram": {
+        "1": 4,
+        "2": 4,
+        "3": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 15,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 37,
+      "empty_domain_depth_histogram": {
+        "1": 5,
+        "2": 21,
+        "3": 11
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 51,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 44,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 12,
+        "3": 15,
+        "4": 11,
+        "5": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 81,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 11,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 4,
+        "3": 3,
+        "4": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 20,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 39,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 25,
+        "3": 11
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 56,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 36,
+      "empty_domain_depth_histogram": {
+        "2": 8,
+        "3": 11,
+        "4": 4,
+        "5": 12,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 71,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 8,
+        "3": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 27,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 17,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 10,
+        "3": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 23,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 32,
+      "empty_domain_depth_histogram": {
+        "2": 8,
+        "3": 10,
+        "4": 4,
+        "5": 5,
+        "6": 5
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 71,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 29,
+      "empty_domain_depth_histogram": {
+        "2": 14,
+        "3": 14,
+        "4": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 45,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 23,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 16,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 32,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 24,
+      "empty_domain_depth_histogram": {
+        "2": 8,
+        "3": 3,
+        "4": 12,
+        "5": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 51,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 15,
+      "empty_domain_depth_histogram": {
+        "1": 3,
+        "2": 8,
+        "3": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 21,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 14,
+      "empty_domain_depth_histogram": {
+        "1": 4,
+        "2": 6,
+        "3": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 19,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 24,
+      "empty_domain_depth_histogram": {
+        "2": 8,
+        "3": 3,
+        "4": 13
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 50,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 24,
+      "empty_domain_depth_histogram": {
+        "2": 16,
+        "3": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 35,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "1": 2,
+        "2": 12,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 28,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ]
+    },
+    {
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ]
+    }
+  ],
+  "interpretation_warnings": [
+    "This CSP keeps the one-class replacement spaces at centers 3 and 6.",
+    "All seven source-81 rows outside centers 3 and 6 may move as arbitrary selected 4-sets.",
+    "The CSP uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_escape_full_neighborhood.v1",
+  "source_two_row_drop_scan": {
+    "path": "data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP",
+    "schema": "erdos97.bootstrap_t12_81_3_escape_two_row_drop.v1",
+    "status": "BOOTSTRAP_T12_81_3_ESCAPE_TWO_ROW_DROP_SCAN_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_ESCAPE_FULL_NEIGHBORHOOD_CSP_DIAGNOSTIC_ONLY",
+  "summary": {
+    "center_3_connector_avoiding_class_count": 8,
+    "center_6_supply_class_count": 5,
+    "complete_solution_count": 0,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "empty_domain_count": 684,
+    "fixed_replacement_pair_count": 40,
+    "fixed_replacement_row_centers": [
+      3,
+      6
+    ],
+    "free_row_centers": [
+      0,
+      1,
+      2,
+      4,
+      5,
+      7,
+      8
+    ],
+    "free_row_replacement_count_per_center": 70,
+    "implicit_assignment_space_size": 329417200000000,
+    "initial_fixed_pair_incompatible_count": 8,
+    "initial_fixed_pair_searched_count": 32,
+    "remaining_gap": "This does not rule out richer catalogues than one replacement class at centers 3 and 6, multiple simultaneous rich classes per center, or additional minimal/rich-class hypotheses.",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WHEN_ALL_OTHER_SOURCE81_ROWS_MOVE",
+    "search_node_count": 1177,
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "surviving_assignment_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-escape-full-neighborhood.md
+++ b/docs/bootstrap-t12-81-3-escape-full-neighborhood.md
@@ -1,0 +1,104 @@
+# Bootstrap T12 81:3 Full-Neighborhood Escape CSP
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet is the next relaxation after
+`docs/bootstrap-t12-81-3-escape-two-row-drop.md`. The earlier scans allowed
+one or two of the seven source-`81` rows outside centers `3` and `6` to move.
+Here all seven of those rows may move at once.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json`.
+
+## Scan Scope
+
+The scan keeps the same replacement space at centers `3` and `6`:
+
+```text
+5
+```
+
+possible center-`6` supply classes containing deletion seed `[0,1,4]`, and
+
+```text
+8
+```
+
+possible connector-avoiding center-`3` classes using either `[0,4,6]` or
+`[1,4,6]`.
+
+For every fixed pair of such classes, the seven remaining row centers
+
+```text
+0,1,2,4,5,7,8
+```
+
+may each choose any of their
+
+```text
+70
+```
+
+possible selected 4-sets. The implicit assignment space is therefore:
+
+```text
+5 * 8 * 70^7 = 329417200000000
+```
+
+The checker does not enumerate this space naively. It uses exact backtracking
+with row-pair, witness-pair, and cyclic crossing filters as pruning rules.
+
+## Result
+
+The full-neighborhood CSP has no complete assignment satisfying the basic
+filters:
+
+```text
+surviving assignments: 0
+```
+
+The checked scan status is:
+
+```text
+NO_BASIC_FILTER_SURVIVORS_WHEN_ALL_OTHER_SOURCE81_ROWS_MOVE
+```
+
+The deterministic backtracking summary is:
+
+```text
+fixed replacement pairs: 40
+initial fixed-pair incompatible: 8
+initial fixed-pair searched: 32
+search nodes: 1177
+empty domains: 684
+complete solutions: 0
+```
+
+## Remaining Gap
+
+This is still not a bridge proof. It rules out the finite relaxed escape model
+where centers `3` and `6` each receive one replacement class from the specified
+spaces, and the other seven source-`81` rows are arbitrary selected 4-sets.
+
+It does not rule out richer catalogues that use multiple simultaneous rich
+classes per center, replacement classes outside the specified center-`3` and
+center-`6` spaces, or additional minimal/rich-class hypotheses not included in
+this scan.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining diagnostic
+that narrows one concrete escape route.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -591,6 +591,15 @@ under the same basic filters. This remains a finite proof-mining diagnostic
 only, not a proof of row forcing, `n=9`, the bootstrap bridge, or Erdos
 Problem #97.
 
+The full-neighborhood CSP in
+`docs/bootstrap-t12-81-3-escape-full-neighborhood.md` allows all seven of those
+rows to move simultaneously while keeping the same one-class replacement
+spaces at centers `3` and `6`. It proves by exact backtracking that the
+implicit `329417200000000`-assignment space has no complete assignment
+satisfying the same basic filters. This remains a finite proof-mining
+diagnostic only, not a proof of row forcing, `n=9`, the bootstrap bridge, or
+Erdos Problem #97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -102,9 +102,15 @@ Use this queue when no more specific issue is selected.
    The two-row-drop scan in
    `docs/bootstrap-t12-81-3-escape-two-row-drop.md` allows any pair of those
    seven rows to move. All `4116000` candidates still fail the same basic
-   filters. The next useful PR must either relax three or more of those seven
-   rows at once, introduce a stronger genuine rich-class/minimality hypothesis
-   that justifies preserving enough rows, or move to a different bridge target.
+   filters.
+   The full-neighborhood CSP in
+   `docs/bootstrap-t12-81-3-escape-full-neighborhood.md` now lets all seven of
+   those rows move simultaneously and proves no complete basic-filter
+   assignment exists in the implicit `329417200000000`-assignment space. The
+   next useful PR must therefore either introduce a stronger genuine
+   rich-class/minimality hypothesis that justifies the one-class replacement
+   spaces at centers `3` and `6`, allow richer multi-class catalogues at those
+   centers, or move to a different bridge target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,6 +182,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-escape-two-row-drop.md`](bootstrap-t12-81-3-escape-two-row-drop.md):
   two-row-drop relaxation allowing a pair of additional source-`81` rows to
   move while checking the same escape route.
+- [`bootstrap-t12-81-3-escape-full-neighborhood.md`](bootstrap-t12-81-3-escape-full-neighborhood.md):
+  full-neighborhood CSP allowing all seven other source-`81` rows to move
+  while centers `3` and `6` use the same one-class replacement spaces.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -233,6 +233,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_escape_two_row_drop.json"
       verifier: "scripts/check_bootstrap_t12_81_3_escape_two_row_drop.py"
       claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; for each pair of the seven source-81 rows outside centers 3 and 6, allows both rows to move as arbitrary 4-sets and rules out 4116000 candidates by basic incidence/crossing filters, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_escape_full_neighborhood"
+      status: "full-neighborhood CSP for the 81:3 pre-3 label-6 escape"
+      artifact: "data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py"
+      claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; keeps one-class replacement spaces at centers 3 and 6 while allowing all seven other source-81 rows to move as arbitrary 4-sets, and rules out the implicit 329417200000000-assignment space by basic incidence/crossing backtracking, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3052,6 +3052,88 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_escape_full_neighborhood
+    path: data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py
+    command: python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py
+    check_command: python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Full-neighborhood CSP relaxation of the 81:3 escape-candidate scan; no complete assignment exists in the implicit 329417200000000-assignment space under basic incidence/crossing filters, but this is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_escape_full_neighborhood.v1
+      status: BOOTSTRAP_T12_81_3_ESCAPE_FULL_NEIGHBORHOOD_CSP_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.free_row_centers:
+        - 0
+        - 1
+        - 2
+        - 4
+        - 5
+        - 7
+        - 8
+      summary.fixed_replacement_row_centers:
+        - 3
+        - 6
+      summary.center_6_supply_class_count: 5
+      summary.center_3_connector_avoiding_class_count: 8
+      summary.fixed_replacement_pair_count: 40
+      summary.free_row_replacement_count_per_center: 70
+      summary.implicit_assignment_space_size: 329417200000000
+      summary.search_node_count: 1177
+      summary.empty_domain_count: 684
+      summary.initial_fixed_pair_incompatible_count: 8
+      summary.initial_fixed_pair_searched_count: 32
+      summary.complete_solution_count: 0
+      summary.surviving_assignment_count: 0
+      summary.scan_status: NO_BASIC_FILTER_SURVIVORS_WHEN_ALL_OTHER_SOURCE81_ROWS_MOVE
+      source_two_row_drop_scan.schema: erdos97.bootstrap_t12_81_3_escape_two_row_drop.v1
+      source_two_row_drop_scan.scan_status: NO_BASIC_FILTER_SURVIVORS_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP
+      provenance.generator: scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the full-neighborhood CSP proves genuine rich-class order
+      - the full-neighborhood CSP proves no pre-3 label-6 supply exists
+      - the full-neighborhood CSP proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py
+++ b/scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 full-neighborhood escape CSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_escape_full_neighborhood import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_escape_full_neighborhood_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 full-neighborhood escape CSP")
+    print(f"implicit assignment space: {summary['implicit_assignment_space_size']}")
+    print(f"search nodes: {summary['search_node_count']}")
+    print(f"survivors: {summary['surviving_assignment_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_escape_full_neighborhood_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 full-neighborhood artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 full-neighborhood expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_escape_full_neighborhood.py
+++ b/src/erdos97/bootstrap_t12_81_3_escape_full_neighborhood.py
@@ -1,0 +1,400 @@
+"""Full-neighborhood CSP for the bootstrap/T12 81:3 escape.
+
+The one- and two-row-drop scans relax a fixed source-81 neighborhood by moving
+one or two rows outside centers 3 and 6.  This packet lets all seven of those
+other rows move at once.  Centers 3 and 6 still use the same one-class
+replacement spaces from the escape-candidate scan:
+
+* center 6 supplies label 6 before center 3 from seed [0,1,4];
+* center 3 activates through a connector-avoiding class using label 6.
+
+The search is an exact finite CSP over selected-row incidence and cyclic
+crossing filters.  It is not a Euclidean realizability theorem and not a proof
+of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    _center_3_connector_avoiding_classes,
+    _supply_classes,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import (
+    ALL_PAIRS,
+    CROSS_OK,
+    DEFAULT_ARTIFACT as TWO_ROW_DROP_ARTIFACT,
+    LABELS,
+    MASK_TO_PAIR_INDEX,
+    ROW_PAIR_INDICES,
+    SCAN_STATUS as TWO_ROW_DROP_SCAN_STATUS,
+    SCHEMA as TWO_ROW_DROP_SCHEMA,
+    STATUS as TWO_ROW_DROP_STATUS,
+    _all_replacement_row_masks,
+    _row_mask,
+)
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    PRESERVED_ROW_CENTERS,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_escape_full_neighborhood.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ESCAPE_FULL_NEIGHBORHOOD_CSP_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_BASIC_FILTER_SURVIVORS_WHEN_ALL_OTHER_SOURCE81_ROWS_MOVE"
+CLAIM_SCOPE = (
+    "Full-neighborhood CSP relaxation of the 81:3 escape-candidate scan. The "
+    "search keeps the one-class replacement spaces at centers 3 and 6, but "
+    "allows all seven source-81 rows outside centers 3 and 6 to be arbitrary "
+    "4-sets. The implicit space has 329,417,200,000,000 assignments, and exact "
+    "backtracking proves none satisfy the row-pair, witness-pair, and crossing "
+    "filters. This is not a proof of genuine rich-class order, not a proof of "
+    "row forcing, not a proof of n=9, not a proof of the bridge, and not a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_escape_full_neighborhood.json"
+)
+
+REPLACED_ROW_CENTERS = [TARGET_ROW_CENTER, SUPPLY_CENTER]
+ROW_REPLACEMENT_COUNT_PER_CENTER = 70
+FIXED_REPLACEMENT_PAIR_COUNT = 40
+IMPLICIT_ASSIGNMENT_SPACE_SIZE = (
+    FIXED_REPLACEMENT_PAIR_COUNT
+    * (ROW_REPLACEMENT_COUNT_PER_CENTER ** len(PRESERVED_ROW_CENTERS))
+)
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _row_pair_compatible(
+    center_a: int,
+    row_a: int,
+    center_b: int,
+    row_b: int,
+) -> bool:
+    source_a, source_b = sorted((center_a, center_b))
+    intersection = row_a & row_b
+    intersection_size = intersection.bit_count()
+    if intersection_size > 2:
+        return False
+    if intersection_size == 2:
+        pair_index = MASK_TO_PAIR_INDEX[intersection]
+        return bool(CROSS_OK[(source_a, source_b, pair_index)])
+    return True
+
+
+def _compatible_with_assignment(
+    center: int,
+    row_mask: int,
+    assigned: Mapping[int, int],
+    pair_counts: Sequence[int],
+) -> bool:
+    for pair_index in ROW_PAIR_INDICES[row_mask]:
+        if pair_counts[pair_index] >= 2:
+            return False
+    return all(
+        _row_pair_compatible(center, row_mask, other_center, other_row)
+        for other_center, other_row in assigned.items()
+    )
+
+
+def _update_pair_counts(row_mask: int, pair_counts: list[int], delta: int) -> None:
+    for pair_index in ROW_PAIR_INDICES[row_mask]:
+        pair_counts[pair_index] += delta
+
+
+def _search_fixed_pair(
+    supply_mask: int,
+    center_3_mask: int,
+    replacement_masks: Mapping[int, Sequence[int]],
+) -> dict[str, object]:
+    assigned = {
+        TARGET_ROW_CENTER: center_3_mask,
+        SUPPLY_CENTER: supply_mask,
+    }
+    pair_counts = [0] * len(ALL_PAIRS)
+    for row_mask in assigned.values():
+        _update_pair_counts(row_mask, pair_counts, 1)
+
+    if not _row_pair_compatible(TARGET_ROW_CENTER, center_3_mask, SUPPLY_CENTER, supply_mask):
+        return {
+            "initial_status": "INITIAL_FIXED_PAIR_INCOMPATIBLE",
+            "search_node_count": 0,
+            "empty_domain_count": 0,
+            "complete_solution_count": 0,
+            "max_depth": 0,
+            "empty_domain_depth_histogram": {},
+        }
+
+    stats = {
+        "search_node_count": 0,
+        "empty_domain_count": 0,
+        "complete_solution_count": 0,
+        "max_depth": 0,
+    }
+    empty_depths: Counter[int] = Counter()
+
+    def search() -> None:
+        stats["search_node_count"] += 1
+        depth = len(assigned) - len(REPLACED_ROW_CENTERS)
+        stats["max_depth"] = max(int(stats["max_depth"]), depth)
+        if len(assigned) == len(LABELS):
+            stats["complete_solution_count"] += 1
+            return
+
+        best_center: int | None = None
+        best_options: list[int] | None = None
+        for center in PRESERVED_ROW_CENTERS:
+            if center in assigned:
+                continue
+            options = [
+                row_mask
+                for row_mask in replacement_masks[center]
+                if _compatible_with_assignment(center, row_mask, assigned, pair_counts)
+            ]
+            if best_options is None or len(options) < len(best_options):
+                best_center = center
+                best_options = options
+            if not options:
+                stats["empty_domain_count"] += 1
+                empty_depths[depth] += 1
+                return
+
+        if best_center is None or best_options is None:
+            raise AssertionError("search reached inconsistent assignment state")
+        for row_mask in best_options:
+            assigned[best_center] = row_mask
+            _update_pair_counts(row_mask, pair_counts, 1)
+            search()
+            _update_pair_counts(row_mask, pair_counts, -1)
+            del assigned[best_center]
+
+    search()
+    stats["initial_status"] = "SEARCH_EXHAUSTED"
+    stats["empty_domain_depth_histogram"] = {
+        str(depth): count for depth, count in sorted(empty_depths.items())
+    }
+    return stats
+
+
+def _scan_csp() -> dict[str, object]:
+    supply_classes = _supply_classes()
+    center_3_classes = _center_3_connector_avoiding_classes()
+    supply_masks = [_row_mask(row) for row in supply_classes]
+    center_3_masks = [
+        _row_mask(_int_list(record["rich_class"])) for record in center_3_classes
+    ]
+    replacement_masks = {
+        center: _all_replacement_row_masks(center) for center in PRESERVED_ROW_CENTERS
+    }
+
+    fixed_summaries: list[dict[str, object]] = []
+    aggregate = Counter()
+    for supply_class, supply_mask in zip(supply_classes, supply_masks, strict=True):
+        for center_3_data, center_3_mask in zip(
+            center_3_classes, center_3_masks, strict=True
+        ):
+            stats = _search_fixed_pair(supply_mask, center_3_mask, replacement_masks)
+            aggregate["search_node_count"] += int(stats["search_node_count"])
+            aggregate["empty_domain_count"] += int(stats["empty_domain_count"])
+            aggregate["complete_solution_count"] += int(stats["complete_solution_count"])
+            aggregate[f"initial_status:{stats['initial_status']}"] += 1
+            fixed_summaries.append(
+                {
+                    "supply_center_class": supply_class,
+                    "target_center_class": _int_list(center_3_data["rich_class"]),
+                    "target_center_activation_triple": center_3_data[
+                        "activation_triple"
+                    ],
+                    **stats,
+                }
+            )
+
+    return {
+        "fixed_pair_summaries": fixed_summaries,
+        "aggregate": dict(sorted(aggregate.items())),
+    }
+
+
+def build_t12_81_3_escape_full_neighborhood_payload() -> dict[str, object]:
+    """Return the deterministic full-neighborhood escape CSP packet."""
+
+    scan = _scan_csp()
+    aggregate = scan["aggregate"]
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("aggregate must be a mapping")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This CSP keeps the one-class replacement spaces at centers 3 and 6.",
+            "All seven source-81 rows outside centers 3 and 6 may move as arbitrary selected 4-sets.",
+            "The CSP uses incidence and crossing filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "free_row_centers": PRESERVED_ROW_CENTERS,
+            "fixed_replacement_row_centers": REPLACED_ROW_CENTERS,
+            "center_6_supply_class_count": len(_supply_classes()),
+            "center_3_connector_avoiding_class_count": len(
+                _center_3_connector_avoiding_classes()
+            ),
+            "fixed_replacement_pair_count": FIXED_REPLACEMENT_PAIR_COUNT,
+            "free_row_replacement_count_per_center": ROW_REPLACEMENT_COUNT_PER_CENTER,
+            "implicit_assignment_space_size": IMPLICIT_ASSIGNMENT_SPACE_SIZE,
+            "search_node_count": aggregate["search_node_count"],
+            "empty_domain_count": aggregate["empty_domain_count"],
+            "initial_fixed_pair_incompatible_count": aggregate[
+                "initial_status:INITIAL_FIXED_PAIR_INCOMPATIBLE"
+            ],
+            "initial_fixed_pair_searched_count": aggregate[
+                "initial_status:SEARCH_EXHAUSTED"
+            ],
+            "complete_solution_count": aggregate["complete_solution_count"],
+            "surviving_assignment_count": aggregate["complete_solution_count"],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not rule out richer catalogues than one replacement "
+                "class at centers 3 and 6, multiple simultaneous rich classes "
+                "per center, or additional minimal/rich-class hypotheses."
+            ),
+        },
+        "candidate_generation": {
+            "center_6_supply_classes": _supply_classes(),
+            "center_3_connector_avoiding_classes": _center_3_connector_avoiding_classes(),
+            "free_row_choice_count_per_center": {
+                str(center): len(_all_replacement_row_masks(center))
+                for center in PRESERVED_ROW_CENTERS
+            },
+        },
+        "fixed_pair_summaries": scan["fixed_pair_summaries"],
+        "survivors": [],
+        "source_two_row_drop_scan": {
+            "path": TWO_ROW_DROP_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": TWO_ROW_DROP_SCHEMA,
+            "status": TWO_ROW_DROP_STATUS,
+            "scan_status": TWO_ROW_DROP_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "free_row_centers": PRESERVED_ROW_CENTERS,
+        "fixed_replacement_row_centers": REPLACED_ROW_CENTERS,
+        "center_6_supply_class_count": 5,
+        "center_3_connector_avoiding_class_count": 8,
+        "fixed_replacement_pair_count": 40,
+        "free_row_replacement_count_per_center": 70,
+        "implicit_assignment_space_size": 329417200000000,
+        "search_node_count": 1177,
+        "empty_domain_count": 684,
+        "initial_fixed_pair_incompatible_count": 8,
+        "initial_fixed_pair_searched_count": 32,
+        "complete_solution_count": 0,
+        "surviving_assignment_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    fixed_summaries = payload.get("fixed_pair_summaries")
+    if not isinstance(fixed_summaries, Sequence) or len(fixed_summaries) != 40:
+        raise AssertionError("expected 40 fixed-pair summaries")
+    if any(
+        isinstance(record, Mapping) and record.get("complete_solution_count") != 0
+        for record in fixed_summaries
+    ):
+        raise AssertionError("no fixed pair should have a complete solution")
+
+    survivors = payload.get("survivors")
+    if survivors != []:
+        raise AssertionError("survivors must be empty")
+
+    source = payload.get("source_two_row_drop_scan")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_two_row_drop_scan must be a mapping")
+    if source.get("schema") != TWO_ROW_DROP_SCHEMA:
+        raise AssertionError("source two-row-drop schema drifted")
+    if source.get("scan_status") != TWO_ROW_DROP_SCAN_STATUS:
+        raise AssertionError("source two-row-drop scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_escape_full_neighborhood.py
+++ b/tests/test_bootstrap_t12_81_3_escape_full_neighborhood.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_escape_full_neighborhood import (
+    DEFAULT_ARTIFACT,
+    IMPLICIT_ASSIGNMENT_SPACE_SIZE,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_escape_full_neighborhood_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_escape_full_neighborhood_payload()
+
+
+def test_81_3_full_neighborhood_counts_and_scope(payload: dict[str, object]) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_ESCAPE_FULL_NEIGHBORHOOD_CSP_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Full-neighborhood CSP" in claim_scope
+    assert "329,417,200,000,000 assignments" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_full_neighborhood_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["free_row_centers"] == [0, 1, 2, 4, 5, 7, 8]
+    assert summary["fixed_replacement_row_centers"] == [3, 6]
+    assert summary["center_6_supply_class_count"] == 5
+    assert summary["center_3_connector_avoiding_class_count"] == 8
+    assert summary["fixed_replacement_pair_count"] == 40
+    assert summary["free_row_replacement_count_per_center"] == 70
+    assert summary["implicit_assignment_space_size"] == IMPLICIT_ASSIGNMENT_SPACE_SIZE
+    assert summary["search_node_count"] == 1177
+    assert summary["empty_domain_count"] == 684
+    assert summary["initial_fixed_pair_incompatible_count"] == 8
+    assert summary["initial_fixed_pair_searched_count"] == 32
+    assert summary["complete_solution_count"] == 0
+    assert summary["surviving_assignment_count"] == 0
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_full_neighborhood_fixed_pair_summaries(
+    payload: dict[str, object],
+) -> None:
+    fixed_summaries = payload["fixed_pair_summaries"]
+
+    assert len(fixed_summaries) == 40
+    assert sum(record["complete_solution_count"] for record in fixed_summaries) == 0
+    assert {
+        record["initial_status"] for record in fixed_summaries
+    } == {"INITIAL_FIXED_PAIR_INCOMPATIBLE", "SEARCH_EXHAUSTED"}
+    assert sum(record["search_node_count"] for record in fixed_summaries) == 1177
+
+
+def test_81_3_full_neighborhood_generation_space(payload: dict[str, object]) -> None:
+    generation = payload["candidate_generation"]
+
+    assert generation["center_6_supply_classes"] == [
+        [0, 1, 2, 4],
+        [0, 1, 3, 4],
+        [0, 1, 4, 5],
+        [0, 1, 4, 7],
+        [0, 1, 4, 8],
+    ]
+    assert generation["free_row_choice_count_per_center"] == {
+        "0": 70,
+        "1": 70,
+        "2": 70,
+        "4": 70,
+        "5": 70,
+        "7": 70,
+        "8": 70,
+    }
+
+
+def test_81_3_full_neighborhood_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_full_neighborhood_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_assignment_count"] == 0
+
+
+def test_81_3_full_neighborhood_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_assignment_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_assignment_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a generator-backed full-neighborhood CSP for the `81:3` pre-3 label-6 escape scan
- keep the one-class replacement spaces at centers `3` and `6`, while allowing all seven other source-81 rows to be arbitrary 4-sets
- prove by exact backtracking that the implicit `329,417,200,000,000` assignment space has zero basic row-pair, witness-pair, and crossing survivors
- update the ledgers, manifest, and docs without changing the global/open or strongest local finite-case status

## Verification

- `python scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_escape_full_neighborhood.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`789 passed, 285 deselected`)