### PR TITLE
Add 151:6 outside-pair audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the source-`81` row-`8` singleton-support audit, where all fixed and
   one-row-drop activation-row survivors keep the original row `8`, read
   [`docs/bootstrap-t12-81-8-singleton-support-audit.md`](docs/bootstrap-t12-81-8-singleton-support-audit.md).
+- For the source-`151` row-`6` outside-pair audit, where all fixed and
+  one-row-drop activation-row survivors keep the original row `6`, read
+  [`docs/bootstrap-t12-151-6-outside-pair-audit.md`](docs/bootstrap-t12-151-6-outside-pair-audit.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -376,6 +376,20 @@ existence, row forcing, `n=9`, or the bootstrap bridge. See
 `scripts/check_bootstrap_t12_81_8_singleton_support_audit.py`, and
 `data/certificates/bootstrap_t12_81_8_singleton_support_audit.json`.
 
+The source-`151` row-`6` outside-pair audit probes the remaining
+relation-sufficient row target. Center `6` has bootstrap-core witness `[0]`
+and outside support pairs `[3,5]`, `[3,8]`, and `[5,8]`; the audit enumerates
+the thirteen selected rows containing `[0]` and one of those support pairs. In
+the fixed source-`151` neighborhood, only the original row `[0,3,5,8]`
+survives the row-pair, witness-pair, and crossing filters. In the one-row-drop
+relaxation, all eight survivors are trivial original-neighborhood survivors:
+row `6` remains `[0,3,5,8]`, and the dropped row remains its original
+source-`151` row. This is still a finite diagnostic only, not a proof of
+outside-pair support existence, row forcing, `n=9`, or the bootstrap bridge.
+See `docs/bootstrap-t12-151-6-outside-pair-audit.md`,
+`scripts/check_bootstrap_t12_151_6_outside_pair_audit.py`, and
+`data/certificates/bootstrap_t12_151_6_outside_pair_audit.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -202,6 +202,16 @@ incidence/crossing bookkeeping only, not singleton-support existence, row
 forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-8-singleton-support-audit.md`.
 
+A source-`151` row-`6` outside-pair audit now probes the remaining
+relation-sufficient row target. It enumerates the thirteen center-`6` rows
+containing bootstrap-core witness `[0]` and one outside support pair from
+`[3,5]`, `[3,8]`, or `[5,8]`; only the original row `[0,3,5,8]` survives with
+the fixed source-`151` neighborhood. A one-row-drop relaxation checks `7280`
+candidates and again has no non-original row-`6` survivor. This remains basic
+incidence/crossing bookkeeping only, not outside-pair support existence, row
+forcing, `n=9`, or the bridge. See
+`docs/bootstrap-t12-151-6-outside-pair-audit.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_151_6_outside_pair_audit.json
+++ b/data/certificates/bootstrap_t12_151_6_outside_pair_audit.json
@@ -1,0 +1,1601 @@
+{
+  "candidate_generation": {
+    "candidate_rule": "4-sets at center 6 containing bootstrap-core witness [0] and at least one outside support pair from [3,5], [3,8], or [5,8].",
+    "target_center_candidate_classes": [
+      [
+        0,
+        1,
+        3,
+        5
+      ],
+      [
+        0,
+        1,
+        3,
+        8
+      ],
+      [
+        0,
+        1,
+        5,
+        8
+      ],
+      [
+        0,
+        2,
+        3,
+        5
+      ],
+      [
+        0,
+        2,
+        3,
+        8
+      ],
+      [
+        0,
+        2,
+        5,
+        8
+      ],
+      [
+        0,
+        3,
+        4,
+        5
+      ],
+      [
+        0,
+        3,
+        4,
+        8
+      ],
+      [
+        0,
+        3,
+        5,
+        7
+      ],
+      [
+        0,
+        3,
+        5,
+        8
+      ],
+      [
+        0,
+        3,
+        7,
+        8
+      ],
+      [
+        0,
+        4,
+        5,
+        8
+      ],
+      [
+        0,
+        5,
+        7,
+        8
+      ]
+    ]
+  },
+  "claim_scope": "Fixed selected-row-neighborhood outside-pair audit for source 151 row 6. It enumerates the thirteen center-6 selected rows containing bootstrap-core witness [0] and one outside support pair from [3,5], [3,8], or [5,8], then checks the fixed source-151 neighborhood and a one-row-drop relaxation by row-pair, witness-pair, and crossing filters. The only survivors keep the original row 6 and, in the one-row-drop scan, also keep the dropped row equal to its original source-151 row. This does not prove outside-pair support existence, row forcing, does not prove n=9, does not prove the bridge, and is not a counterexample.",
+  "fixed_neighborhood_candidates": [
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "witness_pair+crossing",
+      "rejection_reasons": [
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            1,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            1,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            0,
+            1
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "crossing",
+      "rejection_reasons": [
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        1,
+        3,
+        8
+      ],
+      "witness_pair_cap_violations": []
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            0,
+            1
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            1,
+            5
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            2,
+            6
+          ],
+          "intersection": [
+            1,
+            5,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        1,
+        5,
+        8
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            6,
+            8
+          ],
+          "pair": [
+            1,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            0,
+            6
+          ],
+          "witness_chord": [
+            2,
+            3
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            2,
+            5
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            0,
+            2,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            8
+          ],
+          "pair": [
+            2,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            3,
+            6
+          ],
+          "witness_chord": [
+            0,
+            2
+          ]
+        },
+        {
+          "source_chord": [
+            5,
+            6
+          ],
+          "witness_chord": [
+            2,
+            8
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            0,
+            6
+          ],
+          "intersection": [
+            2,
+            3,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        2,
+        3,
+        8
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            5,
+            6
+          ],
+          "pair": [
+            2,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            5,
+            6
+          ],
+          "witness_chord": [
+            2,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            8
+          ],
+          "witness_chord": [
+            2,
+            5
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            3,
+            6
+          ],
+          "intersection": [
+            0,
+            2,
+            5
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        2,
+        5,
+        8
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            3,
+            6,
+            8
+          ],
+          "pair": [
+            2,
+            5
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            0,
+            5,
+            6
+          ],
+          "pair": [
+            2,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            2,
+            6
+          ],
+          "witness_chord": [
+            4,
+            5
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            0,
+            4
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            1,
+            6
+          ],
+          "intersection": [
+            0,
+            3,
+            4
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        3,
+        4,
+        5
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            0,
+            4
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            5,
+            6
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            0,
+            4
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            1,
+            6
+          ],
+          "intersection": [
+            0,
+            3,
+            4
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        3,
+        4,
+        8
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            5,
+            6
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            3,
+            7
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            1,
+            6
+          ],
+          "intersection": [
+            0,
+            3,
+            7
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            4,
+            6
+          ],
+          "pair": [
+            3,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [],
+      "is_original_row": true,
+      "passes_basic_incidence_crossing_filters": true,
+      "rejection_category": "survive",
+      "rejection_reasons": [],
+      "row_pair_cap_violations": [],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "witness_pair_cap_violations": []
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            4,
+            6
+          ],
+          "witness_chord": [
+            3,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            5,
+            6
+          ],
+          "witness_chord": [
+            7,
+            8
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            1,
+            6
+          ],
+          "intersection": [
+            0,
+            3,
+            7
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        3,
+        7,
+        8
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            4,
+            6
+          ],
+          "pair": [
+            3,
+            7
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            5,
+            6
+          ],
+          "witness_chord": [
+            4,
+            8
+          ]
+        },
+        {
+          "source_chord": [
+            6,
+            7
+          ],
+          "witness_chord": [
+            0,
+            4
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "row_pair+witness_pair+crossing",
+      "rejection_reasons": [
+        "row_pair",
+        "witness_pair",
+        "crossing"
+      ],
+      "row_pair_cap_violations": [
+        {
+          "centers": [
+            2,
+            6
+          ],
+          "intersection": [
+            4,
+            5,
+            8
+          ],
+          "intersection_size": 3
+        }
+      ],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        4,
+        5,
+        8
+      ],
+      "witness_pair_cap_violations": [
+        {
+          "center_count": 3,
+          "centers": [
+            1,
+            6,
+            7
+          ],
+          "pair": [
+            0,
+            4
+          ]
+        },
+        {
+          "center_count": 3,
+          "centers": [
+            2,
+            5,
+            6
+          ],
+          "pair": [
+            4,
+            8
+          ]
+        }
+      ]
+    },
+    {
+      "crossing_violations": [
+        {
+          "source_chord": [
+            1,
+            6
+          ],
+          "witness_chord": [
+            0,
+            7
+          ]
+        },
+        {
+          "source_chord": [
+            5,
+            6
+          ],
+          "witness_chord": [
+            7,
+            8
+          ]
+        }
+      ],
+      "is_original_row": false,
+      "passes_basic_incidence_crossing_filters": false,
+      "rejection_category": "crossing",
+      "rejection_reasons": [
+        "crossing"
+      ],
+      "row_pair_cap_violations": [],
+      "target_center": 6,
+      "target_center_class": [
+        0,
+        5,
+        7,
+        8
+      ],
+      "witness_pair_cap_violations": []
+    }
+  ],
+  "interpretation_warnings": [
+    "This audit preserves the source-151 selected-row neighborhood, or drops exactly one non-target row in the relaxation.",
+    "A row containing bootstrap-core witnesses plus an outside support pair is activation bookkeeping, not a proof that a genuine rich class exists.",
+    "The audit uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "one_row_drop": {
+    "candidate_count": 7280,
+    "per_dropped_center": [
+      {
+        "candidate_count": 910,
+        "dropped_center": 0,
+        "rejection_category_counts": {
+          "crossing": 16,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 850,
+          "survive": 1,
+          "witness_pair+crossing": 39
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 1,
+        "rejection_category_counts": {
+          "crossing": 22,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 826,
+          "survive": 1,
+          "witness_pair+crossing": 57
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 2,
+        "rejection_category_counts": {
+          "crossing": 21,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 839,
+          "survive": 1,
+          "witness_pair+crossing": 45
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 3,
+        "rejection_category_counts": {
+          "crossing": 17,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 849,
+          "survive": 1,
+          "witness_pair+crossing": 39
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          0,
+          2,
+          5,
+          6
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 4,
+        "rejection_category_counts": {
+          "crossing": 10,
+          "row_pair+crossing": 4,
+          "row_pair+witness_pair": 8,
+          "row_pair+witness_pair+crossing": 861,
+          "survive": 1,
+          "witness_pair+crossing": 26
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 5,
+        "rejection_category_counts": {
+          "crossing": 11,
+          "row_pair+crossing": 4,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 868,
+          "survive": 1,
+          "witness_pair+crossing": 22
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 7,
+        "rejection_category_counts": {
+          "crossing": 11,
+          "row_pair+crossing": 5,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 863,
+          "survive": 1,
+          "witness_pair+crossing": 26
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "surviving_candidate_count": 1
+      },
+      {
+        "candidate_count": 910,
+        "dropped_center": 8,
+        "rejection_category_counts": {
+          "crossing": 10,
+          "row_pair+crossing": 2,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 868,
+          "survive": 1,
+          "witness_pair+crossing": 25
+        },
+        "replacement_row_count": 70,
+        "source_row": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "surviving_candidate_count": 1
+      }
+    ],
+    "per_target_center_class": [
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 4,
+          "row_pair+witness_pair+crossing": 472,
+          "witness_pair+crossing": 84
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 36,
+          "row_pair+crossing": 3,
+          "row_pair+witness_pair+crossing": 477,
+          "witness_pair+crossing": 44
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          1,
+          3,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 4,
+          "row_pair+crossing": 1,
+          "row_pair+witness_pair+crossing": 550,
+          "witness_pair+crossing": 5
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          1,
+          5,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 5,
+          "row_pair+witness_pair+crossing": 550,
+          "witness_pair+crossing": 5
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          2,
+          3,
+          5
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 4,
+          "row_pair+crossing": 1,
+          "row_pair+witness_pair+crossing": 549,
+          "witness_pair+crossing": 6
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          2,
+          3,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "row_pair+witness_pair+crossing": 553,
+          "witness_pair+crossing": 7
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          2,
+          5,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 3,
+          "row_pair+crossing": 1,
+          "row_pair+witness_pair+crossing": 552,
+          "witness_pair+crossing": 4
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          3,
+          4,
+          5
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "row_pair+witness_pair+crossing": 549,
+          "witness_pair+crossing": 11
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 1,
+          "row_pair+crossing": 3,
+          "row_pair+witness_pair": 4,
+          "row_pair+witness_pair+crossing": 546,
+          "witness_pair+crossing": 6
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 24,
+          "row_pair+witness_pair": 32,
+          "row_pair+witness_pair+crossing": 448,
+          "survive": 8,
+          "witness_pair+crossing": 48
+        },
+        "surviving_candidate_count": 8,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 4,
+          "row_pair+witness_pair+crossing": 552,
+          "witness_pair+crossing": 4
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          3,
+          7,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "row_pair+witness_pair+crossing": 548,
+          "witness_pair+crossing": 12
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "target_center_class_is_original": false
+      },
+      {
+        "candidate_count": 560,
+        "rejection_category_counts": {
+          "crossing": 33,
+          "row_pair+crossing": 6,
+          "row_pair+witness_pair+crossing": 478,
+          "witness_pair+crossing": 43
+        },
+        "surviving_candidate_count": 0,
+        "target_center_class": [
+          0,
+          5,
+          7,
+          8
+        ],
+        "target_center_class_is_original": false
+      }
+    ],
+    "rejection_category_counts": {
+      "crossing": 118,
+      "row_pair+crossing": 15,
+      "row_pair+witness_pair": 36,
+      "row_pair+witness_pair+crossing": 6824,
+      "survive": 8,
+      "witness_pair+crossing": 279
+    },
+    "survivors": [
+      {
+        "dropped_center": 0,
+        "dropped_center_class": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 1,
+        "dropped_center_class": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 2,
+        "dropped_center_class": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 3,
+        "dropped_center_class": [
+          0,
+          2,
+          5,
+          6
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 4,
+        "dropped_center_class": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 5,
+        "dropped_center_class": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 7,
+        "dropped_center_class": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      },
+      {
+        "dropped_center": 8,
+        "dropped_center_class": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "dropped_center_class_is_original": true,
+        "target_center_class": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "target_center_class_is_original": true
+      }
+    ]
+  },
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_151_6_outside_pair_audit.py"
+  },
+  "schema": "erdos97.bootstrap_t12_151_6_outside_pair_audit.v1",
+  "source_outside_pair_packet": {
+    "path": "data/certificates/bootstrap_t12_outside_pair.json",
+    "schema": "erdos97.bootstrap_t12_outside_pair.v1",
+    "status": "BOOTSTRAP_T12_OUTSIDE_PAIR_DIAGNOSTIC_ONLY"
+  },
+  "source_outside_pair_record": {
+    "bootstrap_core_witnesses": [
+      0
+    ],
+    "ledger_private_pair_support_hit_count": 2,
+    "outside_witnesses": [
+      3,
+      5,
+      8
+    ],
+    "pressure_class": "NEEDS_OUTSIDE_PAIR_AND_PRIVATE_CENTER",
+    "row_center": 6,
+    "row_center_private_in_all_deletion_closures": true,
+    "source_record_id": 151,
+    "support_pair_modes": {
+      "LEDGER_PRIVATE_PAIR_HIT": 2,
+      "PRIVATE_HALO_ONLY": 1
+    },
+    "support_pairs": [
+      [
+        3,
+        5
+      ],
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "witnesses": [
+      0,
+      3,
+      5,
+      8
+    ]
+  },
+  "source_overlay_packet": {
+    "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+    "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+    "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY"
+  },
+  "source_rows": {
+    "0": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "1": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "2": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "3": [
+      0,
+      2,
+      5,
+      6
+    ],
+    "4": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "5": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "6": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "7": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "8": [
+      1,
+      2,
+      5,
+      7
+    ]
+  },
+  "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_AUDIT_DIAGNOSTIC_ONLY",
+  "summary": {
+    "bootstrap_core_witnesses": [
+      0
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "fixed_neighborhood_candidate_count": 13,
+    "fixed_neighborhood_non_original_survivor_count": 0,
+    "fixed_neighborhood_rejection_category_counts": {
+      "crossing": 2,
+      "row_pair+witness_pair+crossing": 9,
+      "survive": 1,
+      "witness_pair+crossing": 1
+    },
+    "fixed_neighborhood_surviving_candidate_count": 1,
+    "one_row_drop_candidate_count": 7280,
+    "one_row_drop_centers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      7,
+      8
+    ],
+    "one_row_drop_non_original_row6_survivor_count": 0,
+    "one_row_drop_rejection_category_counts": {
+      "crossing": 118,
+      "row_pair+crossing": 15,
+      "row_pair+witness_pair": 36,
+      "row_pair+witness_pair+crossing": 6824,
+      "survive": 8,
+      "witness_pair+crossing": 279
+    },
+    "one_row_drop_replacement_count_per_center": 70,
+    "one_row_drop_surviving_candidate_count": 8,
+    "one_row_drop_survivors_all_original_rows": true,
+    "original_target_center_class": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "outside_support_pairs": [
+      [
+        3,
+        5
+      ],
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "remaining_gap": "This does not prove outside-pair support existence, does not prove the row is forced by minimal or rich-class geometry, does not allow two or more other rows to move, and does not model additional auxiliary rich supports.",
+    "scan_status": "ONLY_ORIGINAL_ROW6_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS",
+    "source_record_ids": [
+      151
+    ],
+    "target_center": 6,
+    "target_center_candidate_count": 13,
+    "target_row_key": "151:6"
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-151-6-outside-pair-audit.md
+++ b/docs/bootstrap-t12-151-6-outside-pair-audit.md
@@ -1,0 +1,129 @@
+# Bootstrap T12 151:6 Outside-Pair Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet follows the outside-pair and relation-sufficient ledgers for source
+`151`, row `6`. That row has bootstrap-core witness `[0]` and three outside
+support pairs:
+
+```text
+[3,5]
+[3,8]
+[5,8]
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_151_6_outside_pair_audit.json`.
+
+## Scan Scope
+
+The scan enumerates every center-`6` selected row containing bootstrap-core
+witness `[0]` and at least one outside support pair from `[3,5]`, `[3,8]`, or
+`[5,8]`. There are thirteen such rows:
+
+```text
+[0,1,3,5]
+[0,1,3,8]
+[0,1,5,8]
+[0,2,3,5]
+[0,2,3,8]
+[0,2,5,8]
+[0,3,4,5]
+[0,3,4,8]
+[0,3,5,7]
+[0,3,5,8]
+[0,3,7,8]
+[0,4,5,8]
+[0,5,7,8]
+```
+
+First, the scan replaces only source-`151` row `6` and preserves the other
+eight source-`151` selected rows.
+
+Second, it performs a one-row-drop relaxation: for each dropped center in
+
+```text
+0,1,2,3,4,5,7,8
+```
+
+the dropped row may be any of its `70` possible selected 4-sets while row `6`
+uses one of the thirteen outside-pair activation rows. This gives
+
+```text
+13 * 8 * 70 = 7280
+```
+
+one-row-drop candidates.
+
+Both scans use only the basic selected-row filters:
+
+- row-pair cap;
+- witness-pair cap;
+- two-overlap crossing.
+
+No Euclidean realization, exact distance equation, minimality hypothesis, or
+rich-class forcing hypothesis is used.
+
+## Result
+
+In the fixed-neighborhood scan, the only survivor is the original row:
+
+```text
+[0,3,5,8]
+```
+
+The fixed-neighborhood rejection counts are:
+
+```text
+crossing: 2
+row_pair+witness_pair+crossing: 9
+witness_pair+crossing: 1
+survive: 1
+```
+
+In the one-row-drop relaxation, there are eight survivors. All eight are the
+trivial original-neighborhood survivors: row `6` is `[0,3,5,8]`, and the
+dropped row is also equal to its original source-`151` row.
+
+The aggregate one-row-drop rejection counts are:
+
+```text
+crossing: 118
+row_pair+crossing: 15
+row_pair+witness_pair: 36
+row_pair+witness_pair+crossing: 6824
+witness_pair+crossing: 279
+survive: 8
+```
+
+The checked scan status is:
+
+```text
+ONLY_ORIGINAL_ROW6_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS
+```
+
+## Remaining Gap
+
+This closes a narrow local escape route for the `151:6` bridge target under a
+fixed source-`151` neighborhood and a one-row-drop stress test. It does not
+prove that outside support pairs are forced by a genuine rich-class catalogue,
+does not allow two or more other rows to move, and does not model additional
+auxiliary rich supports.
+
+## What This Does Not Prove
+
+This artifact does not prove outside-pair support existence, row forcing,
+`n=9`, the bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining
+diagnostic for one relation-sufficient row target.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -640,6 +640,17 @@ dropped row equal to its original source-`81` row. This remains a finite
 proof-mining diagnostic only, not a proof of singleton support existence, row
 forcing, `n=9`, the bootstrap bridge, or Erdos Problem #97.
 
+The source-`151` row-`6` outside-pair audit in
+`docs/bootstrap-t12-151-6-outside-pair-audit.md` checks the remaining
+relation-sufficient row target. It enumerates the thirteen center-`6` rows
+that contain bootstrap-core witness `[0]` and one outside support pair from
+`[3,5]`, `[3,8]`, or `[5,8]`. Only the original row `[0,3,5,8]` survives in
+the fixed source-`151` neighborhood; in the one-row-drop relaxation, the only
+survivors also keep the dropped row equal to its original source-`151` row.
+This remains a finite proof-mining diagnostic only, not a proof of outside-pair
+support existence, row forcing, `n=9`, the bootstrap bridge, or Erdos Problem
+#97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -126,7 +126,13 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-8-singleton-support-audit.md` is one such adjacent
    target: it finds no non-original row-`8` activation survivor in the fixed
    source-`81` neighborhood or a one-row-drop relaxation, but still leaves
-   genuine singleton-support existence and row forcing open.
+   genuine singleton-support existence and row forcing open. The
+   source-`151` row-`6` outside-pair audit in
+   `docs/bootstrap-t12-151-6-outside-pair-audit.md` does the analogous check
+   for the remaining relation-sufficient row target: no non-original row-`6`
+   activation survivor appears in the fixed source-`151` neighborhood or a
+   one-row-drop relaxation, but genuine outside-pair support existence and row
+   forcing remain open.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,6 +197,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-8-singleton-support-audit.md`](bootstrap-t12-81-8-singleton-support-audit.md):
   source-`81` row-`8` singleton-support audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.
+- [`bootstrap-t12-151-6-outside-pair-audit.md`](bootstrap-t12-151-6-outside-pair-audit.md):
+  source-`151` row-`6` outside-pair audit showing only the original row
+  survives the fixed-neighborhood and one-row-drop activation-row scans.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -389,6 +389,12 @@ condition that the surviving multi-block family does not automatically satisfy:
   row-`8` activation survivor under basic incidence/crossing filters. The
   remaining target is still genuine singleton-support or row-forcing
   geometry, not a proof that row `8` is forced.
+- bootstrap/T12 focused `151:6` outside-pair evidence, as recorded in
+  `docs/bootstrap-t12-151-6-outside-pair-audit.md`, showing that the fixed
+  source-`151` neighborhood and one-row-drop relaxation have no non-original
+  row-`6` activation survivor under basic incidence/crossing filters. The
+  remaining target is still genuine outside-pair support or row-forcing
+  geometry, not a proof that row `6` is forced.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -258,6 +258,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_81_8_singleton_support_audit.json"
       verifier: "scripts/check_bootstrap_t12_81_8_singleton_support_audit.py"
       claim_scope: "proof-mining diagnostic only; enumerates the nine center-8 rows containing bootstrap-core witnesses [0,2] and singleton support label 5 or 6, and finds no non-original row-8 survivor in the fixed source-81 neighborhood or one-row-drop relaxation, but does not prove singleton support existence, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_151_6_outside_pair_audit"
+      status: "outside-pair activation-row audit for the 151:6 relation-sufficient target"
+      artifact: "data/certificates/bootstrap_t12_151_6_outside_pair_audit.json"
+      verifier: "scripts/check_bootstrap_t12_151_6_outside_pair_audit.py"
+      claim_scope: "proof-mining diagnostic only; enumerates the thirteen center-6 rows containing bootstrap-core witness [0] and outside support pair [3,5], [3,8], or [5,8], and finds no non-original row-6 survivor in the fixed source-151 neighborhood or one-row-drop relaxation, but does not prove outside-pair support existence, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3478,6 +3478,100 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_151_6_outside_pair_audit
+    path: data/certificates/bootstrap_t12_151_6_outside_pair_audit.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_151_6_outside_pair_audit.py
+    command: python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_151_6_outside_pair_audit.py
+    check_command: python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-151 row-6 outside-pair activation-row audit; no non-original row-6 activation survivor exists in the fixed source-151 neighborhood or one-row-drop relaxation under basic incidence/crossing filters, but this is not outside-pair support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_151_6_outside_pair_audit.v1
+      status: BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_AUDIT_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "151:6"
+      summary.source_record_ids:
+        - 151
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.target_center: 6
+      summary.bootstrap_core_witnesses:
+        - 0
+      summary.outside_support_pairs:
+        - [3, 5]
+        - [3, 8]
+        - [5, 8]
+      summary.original_target_center_class:
+        - 0
+        - 3
+        - 5
+        - 8
+      summary.target_center_candidate_count: 13
+      summary.fixed_neighborhood_candidate_count: 13
+      summary.fixed_neighborhood_surviving_candidate_count: 1
+      summary.fixed_neighborhood_non_original_survivor_count: 0
+      summary.fixed_neighborhood_rejection_category_counts.crossing: 2
+      summary.fixed_neighborhood_rejection_category_counts.row_pair+witness_pair+crossing: 9
+      summary.fixed_neighborhood_rejection_category_counts.witness_pair+crossing: 1
+      summary.fixed_neighborhood_rejection_category_counts.survive: 1
+      summary.one_row_drop_centers:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 7
+        - 8
+      summary.one_row_drop_replacement_count_per_center: 70
+      summary.one_row_drop_candidate_count: 7280
+      summary.one_row_drop_surviving_candidate_count: 8
+      summary.one_row_drop_non_original_row6_survivor_count: 0
+      summary.one_row_drop_survivors_all_original_rows: true
+      summary.one_row_drop_rejection_category_counts.crossing: 118
+      summary.one_row_drop_rejection_category_counts.row_pair+crossing: 15
+      summary.one_row_drop_rejection_category_counts.row_pair+witness_pair: 36
+      summary.one_row_drop_rejection_category_counts.row_pair+witness_pair+crossing: 6824
+      summary.one_row_drop_rejection_category_counts.witness_pair+crossing: 279
+      summary.one_row_drop_rejection_category_counts.survive: 8
+      summary.scan_status: ONLY_ORIGINAL_ROW6_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS
+      source_outside_pair_packet.schema: erdos97.bootstrap_t12_outside_pair.v1
+      source_outside_pair_record.support_pairs:
+        - [3, 5]
+        - [3, 8]
+        - [5, 8]
+      source_overlay_packet.schema: erdos97.bootstrap_vertex_circle_overlay.v1
+      provenance.generator: scripts/check_bootstrap_t12_151_6_outside_pair_audit.py
+      provenance.command: python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - outside pair support proves row-center forcing
+      - the 151:6 row is forced
+      - the 151:6 outside support exists
+      - the 151:6 audit proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_151_6_outside_pair_audit.py
+++ b/scripts/check_bootstrap_t12_151_6_outside_pair_audit.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 151:6 outside-pair audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_151_6_outside_pair_audit import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_151_6_outside_pair_audit_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 151:6 outside-pair audit")
+    print(f"row-6 candidate count: {summary['target_center_candidate_count']}")
+    print(
+        "fixed-neighborhood survivors: "
+        f"{summary['fixed_neighborhood_surviving_candidate_count']}"
+    )
+    print(
+        "one-row-drop survivors: "
+        f"{summary['one_row_drop_surviving_candidate_count']}"
+    )
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_151_6_outside_pair_audit_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 151:6 outside-pair artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 151:6 outside-pair expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_151_6_outside_pair_audit.py
+++ b/src/erdos97/bootstrap_t12_151_6_outside_pair_audit.py
@@ -1,0 +1,659 @@
+"""Outside-pair audit for the bootstrap/T12 151:6 target.
+
+The outside-pair packet says source 151 row 6 has bootstrap-core witness [0]
+and outside-pair supports [3,5], [3,8], and [5,8].  This audit asks a narrow
+proof-mining question: if center 6 is activated by one of those outside pairs,
+can its selected row differ from the fixed source-151 row while the surrounding
+source-151 selected rows are preserved, or while one additional row is allowed
+to move?
+
+The answer is no under the basic selected-row incidence and crossing filters.
+This is not a Euclidean realizability theorem and not a proof of row forcing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CYCLIC_ORDER,
+    _crossing_violations,
+    _row_pair_cap_violations,
+    _witness_pair_cap_violations,
+)
+from erdos97.bootstrap_t12_outside_pair import (
+    DEFAULT_ARTIFACT as OUTSIDE_PAIR_ARTIFACT,
+    SCHEMA as OUTSIDE_PAIR_SCHEMA,
+    STATUS as OUTSIDE_PAIR_STATUS,
+    build_t12_outside_pair_payload,
+)
+from erdos97.bootstrap_vertex_circle_overlay import (
+    SCHEMA as OVERLAY_SCHEMA,
+    STATUS as OVERLAY_STATUS,
+    build_overlay_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_151_6_outside_pair_audit.v1"
+STATUS = "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_AUDIT_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "ONLY_ORIGINAL_ROW6_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS"
+CLAIM_SCOPE = (
+    "Fixed selected-row-neighborhood outside-pair audit for source 151 row 6. "
+    "It enumerates the thirteen center-6 selected rows containing "
+    "bootstrap-core witness [0] and one outside support pair from [3,5], "
+    "[3,8], or [5,8], then checks the fixed source-151 neighborhood and a "
+    "one-row-drop relaxation by row-pair, witness-pair, and crossing filters. "
+    "The only survivors keep the original row 6 and, in the one-row-drop scan, "
+    "also keep the dropped row equal to its original source-151 row. This does "
+    "not prove outside-pair support existence, row forcing, does not prove "
+    "n=9, does not prove the bridge, and is not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_outside_pair_audit.json"
+)
+
+SOURCE_RECORD_ID = 151
+TARGET_ROW_KEY = "151:6"
+TARGET_ROW_CENTER = 6
+BOOTSTRAP_CORE_WITNESSES = [0]
+OUTSIDE_SUPPORT_PAIRS = [[3, 5], [3, 8], [5, 8]]
+ORIGINAL_ROW = [0, 3, 5, 8]
+ONE_ROW_DROP_CENTERS = [0, 1, 2, 3, 4, 5, 7, 8]
+
+EXPECTED_FIXED_REJECTION_COUNTS = {
+    "crossing": 2,
+    "row_pair+witness_pair+crossing": 9,
+    "survive": 1,
+    "witness_pair+crossing": 1,
+}
+EXPECTED_ONE_ROW_DROP_REJECTION_COUNTS = {
+    "crossing": 118,
+    "row_pair+crossing": 15,
+    "row_pair+witness_pair": 36,
+    "row_pair+witness_pair+crossing": 6824,
+    "survive": 8,
+    "witness_pair+crossing": 279,
+}
+EXPECTED_ONE_ROW_DROP_PER_ROW6 = {
+    "0,1,3,5": {
+        "crossing": 4,
+        "row_pair+witness_pair+crossing": 472,
+        "witness_pair+crossing": 84,
+    },
+    "0,1,3,8": {
+        "crossing": 36,
+        "row_pair+crossing": 3,
+        "row_pair+witness_pair+crossing": 477,
+        "witness_pair+crossing": 44,
+    },
+    "0,1,5,8": {
+        "crossing": 4,
+        "row_pair+crossing": 1,
+        "row_pair+witness_pair+crossing": 550,
+        "witness_pair+crossing": 5,
+    },
+    "0,2,3,5": {
+        "crossing": 5,
+        "row_pair+witness_pair+crossing": 550,
+        "witness_pair+crossing": 5,
+    },
+    "0,2,3,8": {
+        "crossing": 4,
+        "row_pair+crossing": 1,
+        "row_pair+witness_pair+crossing": 549,
+        "witness_pair+crossing": 6,
+    },
+    "0,2,5,8": {
+        "row_pair+witness_pair+crossing": 553,
+        "witness_pair+crossing": 7,
+    },
+    "0,3,4,5": {
+        "crossing": 3,
+        "row_pair+crossing": 1,
+        "row_pair+witness_pair+crossing": 552,
+        "witness_pair+crossing": 4,
+    },
+    "0,3,4,8": {
+        "row_pair+witness_pair+crossing": 549,
+        "witness_pair+crossing": 11,
+    },
+    "0,3,5,7": {
+        "crossing": 1,
+        "row_pair+crossing": 3,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 546,
+        "witness_pair+crossing": 6,
+    },
+    "0,3,5,8": {
+        "crossing": 24,
+        "row_pair+witness_pair": 32,
+        "row_pair+witness_pair+crossing": 448,
+        "survive": 8,
+        "witness_pair+crossing": 48,
+    },
+    "0,3,7,8": {
+        "crossing": 4,
+        "row_pair+witness_pair+crossing": 552,
+        "witness_pair+crossing": 4,
+    },
+    "0,4,5,8": {
+        "row_pair+witness_pair+crossing": 548,
+        "witness_pair+crossing": 12,
+    },
+    "0,5,7,8": {
+        "crossing": 33,
+        "row_pair+crossing": 6,
+        "row_pair+witness_pair+crossing": 478,
+        "witness_pair+crossing": 43,
+    },
+}
+EXPECTED_ONE_ROW_DROP_PER_DROPPED = {
+    0: {
+        "crossing": 16,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 850,
+        "survive": 1,
+        "witness_pair+crossing": 39,
+    },
+    1: {
+        "crossing": 22,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 826,
+        "survive": 1,
+        "witness_pair+crossing": 57,
+    },
+    2: {
+        "crossing": 21,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 839,
+        "survive": 1,
+        "witness_pair+crossing": 45,
+    },
+    3: {
+        "crossing": 17,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 849,
+        "survive": 1,
+        "witness_pair+crossing": 39,
+    },
+    4: {
+        "crossing": 10,
+        "row_pair+crossing": 4,
+        "row_pair+witness_pair": 8,
+        "row_pair+witness_pair+crossing": 861,
+        "survive": 1,
+        "witness_pair+crossing": 26,
+    },
+    5: {
+        "crossing": 11,
+        "row_pair+crossing": 4,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 868,
+        "survive": 1,
+        "witness_pair+crossing": 22,
+    },
+    7: {
+        "crossing": 11,
+        "row_pair+crossing": 5,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 863,
+        "survive": 1,
+        "witness_pair+crossing": 26,
+    },
+    8: {
+        "crossing": 10,
+        "row_pair+crossing": 2,
+        "row_pair+witness_pair": 4,
+        "row_pair+witness_pair+crossing": 868,
+        "survive": 1,
+        "witness_pair+crossing": 25,
+    },
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _row_key(row: Sequence[int]) -> str:
+    return ",".join(str(label) for label in row)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _source_151_rows() -> list[list[int]]:
+    overlay = build_overlay_payload()
+    records = overlay.get("records")
+    if not isinstance(records, Sequence):
+        raise AssertionError("overlay records must be a sequence")
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise AssertionError("overlay records must be mappings")
+        if int(record["source_record_id"]) == SOURCE_RECORD_ID:
+            return [_int_list(row) for row in record["selected_rows"]]
+    raise AssertionError("could not find source 151 in overlay packet")
+
+
+def _target_outside_pair_record() -> dict[str, object]:
+    outside_pair = build_t12_outside_pair_payload()
+    records = outside_pair.get("records")
+    if not isinstance(records, Sequence):
+        raise AssertionError("outside-pair packet records must be a sequence")
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise AssertionError("outside-pair records must be mappings")
+        if (
+            int(record["source_record_id"]) == SOURCE_RECORD_ID
+            and int(record["row_center"]) == TARGET_ROW_CENTER
+        ):
+            support_pairs = [
+                _int_list(option["support_pair"])
+                for option in record["support_pair_options"]
+            ]
+            return {
+                "source_record_id": int(record["source_record_id"]),
+                "row_center": int(record["row_center"]),
+                "witnesses": _int_list(record["witnesses"]),
+                "bootstrap_core_witnesses": _int_list(
+                    record["bootstrap_core_witnesses"]
+                ),
+                "outside_witnesses": _int_list(record["outside_witnesses"]),
+                "support_pairs": support_pairs,
+                "support_pair_modes": record["support_pair_modes"],
+                "ledger_private_pair_support_hit_count": int(
+                    record["ledger_private_pair_support_hit_count"]
+                ),
+                "pressure_class": str(record["pressure_class"]),
+                "row_center_private_in_all_deletion_closures": bool(
+                    record["row_center_private_in_all_deletion_closures"]
+                ),
+            }
+    raise AssertionError("could not find source 151 row 6 in outside-pair packet")
+
+
+def _target_row_candidates() -> list[list[int]]:
+    candidates: set[tuple[int, ...]] = set()
+    core = set(BOOTSTRAP_CORE_WITNESSES)
+    for support_pair in OUTSIDE_SUPPORT_PAIRS:
+        required = core | set(support_pair)
+        for fourth in CYCLIC_ORDER:
+            if fourth != TARGET_ROW_CENTER and fourth not in required:
+                candidates.add(tuple(sorted(required | {fourth})))
+    return [list(candidate) for candidate in sorted(candidates)]
+
+
+def _all_replacement_rows(center: int) -> list[list[int]]:
+    labels = [label for label in CYCLIC_ORDER if label != center]
+    return [list(row) for row in combinations(labels, 4)]
+
+
+def _rejection_data(rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    row_pair_violations = _row_pair_cap_violations(rows)
+    witness_pair_violations = _witness_pair_cap_violations(rows)
+    crossing_violations = _crossing_violations(rows)
+    reasons = []
+    if row_pair_violations:
+        reasons.append("row_pair")
+    if witness_pair_violations:
+        reasons.append("witness_pair")
+    if crossing_violations:
+        reasons.append("crossing")
+    return {
+        "row_pair_cap_violations": row_pair_violations,
+        "witness_pair_cap_violations": witness_pair_violations,
+        "crossing_violations": crossing_violations,
+        "rejection_reasons": reasons,
+        "rejection_category": "+".join(reasons) if reasons else "survive",
+        "passes_basic_incidence_crossing_filters": not reasons,
+    }
+
+
+def _fixed_candidate_records(
+    base_rows: Sequence[Sequence[int]],
+) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for candidate in _target_row_candidates():
+        rows = [list(row) for row in base_rows]
+        rows[TARGET_ROW_CENTER] = list(candidate)
+        rejection = _rejection_data(rows)
+        records.append(
+            {
+                "target_center": TARGET_ROW_CENTER,
+                "target_center_class": candidate,
+                "is_original_row": candidate == ORIGINAL_ROW,
+                **rejection,
+            }
+        )
+    return records
+
+
+def _scan_one_row_drop(base_rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    total_counts: Counter[str] = Counter()
+    per_target_row_counts: dict[str, Counter[str]] = {
+        _row_key(candidate): Counter() for candidate in _target_row_candidates()
+    }
+    per_dropped_counts: dict[int, Counter[str]] = {
+        center: Counter() for center in ONE_ROW_DROP_CENTERS
+    }
+    survivors: list[dict[str, object]] = []
+
+    for target_row in _target_row_candidates():
+        target_key = _row_key(target_row)
+        for dropped_center in ONE_ROW_DROP_CENTERS:
+            for replacement_row in _all_replacement_rows(dropped_center):
+                rows = [list(row) for row in base_rows]
+                rows[TARGET_ROW_CENTER] = list(target_row)
+                rows[dropped_center] = list(replacement_row)
+                category = str(_rejection_data(rows)["rejection_category"])
+                total_counts[category] += 1
+                per_target_row_counts[target_key][category] += 1
+                per_dropped_counts[dropped_center][category] += 1
+                if category == "survive":
+                    survivors.append(
+                        {
+                            "target_center_class": list(target_row),
+                            "target_center_class_is_original": (
+                                target_row == ORIGINAL_ROW
+                            ),
+                            "dropped_center": dropped_center,
+                            "dropped_center_class": list(replacement_row),
+                            "dropped_center_class_is_original": (
+                                replacement_row == list(base_rows[dropped_center])
+                            ),
+                        }
+                    )
+
+    return {
+        "candidate_count": sum(total_counts.values()),
+        "rejection_category_counts": _json_counter(total_counts),
+        "per_target_center_class": [
+            {
+                "target_center_class": list(candidate),
+                "target_center_class_is_original": candidate == ORIGINAL_ROW,
+                "candidate_count": sum(
+                    per_target_row_counts[_row_key(candidate)].values()
+                ),
+                "surviving_candidate_count": per_target_row_counts[
+                    _row_key(candidate)
+                ].get("survive", 0),
+                "rejection_category_counts": _json_counter(
+                    per_target_row_counts[_row_key(candidate)]
+                ),
+            }
+            for candidate in _target_row_candidates()
+        ],
+        "per_dropped_center": [
+            {
+                "dropped_center": center,
+                "source_row": list(base_rows[center]),
+                "replacement_row_count": len(_all_replacement_rows(center)),
+                "candidate_count": sum(per_dropped_counts[center].values()),
+                "surviving_candidate_count": per_dropped_counts[center].get(
+                    "survive", 0
+                ),
+                "rejection_category_counts": _json_counter(per_dropped_counts[center]),
+            }
+            for center in ONE_ROW_DROP_CENTERS
+        ],
+        "survivors": survivors,
+    }
+
+
+def build_t12_151_6_outside_pair_audit_payload() -> dict[str, object]:
+    """Return the deterministic source-151 row-6 outside-pair audit."""
+
+    base_rows = _source_151_rows()
+    target_outside_pair_record = _target_outside_pair_record()
+    if (
+        target_outside_pair_record["bootstrap_core_witnesses"]
+        != BOOTSTRAP_CORE_WITNESSES
+    ):
+        raise AssertionError("source outside-pair bootstrap-core witnesses drifted")
+    if target_outside_pair_record["support_pairs"] != OUTSIDE_SUPPORT_PAIRS:
+        raise AssertionError("source outside-pair supports drifted")
+    if base_rows[TARGET_ROW_CENTER] != ORIGINAL_ROW:
+        raise AssertionError("source-151 row 6 drifted")
+
+    fixed_records = _fixed_candidate_records(base_rows)
+    fixed_counts = Counter(str(record["rejection_category"]) for record in fixed_records)
+    fixed_survivors = [
+        record
+        for record in fixed_records
+        if record["passes_basic_incidence_crossing_filters"]
+    ]
+    one_row_drop = _scan_one_row_drop(base_rows)
+    one_row_drop_survivors = one_row_drop["survivors"]
+    if not isinstance(one_row_drop_survivors, Sequence):
+        raise AssertionError("one-row-drop survivors must be a sequence")
+    non_original_one_drop_survivors = [
+        survivor
+        for survivor in one_row_drop_survivors
+        if not survivor["target_center_class_is_original"]
+    ]
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This audit preserves the source-151 selected-row neighborhood, or drops exactly one non-target row in the relaxation.",
+            "A row containing bootstrap-core witnesses plus an outside support pair is activation bookkeeping, not a proof that a genuine rich class exists.",
+            "The audit uses incidence and crossing filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [SOURCE_RECORD_ID],
+            "cyclic_order": CYCLIC_ORDER,
+            "target_center": TARGET_ROW_CENTER,
+            "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+            "outside_support_pairs": OUTSIDE_SUPPORT_PAIRS,
+            "original_target_center_class": ORIGINAL_ROW,
+            "target_center_candidate_count": len(_target_row_candidates()),
+            "fixed_neighborhood_candidate_count": len(fixed_records),
+            "fixed_neighborhood_surviving_candidate_count": len(fixed_survivors),
+            "fixed_neighborhood_non_original_survivor_count": sum(
+                1 for survivor in fixed_survivors if not survivor["is_original_row"]
+            ),
+            "fixed_neighborhood_rejection_category_counts": _json_counter(
+                fixed_counts
+            ),
+            "one_row_drop_centers": ONE_ROW_DROP_CENTERS,
+            "one_row_drop_replacement_count_per_center": 70,
+            "one_row_drop_candidate_count": one_row_drop["candidate_count"],
+            "one_row_drop_surviving_candidate_count": len(one_row_drop_survivors),
+            "one_row_drop_non_original_row6_survivor_count": len(
+                non_original_one_drop_survivors
+            ),
+            "one_row_drop_survivors_all_original_rows": all(
+                survivor["target_center_class_is_original"]
+                and survivor["dropped_center_class_is_original"]
+                for survivor in one_row_drop_survivors
+            ),
+            "one_row_drop_rejection_category_counts": one_row_drop[
+                "rejection_category_counts"
+            ],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not prove outside-pair support existence, does not "
+                "prove the row is forced by minimal or rich-class geometry, "
+                "does not allow two or more other rows to move, and does not "
+                "model additional auxiliary rich supports."
+            ),
+        },
+        "source_rows": {str(center): base_rows[center] for center in CYCLIC_ORDER},
+        "candidate_generation": {
+            "target_center_candidate_classes": _target_row_candidates(),
+            "candidate_rule": (
+                "4-sets at center 6 containing bootstrap-core witness [0] "
+                "and at least one outside support pair from [3,5], [3,8], "
+                "or [5,8]."
+            ),
+        },
+        "source_outside_pair_record": target_outside_pair_record,
+        "fixed_neighborhood_candidates": fixed_records,
+        "one_row_drop": one_row_drop,
+        "source_outside_pair_packet": {
+            "path": OUTSIDE_PAIR_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": OUTSIDE_PAIR_SCHEMA,
+            "status": OUTSIDE_PAIR_STATUS,
+        },
+        "source_overlay_packet": {
+            "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+            "schema": OVERLAY_SCHEMA,
+            "status": OVERLAY_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_151_6_outside_pair_audit.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [SOURCE_RECORD_ID],
+        "cyclic_order": CYCLIC_ORDER,
+        "target_center": TARGET_ROW_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "outside_support_pairs": OUTSIDE_SUPPORT_PAIRS,
+        "original_target_center_class": ORIGINAL_ROW,
+        "target_center_candidate_count": 13,
+        "fixed_neighborhood_candidate_count": 13,
+        "fixed_neighborhood_surviving_candidate_count": 1,
+        "fixed_neighborhood_non_original_survivor_count": 0,
+        "fixed_neighborhood_rejection_category_counts": (
+            EXPECTED_FIXED_REJECTION_COUNTS
+        ),
+        "one_row_drop_centers": ONE_ROW_DROP_CENTERS,
+        "one_row_drop_replacement_count_per_center": 70,
+        "one_row_drop_candidate_count": 7280,
+        "one_row_drop_surviving_candidate_count": 8,
+        "one_row_drop_non_original_row6_survivor_count": 0,
+        "one_row_drop_survivors_all_original_rows": True,
+        "one_row_drop_rejection_category_counts": (
+            EXPECTED_ONE_ROW_DROP_REJECTION_COUNTS
+        ),
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    outside_pair = payload.get("source_outside_pair_record")
+    if not isinstance(outside_pair, Mapping):
+        raise AssertionError("source_outside_pair_record must be a mapping")
+    if outside_pair.get("support_pairs") != OUTSIDE_SUPPORT_PAIRS:
+        raise AssertionError("source outside-pair support pairs drifted")
+
+    fixed_candidates = payload.get("fixed_neighborhood_candidates")
+    if not isinstance(fixed_candidates, Sequence) or len(fixed_candidates) != 13:
+        raise AssertionError("expected thirteen fixed-neighborhood candidates")
+    fixed_survivors = [
+        record
+        for record in fixed_candidates
+        if isinstance(record, Mapping)
+        and record.get("passes_basic_incidence_crossing_filters")
+    ]
+    if len(fixed_survivors) != 1:
+        raise AssertionError("expected exactly one fixed-neighborhood survivor")
+    if fixed_survivors[0].get("target_center_class") != ORIGINAL_ROW:
+        raise AssertionError("fixed-neighborhood survivor should be the original row")
+
+    one_row_drop = payload.get("one_row_drop")
+    if not isinstance(one_row_drop, Mapping):
+        raise AssertionError("one_row_drop must be a mapping")
+    if one_row_drop.get("rejection_category_counts") != (
+        EXPECTED_ONE_ROW_DROP_REJECTION_COUNTS
+    ):
+        raise AssertionError("one-row-drop rejection counts drifted")
+
+    per_target = one_row_drop.get("per_target_center_class")
+    if not isinstance(per_target, Sequence) or len(per_target) != 13:
+        raise AssertionError("expected thirteen per-target-center-class summaries")
+    for record in per_target:
+        if not isinstance(record, Mapping):
+            raise AssertionError("per-target-center-class summaries must be mappings")
+        row_key = _row_key(_int_list(record["target_center_class"]))
+        expected_counts = EXPECTED_ONE_ROW_DROP_PER_ROW6[row_key]
+        if record.get("rejection_category_counts") != expected_counts:
+            raise AssertionError(f"one-row-drop counts drifted for row {row_key}")
+
+    per_dropped = one_row_drop.get("per_dropped_center")
+    if not isinstance(per_dropped, Sequence) or len(per_dropped) != 8:
+        raise AssertionError("expected eight dropped-center summaries")
+    for record in per_dropped:
+        if not isinstance(record, Mapping):
+            raise AssertionError("dropped-center summaries must be mappings")
+        center = int(record["dropped_center"])
+        if record.get("replacement_row_count") != 70:
+            raise AssertionError(f"dropped center {center} has bad row count")
+        if record.get("candidate_count") != 910:
+            raise AssertionError(f"dropped center {center} has bad candidate count")
+        if record.get("rejection_category_counts") != (
+            EXPECTED_ONE_ROW_DROP_PER_DROPPED[center]
+        ):
+            raise AssertionError(f"dropped center {center} counts drifted")
+
+    survivors = one_row_drop.get("survivors")
+    if not isinstance(survivors, Sequence) or len(survivors) != 8:
+        raise AssertionError("expected eight one-row-drop survivors")
+    if any(
+        not isinstance(survivor, Mapping)
+        or not survivor.get("target_center_class_is_original")
+        or not survivor.get("dropped_center_class_is_original")
+        for survivor in survivors
+    ):
+        raise AssertionError("one-row-drop survivors should keep original rows")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_151_6_outside_pair_audit.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_151_6_outside_pair_audit.py
+++ b/tests/test_bootstrap_t12_151_6_outside_pair_audit.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_151_6_outside_pair_audit import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_151_6_outside_pair_audit_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_151_6_outside_pair_audit_payload()
+
+
+def test_151_6_outside_pair_audit_counts_and_scope(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_AUDIT_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "outside-pair audit" in claim_scope
+    assert "does not prove outside-pair support existence" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert "counterexample" in claim_scope
+
+
+def test_151_6_outside_pair_audit_summary(
+    payload: dict[str, object],
+) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "151:6"
+    assert summary["source_record_ids"] == [151]
+    assert summary["target_center"] == 6
+    assert summary["bootstrap_core_witnesses"] == [0]
+    assert summary["outside_support_pairs"] == [[3, 5], [3, 8], [5, 8]]
+    assert summary["original_target_center_class"] == [0, 3, 5, 8]
+    assert summary["target_center_candidate_count"] == 13
+    assert summary["fixed_neighborhood_candidate_count"] == 13
+    assert summary["fixed_neighborhood_surviving_candidate_count"] == 1
+    assert summary["fixed_neighborhood_non_original_survivor_count"] == 0
+    assert summary["one_row_drop_candidate_count"] == 7280
+    assert summary["one_row_drop_surviving_candidate_count"] == 8
+    assert summary["one_row_drop_non_original_row6_survivor_count"] == 0
+    assert summary["one_row_drop_survivors_all_original_rows"] is True
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_151_6_outside_pair_candidate_generation(
+    payload: dict[str, object],
+) -> None:
+    generation = payload["candidate_generation"]
+
+    assert generation["target_center_candidate_classes"] == [
+        [0, 1, 3, 5],
+        [0, 1, 3, 8],
+        [0, 1, 5, 8],
+        [0, 2, 3, 5],
+        [0, 2, 3, 8],
+        [0, 2, 5, 8],
+        [0, 3, 4, 5],
+        [0, 3, 4, 8],
+        [0, 3, 5, 7],
+        [0, 3, 5, 8],
+        [0, 3, 7, 8],
+        [0, 4, 5, 8],
+        [0, 5, 7, 8],
+    ]
+
+
+def test_151_6_outside_pair_fixed_scan(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    fixed = payload["fixed_neighborhood_candidates"]
+
+    assert summary["fixed_neighborhood_rejection_category_counts"] == {
+        "crossing": 2,
+        "row_pair+witness_pair+crossing": 9,
+        "survive": 1,
+        "witness_pair+crossing": 1,
+    }
+    survivors = [
+        record
+        for record in fixed
+        if record["passes_basic_incidence_crossing_filters"]
+    ]
+    assert len(survivors) == 1
+    assert survivors[0]["target_center_class"] == [0, 3, 5, 8]
+    assert survivors[0]["is_original_row"] is True
+
+
+def test_151_6_outside_pair_one_row_drop_scan(
+    payload: dict[str, object],
+) -> None:
+    summary = payload["summary"]
+    one_row_drop = payload["one_row_drop"]
+
+    assert summary["one_row_drop_rejection_category_counts"] == {
+        "crossing": 118,
+        "row_pair+crossing": 15,
+        "row_pair+witness_pair": 36,
+        "row_pair+witness_pair+crossing": 6824,
+        "survive": 8,
+        "witness_pair+crossing": 279,
+    }
+    survivors = one_row_drop["survivors"]
+    assert len(survivors) == 8
+    assert {survivor["dropped_center"] for survivor in survivors} == {
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+    }
+    assert all(
+        survivor["target_center_class"] == [0, 3, 5, 8]
+        and survivor["target_center_class_is_original"]
+        and survivor["dropped_center_class_is_original"]
+        for survivor in survivors
+    )
+
+
+def test_151_6_outside_pair_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_151_6_outside_pair_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_151_6_outside_pair_audit.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["one_row_drop_non_original_row6_survivor_count"] == 0
+
+
+def test_151_6_outside_pair_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["one_row_drop_non_original_row6_survivor_count"] = 1
+
+    with pytest.raises(AssertionError, match="non_original_row6_survivor_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- Add a generator-backed source-151 row-6 outside-pair audit.
- Enumerate the thirteen center-6 rows containing bootstrap-core witness `[0]` and outside support pair `[3,5]`, `[3,8]`, or `[5,8]`.
- Record that the fixed source-151 neighborhood has only the original row `[0,3,5,8]` as a survivor, and that the one-row-drop relaxation has only trivial original-neighborhood survivors.
- Keep the scope diagnostic: this does not prove outside-pair support existence, row forcing, `n=9`, the bridge, or a counterexample.

## Verification

- `python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_t12_151_6_outside_pair_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check --cached`
- `python -m ruff check .`
- `python -m pytest -q`