### PR TITLE
Add 81:3 auxiliary-rich-class escape CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,18 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the order-resolved `81:3` fixed-row escape audit, where label `6`
   appears only after center `3` in the fixed singleton-rich closure, read
   [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
-- For the relaxed `81:3` escape-candidate scans, which replace centers `3`
-  and `6` and then allow one, two, or all other source-`81` rows to move, read
+- For the relaxed `81:3` escape-candidate scans and auxiliary-class CSP, which
+  probe center-`3` connector and center-`6` supply escapes around source `81`,
+  read
   [`docs/bootstrap-t12-81-3-escape-candidates.md`](docs/bootstrap-t12-81-3-escape-candidates.md)
   and
   [`docs/bootstrap-t12-81-3-escape-one-row-drop.md`](docs/bootstrap-t12-81-3-escape-one-row-drop.md),
   then
   [`docs/bootstrap-t12-81-3-escape-two-row-drop.md`](docs/bootstrap-t12-81-3-escape-two-row-drop.md)
   and
-  [`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`](docs/bootstrap-t12-81-3-escape-full-neighborhood.md).
+  [`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`](docs/bootstrap-t12-81-3-escape-full-neighborhood.md),
+  plus
+  [`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`](docs/bootstrap-t12-81-3-escape-auxiliary-csp.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -321,6 +321,19 @@ bridge; see `docs/bootstrap-t12-81-3-escape-full-neighborhood.md`,
 `scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py`, and
 `data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json`.
 
+The auxiliary-rich-class CSP relaxes the selected-row role of those two escape
+classes. The center-`6` supply class and center-`3` connector class may exist
+as auxiliary rich classes, while the selected rows at centers `3` and `6` may
+be either those classes or disjoint classes. All seven other selected rows are
+arbitrary. The implicit selected-row space has `1317668800000000` assignments;
+exact backtracking visits `1287` nodes and finds no complete assignment under
+the row-pair, witness-pair, crossing, and same-center disjointness filters.
+This remains a finite diagnostic only, not a proof of genuine rich-class
+order, `n=9`, or the bootstrap bridge; see
+`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`,
+`scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py`, and
+`data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -166,13 +166,18 @@ of those seven rows to move and all `4116000` candidates fail as well. This is
 now subsumed by a full-neighborhood CSP: with centers `3` and `6` still using
 the same one-class replacement spaces, all seven other source-`81` rows may be
 arbitrary 4-sets, and the exact backtracker finds no complete basic-filter
-assignment in the implicit `329417200000000`-assignment space. This is still
-proof-mining bookkeeping only, not a theorem about all genuine rich-class
-catalogues. See
+assignment in the implicit `329417200000000`-assignment space. The auxiliary
+CSP then lets the center-`3` connector and center-`6` supply classes exist as
+extra rich classes while selected rows at those centers may be equal or
+disjoint; it rules out the implicit `1317668800000000` selected-row assignment
+space under the same basic filters plus same-center disjointness. This is
+still proof-mining bookkeeping only, not a theorem about all genuine
+rich-class catalogues. See
 `docs/bootstrap-t12-81-3-escape-candidates.md` and
 `docs/bootstrap-t12-81-3-escape-one-row-drop.md`, plus
 `docs/bootstrap-t12-81-3-escape-two-row-drop.md` and
-`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`.
+`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`, and then
+`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`.
 
 ## New exact fixed-pattern obstructions
 

--- a/data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json
+++ b/data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json
@@ -1,0 +1,1496 @@
+{
+  "candidate_generation": {
+    "center_3_connector_avoiding_classes": [
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          0,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          0,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          0,
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 2,
+        "rich_class": [
+          1,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 5,
+        "rich_class": [
+          1,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 7,
+        "rich_class": [
+          1,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "fourth": 8,
+        "rich_class": [
+          1,
+          4,
+          6,
+          8
+        ]
+      }
+    ],
+    "center_6_supply_classes": [
+      [
+        0,
+        1,
+        2,
+        4
+      ],
+      [
+        0,
+        1,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        8
+      ]
+    ],
+    "free_row_choice_count_per_non_auxiliary_center": {
+      "0": 70,
+      "1": 70,
+      "2": 70,
+      "4": 70,
+      "5": 70,
+      "7": 70,
+      "8": 70
+    }
+  },
+  "claim_scope": "Auxiliary-rich-class CSP relaxation of the 81:3 escape scan. The center-6 pre-3 supply class and center-3 connector-avoiding class are allowed to exist as auxiliary rich classes, while the selected rows at centers 3 and 6 may be the same classes or disjoint classes. All seven other selected rows are arbitrary 4-sets. The implicit space has 1,317,668,800,000,000 selected-row assignments, and exact backtracking proves none satisfy the row-pair, witness-pair, crossing, and same-center disjointness filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "fixed_auxiliary_pair_summaries": [
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 13,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 6,
+        "6": 1,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 36,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 6,
+        "6": 1,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 36,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 13,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 7
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 21,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 9,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 37,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 8,
+        "5": 10
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 37,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 14,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 9,
+        "5": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 26,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 8,
+        "5": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 35,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 14,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 9,
+        "5": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 26,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 3,
+        "6": 2,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 37,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 3,
+        "6": 3,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 39,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 44,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 14,
+        "5": 13,
+        "6": 12
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 79,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 12,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 4,
+        "4": 4,
+        "5": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 19,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 39,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 5,
+        "4": 21,
+        "5": 11
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 55,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 46,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 12,
+        "5": 15,
+        "6": 11,
+        "7": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 85,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 13,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 4,
+        "5": 3,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 41,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 25,
+        "5": 11
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 60,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 37,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 11,
+        "6": 4,
+        "7": 12,
+        "8": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 8,
+      "search_node_count": 74,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 3,
+        "4": 8,
+        "5": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 30,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 3,
+        "4": 10,
+        "5": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 26,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 33,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 10,
+        "6": 4,
+        "7": 5,
+        "8": 5
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 8,
+      "search_node_count": 74,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 30,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 14,
+        "5": 14,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 48,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 24,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 1,
+        "4": 16,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 35,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 25,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 3,
+        "6": 12,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 54,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 16,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 3,
+        "4": 8,
+        "5": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 15,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 4,
+        "4": 6,
+        "5": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 22,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 25,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 3,
+        "6": 13
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 53,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 25,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 16,
+        "5": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 38,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 21,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 2,
+        "4": 12,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 31,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "auxiliary_supply_center_class": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_target_center_class": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ]
+    }
+  ],
+  "interpretation_warnings": [
+    "This CSP treats the center-6 supply class and center-3 connector class as auxiliary rich classes.",
+    "Selected rows at centers 3 and 6 may equal their auxiliary class or be disjoint from it.",
+    "The CSP uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_escape_auxiliary_csp.v1",
+  "source_full_neighborhood_scan": {
+    "path": "data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WHEN_ALL_OTHER_SOURCE81_ROWS_MOVE",
+    "schema": "erdos97.bootstrap_t12_81_3_escape_full_neighborhood.v1",
+    "status": "BOOTSTRAP_T12_81_3_ESCAPE_FULL_NEIGHBORHOOD_CSP_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_ESCAPE_AUXILIARY_CSP_DIAGNOSTIC_ONLY",
+  "summary": {
+    "auxiliary_class_centers": [
+      3,
+      6
+    ],
+    "center_3_connector_avoiding_class_count": 8,
+    "center_6_supply_class_count": 5,
+    "complete_solution_count": 0,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "empty_domain_count": 730,
+    "fixed_auxiliary_pair_count": 40,
+    "free_row_replacement_count_per_non_auxiliary_center": 70,
+    "free_selected_row_centers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "implicit_selected_assignment_space_size": 1317668800000000,
+    "initial_auxiliary_pair_incompatible_count": 8,
+    "initial_auxiliary_pair_searched_count": 32,
+    "remaining_gap": "This does not rule out richer catalogues with more than one auxiliary supply/connector class, replacement classes outside the specified center-3 and center-6 spaces, or additional minimal/rich-class hypotheses.",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WITH_AUXILIARY_SUPPLY_AND_CONNECTOR_CLASSES",
+    "search_node_count": 1287,
+    "selected_row_options_at_auxiliary_centers": 2,
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "surviving_assignment_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-escape-auxiliary-csp.md
+++ b/docs/bootstrap-t12-81-3-escape-auxiliary-csp.md
@@ -1,0 +1,107 @@
+# Bootstrap T12 81:3 Auxiliary-Rich-Class Escape CSP
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet relaxes `docs/bootstrap-t12-81-3-escape-full-neighborhood.md`.
+There, the center-`6` supply class and center-`3` connector class were also the
+selected rows at their centers. Here those two classes may instead be
+auxiliary rich classes.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json`.
+
+## Scan Scope
+
+The scan keeps the same auxiliary escape classes:
+
+```text
+5
+```
+
+possible center-`6` supply classes containing deletion seed `[0,1,4]`, and
+
+```text
+8
+```
+
+possible connector-avoiding center-`3` classes using either `[0,4,6]` or
+`[1,4,6]`.
+
+For centers `3` and `6`, the selected row may be either the auxiliary class or
+the unique disjoint 4-set at that center. This encodes the same-center
+distance-class rule: two distinct rich classes at one center are disjoint.
+
+All seven other selected-row centers
+
+```text
+0,1,2,4,5,7,8
+```
+
+may choose any of their
+
+```text
+70
+```
+
+possible selected 4-sets. The implicit selected-row assignment space is:
+
+```text
+5 * 8 * 2 * 2 * 70^7 = 1317668800000000
+```
+
+The checker uses exact backtracking with row-pair, witness-pair, cyclic
+crossing, and same-center disjointness filters.
+
+## Result
+
+The auxiliary-rich-class CSP has no complete assignment satisfying these basic
+filters:
+
+```text
+surviving assignments: 0
+```
+
+The checked scan status is:
+
+```text
+NO_BASIC_FILTER_SURVIVORS_WITH_AUXILIARY_SUPPLY_AND_CONNECTOR_CLASSES
+```
+
+The deterministic backtracking summary is:
+
+```text
+fixed auxiliary pairs: 40
+initial auxiliary-pair incompatible: 8
+initial auxiliary-pair searched: 32
+search nodes: 1287
+empty domains: 730
+complete solutions: 0
+```
+
+## Remaining Gap
+
+This is still not a bridge proof. It rules out the finite relaxed escape model
+where one center-`6` supply class and one center-`3` connector class are added
+as auxiliary rich classes, and each center still contributes one selected row.
+
+It does not rule out richer catalogues with more than one auxiliary
+supply/connector class, replacement classes outside the specified spaces, or
+additional minimal/rich-class hypotheses not included in this scan.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining diagnostic
+that narrows one concrete escape route.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -600,6 +600,15 @@ satisfying the same basic filters. This remains a finite proof-mining
 diagnostic only, not a proof of row forcing, `n=9`, the bootstrap bridge, or
 Erdos Problem #97.
 
+The auxiliary-rich-class CSP in
+`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md` treats the center-`6` supply
+class and center-`3` connector class as auxiliary rich classes rather than
+necessarily selected rows. The selected rows at centers `3` and `6` may equal
+those auxiliary classes or be disjoint from them. Exact backtracking proves no
+complete assignment satisfies the same basic filters plus same-center
+disjointness. This remains a finite proof-mining diagnostic only, not a proof
+of row forcing, `n=9`, the bootstrap bridge, or Erdos Problem #97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -107,10 +107,14 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-escape-full-neighborhood.md` now lets all seven of
    those rows move simultaneously and proves no complete basic-filter
    assignment exists in the implicit `329417200000000`-assignment space. The
-   next useful PR must therefore either introduce a stronger genuine
-   rich-class/minimality hypothesis that justifies the one-class replacement
-   spaces at centers `3` and `6`, allow richer multi-class catalogues at those
-   centers, or move to a different bridge target.
+   auxiliary-rich-class CSP in
+   `docs/bootstrap-t12-81-3-escape-auxiliary-csp.md` then lets the center-`3`
+   connector and center-`6` supply classes exist as auxiliary rich classes
+   while selected rows at those centers are free to be equal or disjoint. It
+   also has no basic-filter survivor. The next useful PR must therefore either
+   allow richer multi-auxiliary catalogues at centers `3` and `6`, introduce a
+   genuine rich-class/minimality hypothesis strong enough to forbid those
+   catalogues, or move to a different bridge target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,6 +185,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-escape-full-neighborhood.md`](bootstrap-t12-81-3-escape-full-neighborhood.md):
   full-neighborhood CSP allowing all seven other source-`81` rows to move
   while centers `3` and `6` use the same one-class replacement spaces.
+- [`bootstrap-t12-81-3-escape-auxiliary-csp.md`](bootstrap-t12-81-3-escape-auxiliary-csp.md):
+  auxiliary-rich-class CSP allowing the center-`3` connector and center-`6`
+  supply classes to be extra classes while selected rows remain free.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -238,6 +238,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_escape_full_neighborhood.json"
       verifier: "scripts/check_bootstrap_t12_81_3_escape_full_neighborhood.py"
       claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; keeps one-class replacement spaces at centers 3 and 6 while allowing all seven other source-81 rows to move as arbitrary 4-sets, and rules out the implicit 329417200000000-assignment space by basic incidence/crossing backtracking, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_escape_auxiliary_csp"
+      status: "auxiliary-rich-class CSP for the 81:3 pre-3 label-6 escape"
+      artifact: "data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py"
+      claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; treats the center-6 supply class and center-3 connector class as auxiliary rich classes while selected rows at those centers may equal or be disjoint from them, and rules out the implicit 1317668800000000 selected-row assignment space by basic incidence/crossing/same-center-disjointness backtracking, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3134,6 +3134,91 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_escape_auxiliary_csp
+    path: data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py
+    command: python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py
+    check_command: python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Auxiliary-rich-class CSP relaxation of the 81:3 escape scan; no complete selected-row assignment exists in the implicit 1317668800000000-assignment space under basic incidence/crossing/same-center-disjointness filters, but this is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_escape_auxiliary_csp.v1
+      status: BOOTSTRAP_T12_81_3_ESCAPE_AUXILIARY_CSP_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.free_selected_row_centers:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.auxiliary_class_centers:
+        - 3
+        - 6
+      summary.center_6_supply_class_count: 5
+      summary.center_3_connector_avoiding_class_count: 8
+      summary.fixed_auxiliary_pair_count: 40
+      summary.free_row_replacement_count_per_non_auxiliary_center: 70
+      summary.selected_row_options_at_auxiliary_centers: 2
+      summary.implicit_selected_assignment_space_size: 1317668800000000
+      summary.search_node_count: 1287
+      summary.empty_domain_count: 730
+      summary.initial_auxiliary_pair_incompatible_count: 8
+      summary.initial_auxiliary_pair_searched_count: 32
+      summary.complete_solution_count: 0
+      summary.surviving_assignment_count: 0
+      summary.scan_status: NO_BASIC_FILTER_SURVIVORS_WITH_AUXILIARY_SUPPLY_AND_CONNECTOR_CLASSES
+      source_full_neighborhood_scan.schema: erdos97.bootstrap_t12_81_3_escape_full_neighborhood.v1
+      source_full_neighborhood_scan.scan_status: NO_BASIC_FILTER_SURVIVORS_WHEN_ALL_OTHER_SOURCE81_ROWS_MOVE
+      provenance.generator: scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - the auxiliary-rich-class CSP proves genuine rich-class order
+      - the auxiliary-rich-class CSP proves no pre-3 label-6 supply exists
+      - the auxiliary-rich-class CSP proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py
+++ b/scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 auxiliary-rich-class escape CSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_escape_auxiliary_csp import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_escape_auxiliary_csp_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 auxiliary-rich-class escape CSP")
+    print(
+        "implicit selected assignment space: "
+        f"{summary['implicit_selected_assignment_space_size']}"
+    )
+    print(f"search nodes: {summary['search_node_count']}")
+    print(f"survivors: {summary['surviving_assignment_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_escape_auxiliary_csp_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 auxiliary-CSP artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 auxiliary-CSP expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_escape_auxiliary_csp.py
+++ b/src/erdos97/bootstrap_t12_81_3_escape_auxiliary_csp.py
@@ -1,0 +1,460 @@
+"""Auxiliary-rich-class CSP for the bootstrap/T12 81:3 escape.
+
+The full-neighborhood CSP keeps the center-3 connector class and center-6
+supply class as the selected rows at those centers.  This packet allows those
+two classes to be auxiliary rich classes instead.  The selected rows at centers
+3 and 6 may either be the auxiliary class itself or a disjoint selected 4-set,
+as required for distinct distance classes at the same center.
+
+The search is an exact finite CSP over selected/rich-class incidence and cyclic
+crossing filters.  It is not a Euclidean realizability theorem and not a proof
+of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    _center_3_connector_avoiding_classes,
+    _supply_classes,
+)
+from erdos97.bootstrap_t12_81_3_escape_full_neighborhood import (
+    DEFAULT_ARTIFACT as FULL_NEIGHBORHOOD_ARTIFACT,
+    SCAN_STATUS as FULL_NEIGHBORHOOD_SCAN_STATUS,
+    SCHEMA as FULL_NEIGHBORHOOD_SCHEMA,
+    STATUS as FULL_NEIGHBORHOOD_STATUS,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import (
+    CROSS_OK,
+    LABELS,
+    MASK_TO_PAIR_INDEX,
+    ROW_PAIR_INDICES,
+    _all_replacement_row_masks,
+    _row_mask,
+)
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    PRESERVED_ROW_CENTERS,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_escape_auxiliary_csp.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ESCAPE_AUXILIARY_CSP_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_BASIC_FILTER_SURVIVORS_WITH_AUXILIARY_SUPPLY_AND_CONNECTOR_CLASSES"
+CLAIM_SCOPE = (
+    "Auxiliary-rich-class CSP relaxation of the 81:3 escape scan. The center-6 "
+    "pre-3 supply class and center-3 connector-avoiding class are allowed to "
+    "exist as auxiliary rich classes, while the selected rows at centers 3 and "
+    "6 may be the same classes or disjoint classes. All seven other selected "
+    "rows are arbitrary 4-sets. The implicit space has 1,317,668,800,000,000 "
+    "selected-row assignments, and exact backtracking proves none satisfy the "
+    "row-pair, witness-pair, crossing, and same-center disjointness filters. "
+    "This is not a proof of genuine rich-class order, not a proof of row "
+    "forcing, not a proof of n=9, not a proof of the bridge, and not a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_escape_auxiliary_csp.json"
+)
+
+FIXED_AUXILIARY_PAIR_COUNT = 40
+FREE_ROW_REPLACEMENT_COUNT_PER_CENTER = 70
+SELECTED_ROW_OPTIONS_AT_AUXILIARY_CENTERS = 2
+IMPLICIT_SELECTED_ASSIGNMENT_SPACE_SIZE = (
+    FIXED_AUXILIARY_PAIR_COUNT
+    * (FREE_ROW_REPLACEMENT_COUNT_PER_CENTER ** len(PRESERVED_ROW_CENTERS))
+    * (SELECTED_ROW_OPTIONS_AT_AUXILIARY_CENTERS ** 2)
+)
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _row_pair_compatible(
+    center_a: int,
+    row_a: int,
+    center_b: int,
+    row_b: int,
+) -> bool:
+    source_a, source_b = sorted((center_a, center_b))
+    intersection = row_a & row_b
+    intersection_size = intersection.bit_count()
+    if intersection_size > 2:
+        return False
+    if intersection_size == 2:
+        pair_index = MASK_TO_PAIR_INDEX[intersection]
+        return bool(CROSS_OK[(source_a, source_b, pair_index)])
+    return True
+
+
+def _auxiliary_selected_choices(center: int, auxiliary_row: int) -> list[int]:
+    choices = []
+    for row_mask in _all_replacement_row_masks(center):
+        if row_mask == auxiliary_row or not (row_mask & auxiliary_row):
+            choices.append(row_mask)
+    return choices
+
+
+def _add_pair_centers(
+    center: int,
+    row_mask: int,
+    pair_centers: dict[int, set[int]],
+) -> None:
+    for pair_index in ROW_PAIR_INDICES[row_mask]:
+        pair_centers.setdefault(pair_index, set()).add(center)
+
+
+def _build_pair_centers(
+    auxiliary: Mapping[int, int],
+    selected: Mapping[int, Sequence[int]],
+) -> dict[int, set[int]]:
+    pair_centers: dict[int, set[int]] = {}
+    for center, row_mask in auxiliary.items():
+        _add_pair_centers(center, row_mask, pair_centers)
+    for center, row_masks in selected.items():
+        for row_mask in row_masks:
+            _add_pair_centers(center, row_mask, pair_centers)
+    return pair_centers
+
+
+def _compatible_with_catalogue(
+    center: int,
+    row_mask: int,
+    auxiliary: Mapping[int, int],
+    selected: Mapping[int, Sequence[int]],
+    pair_centers: Mapping[int, set[int]],
+) -> bool:
+    if center in auxiliary:
+        auxiliary_row = auxiliary[center]
+        if row_mask != auxiliary_row and row_mask & auxiliary_row:
+            return False
+
+    for pair_index in ROW_PAIR_INDICES[row_mask]:
+        centers = pair_centers.get(pair_index, set())
+        if center not in centers and len(centers) >= 2:
+            return False
+
+    for other_center, other_row in auxiliary.items():
+        if other_center != center and not _row_pair_compatible(
+            center, row_mask, other_center, other_row
+        ):
+            return False
+
+    for other_center, other_rows in selected.items():
+        if other_center == center:
+            continue
+        for other_row in other_rows:
+            if not _row_pair_compatible(center, row_mask, other_center, other_row):
+                return False
+    return True
+
+
+def _search_auxiliary_pair(
+    supply_mask: int,
+    center_3_mask: int,
+) -> dict[str, object]:
+    auxiliary = {
+        SUPPLY_CENTER: supply_mask,
+        TARGET_ROW_CENTER: center_3_mask,
+    }
+    if not _row_pair_compatible(SUPPLY_CENTER, supply_mask, TARGET_ROW_CENTER, center_3_mask):
+        return {
+            "initial_status": "INITIAL_AUXILIARY_PAIR_INCOMPATIBLE",
+            "search_node_count": 0,
+            "empty_domain_count": 0,
+            "complete_solution_count": 0,
+            "max_depth": 0,
+            "empty_domain_depth_histogram": {},
+        }
+
+    selected: dict[int, list[int]] = {}
+    pair_centers = _build_pair_centers(auxiliary, selected)
+    choices = {
+        center: _all_replacement_row_masks(center) for center in PRESERVED_ROW_CENTERS
+    }
+    choices[TARGET_ROW_CENTER] = _auxiliary_selected_choices(
+        TARGET_ROW_CENTER, center_3_mask
+    )
+    choices[SUPPLY_CENTER] = _auxiliary_selected_choices(SUPPLY_CENTER, supply_mask)
+
+    stats = {
+        "search_node_count": 0,
+        "empty_domain_count": 0,
+        "complete_solution_count": 0,
+        "max_depth": 0,
+    }
+    empty_depths: Counter[int] = Counter()
+
+    def search() -> None:
+        nonlocal pair_centers
+        stats["search_node_count"] += 1
+        depth = len(selected)
+        stats["max_depth"] = max(int(stats["max_depth"]), depth)
+        if len(selected) == len(LABELS):
+            stats["complete_solution_count"] += 1
+            return
+
+        best_center: int | None = None
+        best_options: list[int] | None = None
+        for center in LABELS:
+            if center in selected:
+                continue
+            options = [
+                row_mask
+                for row_mask in choices[center]
+                if _compatible_with_catalogue(
+                    center, row_mask, auxiliary, selected, pair_centers
+                )
+            ]
+            if best_options is None or len(options) < len(best_options):
+                best_center = center
+                best_options = options
+            if not options:
+                stats["empty_domain_count"] += 1
+                empty_depths[depth] += 1
+                return
+
+        if best_center is None or best_options is None:
+            raise AssertionError("search reached inconsistent assignment state")
+        for row_mask in best_options:
+            selected[best_center] = [row_mask]
+            pair_centers = _build_pair_centers(auxiliary, selected)
+            search()
+            del selected[best_center]
+            pair_centers = _build_pair_centers(auxiliary, selected)
+
+    search()
+    stats["initial_status"] = "SEARCH_EXHAUSTED"
+    stats["empty_domain_depth_histogram"] = {
+        str(depth): count for depth, count in sorted(empty_depths.items())
+    }
+    return stats
+
+
+def _scan_csp() -> dict[str, object]:
+    supply_classes = _supply_classes()
+    center_3_classes = _center_3_connector_avoiding_classes()
+    supply_masks = [_row_mask(row) for row in supply_classes]
+    center_3_masks = [
+        _row_mask(_int_list(record["rich_class"])) for record in center_3_classes
+    ]
+
+    fixed_summaries: list[dict[str, object]] = []
+    aggregate = Counter()
+    for supply_class, supply_mask in zip(supply_classes, supply_masks, strict=True):
+        for center_3_data, center_3_mask in zip(
+            center_3_classes, center_3_masks, strict=True
+        ):
+            stats = _search_auxiliary_pair(supply_mask, center_3_mask)
+            aggregate["search_node_count"] += int(stats["search_node_count"])
+            aggregate["empty_domain_count"] += int(stats["empty_domain_count"])
+            aggregate["complete_solution_count"] += int(stats["complete_solution_count"])
+            aggregate[f"initial_status:{stats['initial_status']}"] += 1
+            fixed_summaries.append(
+                {
+                    "auxiliary_supply_center_class": supply_class,
+                    "auxiliary_target_center_class": _int_list(
+                        center_3_data["rich_class"]
+                    ),
+                    "target_center_activation_triple": center_3_data[
+                        "activation_triple"
+                    ],
+                    "selected_row_choice_count_at_supply_center": len(
+                        _auxiliary_selected_choices(SUPPLY_CENTER, supply_mask)
+                    ),
+                    "selected_row_choice_count_at_target_center": len(
+                        _auxiliary_selected_choices(TARGET_ROW_CENTER, center_3_mask)
+                    ),
+                    **stats,
+                }
+            )
+
+    return {
+        "fixed_auxiliary_pair_summaries": fixed_summaries,
+        "aggregate": dict(sorted(aggregate.items())),
+    }
+
+
+def build_t12_81_3_escape_auxiliary_csp_payload() -> dict[str, object]:
+    """Return the deterministic auxiliary-rich-class escape CSP packet."""
+
+    scan = _scan_csp()
+    aggregate = scan["aggregate"]
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("aggregate must be a mapping")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This CSP treats the center-6 supply class and center-3 connector class as auxiliary rich classes.",
+            "Selected rows at centers 3 and 6 may equal their auxiliary class or be disjoint from it.",
+            "The CSP uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "free_selected_row_centers": CYCLIC_ORDER,
+            "auxiliary_class_centers": [TARGET_ROW_CENTER, SUPPLY_CENTER],
+            "center_6_supply_class_count": len(_supply_classes()),
+            "center_3_connector_avoiding_class_count": len(
+                _center_3_connector_avoiding_classes()
+            ),
+            "fixed_auxiliary_pair_count": FIXED_AUXILIARY_PAIR_COUNT,
+            "free_row_replacement_count_per_non_auxiliary_center": FREE_ROW_REPLACEMENT_COUNT_PER_CENTER,
+            "selected_row_options_at_auxiliary_centers": SELECTED_ROW_OPTIONS_AT_AUXILIARY_CENTERS,
+            "implicit_selected_assignment_space_size": IMPLICIT_SELECTED_ASSIGNMENT_SPACE_SIZE,
+            "search_node_count": aggregate["search_node_count"],
+            "empty_domain_count": aggregate["empty_domain_count"],
+            "initial_auxiliary_pair_incompatible_count": aggregate[
+                "initial_status:INITIAL_AUXILIARY_PAIR_INCOMPATIBLE"
+            ],
+            "initial_auxiliary_pair_searched_count": aggregate[
+                "initial_status:SEARCH_EXHAUSTED"
+            ],
+            "complete_solution_count": aggregate["complete_solution_count"],
+            "surviving_assignment_count": aggregate["complete_solution_count"],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not rule out richer catalogues with more than one "
+                "auxiliary supply/connector class, replacement classes outside "
+                "the specified center-3 and center-6 spaces, or additional "
+                "minimal/rich-class hypotheses."
+            ),
+        },
+        "candidate_generation": {
+            "center_6_supply_classes": _supply_classes(),
+            "center_3_connector_avoiding_classes": _center_3_connector_avoiding_classes(),
+            "free_row_choice_count_per_non_auxiliary_center": {
+                str(center): len(_all_replacement_row_masks(center))
+                for center in PRESERVED_ROW_CENTERS
+            },
+        },
+        "fixed_auxiliary_pair_summaries": scan["fixed_auxiliary_pair_summaries"],
+        "survivors": [],
+        "source_full_neighborhood_scan": {
+            "path": FULL_NEIGHBORHOOD_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": FULL_NEIGHBORHOOD_SCHEMA,
+            "status": FULL_NEIGHBORHOOD_STATUS,
+            "scan_status": FULL_NEIGHBORHOOD_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "free_selected_row_centers": CYCLIC_ORDER,
+        "auxiliary_class_centers": [TARGET_ROW_CENTER, SUPPLY_CENTER],
+        "center_6_supply_class_count": 5,
+        "center_3_connector_avoiding_class_count": 8,
+        "fixed_auxiliary_pair_count": 40,
+        "free_row_replacement_count_per_non_auxiliary_center": 70,
+        "selected_row_options_at_auxiliary_centers": 2,
+        "implicit_selected_assignment_space_size": 1317668800000000,
+        "search_node_count": 1287,
+        "empty_domain_count": 730,
+        "initial_auxiliary_pair_incompatible_count": 8,
+        "initial_auxiliary_pair_searched_count": 32,
+        "complete_solution_count": 0,
+        "surviving_assignment_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    fixed_summaries = payload.get("fixed_auxiliary_pair_summaries")
+    if not isinstance(fixed_summaries, Sequence) or len(fixed_summaries) != 40:
+        raise AssertionError("expected 40 fixed-auxiliary-pair summaries")
+    if any(
+        isinstance(record, Mapping) and record.get("complete_solution_count") != 0
+        for record in fixed_summaries
+    ):
+        raise AssertionError("no fixed auxiliary pair should have a complete solution")
+
+    survivors = payload.get("survivors")
+    if survivors != []:
+        raise AssertionError("survivors must be empty")
+
+    source = payload.get("source_full_neighborhood_scan")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_full_neighborhood_scan must be a mapping")
+    if source.get("schema") != FULL_NEIGHBORHOOD_SCHEMA:
+        raise AssertionError("source full-neighborhood schema drifted")
+    if source.get("scan_status") != FULL_NEIGHBORHOOD_SCAN_STATUS:
+        raise AssertionError("source full-neighborhood scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_escape_auxiliary_csp.py
+++ b/tests/test_bootstrap_t12_81_3_escape_auxiliary_csp.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_escape_auxiliary_csp import (
+    DEFAULT_ARTIFACT,
+    IMPLICIT_SELECTED_ASSIGNMENT_SPACE_SIZE,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_escape_auxiliary_csp_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_escape_auxiliary_csp_payload()
+
+
+def test_81_3_auxiliary_csp_counts_and_scope(payload: dict[str, object]) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_ESCAPE_AUXILIARY_CSP_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Auxiliary-rich-class CSP" in claim_scope
+    assert "1,317,668,800,000,000" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_auxiliary_csp_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["free_selected_row_centers"] == list(range(9))
+    assert summary["auxiliary_class_centers"] == [3, 6]
+    assert summary["center_6_supply_class_count"] == 5
+    assert summary["center_3_connector_avoiding_class_count"] == 8
+    assert summary["fixed_auxiliary_pair_count"] == 40
+    assert summary["free_row_replacement_count_per_non_auxiliary_center"] == 70
+    assert summary["selected_row_options_at_auxiliary_centers"] == 2
+    assert (
+        summary["implicit_selected_assignment_space_size"]
+        == IMPLICIT_SELECTED_ASSIGNMENT_SPACE_SIZE
+    )
+    assert summary["search_node_count"] == 1287
+    assert summary["empty_domain_count"] == 730
+    assert summary["initial_auxiliary_pair_incompatible_count"] == 8
+    assert summary["initial_auxiliary_pair_searched_count"] == 32
+    assert summary["complete_solution_count"] == 0
+    assert summary["surviving_assignment_count"] == 0
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_auxiliary_csp_fixed_pair_summaries(
+    payload: dict[str, object],
+) -> None:
+    fixed_summaries = payload["fixed_auxiliary_pair_summaries"]
+
+    assert len(fixed_summaries) == 40
+    assert sum(record["complete_solution_count"] for record in fixed_summaries) == 0
+    assert {
+        record["initial_status"] for record in fixed_summaries
+    } == {"INITIAL_AUXILIARY_PAIR_INCOMPATIBLE", "SEARCH_EXHAUSTED"}
+    assert sum(record["search_node_count"] for record in fixed_summaries) == 1287
+    assert {
+        record["selected_row_choice_count_at_supply_center"]
+        for record in fixed_summaries
+    } == {2}
+    assert {
+        record["selected_row_choice_count_at_target_center"]
+        for record in fixed_summaries
+    } == {2}
+
+
+def test_81_3_auxiliary_csp_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_auxiliary_csp_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_assignment_count"] == 0
+
+
+def test_81_3_auxiliary_csp_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_assignment_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_assignment_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a generator-backed auxiliary-rich-class CSP for the `81:3` pre-3 label-6 escape scan
- allow the center-6 supply class and center-3 connector class to exist as auxiliary rich classes, while selected rows at centers 3 and 6 may equal them or be disjoint
- prove by exact backtracking that the implicit `1,317,668,800,000,000` selected-row assignment space has zero survivors under row-pair, witness-pair, crossing, and same-center disjointness filters
- update the ledgers, manifest, and docs without changing the global/open or strongest local finite-case status

## Verification

- `python scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_escape_auxiliary_csp.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`795 passed, 285 deselected`)