### PR TITLE
Add 81:3 rich-support auxiliary CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the order-resolved `81:3` fixed-row escape audit, where label `6`
   appears only after center `3` in the fixed singleton-rich closure, read
   [`docs/bootstrap-t12-81-3-order-escape.md`](docs/bootstrap-t12-81-3-order-escape.md).
-- For the relaxed `81:3` escape-candidate scans, auxiliary-class CSP, and
-  trigger-family uniqueness audit, which probe center-`3` connector and
+- For the relaxed `81:3` escape-candidate scans, auxiliary/rich-support CSPs,
+  and trigger-family uniqueness audit, which probe center-`3` connector and
   center-`6` supply escapes around source `81`, read
   [`docs/bootstrap-t12-81-3-escape-candidates.md`](docs/bootstrap-t12-81-3-escape-candidates.md)
   and
@@ -114,7 +114,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   plus
   [`docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`](docs/bootstrap-t12-81-3-escape-auxiliary-csp.md)
   and
-  [`docs/bootstrap-t12-81-3-trigger-uniqueness.md`](docs/bootstrap-t12-81-3-trigger-uniqueness.md).
+  [`docs/bootstrap-t12-81-3-trigger-uniqueness.md`](docs/bootstrap-t12-81-3-trigger-uniqueness.md),
+  then
+  [`docs/bootstrap-t12-81-3-escape-rich-support-csp.md`](docs/bootstrap-t12-81-3-escape-rich-support-csp.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -347,6 +347,21 @@ bridge. See `docs/bootstrap-t12-81-3-trigger-uniqueness.md`,
 `scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py`, and
 `data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json`.
 
+The rich-support auxiliary CSP then allows those two auxiliary objects to be
+larger rich distance-class supports. It enumerates 31 center-`6` supply
+supports containing `[0,1,4]` and 30 center-`3` connector-avoiding supports
+using label `6`, for 930 fixed auxiliary support pairs. Selected rows at
+centers `3` and `6` may be any 4-subset of the auxiliary support or any
+disjoint 4-set; the other seven selected rows are arbitrary. The implicit
+selected-row space has `996734092900000000` assignments, and exact
+backtracking visits `2169` nodes with no complete assignment under the
+row-pair, witness-pair, crossing, and same-center disjointness filters. This
+is still a finite diagnostic only, not a proof of support existence, row
+forcing, `n=9`, or the bootstrap bridge. See
+`docs/bootstrap-t12-81-3-escape-rich-support-csp.md`,
+`scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py`, and
+`data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -177,13 +177,20 @@ the specified center-`6` supply family and center-`3` connector-avoiding family
 are each same-center unique: all pairs inside either family intersect, so a
 genuine rich-class catalogue can contain at most one class from each specified
 trigger family. This narrows the auxiliary-CSP wording only; it still does not
-prove trigger-class existence, row forcing, `n=9`, or the bridge. See
+prove trigger-class existence, row forcing, `n=9`, or the bridge. A richer
+support CSP then allows the center-`6` supply object and center-`3`
+connector-avoiding object to be full rich supports of size larger than four:
+31 supply supports and 30 connector-avoiding supports produce 930 auxiliary
+support pairs, and exact backtracking finds no complete basic-filter
+assignment in the implicit `996734092900000000` selected-row space. This still
+does not prove the supports exist, row forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-3-escape-candidates.md` and
 `docs/bootstrap-t12-81-3-escape-one-row-drop.md`, plus
 `docs/bootstrap-t12-81-3-escape-two-row-drop.md` and
 `docs/bootstrap-t12-81-3-escape-full-neighborhood.md`, and then
 `docs/bootstrap-t12-81-3-escape-auxiliary-csp.md` and
-`docs/bootstrap-t12-81-3-trigger-uniqueness.md`.
+`docs/bootstrap-t12-81-3-trigger-uniqueness.md`, plus
+`docs/bootstrap-t12-81-3-escape-rich-support-csp.md`.
 
 ## New exact fixed-pattern obstructions
 

--- a/data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json
+++ b/data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json
@@ -1,0 +1,31881 @@
+{
+  "claim_scope": "Rich-support auxiliary CSP relaxation of the 81:3 escape scan. The center-6 pre-3 supply object may be any rich support of size 4 through 8 containing deletion seed [0,1,4]. The center-3 connector-avoiding object may be any rich support of size 4 through 7 containing [0,4,6] but not 1, or [1,4,6] but not 0. Selected rows at those centers may be any 4-subset of the auxiliary support or any disjoint 4-set; all seven other selected rows are arbitrary 4-sets. Exact backtracking proves no complete assignment satisfies the row-pair, witness-pair, crossing, and same-center disjointness filters. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "empty_domain_depth_histogram": {
+    "0": 164,
+    "1": 28,
+    "2": 106,
+    "3": 151,
+    "4": 437,
+    "5": 230,
+    "6": 71,
+    "7": 55,
+    "8": 26
+  },
+  "fixed_auxiliary_support_pair_summaries": [
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 13,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 6,
+        "6": 1,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 36,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 6,
+        "6": 1,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 36,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 7,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 13,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 7
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 21,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 10,
+        "5": 9,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 37,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 7,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 8,
+        "5": 10
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 37,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 14,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 9,
+        "5": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 26,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 33,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "3": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 11,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 8,
+        "5": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 35,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 14,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 9,
+        "5": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 26,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 19,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 3,
+        "6": 2,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 37,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "4": 11,
+        "5": 3,
+        "6": 3,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 39,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "3": 3,
+        "4": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 12,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 44,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 14,
+        "5": 13,
+        "6": 12
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 79,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 12,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 4,
+        "4": 4,
+        "5": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 19,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 39,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 5,
+        "4": 21,
+        "5": 11
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 55,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "2": 3,
+        "3": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 8,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 7,
+      "empty_domain_depth_histogram": {
+        "2": 2,
+        "3": 2,
+        "4": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 14,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 5,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 46,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 12,
+        "5": 15,
+        "6": 11,
+        "7": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 85,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 13,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 4,
+        "5": 3,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 41,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 1,
+        "3": 3,
+        "4": 25,
+        "5": 11
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 60,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "2": 2,
+        "3": 2,
+        "4": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 10,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 7,
+      "empty_domain_depth_histogram": {
+        "2": 2,
+        "3": 3,
+        "4": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 13,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 5,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 37,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 11,
+        "6": 4,
+        "7": 12,
+        "8": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 8,
+      "search_node_count": 74,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 20,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 3,
+        "4": 8,
+        "5": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 30,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 18,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 3,
+        "4": 10,
+        "5": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 26,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 46,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "3": 15,
+        "4": 30
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 68,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 33,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 10,
+        "6": 4,
+        "7": 5,
+        "8": 5
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 8,
+      "search_node_count": 74,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 30,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 14,
+        "5": 14,
+        "6": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 48,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 24,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 1,
+        "4": 16,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 35,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 46,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "3": 15,
+        "4": 30
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 4,
+      "search_node_count": 68,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 25,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 3,
+        "6": 12,
+        "7": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 7,
+      "search_node_count": 54,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 16,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 3,
+        "4": 8,
+        "5": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 24,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 15,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 4,
+        "4": 6,
+        "5": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 22,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 7,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 13,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 25,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 8,
+        "5": 3,
+        "6": 13
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 6,
+      "search_node_count": 53,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 25,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "4": 16,
+        "5": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 38,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 21,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 2,
+        "4": 12,
+        "5": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 5,
+      "search_node_count": 31,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 7,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 13,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 4,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 2,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 5,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 5,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "2": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "2": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 4,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 6,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "2": 3,
+        "3": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 8,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 6,
+      "empty_domain_depth_histogram": {
+        "2": 2,
+        "3": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 10,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 65,
+      "empty_domain_depth_histogram": {
+        "3": 15,
+        "4": 15,
+        "5": 10,
+        "6": 5,
+        "7": 5,
+        "8": 15
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 8,
+      "search_node_count": 167,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 8,
+      "empty_domain_depth_histogram": {
+        "2": 2,
+        "3": 6
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 12,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 70,
+      "empty_domain_depth_histogram": {
+        "3": 15,
+        "4": 15,
+        "5": 10,
+        "7": 25,
+        "8": 5
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 8,
+      "search_node_count": 167,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 9,
+      "empty_domain_depth_histogram": {
+        "2": 1,
+        "3": 8
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 14,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 5,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 5,
+      "empty_domain_depth_histogram": {
+        "2": 3,
+        "3": 2
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 8,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "2": 3
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 2,
+      "search_node_count": 5,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 6,
+      "empty_domain_depth_histogram": {
+        "2": 2,
+        "3": 4
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 3,
+      "search_node_count": 10,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 5,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 5,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 6,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 15,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "initial_status": "SEARCH_EXHAUSTED",
+      "max_depth": 0,
+      "search_node_count": 1,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 7,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 35,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 5,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 5,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 6,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 15,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_supply_support": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      "auxiliary_supply_support_size": 8,
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "auxiliary_target_support_size": 7,
+      "complete_solution_count": 0,
+      "empty_domain_count": 0,
+      "empty_domain_depth_histogram": {},
+      "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+      "max_depth": 0,
+      "search_node_count": 0,
+      "selected_row_choice_count_at_supply_center": 70,
+      "selected_row_choice_count_at_target_center": 35,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    }
+  ],
+  "interpretation_warnings": [
+    "This CSP treats the center-6 supply object and center-3 connector object as auxiliary rich supports, not merely 4-set classes.",
+    "Selected rows at centers 3 and 6 may be any 4-subset of the auxiliary support or any disjoint 4-set.",
+    "The CSP uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_escape_rich_support_csp.v1",
+  "source_trigger_uniqueness_audit": {
+    "path": "data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json",
+    "scan_status": "SPECIFIED_TRIGGER_FAMILIES_ARE_SAME_CENTER_UNIQUE",
+    "schema": "erdos97.bootstrap_t12_81_3_trigger_uniqueness.v1",
+    "status": "BOOTSTRAP_T12_81_3_TRIGGER_UNIQUENESS_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_ESCAPE_RICH_SUPPORT_CSP_DIAGNOSTIC_ONLY",
+  "summary": {
+    "auxiliary_support_centers": [
+      3,
+      6
+    ],
+    "center_3_connector_avoiding_support_count": 30,
+    "center_6_supply_support_count": 31,
+    "complete_solution_count": 0,
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "empty_domain_count": 1268,
+    "fixed_auxiliary_support_pair_count": 930,
+    "free_row_replacement_count_per_non_auxiliary_center": 70,
+    "free_selected_row_centers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "implicit_selected_assignment_space_size": 996734092900000000,
+    "initial_auxiliary_support_pair_incompatible_count": 700,
+    "initial_auxiliary_support_pair_searched_count": 230,
+    "remaining_gap": "This does not prove the supply or connector support exists, does not model additional auxiliary rich supports at other centers, and does not add new minimal/rich-class forcing hypotheses.",
+    "scan_status": "NO_BASIC_FILTER_SURVIVORS_WITH_RICH_SUPPORT_AUXILIARIES",
+    "search_node_count": 2169,
+    "source_record_ids": [
+      81
+    ],
+    "supply_center": 6,
+    "surviving_assignment_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "support_generation": {
+    "center_3_connector_avoiding_supports": [
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          5,
+          6
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          6,
+          7
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          6,
+          8
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          5,
+          6
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          6,
+          7
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          6,
+          8
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          5,
+          6,
+          7
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          5,
+          6,
+          8
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          6,
+          7,
+          8
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          5,
+          6,
+          7
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          5,
+          6,
+          8
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          6,
+          7,
+          8
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          0,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 1,
+        "support": [
+          0,
+          2,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "support_size": 7
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          6
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          5,
+          6
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "support_size": 4
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          6,
+          7
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          6,
+          8
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          5,
+          6,
+          7
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          5,
+          6,
+          8
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          6,
+          7,
+          8
+        ],
+        "support_size": 5
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          5,
+          6,
+          7
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          5,
+          6,
+          8
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          6,
+          7,
+          8
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "support_size": 6
+      },
+      {
+        "activation_triple": [
+          1,
+          4,
+          6
+        ],
+        "forbidden_connector_endpoint": 0,
+        "support": [
+          1,
+          2,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "support_size": 7
+      }
+    ],
+    "center_3_connector_support_size_histogram": {
+      "4": 8,
+      "5": 12,
+      "6": 8,
+      "7": 2
+    },
+    "center_3_selected_row_choice_count_histogram": {
+      "15": 8,
+      "2": 8,
+      "35": 2,
+      "5": 12
+    },
+    "center_3_total_selected_row_choices_over_supports": 266,
+    "center_6_selected_row_choice_count_histogram": {
+      "15": 10,
+      "2": 5,
+      "35": 5,
+      "5": 10,
+      "70": 1
+    },
+    "center_6_supply_support_size_histogram": {
+      "4": 5,
+      "5": 10,
+      "6": 10,
+      "7": 5,
+      "8": 1
+    },
+    "center_6_supply_supports": [
+      [
+        0,
+        1,
+        2,
+        4
+      ],
+      [
+        0,
+        1,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        8
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        8
+      ],
+      [
+        0,
+        1,
+        4,
+        5,
+        7
+      ],
+      [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        1,
+        4,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        4,
+        5,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        3,
+        4,
+        5,
+        7,
+        8
+      ],
+      [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8
+      ]
+    ],
+    "center_6_total_selected_row_choices_over_supports": 455
+  },
+  "survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-escape-rich-support-csp.md
+++ b/docs/bootstrap-t12-81-3-escape-rich-support-csp.md
@@ -1,0 +1,109 @@
+# Bootstrap T12 81:3 Rich-Support Auxiliary Escape CSP
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet strengthens `docs/bootstrap-t12-81-3-escape-auxiliary-csp.md`.
+There, the center-`6` supply object and center-`3` connector-avoiding object
+were represented by 4-set auxiliary classes. Here they may be larger rich
+distance-class supports.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json`.
+
+## Scan Scope
+
+The center-`6` supply support may be any rich support of size `4` through `8`
+containing the deletion seed `[0,1,4]`. The support-size histogram is:
+
+```text
+size 4:  5
+size 5: 10
+size 6: 10
+size 7:  5
+size 8:  1
+```
+
+The center-`3` connector-avoiding support may contain `[0,4,6]` but not `1`,
+or `[1,4,6]` but not `0`. This keeps the support from already containing the
+connector pair `[0,1]`. The support-size histogram is:
+
+```text
+size 4:  8
+size 5: 12
+size 6:  8
+size 7:  2
+```
+
+For centers `3` and `6`, the selected row may be any 4-subset of the auxiliary
+support or any 4-set disjoint from it. The seven other selected-row centers
+
+```text
+0,1,2,4,5,7,8
+```
+
+may choose any of their `70` possible selected 4-sets.
+
+The total implicit selected-row assignment space is:
+
+```text
+996734092900000000
+```
+
+The checker treats each auxiliary support as a genuine rich support for the
+basic filters: support pairs contribute all witness-pairs inside the support,
+two supports at different centers may not share three witnesses, and a
+two-witness overlap must satisfy the same crossing condition as selected rows.
+
+## Result
+
+The rich-support auxiliary CSP has no complete assignment satisfying the basic
+filters:
+
+```text
+surviving assignments: 0
+```
+
+The checked scan status is:
+
+```text
+NO_BASIC_FILTER_SURVIVORS_WITH_RICH_SUPPORT_AUXILIARIES
+```
+
+The deterministic backtracking summary is:
+
+```text
+auxiliary support pairs: 930
+initial support-pair incompatible: 700
+initial support-pair searched: 230
+search nodes: 2169
+empty domains: 1268
+complete solutions: 0
+```
+
+## Remaining Gap
+
+This closes the larger-support version of the focused `81:3` escape model:
+within this model, the supply or connector need not be exactly a 4-set class.
+
+It still does not prove that a supply or connector support exists, does not
+model additional auxiliary rich supports at other centers, and does not add a
+minimality or rich-class forcing hypothesis. It also remains an incidence and
+crossing diagnostic, not a Euclidean realizability theorem.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It narrows one concrete escape route in
+the `81:3` proof-mining chain.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -619,6 +619,17 @@ catalogue. This narrows the auxiliary-CSP catalogue gap only; it does not prove
 trigger-class existence, row forcing, `n=9`, the bootstrap bridge, or Erdos
 Problem #97.
 
+The rich-support auxiliary CSP in
+`docs/bootstrap-t12-81-3-escape-rich-support-csp.md` extends that audit by
+allowing the center-`6` supply object and center-`3` connector-avoiding object
+to be rich supports of size larger than four. It checks all 930 support pairs
+from 31 supply supports and 30 connector-avoiding supports, with selected rows
+at those centers allowed to be 4-subsets of the support or disjoint 4-sets.
+Exact backtracking leaves no complete assignment satisfying the same basic
+filters. This remains a finite proof-mining diagnostic only, not a proof of
+support existence, row forcing, `n=9`, the bootstrap bridge, or Erdos Problem
+#97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -115,10 +115,13 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-trigger-uniqueness.md` checks that richer
    catalogues cannot contain two classes from the specified center-`6` supply
    family or two classes from the specified center-`3` connector-avoiding
-   family, because the classes pairwise intersect at the same center. The next
-   useful PR must therefore either allow replacement classes outside those
-   specified trigger families, introduce a genuine rich-class/minimality
-   hypothesis strong enough to forbid those outside replacements, or move to a
+   family, because the classes pairwise intersect at the same center. The
+   rich-support CSP in
+   `docs/bootstrap-t12-81-3-escape-rich-support-csp.md` then lets those
+   auxiliary objects be supports larger than four labels and still finds no
+   complete basic-filter assignment. The next useful PR must therefore either
+   introduce a genuine rich-class/minimality hypothesis that forces such a
+   support to exist, add other-center auxiliary supports, or move to a
    different bridge target.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,6 +191,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-trigger-uniqueness.md`](bootstrap-t12-81-3-trigger-uniqueness.md):
   same-center disjointness audit showing the specified center-`6` supply and
   center-`3` connector trigger families are each internally unique.
+- [`bootstrap-t12-81-3-escape-rich-support-csp.md`](bootstrap-t12-81-3-escape-rich-support-csp.md):
+  rich-support auxiliary CSP allowing the center-`3` connector and center-`6`
+  supply objects to be supports larger than four labels.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -378,6 +378,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   trigger family is same-center unique. The remaining target is outside those
   specified trigger families or a genuine rich-class/minimality hypothesis,
   not more copies of the same supply or connector trigger at the same center.
+- bootstrap/T12 focused `81:3` rich-support evidence, as recorded in
+  `docs/bootstrap-t12-81-3-escape-rich-support-csp.md`, extending the auxiliary
+  escape CSP from 4-set trigger classes to larger rich supports at centers `3`
+  and `6`. The remaining target is now support existence, additional
+  auxiliary supports at other centers, or a different bridge target.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -248,6 +248,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_3_trigger_uniqueness.json"
       verifier: "scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py"
       claim_scope: "proof-mining diagnostic only; shows the specified center-6 supply-trigger family and center-3 connector-avoiding trigger family each have maximum same-center pairwise-disjoint subfamily size 1, but does not prove trigger-class existence, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_81_3_escape_rich_support_csp"
+      status: "rich-support auxiliary CSP for the 81:3 pre-3 label-6 escape"
+      artifact: "data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json"
+      verifier: "scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py"
+      claim_scope: "proof-mining diagnostic only; allows the center-6 supply object and center-3 connector-avoiding object to be rich supports larger than four labels and rules out the implicit 996734092900000000 selected-row assignment space by basic incidence/crossing/same-center-disjointness backtracking, but does not prove support existence, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3292,6 +3292,101 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_escape_rich_support_csp
+    path: data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py
+    command: python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py
+    check_command: python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Rich-support auxiliary CSP for the 81:3 pre-3 label-6 escape; no complete selected-row assignment exists in the implicit 996734092900000000-assignment space under basic incidence/crossing/same-center-disjointness filters, but this is not support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_escape_rich_support_csp.v1
+      status: BOOTSTRAP_T12_81_3_ESCAPE_RICH_SUPPORT_CSP_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.supply_center: 6
+      summary.target_center: 3
+      summary.free_selected_row_centers:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.auxiliary_support_centers:
+        - 3
+        - 6
+      summary.center_6_supply_support_count: 31
+      summary.center_3_connector_avoiding_support_count: 30
+      summary.fixed_auxiliary_support_pair_count: 930
+      summary.free_row_replacement_count_per_non_auxiliary_center: 70
+      summary.implicit_selected_assignment_space_size: 996734092900000000
+      summary.search_node_count: 2169
+      summary.empty_domain_count: 1268
+      summary.initial_auxiliary_support_pair_incompatible_count: 700
+      summary.initial_auxiliary_support_pair_searched_count: 230
+      summary.complete_solution_count: 0
+      summary.surviving_assignment_count: 0
+      summary.scan_status: NO_BASIC_FILTER_SURVIVORS_WITH_RICH_SUPPORT_AUXILIARIES
+      support_generation.center_6_supply_support_size_histogram.4: 5
+      support_generation.center_6_supply_support_size_histogram.5: 10
+      support_generation.center_6_supply_support_size_histogram.6: 10
+      support_generation.center_6_supply_support_size_histogram.7: 5
+      support_generation.center_6_supply_support_size_histogram.8: 1
+      support_generation.center_3_connector_support_size_histogram.4: 8
+      support_generation.center_3_connector_support_size_histogram.5: 12
+      support_generation.center_3_connector_support_size_histogram.6: 8
+      support_generation.center_3_connector_support_size_histogram.7: 2
+      support_generation.center_6_total_selected_row_choices_over_supports: 455
+      support_generation.center_3_total_selected_row_choices_over_supports: 266
+      source_trigger_uniqueness_audit.schema: erdos97.bootstrap_t12_81_3_trigger_uniqueness.v1
+      source_trigger_uniqueness_audit.scan_status: SPECIFIED_TRIGGER_FAMILIES_ARE_SAME_CENTER_UNIQUE
+      provenance.generator: scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich support exists
+      - the 81:3 row is forced
+      - the rich-support CSP proves genuine rich-class order
+      - the rich-support CSP proves no pre-3 label-6 supply exists
+      - the rich-support CSP proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py
+++ b/scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 rich-support auxiliary escape CSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_escape_rich_support_csp import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_escape_rich_support_csp_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 rich-support auxiliary escape CSP")
+    print(
+        "implicit selected assignment space: "
+        f"{summary['implicit_selected_assignment_space_size']}"
+    )
+    print(f"support pairs: {summary['fixed_auxiliary_support_pair_count']}")
+    print(f"search nodes: {summary['search_node_count']}")
+    print(f"survivors: {summary['surviving_assignment_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_escape_rich_support_csp_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 rich-support CSP artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 rich-support CSP expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_81_3_escape_rich_support_csp.py
+++ b/src/erdos97/bootstrap_t12_81_3_escape_rich_support_csp.py
@@ -1,0 +1,615 @@
+"""Rich-support auxiliary CSP for the bootstrap/T12 81:3 escape.
+
+The auxiliary-class CSP treats the center-6 supply and center-3
+connector-avoiding objects as 4-set rich classes.  This packet allows those
+objects to be larger rich distance-class supports.  A selected row at the same
+center may be any 4-subset of the support, or any 4-set disjoint from it.
+
+The search is exact finite incidence/crossing bookkeeping.  It is not a
+Euclidean realizability theorem and not a proof of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_escape_full_neighborhood import (
+    ROW_REPLACEMENT_COUNT_PER_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+from erdos97.bootstrap_t12_81_3_trigger_uniqueness import (
+    DEFAULT_ARTIFACT as TRIGGER_UNIQUENESS_ARTIFACT,
+    SCAN_STATUS as TRIGGER_UNIQUENESS_SCAN_STATUS,
+    SCHEMA as TRIGGER_UNIQUENESS_SCHEMA,
+    STATUS as TRIGGER_UNIQUENESS_STATUS,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import (
+    CROSS_OK,
+    LABELS,
+    MASK_TO_PAIR_INDEX,
+    _all_replacement_row_masks,
+    _row_mask,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_escape_rich_support_csp.v1"
+STATUS = "BOOTSTRAP_T12_81_3_ESCAPE_RICH_SUPPORT_CSP_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_BASIC_FILTER_SURVIVORS_WITH_RICH_SUPPORT_AUXILIARIES"
+CLAIM_SCOPE = (
+    "Rich-support auxiliary CSP relaxation of the 81:3 escape scan. The "
+    "center-6 pre-3 supply object may be any rich support of size 4 through 8 "
+    "containing deletion seed [0,1,4]. The center-3 connector-avoiding object "
+    "may be any rich support of size 4 through 7 containing [0,4,6] but not 1, "
+    "or [1,4,6] but not 0. Selected rows at those centers may be any 4-subset "
+    "of the auxiliary support or any disjoint 4-set; all seven other selected "
+    "rows are arbitrary 4-sets. Exact backtracking proves no complete "
+    "assignment satisfies the row-pair, witness-pair, crossing, and "
+    "same-center disjointness filters. This is not a proof of genuine "
+    "rich-class order, not a proof of row forcing, not a proof of n=9, not a "
+    "proof of the bridge, and not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_escape_rich_support_csp.json"
+)
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _bit_labels(mask: int) -> list[int]:
+    return [label for label in CYCLIC_ORDER if mask & (1 << label)]
+
+
+def _pair_indices(mask: int) -> list[int]:
+    indices: list[int] = []
+    for left, right in combinations(_bit_labels(mask), 2):
+        indices.append(MASK_TO_PAIR_INDEX[(1 << left) | (1 << right)])
+    return indices
+
+
+def _support_masks_containing(
+    center: int,
+    required: Sequence[int],
+    *,
+    forbidden: Sequence[int] = (),
+) -> list[int]:
+    required_set = set(required)
+    forbidden_set = set(forbidden)
+    universe = [
+        label
+        for label in CYCLIC_ORDER
+        if label != center and label not in forbidden_set
+    ]
+    optional = [label for label in universe if label not in required_set]
+    support_masks: list[int] = []
+    for size in range(len(optional) + 1):
+        for extra in combinations(optional, size):
+            support = sorted(required_set | set(extra))
+            if len(support) >= 4:
+                support_masks.append(_row_mask(support))
+    return support_masks
+
+
+def _supply_support_masks() -> list[int]:
+    return _support_masks_containing(SUPPLY_CENTER, TARGET_DELETION_SEED)
+
+
+def _connector_support_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for activation_triple, forbidden in (
+        ([0, 4, 6], [1]),
+        ([1, 4, 6], [0]),
+    ):
+        for support_mask in _support_masks_containing(
+            TARGET_ROW_CENTER,
+            activation_triple,
+            forbidden=forbidden,
+        ):
+            records.append(
+                {
+                    "activation_triple": activation_triple,
+                    "forbidden_connector_endpoint": forbidden[0],
+                    "support": _bit_labels(support_mask),
+                    "support_mask": support_mask,
+                    "support_size": support_mask.bit_count(),
+                }
+            )
+    return records
+
+
+def _selected_row_choices_for_support(center: int, support_mask: int) -> list[int]:
+    return [
+        row_mask
+        for row_mask in _all_replacement_row_masks(center)
+        if (row_mask & ~support_mask) == 0 or not (row_mask & support_mask)
+    ]
+
+
+def _support_pair_compatible(
+    center_a: int,
+    support_a: int,
+    center_b: int,
+    support_b: int,
+) -> bool:
+    source_a, source_b = sorted((center_a, center_b))
+    intersection = support_a & support_b
+    intersection_size = intersection.bit_count()
+    if intersection_size > 2:
+        return False
+    if intersection_size == 2:
+        pair_index = MASK_TO_PAIR_INDEX[intersection]
+        return bool(CROSS_OK[(source_a, source_b, pair_index)])
+    return True
+
+
+def _add_pair_centers(
+    center: int,
+    support_mask: int,
+    pair_centers: dict[int, set[int]],
+) -> None:
+    for pair_index in _pair_indices(support_mask):
+        pair_centers.setdefault(pair_index, set()).add(center)
+
+
+def _build_pair_centers(
+    auxiliary_supports: Mapping[int, int],
+    selected: Mapping[int, Sequence[int]],
+) -> dict[int, set[int]]:
+    pair_centers: dict[int, set[int]] = {}
+    for center, support_mask in auxiliary_supports.items():
+        _add_pair_centers(center, support_mask, pair_centers)
+    for center, row_masks in selected.items():
+        for row_mask in row_masks:
+            _add_pair_centers(center, row_mask, pair_centers)
+    return pair_centers
+
+
+def _compatible_with_catalogue(
+    center: int,
+    row_mask: int,
+    auxiliary_supports: Mapping[int, int],
+    selected: Mapping[int, Sequence[int]],
+    pair_centers: Mapping[int, set[int]],
+) -> bool:
+    for pair_index in _pair_indices(row_mask):
+        centers = pair_centers.get(pair_index, set())
+        if center not in centers and len(centers) >= 2:
+            return False
+
+    for other_center, other_support in auxiliary_supports.items():
+        if other_center != center and not _support_pair_compatible(
+            center, row_mask, other_center, other_support
+        ):
+            return False
+
+    for other_center, other_rows in selected.items():
+        if other_center == center:
+            continue
+        for other_row in other_rows:
+            if not _support_pair_compatible(center, row_mask, other_center, other_row):
+                return False
+    return True
+
+
+def _search_support_pair(
+    supply_support: int,
+    connector_support: int,
+) -> dict[str, object]:
+    auxiliary_supports = {
+        SUPPLY_CENTER: supply_support,
+        TARGET_ROW_CENTER: connector_support,
+    }
+    if not _support_pair_compatible(
+        SUPPLY_CENTER,
+        supply_support,
+        TARGET_ROW_CENTER,
+        connector_support,
+    ):
+        return {
+            "initial_status": "INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE",
+            "search_node_count": 0,
+            "empty_domain_count": 0,
+            "complete_solution_count": 0,
+            "max_depth": 0,
+            "empty_domain_depth_histogram": {},
+        }
+
+    selected: dict[int, list[int]] = {}
+    pair_centers = _build_pair_centers(auxiliary_supports, selected)
+    choices = {
+        center: _all_replacement_row_masks(center) for center in CYCLIC_ORDER
+    }
+    choices[SUPPLY_CENTER] = _selected_row_choices_for_support(
+        SUPPLY_CENTER, supply_support
+    )
+    choices[TARGET_ROW_CENTER] = _selected_row_choices_for_support(
+        TARGET_ROW_CENTER, connector_support
+    )
+
+    stats = {
+        "search_node_count": 0,
+        "empty_domain_count": 0,
+        "complete_solution_count": 0,
+        "max_depth": 0,
+    }
+    empty_depths: Counter[int] = Counter()
+
+    def search() -> None:
+        nonlocal pair_centers
+        stats["search_node_count"] += 1
+        depth = len(selected)
+        stats["max_depth"] = max(int(stats["max_depth"]), depth)
+        if len(selected) == len(LABELS):
+            stats["complete_solution_count"] += 1
+            return
+
+        best_center: int | None = None
+        best_options: list[int] | None = None
+        for center in LABELS:
+            if center in selected:
+                continue
+            options = [
+                row_mask
+                for row_mask in choices[center]
+                if _compatible_with_catalogue(
+                    center, row_mask, auxiliary_supports, selected, pair_centers
+                )
+            ]
+            if best_options is None or len(options) < len(best_options):
+                best_center = center
+                best_options = options
+            if not options:
+                stats["empty_domain_count"] += 1
+                empty_depths[depth] += 1
+                return
+
+        if best_center is None or best_options is None:
+            raise AssertionError("search reached inconsistent assignment state")
+        for row_mask in best_options:
+            selected[best_center] = [row_mask]
+            pair_centers = _build_pair_centers(auxiliary_supports, selected)
+            search()
+            del selected[best_center]
+            pair_centers = _build_pair_centers(auxiliary_supports, selected)
+
+    search()
+    stats["initial_status"] = "SEARCH_EXHAUSTED"
+    stats["empty_domain_depth_histogram"] = {
+        str(depth): count for depth, count in sorted(empty_depths.items())
+    }
+    return stats
+
+
+def _scan_csp() -> dict[str, object]:
+    supply_supports = _supply_support_masks()
+    connector_records = _connector_support_records()
+    connector_supports = [
+        int(record["support_mask"]) for record in connector_records
+    ]
+
+    support_pair_summaries: list[dict[str, object]] = []
+    aggregate = Counter()
+    empty_depths: Counter[str] = Counter()
+    for supply_support in supply_supports:
+        for connector_record, connector_support in zip(
+            connector_records, connector_supports, strict=True
+        ):
+            stats = _search_support_pair(supply_support, connector_support)
+            aggregate["search_node_count"] += int(stats["search_node_count"])
+            aggregate["empty_domain_count"] += int(stats["empty_domain_count"])
+            aggregate["complete_solution_count"] += int(stats["complete_solution_count"])
+            aggregate[f"initial_status:{stats['initial_status']}"] += 1
+            for depth, count in dict(stats["empty_domain_depth_histogram"]).items():
+                empty_depths[str(depth)] += int(count)
+            support_pair_summaries.append(
+                {
+                    "auxiliary_supply_support": _bit_labels(supply_support),
+                    "auxiliary_supply_support_size": supply_support.bit_count(),
+                    "auxiliary_target_support": connector_record["support"],
+                    "auxiliary_target_support_size": connector_record["support_size"],
+                    "target_center_activation_triple": connector_record[
+                        "activation_triple"
+                    ],
+                    "target_center_forbidden_connector_endpoint": connector_record[
+                        "forbidden_connector_endpoint"
+                    ],
+                    "selected_row_choice_count_at_supply_center": len(
+                        _selected_row_choices_for_support(
+                            SUPPLY_CENTER, supply_support
+                        )
+                    ),
+                    "selected_row_choice_count_at_target_center": len(
+                        _selected_row_choices_for_support(
+                            TARGET_ROW_CENTER, connector_support
+                        )
+                    ),
+                    **stats,
+                }
+            )
+
+    return {
+        "support_pair_summaries": support_pair_summaries,
+        "aggregate": dict(sorted(aggregate.items())),
+        "empty_domain_depth_histogram": dict(sorted(empty_depths.items())),
+    }
+
+
+def _support_generation_summary() -> dict[str, object]:
+    supply_supports = _supply_support_masks()
+    connector_records = _connector_support_records()
+    connector_supports = [
+        int(record["support_mask"]) for record in connector_records
+    ]
+    supply_choice_counts = [
+        len(_selected_row_choices_for_support(SUPPLY_CENTER, support))
+        for support in supply_supports
+    ]
+    connector_choice_counts = [
+        len(_selected_row_choices_for_support(TARGET_ROW_CENTER, support))
+        for support in connector_supports
+    ]
+    return {
+        "center_6_supply_supports": [
+            _bit_labels(support) for support in supply_supports
+        ],
+        "center_3_connector_avoiding_supports": [
+            {
+                key: value
+                for key, value in record.items()
+                if key not in {"support_mask"}
+            }
+            for record in connector_records
+        ],
+        "center_6_supply_support_size_histogram": {
+            str(size): count
+            for size, count in sorted(
+                Counter(support.bit_count() for support in supply_supports).items()
+            )
+        },
+        "center_3_connector_support_size_histogram": {
+            str(size): count
+            for size, count in sorted(
+                Counter(support.bit_count() for support in connector_supports).items()
+            )
+        },
+        "center_6_selected_row_choice_count_histogram": {
+            str(size): count
+            for size, count in sorted(Counter(supply_choice_counts).items())
+        },
+        "center_3_selected_row_choice_count_histogram": {
+            str(size): count
+            for size, count in sorted(Counter(connector_choice_counts).items())
+        },
+        "center_6_total_selected_row_choices_over_supports": sum(
+            supply_choice_counts
+        ),
+        "center_3_total_selected_row_choices_over_supports": sum(
+            connector_choice_counts
+        ),
+    }
+
+
+def build_t12_81_3_escape_rich_support_csp_payload() -> dict[str, object]:
+    """Return the deterministic rich-support auxiliary escape CSP packet."""
+
+    support_generation = _support_generation_summary()
+    scan = _scan_csp()
+    aggregate = scan["aggregate"]
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("aggregate must be a mapping")
+    implicit_space = (
+        int(support_generation["center_6_total_selected_row_choices_over_supports"])
+        * int(support_generation["center_3_total_selected_row_choices_over_supports"])
+        * (ROW_REPLACEMENT_COUNT_PER_CENTER ** 7)
+    )
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This CSP treats the center-6 supply object and center-3 connector object as auxiliary rich supports, not merely 4-set classes.",
+            "Selected rows at centers 3 and 6 may be any 4-subset of the auxiliary support or any disjoint 4-set.",
+            "The CSP uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "free_selected_row_centers": CYCLIC_ORDER,
+            "auxiliary_support_centers": [TARGET_ROW_CENTER, SUPPLY_CENTER],
+            "center_6_supply_support_count": len(_supply_support_masks()),
+            "center_3_connector_avoiding_support_count": len(
+                _connector_support_records()
+            ),
+            "fixed_auxiliary_support_pair_count": len(
+                scan["support_pair_summaries"]
+            ),
+            "free_row_replacement_count_per_non_auxiliary_center": ROW_REPLACEMENT_COUNT_PER_CENTER,
+            "implicit_selected_assignment_space_size": implicit_space,
+            "search_node_count": aggregate["search_node_count"],
+            "empty_domain_count": aggregate["empty_domain_count"],
+            "initial_auxiliary_support_pair_incompatible_count": aggregate[
+                "initial_status:INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE"
+            ],
+            "initial_auxiliary_support_pair_searched_count": aggregate[
+                "initial_status:SEARCH_EXHAUSTED"
+            ],
+            "complete_solution_count": aggregate["complete_solution_count"],
+            "surviving_assignment_count": aggregate["complete_solution_count"],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not prove the supply or connector support exists, "
+                "does not model additional auxiliary rich supports at other "
+                "centers, and does not add new minimal/rich-class forcing "
+                "hypotheses."
+            ),
+        },
+        "support_generation": support_generation,
+        "empty_domain_depth_histogram": scan["empty_domain_depth_histogram"],
+        "fixed_auxiliary_support_pair_summaries": scan["support_pair_summaries"],
+        "survivors": [],
+        "source_trigger_uniqueness_audit": {
+            "path": TRIGGER_UNIQUENESS_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": TRIGGER_UNIQUENESS_SCHEMA,
+            "status": TRIGGER_UNIQUENESS_STATUS,
+            "scan_status": TRIGGER_UNIQUENESS_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "free_selected_row_centers": CYCLIC_ORDER,
+        "auxiliary_support_centers": [TARGET_ROW_CENTER, SUPPLY_CENTER],
+        "center_6_supply_support_count": 31,
+        "center_3_connector_avoiding_support_count": 30,
+        "fixed_auxiliary_support_pair_count": 930,
+        "free_row_replacement_count_per_non_auxiliary_center": 70,
+        "implicit_selected_assignment_space_size": 996734092900000000,
+        "search_node_count": 2169,
+        "empty_domain_count": 1268,
+        "initial_auxiliary_support_pair_incompatible_count": 700,
+        "initial_auxiliary_support_pair_searched_count": 230,
+        "complete_solution_count": 0,
+        "surviving_assignment_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    support_generation = payload.get("support_generation")
+    if not isinstance(support_generation, Mapping):
+        raise AssertionError("support_generation must be a mapping")
+    expected_generation = {
+        "center_6_supply_support_size_histogram": {
+            "4": 5,
+            "5": 10,
+            "6": 10,
+            "7": 5,
+            "8": 1,
+        },
+        "center_3_connector_support_size_histogram": {
+            "4": 8,
+            "5": 12,
+            "6": 8,
+            "7": 2,
+        },
+        "center_6_selected_row_choice_count_histogram": {
+            "2": 5,
+            "5": 10,
+            "15": 10,
+            "35": 5,
+            "70": 1,
+        },
+        "center_3_selected_row_choice_count_histogram": {
+            "2": 8,
+            "5": 12,
+            "15": 8,
+            "35": 2,
+        },
+        "center_6_total_selected_row_choices_over_supports": 455,
+        "center_3_total_selected_row_choices_over_supports": 266,
+    }
+    for key, expected in expected_generation.items():
+        if support_generation.get(key) != expected:
+            raise AssertionError(
+                f"support_generation {key} is {support_generation.get(key)!r}, expected {expected!r}"
+            )
+
+    fixed_summaries = payload.get("fixed_auxiliary_support_pair_summaries")
+    if not isinstance(fixed_summaries, Sequence) or len(fixed_summaries) != 930:
+        raise AssertionError("expected 930 fixed-auxiliary-support-pair summaries")
+    if any(
+        isinstance(record, Mapping) and record.get("complete_solution_count") != 0
+        for record in fixed_summaries
+    ):
+        raise AssertionError("no fixed auxiliary support pair should have a solution")
+
+    survivors = payload.get("survivors")
+    if survivors != []:
+        raise AssertionError("survivors must be empty")
+
+    source = payload.get("source_trigger_uniqueness_audit")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_trigger_uniqueness_audit must be a mapping")
+    if source.get("schema") != TRIGGER_UNIQUENESS_SCHEMA:
+        raise AssertionError("source trigger-uniqueness schema drifted")
+    if source.get("scan_status") != TRIGGER_UNIQUENESS_SCAN_STATUS:
+        raise AssertionError("source trigger-uniqueness scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_escape_rich_support_csp.py
+++ b/tests/test_bootstrap_t12_81_3_escape_rich_support_csp.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_escape_rich_support_csp import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_escape_rich_support_csp_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_escape_rich_support_csp_payload()
+
+
+def test_81_3_rich_support_csp_counts_and_scope(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_ESCAPE_RICH_SUPPORT_CSP_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Rich-support auxiliary CSP" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_rich_support_csp_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["free_selected_row_centers"] == list(range(9))
+    assert summary["auxiliary_support_centers"] == [3, 6]
+    assert summary["center_6_supply_support_count"] == 31
+    assert summary["center_3_connector_avoiding_support_count"] == 30
+    assert summary["fixed_auxiliary_support_pair_count"] == 930
+    assert summary["free_row_replacement_count_per_non_auxiliary_center"] == 70
+    assert summary["implicit_selected_assignment_space_size"] == 996734092900000000
+    assert summary["search_node_count"] == 2169
+    assert summary["empty_domain_count"] == 1268
+    assert summary["initial_auxiliary_support_pair_incompatible_count"] == 700
+    assert summary["initial_auxiliary_support_pair_searched_count"] == 230
+    assert summary["complete_solution_count"] == 0
+    assert summary["surviving_assignment_count"] == 0
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_rich_support_csp_generation(payload: dict[str, object]) -> None:
+    generation = payload["support_generation"]
+
+    assert generation["center_6_supply_support_size_histogram"] == {
+        "4": 5,
+        "5": 10,
+        "6": 10,
+        "7": 5,
+        "8": 1,
+    }
+    assert generation["center_3_connector_support_size_histogram"] == {
+        "4": 8,
+        "5": 12,
+        "6": 8,
+        "7": 2,
+    }
+    assert generation["center_6_selected_row_choice_count_histogram"] == {
+        "2": 5,
+        "5": 10,
+        "15": 10,
+        "35": 5,
+        "70": 1,
+    }
+    assert generation["center_3_selected_row_choice_count_histogram"] == {
+        "2": 8,
+        "5": 12,
+        "15": 8,
+        "35": 2,
+    }
+    assert generation["center_6_total_selected_row_choices_over_supports"] == 455
+    assert generation["center_3_total_selected_row_choices_over_supports"] == 266
+
+
+def test_81_3_rich_support_csp_pair_summaries(
+    payload: dict[str, object],
+) -> None:
+    fixed_summaries = payload["fixed_auxiliary_support_pair_summaries"]
+
+    assert len(fixed_summaries) == 930
+    assert sum(record["complete_solution_count"] for record in fixed_summaries) == 0
+    assert {
+        record["initial_status"] for record in fixed_summaries
+    } == {"INITIAL_AUXILIARY_SUPPORT_PAIR_INCOMPATIBLE", "SEARCH_EXHAUSTED"}
+    assert sum(record["search_node_count"] for record in fixed_summaries) == 2169
+    assert sum(record["empty_domain_count"] for record in fixed_summaries) == 1268
+
+
+def test_81_3_rich_support_csp_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_rich_support_csp_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_assignment_count"] == 0
+
+
+def test_81_3_rich_support_csp_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_assignment_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_assignment_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- extend the focused `81:3` auxiliary escape audit from 4-set trigger classes to larger rich supports
- enumerate 31 center-6 supply supports and 30 center-3 connector-avoiding supports, covering 930 support pairs
- record that the implicit `996734092900000000` selected-row assignment space has zero basic-filter survivors, while keeping the result scoped as a review-pending diagnostic

## Verification

- `python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json`
- `python -m pytest tests/test_bootstrap_t12_81_3_escape_rich_support_csp.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`