### PR TITLE
Add 81:3 trigger-family uniqueness audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the order-resolved `81:3` fixed-row escape audit, where label `6`
   appears only after center `3` in the fixed singleton-rich closure, read
   [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
-- For the relaxed `81:3` escape-candidate scans and auxiliary-class CSP, which
-  probe center-`3` connector and center-`6` supply escapes around source `81`,
-  read
+- For the relaxed `81:3` escape-candidate scans, auxiliary-class CSP, and
+  trigger-family uniqueness audit, which probe center-`3` connector and
+  center-`6` supply escapes around source `81`, read
   [`docs/bootstrap-t12-81-3-escape-candidates.md`](docs/bootstrap-t12-81-3-escape-candidates.md)
   and
   [`docs/bootstrap-t12-81-3-escape-one-row-drop.md`](docs/bootstrap-t12-81-3-escape-one-row-drop.md),
@@ -112,7 +112,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/bootstrap-t12-81-3-escape-full-neighborhood.md`](docs/bootstrap-t12-81-3-escape-full-neighborhood.md),
   plus
-  [`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`](docs/bootstrap-t12-81-3-escape-auxiliary-csp.md).
+  [`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`](docs/bootstrap-t12-81-3-escape-auxiliary-csp.md)
+  and
+  [`docs/bootstrap-t12-81-3-trigger-uniqueness.md`](docs/bootstrap-t12-81-3-trigger-uniqueness.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -334,6 +334,19 @@ order, `n=9`, or the bootstrap bridge; see
 `scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py`, and
 `data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json`.
 
+The trigger-family uniqueness audit checks the two specified auxiliary trigger
+families from that CSP. All five center-`6` supply classes containing
+`[0,1,4]` pairwise intersect, and all eight center-`3` connector-avoiding
+classes using label `6` pairwise intersect. Thus same-center distance-class
+disjointness permits at most one class from each specified trigger family, and
+for any fixed auxiliary trigger the selected row at that center has exactly
+two equal-or-disjoint 4-set options: the trigger itself or the unique disjoint
+complement. This is only a proof-mining audit of those trigger families; it
+does not prove trigger-class existence, row forcing, `n=9`, or the bootstrap
+bridge. See `docs/bootstrap-t12-81-3-trigger-uniqueness.md`,
+`scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py`, and
+`data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -172,12 +172,18 @@ extra rich classes while selected rows at those centers may be equal or
 disjoint; it rules out the implicit `1317668800000000` selected-row assignment
 space under the same basic filters plus same-center disjointness. This is
 still proof-mining bookkeeping only, not a theorem about all genuine
-rich-class catalogues. See
+rich-class catalogues. A follow-up trigger-family uniqueness audit checks that
+the specified center-`6` supply family and center-`3` connector-avoiding family
+are each same-center unique: all pairs inside either family intersect, so a
+genuine rich-class catalogue can contain at most one class from each specified
+trigger family. This narrows the auxiliary-CSP wording only; it still does not
+prove trigger-class existence, row forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-3-escape-candidates.md` and
 `docs/bootstrap-t12-81-3-escape-one-row-drop.md`, plus
 `docs/bootstrap-t12-81-3-escape-two-row-drop.md` and
 `docs/bootstrap-t12-81-3-escape-full-neighborhood.md`, and then
-`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`.
+`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md` and
+`docs/bootstrap-t12-81-3-trigger-uniqueness.md`.
 
 ## New exact fixed-pattern obstructions
 

--- a/data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json
+++ b/data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json
@@ -1,0 +1,1431 @@
+{
+  "claim_scope": "Same-center disjointness audit for the specified 81:3 escape trigger families. It proves only that the center-6 supply-trigger family contains no two pairwise disjoint classes, and the center-3 connector-avoiding trigger family contains no two pairwise disjoint classes. Therefore a genuine rich-class catalogue at those centers can contain at most one class from each specified family. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "family_audits": {
+    "center_3_connector_avoiding": {
+      "all_pairs_intersect": true,
+      "center": 3,
+      "class_count": 8,
+      "classes": [
+        [
+          0,
+          2,
+          4,
+          6
+        ],
+        [
+          0,
+          4,
+          5,
+          6
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ]
+      ],
+      "common_trigger": [
+        4,
+        6
+      ],
+      "disjoint_pair_count": 0,
+      "family_name": "center_3_connector_avoiding_classes_using_label_6",
+      "intersection_size_histogram": {
+        "2": 12,
+        "3": 16
+      },
+      "max_same_center_pairwise_disjoint_family_size": 1,
+      "pair_count": 28,
+      "pairwise_intersections": [
+        {
+          "class_indices": [
+            0,
+            1
+          ],
+          "intersection": [
+            0,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            4,
+            5,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            2
+          ],
+          "intersection": [
+            0,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            3
+          ],
+          "intersection": [
+            0,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            4
+          ],
+          "intersection": [
+            2,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            5
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            5,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            6
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            7
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            2
+          ],
+          "intersection": [
+            0,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            3
+          ],
+          "intersection": [
+            0,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            4
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            5
+          ],
+          "intersection": [
+            4,
+            5,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            5,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            6
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            7
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            3
+          ],
+          "intersection": [
+            0,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            4
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            5
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            5,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            6
+          ],
+          "intersection": [
+            4,
+            6,
+            7
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            7
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            3,
+            4
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            3,
+            5
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            5,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            3,
+            6
+          ],
+          "intersection": [
+            4,
+            6
+          ],
+          "intersection_size": 2,
+          "left_class": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            3,
+            7
+          ],
+          "intersection": [
+            4,
+            6,
+            8
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            4,
+            5
+          ],
+          "intersection": [
+            1,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            1,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            5,
+            6
+          ]
+        },
+        {
+          "class_indices": [
+            4,
+            6
+          ],
+          "intersection": [
+            1,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            1,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            4,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            1,
+            2,
+            4,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            5,
+            6
+          ],
+          "intersection": [
+            1,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            1,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            5,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            1,
+            4,
+            5,
+            6
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            6,
+            7
+          ],
+          "intersection": [
+            1,
+            4,
+            6
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            1,
+            4,
+            6,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            1,
+            4,
+            6,
+            8
+          ]
+        }
+      ],
+      "selected_row_option_count_histogram": {
+        "2": 8
+      },
+      "selected_row_option_records": [
+        {
+          "auxiliary_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              2,
+              4,
+              6
+            ],
+            [
+              1,
+              5,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            4,
+            5,
+            6
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              4,
+              5,
+              6
+            ],
+            [
+              1,
+              2,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              4,
+              6,
+              7
+            ],
+            [
+              1,
+              2,
+              5,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              4,
+              6,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            1,
+            2,
+            4,
+            6
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              1,
+              2,
+              4,
+              6
+            ],
+            [
+              0,
+              5,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            1,
+            4,
+            5,
+            6
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              1,
+              4,
+              5,
+              6
+            ],
+            [
+              0,
+              2,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            1,
+            4,
+            6,
+            7
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              1,
+              4,
+              6,
+              7
+            ],
+            [
+              0,
+              2,
+              5,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            1,
+            4,
+            6,
+            8
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              1,
+              4,
+              6,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              7
+            ]
+          ]
+        }
+      ]
+    },
+    "center_6_supply": {
+      "all_pairs_intersect": true,
+      "center": 6,
+      "class_count": 5,
+      "classes": [
+        [
+          0,
+          1,
+          2,
+          4
+        ],
+        [
+          0,
+          1,
+          3,
+          4
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          7
+        ],
+        [
+          0,
+          1,
+          4,
+          8
+        ]
+      ],
+      "common_trigger": [
+        0,
+        1,
+        4
+      ],
+      "disjoint_pair_count": 0,
+      "family_name": "center_6_supply_classes_containing_deletion_seed",
+      "intersection_size_histogram": {
+        "3": 10
+      },
+      "max_same_center_pairwise_disjoint_family_size": 1,
+      "pair_count": 10,
+      "pairwise_intersections": [
+        {
+          "class_indices": [
+            0,
+            1
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            3,
+            4
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            2
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            5
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            3
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            0,
+            4
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            2
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            5
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            3
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            1,
+            4
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            3
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            4,
+            5
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            7
+          ]
+        },
+        {
+          "class_indices": [
+            2,
+            4
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            4,
+            5
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            8
+          ]
+        },
+        {
+          "class_indices": [
+            3,
+            4
+          ],
+          "intersection": [
+            0,
+            1,
+            4
+          ],
+          "intersection_size": 3,
+          "left_class": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "pairwise_disjoint": false,
+          "right_class": [
+            0,
+            1,
+            4,
+            8
+          ]
+        }
+      ],
+      "selected_row_option_count_histogram": {
+        "2": 5
+      },
+      "selected_row_option_records": [
+        {
+          "auxiliary_class": [
+            0,
+            1,
+            2,
+            4
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              1,
+              2,
+              4
+            ],
+            [
+              3,
+              5,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              1,
+              3,
+              4
+            ],
+            [
+              2,
+              5,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            1,
+            4,
+            5
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              1,
+              4,
+              5
+            ],
+            [
+              2,
+              3,
+              7,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              1,
+              4,
+              7
+            ],
+            [
+              2,
+              3,
+              5,
+              8
+            ]
+          ]
+        },
+        {
+          "auxiliary_class": [
+            0,
+            1,
+            4,
+            8
+          ],
+          "selected_row_options_equal_or_disjoint": [
+            [
+              0,
+              1,
+              4,
+              8
+            ],
+            [
+              2,
+              3,
+              5,
+              7
+            ]
+          ]
+        }
+      ]
+    }
+  },
+  "interpretation_warnings": [
+    "This audit is internal to the specified center-6 supply-trigger family and center-3 connector-avoiding family.",
+    "It does not enumerate rich classes outside those specified trigger families.",
+    "It does not prove that either trigger class exists in a genuine counterexample.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py"
+  },
+  "same_center_disjointness_rule": "At one fixed center, two distinct rich distance classes are disjoint: if they shared a witness, the two radii would be equal and the classes would be the same distance class.",
+  "schema": "erdos97.bootstrap_t12_81_3_trigger_uniqueness.v1",
+  "source_auxiliary_csp": {
+    "path": "data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WITH_AUXILIARY_SUPPLY_AND_CONNECTOR_CLASSES",
+    "schema": "erdos97.bootstrap_t12_81_3_escape_auxiliary_csp.v1",
+    "status": "BOOTSTRAP_T12_81_3_ESCAPE_AUXILIARY_CSP_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_TRIGGER_UNIQUENESS_DIAGNOSTIC_ONLY",
+  "summary": {
+    "catalogue_gap_removed": "Within these specified trigger families, a richer catalogue cannot contain two center-6 supply triggers or two center-3 connector-avoiding triggers at the same center, because any two such classes intersect.",
+    "center_3_connector_avoiding_class_count": 8,
+    "center_3_connector_disjoint_pair_count": 0,
+    "center_3_connector_intersection_size_histogram": {
+      "2": 12,
+      "3": 16
+    },
+    "center_3_connector_max_same_center_pairwise_disjoint_family_size": 1,
+    "center_3_connector_pair_count": 28,
+    "center_3_selected_row_option_count_histogram": {
+      "2": 8
+    },
+    "center_6_selected_row_option_count_histogram": {
+      "2": 5
+    },
+    "center_6_supply_class_count": 5,
+    "center_6_supply_disjoint_pair_count": 0,
+    "center_6_supply_intersection_size_histogram": {
+      "3": 10
+    },
+    "center_6_supply_max_same_center_pairwise_disjoint_family_size": 1,
+    "center_6_supply_pair_count": 10,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "remaining_gap": "This does not rule out replacement classes outside the specified trigger families, does not prove trigger-class existence, and does not add new minimal/rich-class forcing hypotheses.",
+    "same_center_trigger_uniqueness_status": "SPECIFIED_TRIGGER_FAMILIES_ARE_SAME_CENTER_UNIQUE",
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-trigger-uniqueness.md
+++ b/docs/bootstrap-t12-81-3-trigger-uniqueness.md
@@ -1,0 +1,103 @@
+# Bootstrap T12 81:3 Trigger-Family Uniqueness
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet follows `docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`. That CSP
+allowed one center-`6` supply class and one center-`3` connector-avoiding class
+to exist as auxiliary rich classes. This audit checks the specified trigger
+families themselves under the same-center disjointness rule:
+
+```text
+At one fixed center, two distinct rich distance classes are disjoint.
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json`.
+
+## Audit Scope
+
+The center-`6` supply-trigger family consists of the five 4-sets containing the
+deletion seed `[0,1,4]`:
+
+```text
+[0,1,2,4], [0,1,3,4], [0,1,4,5], [0,1,4,7], [0,1,4,8]
+```
+
+Every pair in this family intersects in exactly three labels. Therefore a
+same-center rich-class catalogue at center `6` can contain at most one class
+from this supply-trigger family.
+
+The center-`3` connector-avoiding family consists of the eight 4-sets using
+either `[0,4,6]` or `[1,4,6]`:
+
+```text
+[0,2,4,6], [0,4,5,6], [0,4,6,7], [0,4,6,8],
+[1,2,4,6], [1,4,5,6], [1,4,6,7], [1,4,6,8]
+```
+
+Every pair in this family intersects in at least `[4,6]`. The checked
+intersection histogram is:
+
+```text
+intersection size 2: 12 pairs
+intersection size 3: 16 pairs
+```
+
+Therefore a same-center rich-class catalogue at center `3` can contain at most
+one class from this connector-avoiding trigger family.
+
+## Result
+
+The checked scan status is:
+
+```text
+SPECIFIED_TRIGGER_FAMILIES_ARE_SAME_CENTER_UNIQUE
+```
+
+The summary counts are:
+
+```text
+center-6 supply classes: 5
+center-6 disjoint trigger pairs: 0
+center-6 max pairwise-disjoint trigger family size: 1
+
+center-3 connector-avoiding classes: 8
+center-3 disjoint trigger pairs: 0
+center-3 max pairwise-disjoint trigger family size: 1
+```
+
+For any fixed auxiliary class in either family, the selected row at that same
+center has exactly two equal-or-disjoint 4-set options: the class itself, or
+the unique disjoint 4-set complement in the eight labels other than the center.
+This justifies the two-choice selected-row model used by the auxiliary CSP
+inside these specified trigger families.
+
+## Remaining Gap
+
+This removes only one wording-level looseness from the auxiliary-CSP gap:
+within the specified trigger families, a richer catalogue cannot contain two
+center-`6` supply triggers or two center-`3` connector-avoiding triggers at the
+same center.
+
+It does not rule out replacement classes outside these specified trigger
+families, does not prove that either trigger class exists in a genuine
+counterexample, and does not add a new minimality or rich-class forcing
+hypothesis.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a small exact proof-mining audit
+around the `81:3` escape route.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -609,6 +609,16 @@ complete assignment satisfies the same basic filters plus same-center
 disjointness. This remains a finite proof-mining diagnostic only, not a proof
 of row forcing, `n=9`, the bootstrap bridge, or Erdos Problem #97.
 
+The trigger-family uniqueness audit in
+`docs/bootstrap-t12-81-3-trigger-uniqueness.md` checks the specified auxiliary
+trigger families used by that CSP. Since any two classes in the center-`6`
+supply family intersect, and any two classes in the center-`3`
+connector-avoiding family intersect, same-center distance-class disjointness
+allows at most one class from each specified family in a genuine rich-class
+catalogue. This narrows the auxiliary-CSP catalogue gap only; it does not prove
+trigger-class existence, row forcing, `n=9`, the bootstrap bridge, or Erdos
+Problem #97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -111,10 +111,15 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-escape-auxiliary-csp.md` then lets the center-`3`
    connector and center-`6` supply classes exist as auxiliary rich classes
    while selected rows at those centers are free to be equal or disjoint. It
-   also has no basic-filter survivor. The next useful PR must therefore either
-   allow richer multi-auxiliary catalogues at centers `3` and `6`, introduce a
-   genuine rich-class/minimality hypothesis strong enough to forbid those
-   catalogues, or move to a different bridge target.
+   also has no basic-filter survivor. The trigger-family uniqueness audit in
+   `docs/bootstrap-t12-81-3-trigger-uniqueness.md` checks that richer
+   catalogues cannot contain two classes from the specified center-`6` supply
+   family or two classes from the specified center-`3` connector-avoiding
+   family, because the classes pairwise intersect at the same center. The next
+   useful PR must therefore either allow replacement classes outside those
+   specified trigger families, introduce a genuine rich-class/minimality
+   hypothesis strong enough to forbid those outside replacements, or move to a
+   different bridge target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,6 +188,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-escape-auxiliary-csp.md`](bootstrap-t12-81-3-escape-auxiliary-csp.md):
   auxiliary-rich-class CSP allowing the center-`3` connector and center-`6`
   supply classes to be extra classes while selected rows remain free.
+- [`bootstrap-t12-81-3-trigger-uniqueness.md`](bootstrap-t12-81-3-trigger-uniqueness.md):
+  same-center disjointness audit showing the specified center-`6` supply and
+  center-`3` connector trigger families are each internally unique.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -371,6 +371,13 @@ condition that the surviving multi-block family does not automatically satisfy:
   singleton-rich closure does not expose label `6` before center `3`; any
   successful escape now needs genuine rich-class data that supplies label `6`
   first, or a proof that no such supply exists.
+- bootstrap/T12 focused `81:3` escape-CSP evidence, as recorded in
+  `docs/bootstrap-t12-81-3-escape-auxiliary-csp.md` and
+  `docs/bootstrap-t12-81-3-trigger-uniqueness.md`, ruling out the specified
+  one-supply/one-connector auxiliary trigger model and showing each specified
+  trigger family is same-center unique. The remaining target is outside those
+  specified trigger families or a genuine rich-class/minimality hypothesis,
+  not more copies of the same supply or connector trigger at the same center.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -243,6 +243,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_escape_auxiliary_csp.json"
       verifier: "scripts/check_bootstrap_t12_81_3_escape_auxiliary_csp.py"
       claim_scope: "fixed selected-row-neighborhood proof-mining diagnostic only; treats the center-6 supply class and center-3 connector class as auxiliary rich classes while selected rows at those centers may equal or be disjoint from them, and rules out the implicit 1317668800000000 selected-row assignment space by basic incidence/crossing/same-center-disjointness backtracking, but does not prove genuine rich-class order, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_trigger_uniqueness"
+      status: "same-center disjointness audit for the specified 81:3 supply and connector trigger families"
+      artifact: "data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py"
+      claim_scope: "proof-mining diagnostic only; shows the specified center-6 supply-trigger family and center-3 connector-avoiding trigger family each have maximum same-center pairwise-disjoint subfamily size 1, but does not prove trigger-class existence, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3219,6 +3219,79 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_trigger_uniqueness
+    path: data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py
+    command: python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py
+    check_command: python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Same-center disjointness audit for the specified 81:3 supply and connector trigger families; each specified family has maximum pairwise-disjoint subfamily size 1, but this is not genuine rich-class order, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_trigger_uniqueness.v1
+      status: BOOTSTRAP_T12_81_3_TRIGGER_UNIQUENESS_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.center_6_supply_class_count: 5
+      summary.center_6_supply_pair_count: 10
+      summary.center_6_supply_intersection_size_histogram.3: 10
+      summary.center_6_supply_disjoint_pair_count: 0
+      summary.center_6_supply_max_same_center_pairwise_disjoint_family_size: 1
+      summary.center_6_selected_row_option_count_histogram.2: 5
+      summary.center_3_connector_avoiding_class_count: 8
+      summary.center_3_connector_pair_count: 28
+      summary.center_3_connector_intersection_size_histogram.2: 12
+      summary.center_3_connector_intersection_size_histogram.3: 16
+      summary.center_3_connector_disjoint_pair_count: 0
+      summary.center_3_connector_max_same_center_pairwise_disjoint_family_size: 1
+      summary.center_3_selected_row_option_count_histogram.2: 8
+      summary.same_center_trigger_uniqueness_status: SPECIFIED_TRIGGER_FAMILIES_ARE_SAME_CENTER_UNIQUE
+      source_auxiliary_csp.schema: erdos97.bootstrap_t12_81_3_escape_auxiliary_csp.v1
+      source_auxiliary_csp.scan_status: NO_BASIC_FILTER_SURVIVORS_WITH_AUXILIARY_SUPPLY_AND_CONNECTOR_CLASSES
+      provenance.generator: scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich class exists
+      - the 81:3 row is forced
+      - trigger-family uniqueness proves genuine rich-class order
+      - trigger-family uniqueness proves no pre-3 label-6 supply exists
+      - trigger-family uniqueness proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py
+++ b/scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 trigger-family uniqueness audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_trigger_uniqueness import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_trigger_uniqueness_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 trigger-family uniqueness audit")
+    print(
+        "center-6 max disjoint trigger family size: "
+        f"{summary['center_6_supply_max_same_center_pairwise_disjoint_family_size']}"
+    )
+    print(
+        "center-3 max disjoint trigger family size: "
+        f"{summary['center_3_connector_max_same_center_pairwise_disjoint_family_size']}"
+    )
+    print(
+        "scan status: "
+        f"{summary['same_center_trigger_uniqueness_status']}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_trigger_uniqueness_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 trigger-uniqueness artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 trigger-uniqueness expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_trigger_uniqueness.py
+++ b/src/erdos97/bootstrap_t12_81_3_trigger_uniqueness.py
@@ -1,0 +1,378 @@
+"""Trigger-family uniqueness audit for the bootstrap/T12 81:3 escape.
+
+The auxiliary-rich-class CSP lets one center-6 supply class and one center-3
+connector-avoiding class exist as auxiliary rich classes.  This packet checks
+that, inside those specified trigger families, same-center distance-class
+disjointness already permits at most one such class at each center.
+
+The audit is exact finite bookkeeping.  It is not a row-forcing theorem and not
+a proof of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_auxiliary_csp import (
+    DEFAULT_ARTIFACT as AUXILIARY_CSP_ARTIFACT,
+    SCAN_STATUS as AUXILIARY_CSP_SCAN_STATUS,
+    SCHEMA as AUXILIARY_CSP_SCHEMA,
+    STATUS as AUXILIARY_CSP_STATUS,
+)
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    SUPPLY_CENTER,
+    _center_3_connector_avoiding_classes,
+    _supply_classes,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_trigger_uniqueness.v1"
+STATUS = "BOOTSTRAP_T12_81_3_TRIGGER_UNIQUENESS_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "SPECIFIED_TRIGGER_FAMILIES_ARE_SAME_CENTER_UNIQUE"
+CLAIM_SCOPE = (
+    "Same-center disjointness audit for the specified 81:3 escape trigger "
+    "families. It proves only that the center-6 supply-trigger family contains "
+    "no two pairwise disjoint classes, and the center-3 connector-avoiding "
+    "trigger family contains no two pairwise disjoint classes. Therefore a "
+    "genuine rich-class catalogue at those centers can contain at most one "
+    "class from each specified family. This is not a proof of genuine "
+    "rich-class order, not a proof of row forcing, not a proof of n=9, not a "
+    "proof of the bridge, and not a counterexample."
+)
+RICH_CLASS_DISJOINTNESS_RULE = (
+    "At one fixed center, two distinct rich distance classes are disjoint: if "
+    "they shared a witness, the two radii would be equal and the classes would "
+    "be the same distance class."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_trigger_uniqueness.json"
+)
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _max_pairwise_disjoint_family_size(classes: Sequence[Sequence[int]]) -> int:
+    class_sets = [set(row) for row in classes]
+    for size in range(len(class_sets), 0, -1):
+        for indices in combinations(range(len(class_sets)), size):
+            if all(
+                class_sets[a].isdisjoint(class_sets[b])
+                for a, b in combinations(indices, 2)
+            ):
+                return size
+    return 0
+
+
+def _selected_row_options_for_auxiliary_class(
+    center: int,
+    auxiliary_class: Sequence[int],
+) -> list[list[int]]:
+    universe = set(CYCLIC_ORDER) - {center}
+    auxiliary_set = set(auxiliary_class)
+    if len(auxiliary_set) != 4:
+        raise AssertionError("auxiliary classes must be 4-sets")
+    if center in auxiliary_set:
+        raise AssertionError("an auxiliary class cannot contain its center")
+    disjoint_complement = sorted(universe - auxiliary_set)
+    if len(disjoint_complement) != 4:
+        raise AssertionError("expected a unique disjoint 4-set complement")
+
+    options = []
+    for row in combinations(sorted(universe), 4):
+        row_set = set(row)
+        if row_set == auxiliary_set or row_set.isdisjoint(auxiliary_set):
+            options.append(list(row))
+    expected_options = [sorted(auxiliary_set), disjoint_complement]
+    if {tuple(row) for row in options} != {tuple(row) for row in expected_options}:
+        raise AssertionError("unexpected same-center selected-row option set")
+    return expected_options
+
+
+def _class_family_audit(
+    *,
+    family_name: str,
+    center: int,
+    classes: Sequence[Sequence[int]],
+    common_trigger: Sequence[int],
+) -> dict[str, object]:
+    class_sets = [set(row) for row in classes]
+    common_trigger_set = set(common_trigger)
+    if any(len(row) != 4 for row in class_sets):
+        raise AssertionError(f"{family_name} classes must be 4-sets")
+    if any(center in row for row in class_sets):
+        raise AssertionError(f"{family_name} classes cannot contain center {center}")
+    if any(not common_trigger_set <= row for row in class_sets):
+        raise AssertionError(f"{family_name} classes must contain {common_trigger}")
+
+    pair_records: list[dict[str, object]] = []
+    intersection_histogram: Counter[int] = Counter()
+    for left, right in combinations(range(len(classes)), 2):
+        intersection = sorted(class_sets[left] & class_sets[right])
+        intersection_histogram[len(intersection)] += 1
+        pair_records.append(
+            {
+                "class_indices": [left, right],
+                "left_class": _int_list(classes[left]),
+                "right_class": _int_list(classes[right]),
+                "intersection": intersection,
+                "intersection_size": len(intersection),
+                "pairwise_disjoint": len(intersection) == 0,
+            }
+        )
+
+    option_records = [
+        {
+            "auxiliary_class": _int_list(rich_class),
+            "selected_row_options_equal_or_disjoint": _selected_row_options_for_auxiliary_class(
+                center, rich_class
+            ),
+        }
+        for rich_class in classes
+    ]
+    option_count_histogram = Counter(
+        len(record["selected_row_options_equal_or_disjoint"])
+        for record in option_records
+    )
+
+    return {
+        "family_name": family_name,
+        "center": center,
+        "common_trigger": _int_list(common_trigger),
+        "class_count": len(classes),
+        "classes": [_int_list(row) for row in classes],
+        "pair_count": len(pair_records),
+        "intersection_size_histogram": {
+            str(size): count for size, count in sorted(intersection_histogram.items())
+        },
+        "disjoint_pair_count": sum(
+            1 for record in pair_records if record["pairwise_disjoint"]
+        ),
+        "all_pairs_intersect": all(
+            not record["pairwise_disjoint"] for record in pair_records
+        ),
+        "max_same_center_pairwise_disjoint_family_size": _max_pairwise_disjoint_family_size(
+            classes
+        ),
+        "selected_row_option_count_histogram": {
+            str(size): count for size, count in sorted(option_count_histogram.items())
+        },
+        "selected_row_option_records": option_records,
+        "pairwise_intersections": pair_records,
+    }
+
+
+def build_t12_81_3_trigger_uniqueness_payload() -> dict[str, object]:
+    """Return the deterministic 81:3 trigger-family uniqueness packet."""
+
+    supply_classes = _supply_classes()
+    connector_records = _center_3_connector_avoiding_classes()
+    connector_classes = [
+        _int_list(record["rich_class"]) for record in connector_records
+    ]
+
+    supply_audit = _class_family_audit(
+        family_name="center_6_supply_classes_containing_deletion_seed",
+        center=SUPPLY_CENTER,
+        classes=supply_classes,
+        common_trigger=TARGET_DELETION_SEED,
+    )
+    connector_audit = _class_family_audit(
+        family_name="center_3_connector_avoiding_classes_using_label_6",
+        center=TARGET_ROW_CENTER,
+        classes=connector_classes,
+        common_trigger=[4, 6],
+    )
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "same_center_disjointness_rule": RICH_CLASS_DISJOINTNESS_RULE,
+        "interpretation_warnings": [
+            "This audit is internal to the specified center-6 supply-trigger family and center-3 connector-avoiding family.",
+            "It does not enumerate rich classes outside those specified trigger families.",
+            "It does not prove that either trigger class exists in a genuine counterexample.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "center_6_supply_class_count": supply_audit["class_count"],
+            "center_6_supply_pair_count": supply_audit["pair_count"],
+            "center_6_supply_intersection_size_histogram": supply_audit[
+                "intersection_size_histogram"
+            ],
+            "center_6_supply_disjoint_pair_count": supply_audit[
+                "disjoint_pair_count"
+            ],
+            "center_6_supply_max_same_center_pairwise_disjoint_family_size": supply_audit[
+                "max_same_center_pairwise_disjoint_family_size"
+            ],
+            "center_6_selected_row_option_count_histogram": supply_audit[
+                "selected_row_option_count_histogram"
+            ],
+            "center_3_connector_avoiding_class_count": connector_audit[
+                "class_count"
+            ],
+            "center_3_connector_pair_count": connector_audit["pair_count"],
+            "center_3_connector_intersection_size_histogram": connector_audit[
+                "intersection_size_histogram"
+            ],
+            "center_3_connector_disjoint_pair_count": connector_audit[
+                "disjoint_pair_count"
+            ],
+            "center_3_connector_max_same_center_pairwise_disjoint_family_size": connector_audit[
+                "max_same_center_pairwise_disjoint_family_size"
+            ],
+            "center_3_selected_row_option_count_histogram": connector_audit[
+                "selected_row_option_count_histogram"
+            ],
+            "same_center_trigger_uniqueness_status": SCAN_STATUS,
+            "catalogue_gap_removed": (
+                "Within these specified trigger families, a richer catalogue "
+                "cannot contain two center-6 supply triggers or two center-3 "
+                "connector-avoiding triggers at the same center, because any "
+                "two such classes intersect."
+            ),
+            "remaining_gap": (
+                "This does not rule out replacement classes outside the "
+                "specified trigger families, does not prove trigger-class "
+                "existence, and does not add new minimal/rich-class forcing "
+                "hypotheses."
+            ),
+        },
+        "family_audits": {
+            "center_6_supply": supply_audit,
+            "center_3_connector_avoiding": connector_audit,
+        },
+        "source_auxiliary_csp": {
+            "path": AUXILIARY_CSP_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": AUXILIARY_CSP_SCHEMA,
+            "status": AUXILIARY_CSP_STATUS,
+            "scan_status": AUXILIARY_CSP_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "same_center_disjointness_rule": RICH_CLASS_DISJOINTNESS_RULE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "center_6_supply_class_count": 5,
+        "center_6_supply_pair_count": 10,
+        "center_6_supply_intersection_size_histogram": {"3": 10},
+        "center_6_supply_disjoint_pair_count": 0,
+        "center_6_supply_max_same_center_pairwise_disjoint_family_size": 1,
+        "center_6_selected_row_option_count_histogram": {"2": 5},
+        "center_3_connector_avoiding_class_count": 8,
+        "center_3_connector_pair_count": 28,
+        "center_3_connector_intersection_size_histogram": {"2": 12, "3": 16},
+        "center_3_connector_disjoint_pair_count": 0,
+        "center_3_connector_max_same_center_pairwise_disjoint_family_size": 1,
+        "center_3_selected_row_option_count_histogram": {"2": 8},
+        "same_center_trigger_uniqueness_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    family_audits = payload.get("family_audits")
+    if not isinstance(family_audits, Mapping):
+        raise AssertionError("family_audits must be a mapping")
+    supply = family_audits.get("center_6_supply")
+    connector = family_audits.get("center_3_connector_avoiding")
+    for name, audit, expected_class_count in (
+        ("center_6_supply", supply, 5),
+        ("center_3_connector_avoiding", connector, 8),
+    ):
+        if not isinstance(audit, Mapping):
+            raise AssertionError(f"{name} audit must be a mapping")
+        if audit.get("class_count") != expected_class_count:
+            raise AssertionError(f"{name} class count drifted")
+        if audit.get("disjoint_pair_count") != 0:
+            raise AssertionError(f"{name} must have no disjoint trigger pairs")
+        if audit.get("all_pairs_intersect") is not True:
+            raise AssertionError(f"{name} trigger pairs must all intersect")
+        if audit.get("max_same_center_pairwise_disjoint_family_size") != 1:
+            raise AssertionError(f"{name} must be same-center unique")
+
+    source = payload.get("source_auxiliary_csp")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_auxiliary_csp must be a mapping")
+    if source.get("schema") != AUXILIARY_CSP_SCHEMA:
+        raise AssertionError("source auxiliary-CSP schema drifted")
+    if source.get("scan_status") != AUXILIARY_CSP_SCAN_STATUS:
+        raise AssertionError("source auxiliary-CSP scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_trigger_uniqueness.py
+++ b/tests/test_bootstrap_t12_81_3_trigger_uniqueness.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_trigger_uniqueness import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_trigger_uniqueness_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_trigger_uniqueness_payload()
+
+
+def test_81_3_trigger_uniqueness_counts_and_scope(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_TRIGGER_UNIQUENESS_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Same-center disjointness audit" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_trigger_uniqueness_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["center_6_supply_class_count"] == 5
+    assert summary["center_6_supply_pair_count"] == 10
+    assert summary["center_6_supply_intersection_size_histogram"] == {"3": 10}
+    assert summary["center_6_supply_disjoint_pair_count"] == 0
+    assert summary["center_6_supply_max_same_center_pairwise_disjoint_family_size"] == 1
+    assert summary["center_6_selected_row_option_count_histogram"] == {"2": 5}
+    assert summary["center_3_connector_avoiding_class_count"] == 8
+    assert summary["center_3_connector_pair_count"] == 28
+    assert summary["center_3_connector_intersection_size_histogram"] == {
+        "2": 12,
+        "3": 16,
+    }
+    assert summary["center_3_connector_disjoint_pair_count"] == 0
+    assert (
+        summary["center_3_connector_max_same_center_pairwise_disjoint_family_size"]
+        == 1
+    )
+    assert summary["center_3_selected_row_option_count_histogram"] == {"2": 8}
+    assert summary["same_center_trigger_uniqueness_status"] == SCAN_STATUS
+
+
+def test_81_3_trigger_uniqueness_family_audits(
+    payload: dict[str, object],
+) -> None:
+    audits = payload["family_audits"]
+    supply = audits["center_6_supply"]
+    connector = audits["center_3_connector_avoiding"]
+
+    assert supply["all_pairs_intersect"] is True
+    assert supply["disjoint_pair_count"] == 0
+    assert supply["max_same_center_pairwise_disjoint_family_size"] == 1
+    assert {tuple(row) for row in supply["classes"]} == {
+        (0, 1, 2, 4),
+        (0, 1, 3, 4),
+        (0, 1, 4, 5),
+        (0, 1, 4, 7),
+        (0, 1, 4, 8),
+    }
+
+    assert connector["all_pairs_intersect"] is True
+    assert connector["disjoint_pair_count"] == 0
+    assert connector["max_same_center_pairwise_disjoint_family_size"] == 1
+    assert {tuple(row) for row in connector["classes"]} == {
+        (0, 2, 4, 6),
+        (0, 4, 5, 6),
+        (0, 4, 6, 7),
+        (0, 4, 6, 8),
+        (1, 2, 4, 6),
+        (1, 4, 5, 6),
+        (1, 4, 6, 7),
+        (1, 4, 6, 8),
+    }
+
+
+def test_81_3_trigger_uniqueness_selected_row_options(
+    payload: dict[str, object],
+) -> None:
+    audits = payload["family_audits"]
+    for audit in audits.values():
+        for record in audit["selected_row_option_records"]:
+            rich_class = set(record["auxiliary_class"])
+            options = record["selected_row_options_equal_or_disjoint"]
+            assert len(options) == 2
+            assert set(options[0]) == rich_class
+            assert set(options[1]).isdisjoint(rich_class)
+
+
+def test_81_3_trigger_uniqueness_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_trigger_uniqueness_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["same_center_trigger_uniqueness_status"] == SCAN_STATUS
+
+
+def test_81_3_trigger_uniqueness_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["center_6_supply_disjoint_pair_count"] = 1
+
+    with pytest.raises(AssertionError, match="center_6_supply_disjoint_pair_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a generator-backed `81:3` trigger-family uniqueness audit
- record that the specified center-6 supply family and center-3 connector-avoiding family each have maximum same-center pairwise-disjoint family size 1
- document the narrowed remaining gap without promoting n=9, bridge, or global status claims

## Verification

- `python scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_trigger_uniqueness.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`