### PR TITLE
Add source 151 singleton-support audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the source-`151` row-`6` outside-pair audit, where all fixed and
   one-row-drop activation-row survivors keep the original row `6`, read
   [`docs/bootstrap-t12-151-6-outside-pair-audit.md`](docs/bootstrap-t12-151-6-outside-pair-audit.md).
+- For the source-`151` singleton-support audit covering rows `5` and `8`,
+  where all fixed and one-row-drop activation-row survivors keep the original
+  target rows, read
+  [`docs/bootstrap-t12-151-singleton-support-audit.md`](docs/bootstrap-t12-151-singleton-support-audit.md).
 - For fixed-selection stuck-set mining around the bridge/peeling program, read
   [`docs/stuck-set-miner.md`](docs/stuck-set-miner.md).
 - For search patterns, read [`docs/candidate-patterns.md`](docs/candidate-patterns.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -390,6 +390,20 @@ See `docs/bootstrap-t12-151-6-outside-pair-audit.md`,
 `scripts/check_bootstrap_t12_151_6_outside_pair_audit.py`, and
 `data/certificates/bootstrap_t12_151_6_outside_pair_audit.json`.
 
+The source-`151` singleton-support audit covers the two remaining
+one-outside-label row targets, `151:5` and `151:8`. Row `151:5` uses
+bootstrap-core witnesses `[2,4]` and singleton supports `7` and `8`; row
+`151:8` uses bootstrap-core witnesses `[1,2]` and singleton supports `5` and
+`7`. Each target has nine activation rows. In the fixed source-`151`
+neighborhoods, only the original target rows `[2,4,7,8]` and `[1,2,5,7]`
+survive the row-pair, witness-pair, and crossing filters. The one-row-drop
+relaxations again have only trivial original-neighborhood survivors. This is
+still a finite diagnostic only, not a proof of singleton support existence,
+row forcing, `n=9`, or the bootstrap bridge. See
+`docs/bootstrap-t12-151-singleton-support-audit.md`,
+`scripts/check_bootstrap_t12_151_singleton_support_audit.py`, and
+`data/certificates/bootstrap_t12_151_singleton_support_audit.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -212,6 +212,16 @@ incidence/crossing bookkeeping only, not outside-pair support existence, row
 forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-151-6-outside-pair-audit.md`.
 
+A source-`151` singleton-support audit now probes the two remaining
+one-outside-label rows, `151:5` and `151:8`. Each target has nine activation
+rows built from its bootstrap-core witnesses plus one singleton support; in
+both fixed source-`151` neighborhoods, only the original target row survives.
+The one-row-drop relaxations check `10080` candidates across the two targets
+and have no non-original target-row survivor. This remains basic
+incidence/crossing bookkeeping only, not singleton-support existence, row
+forcing, `n=9`, or the bridge. See
+`docs/bootstrap-t12-151-singleton-support-audit.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_151_singleton_support_audit.json
+++ b/data/certificates/bootstrap_t12_151_singleton_support_audit.json
@@ -1,0 +1,2120 @@
+{
+  "claim_scope": "Fixed selected-row-neighborhood singleton-support audit for source 151 rows 5 and 8. It enumerates activation rows containing each target's bootstrap-core witnesses plus one singleton support label, then checks the fixed source-151 neighborhood and a one-row-drop relaxation by row-pair, witness-pair, and crossing filters. The only survivors keep the original target row and, in the one-row-drop scans, also keep the dropped row equal to its original source-151 row. This does not prove singleton support existence, row forcing, does not prove n=9, does not prove the bridge, and is not a counterexample.",
+  "interpretation_warnings": [
+    "This audit preserves the source-151 selected-row neighborhood, or drops exactly one non-target row in each relaxation.",
+    "A row containing bootstrap-core witnesses plus a singleton support is activation bookkeeping, not a proof that a genuine rich class exists.",
+    "The audit uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_151_singleton_support_audit.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_151_singleton_support_audit.py"
+  },
+  "schema": "erdos97.bootstrap_t12_151_singleton_support_audit.v1",
+  "source_one_outside_packet": {
+    "path": "data/certificates/bootstrap_t12_one_outside.json",
+    "schema": "erdos97.bootstrap_t12_one_outside.v1",
+    "status": "BOOTSTRAP_T12_ONE_OUTSIDE_DIAGNOSTIC_ONLY"
+  },
+  "source_overlay_packet": {
+    "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+    "schema": "erdos97.bootstrap_vertex_circle_overlay.v1",
+    "status": "BOOTSTRAP_VERTEX_CIRCLE_OVERLAY_DIAGNOSTIC_ONLY"
+  },
+  "source_rows": {
+    "0": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "1": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "2": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "3": [
+      0,
+      2,
+      5,
+      6
+    ],
+    "4": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "5": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "6": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "7": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "8": [
+      1,
+      2,
+      5,
+      7
+    ]
+  },
+  "status": "BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY",
+  "summary": {
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "fixed_neighborhood_candidate_count": 18,
+    "fixed_neighborhood_non_original_survivor_count": 0,
+    "fixed_neighborhood_surviving_candidate_count": 2,
+    "one_row_drop_candidate_count": 10080,
+    "one_row_drop_non_original_target_row_survivor_count": 0,
+    "one_row_drop_surviving_candidate_count": 16,
+    "one_row_drop_survivors_all_original_rows": true,
+    "remaining_gap": "This does not prove singleton support existence, does not prove the rows are forced by minimal or rich-class geometry, does not allow two or more other rows to move, and does not model additional auxiliary rich supports.",
+    "scan_status": "ONLY_ORIGINAL_SOURCE151_SINGLETON_ROWS_SURVIVE_SUPPORT_AUDITS",
+    "source_record_ids": [
+      151
+    ],
+    "target_center_candidate_count_by_key": {
+      "151:5": 9,
+      "151:8": 9
+    },
+    "target_centers": [
+      5,
+      8
+    ],
+    "target_count": 2,
+    "target_row_keys": [
+      "151:5",
+      "151:8"
+    ]
+  },
+  "target_audits": [
+    {
+      "bootstrap_core_witnesses": [
+        2,
+        4
+      ],
+      "fixed_neighborhood_candidate_count": 9,
+      "fixed_neighborhood_candidates": [
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                3,
+                5
+              ],
+              "witness_chord": [
+                0,
+                2
+              ]
+            },
+            {
+              "source_chord": [
+                5,
+                7
+              ],
+              "witness_chord": [
+                0,
+                4
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                1,
+                5
+              ],
+              "intersection": [
+                0,
+                4,
+                7
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 5,
+          "target_center_class": [
+            0,
+            2,
+            4,
+            7
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                1,
+                5,
+                7
+              ],
+              "pair": [
+                0,
+                4
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                3,
+                5
+              ],
+              "witness_chord": [
+                0,
+                2
+              ]
+            },
+            {
+              "source_chord": [
+                5,
+                6
+              ],
+              "witness_chord": [
+                0,
+                8
+              ]
+            },
+            {
+              "source_chord": [
+                5,
+                7
+              ],
+              "witness_chord": [
+                0,
+                4
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "witness_pair+crossing",
+          "rejection_reasons": [
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [],
+          "target_center": 5,
+          "target_center_class": [
+            0,
+            2,
+            4,
+            8
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                1,
+                5,
+                7
+              ],
+              "pair": [
+                0,
+                4
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                4,
+                5
+              ],
+              "witness_chord": [
+                1,
+                7
+              ]
+            },
+            {
+              "source_chord": [
+                5,
+                7
+              ],
+              "witness_chord": [
+                1,
+                4
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                5,
+                8
+              ],
+              "intersection": [
+                1,
+                2,
+                7
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 5,
+          "target_center_class": [
+            1,
+            2,
+            4,
+            7
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                2,
+                5,
+                7
+              ],
+              "pair": [
+                1,
+                4
+              ]
+            },
+            {
+              "center_count": 3,
+              "centers": [
+                4,
+                5,
+                8
+              ],
+              "pair": [
+                1,
+                7
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                5,
+                7
+              ],
+              "witness_chord": [
+                1,
+                4
+              ]
+            },
+            {
+              "source_chord": [
+                5,
+                8
+              ],
+              "witness_chord": [
+                1,
+                2
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                2,
+                5
+              ],
+              "intersection": [
+                1,
+                4,
+                8
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 5,
+          "target_center_class": [
+            1,
+            2,
+            4,
+            8
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                2,
+                5,
+                7
+              ],
+              "pair": [
+                1,
+                4
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                0,
+                5
+              ],
+              "witness_chord": [
+                2,
+                3
+              ]
+            },
+            {
+              "source_chord": [
+                4,
+                5
+              ],
+              "witness_chord": [
+                3,
+                7
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                1,
+                5
+              ],
+              "intersection": [
+                3,
+                4,
+                7
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 5,
+          "target_center_class": [
+            2,
+            3,
+            4,
+            7
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                1,
+                4,
+                5
+              ],
+              "pair": [
+                3,
+                7
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                1,
+                5
+              ],
+              "witness_chord": [
+                3,
+                4
+              ]
+            },
+            {
+              "source_chord": [
+                5,
+                6
+              ],
+              "witness_chord": [
+                3,
+                8
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                0,
+                5
+              ],
+              "intersection": [
+                2,
+                3,
+                8
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 5,
+          "target_center_class": [
+            2,
+            3,
+            4,
+            8
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                0,
+                5,
+                6
+              ],
+              "pair": [
+                3,
+                8
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                3,
+                5
+              ],
+              "witness_chord": [
+                2,
+                6
+              ]
+            },
+            {
+              "source_chord": [
+                4,
+                5
+              ],
+              "witness_chord": [
+                6,
+                7
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "witness_pair+crossing",
+          "rejection_reasons": [
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [],
+          "target_center": 5,
+          "target_center_class": [
+            2,
+            4,
+            6,
+            7
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                0,
+                3,
+                5
+              ],
+              "pair": [
+                2,
+                6
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                3,
+                5
+              ],
+              "witness_chord": [
+                2,
+                6
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                0,
+                5
+              ],
+              "intersection": [
+                2,
+                6,
+                8
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 5,
+          "target_center_class": [
+            2,
+            4,
+            6,
+            8
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                0,
+                3,
+                5
+              ],
+              "pair": [
+                2,
+                6
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [],
+          "is_original_row": true,
+          "passes_basic_incidence_crossing_filters": true,
+          "rejection_category": "survive",
+          "rejection_reasons": [],
+          "row_pair_cap_violations": [],
+          "target_center": 5,
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_row_key": "151:5",
+          "witness_pair_cap_violations": []
+        }
+      ],
+      "fixed_neighborhood_non_original_survivor_count": 0,
+      "fixed_neighborhood_rejection_category_counts": {
+        "row_pair+witness_pair+crossing": 6,
+        "survive": 1,
+        "witness_pair+crossing": 2
+      },
+      "fixed_neighborhood_surviving_candidate_count": 1,
+      "one_row_drop": {
+        "candidate_count": 5040,
+        "per_dropped_center": [
+          {
+            "candidate_count": 630,
+            "dropped_center": 0,
+            "rejection_category_counts": {
+              "crossing": 9,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 578,
+              "survive": 1,
+              "witness_pair+crossing": 38
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 1,
+            "rejection_category_counts": {
+              "crossing": 13,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 573,
+              "survive": 1,
+              "witness_pair+crossing": 39
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 2,
+            "rejection_category_counts": {
+              "crossing": 8,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 582,
+              "survive": 1,
+              "witness_pair+crossing": 35
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 3,
+            "rejection_category_counts": {
+              "crossing": 4,
+              "row_pair+crossing": 3,
+              "row_pair+witness_pair": 8,
+              "row_pair+witness_pair+crossing": 590,
+              "survive": 1,
+              "witness_pair+crossing": 24
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              2,
+              5,
+              6
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 4,
+            "rejection_category_counts": {
+              "crossing": 3,
+              "row_pair+crossing": 3,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 593,
+              "survive": 1,
+              "witness_pair+crossing": 26
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 6,
+            "rejection_category_counts": {
+              "crossing": 3,
+              "row_pair+crossing": 1,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 594,
+              "survive": 1,
+              "witness_pair+crossing": 27
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 7,
+            "rejection_category_counts": {
+              "crossing": 4,
+              "row_pair+crossing": 4,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 595,
+              "survive": 1,
+              "witness_pair+crossing": 22
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 8,
+            "rejection_category_counts": {
+              "crossing": 3,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 587,
+              "survive": 1,
+              "witness_pair+crossing": 35
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "surviving_candidate_count": 1
+          }
+        ],
+        "rejection_category_counts": {
+          "crossing": 47,
+          "row_pair+crossing": 11,
+          "row_pair+witness_pair": 36,
+          "row_pair+witness_pair+crossing": 4692,
+          "survive": 8,
+          "witness_pair+crossing": 246
+        },
+        "survivors": [
+          {
+            "dropped_center": 0,
+            "dropped_center_class": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 1,
+            "dropped_center_class": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 2,
+            "dropped_center_class": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 3,
+            "dropped_center_class": [
+              0,
+              2,
+              5,
+              6
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 4,
+            "dropped_center_class": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 6,
+            "dropped_center_class": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 7,
+            "dropped_center_class": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          },
+          {
+            "dropped_center": 8,
+            "dropped_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:5"
+          }
+        ]
+      },
+      "one_row_drop_candidate_count": 5040,
+      "one_row_drop_centers": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        6,
+        7,
+        8
+      ],
+      "one_row_drop_non_original_target_row_survivor_count": 0,
+      "one_row_drop_rejection_category_counts": {
+        "crossing": 47,
+        "row_pair+crossing": 11,
+        "row_pair+witness_pair": 36,
+        "row_pair+witness_pair+crossing": 4692,
+        "survive": 8,
+        "witness_pair+crossing": 246
+      },
+      "one_row_drop_replacement_count_per_center": 70,
+      "one_row_drop_surviving_candidate_count": 8,
+      "one_row_drop_survivors_all_original_rows": true,
+      "original_target_center_class": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "singleton_support_labels": [
+        7,
+        8
+      ],
+      "source_one_outside_record": {
+        "bootstrap_core_witnesses": [
+          2,
+          4
+        ],
+        "outside_witnesses": [
+          7,
+          8
+        ],
+        "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+        "row_center": 5,
+        "row_center_private_in_all_deletion_closures": true,
+        "source_record_id": 151,
+        "support_label_modes": {
+          "INTERNAL_TO_ONE_DELETION_CLOSURE": 1,
+          "PRIVATE_IN_ALL_DELETION_HALOS": 1
+        },
+        "support_labels": [
+          7,
+          8
+        ],
+        "witnesses": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "target_center": 5,
+      "target_center_candidate_classes": [
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          3,
+          4,
+          7
+        ],
+        [
+          2,
+          3,
+          4,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ]
+      ],
+      "target_center_candidate_count": 9,
+      "target_row_key": "151:5"
+    },
+    {
+      "bootstrap_core_witnesses": [
+        1,
+        2
+      ],
+      "fixed_neighborhood_candidate_count": 9,
+      "fixed_neighborhood_candidates": [
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                6,
+                8
+              ],
+              "witness_chord": [
+                0,
+                5
+              ]
+            },
+            {
+              "source_chord": [
+                7,
+                8
+              ],
+              "witness_chord": [
+                0,
+                1
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                3,
+                8
+              ],
+              "intersection": [
+                0,
+                2,
+                5
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 8,
+          "target_center_class": [
+            0,
+            1,
+            2,
+            5
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                3,
+                6,
+                8
+              ],
+              "pair": [
+                0,
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                3,
+                8
+              ],
+              "witness_chord": [
+                0,
+                2
+              ]
+            },
+            {
+              "source_chord": [
+                7,
+                8
+              ],
+              "witness_chord": [
+                0,
+                1
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "crossing",
+          "rejection_reasons": [
+            "crossing"
+          ],
+          "row_pair_cap_violations": [],
+          "target_center": 8,
+          "target_center_class": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": []
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                0,
+                8
+              ],
+              "witness_chord": [
+                2,
+                3
+              ]
+            },
+            {
+              "source_chord": [
+                4,
+                8
+              ],
+              "witness_chord": [
+                1,
+                3
+              ]
+            },
+            {
+              "source_chord": [
+                6,
+                8
+              ],
+              "witness_chord": [
+                3,
+                5
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "crossing",
+          "rejection_reasons": [
+            "crossing"
+          ],
+          "row_pair_cap_violations": [],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            3,
+            5
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": []
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                0,
+                8
+              ],
+              "witness_chord": [
+                2,
+                3
+              ]
+            },
+            {
+              "source_chord": [
+                1,
+                8
+              ],
+              "witness_chord": [
+                3,
+                7
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                4,
+                8
+              ],
+              "intersection": [
+                1,
+                3,
+                7
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            3,
+            7
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                1,
+                4,
+                8
+              ],
+              "pair": [
+                3,
+                7
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                5,
+                8
+              ],
+              "witness_chord": [
+                2,
+                4
+              ]
+            },
+            {
+              "source_chord": [
+                7,
+                8
+              ],
+              "witness_chord": [
+                1,
+                4
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                2,
+                8
+              ],
+              "intersection": [
+                1,
+                4,
+                5
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                2,
+                7,
+                8
+              ],
+              "pair": [
+                1,
+                4
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                1,
+                8
+              ],
+              "witness_chord": [
+                4,
+                7
+              ]
+            },
+            {
+              "source_chord": [
+                7,
+                8
+              ],
+              "witness_chord": [
+                1,
+                4
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                5,
+                8
+              ],
+              "intersection": [
+                2,
+                4,
+                7
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            4,
+            7
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                2,
+                7,
+                8
+              ],
+              "pair": [
+                1,
+                4
+              ]
+            },
+            {
+              "center_count": 3,
+              "centers": [
+                1,
+                5,
+                8
+              ],
+              "pair": [
+                4,
+                7
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                0,
+                8
+              ],
+              "witness_chord": [
+                2,
+                6
+              ]
+            },
+            {
+              "source_chord": [
+                7,
+                8
+              ],
+              "witness_chord": [
+                1,
+                6
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                3,
+                8
+              ],
+              "intersection": [
+                2,
+                5,
+                6
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            5,
+            6
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                4,
+                7,
+                8
+              ],
+              "pair": [
+                1,
+                6
+              ]
+            },
+            {
+              "center_count": 3,
+              "centers": [
+                0,
+                3,
+                8
+              ],
+              "pair": [
+                2,
+                6
+              ]
+            }
+          ]
+        },
+        {
+          "crossing_violations": [],
+          "is_original_row": true,
+          "passes_basic_incidence_crossing_filters": true,
+          "rejection_category": "survive",
+          "rejection_reasons": [],
+          "row_pair_cap_violations": [],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": []
+        },
+        {
+          "crossing_violations": [
+            {
+              "source_chord": [
+                0,
+                8
+              ],
+              "witness_chord": [
+                2,
+                6
+              ]
+            },
+            {
+              "source_chord": [
+                7,
+                8
+              ],
+              "witness_chord": [
+                1,
+                6
+              ]
+            }
+          ],
+          "is_original_row": false,
+          "passes_basic_incidence_crossing_filters": false,
+          "rejection_category": "row_pair+witness_pair+crossing",
+          "rejection_reasons": [
+            "row_pair",
+            "witness_pair",
+            "crossing"
+          ],
+          "row_pair_cap_violations": [
+            {
+              "centers": [
+                4,
+                8
+              ],
+              "intersection": [
+                1,
+                6,
+                7
+              ],
+              "intersection_size": 3
+            }
+          ],
+          "target_center": 8,
+          "target_center_class": [
+            1,
+            2,
+            6,
+            7
+          ],
+          "target_row_key": "151:8",
+          "witness_pair_cap_violations": [
+            {
+              "center_count": 3,
+              "centers": [
+                4,
+                7,
+                8
+              ],
+              "pair": [
+                1,
+                6
+              ]
+            },
+            {
+              "center_count": 3,
+              "centers": [
+                0,
+                3,
+                8
+              ],
+              "pair": [
+                2,
+                6
+              ]
+            }
+          ]
+        }
+      ],
+      "fixed_neighborhood_non_original_survivor_count": 0,
+      "fixed_neighborhood_rejection_category_counts": {
+        "crossing": 2,
+        "row_pair+witness_pair+crossing": 6,
+        "survive": 1
+      },
+      "fixed_neighborhood_surviving_candidate_count": 1,
+      "one_row_drop": {
+        "candidate_count": 5040,
+        "per_dropped_center": [
+          {
+            "candidate_count": 630,
+            "dropped_center": 0,
+            "rejection_category_counts": {
+              "crossing": 11,
+              "row_pair+crossing": 4,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 593,
+              "survive": 1,
+              "witness_pair+crossing": 17
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 1,
+            "rejection_category_counts": {
+              "crossing": 9,
+              "row_pair+crossing": 2,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 595,
+              "survive": 1,
+              "witness_pair+crossing": 19
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 2,
+            "rejection_category_counts": {
+              "crossing": 16,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 583,
+              "survive": 1,
+              "witness_pair+crossing": 26
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 3,
+            "rejection_category_counts": {
+              "crossing": 18,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 574,
+              "survive": 1,
+              "witness_pair+crossing": 33
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              2,
+              5,
+              6
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 4,
+            "rejection_category_counts": {
+              "crossing": 18,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 572,
+              "survive": 1,
+              "witness_pair+crossing": 35
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 5,
+            "rejection_category_counts": {
+              "crossing": 12,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 592,
+              "survive": 1,
+              "witness_pair+crossing": 21
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 6,
+            "rejection_category_counts": {
+              "crossing": 10,
+              "row_pair+crossing": 1,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 598,
+              "survive": 1,
+              "witness_pair+crossing": 16
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "surviving_candidate_count": 1
+          },
+          {
+            "candidate_count": 630,
+            "dropped_center": 7,
+            "rejection_category_counts": {
+              "crossing": 11,
+              "row_pair+crossing": 4,
+              "row_pair+witness_pair": 4,
+              "row_pair+witness_pair+crossing": 597,
+              "survive": 1,
+              "witness_pair+crossing": 13
+            },
+            "replacement_row_count": 70,
+            "source_row": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "surviving_candidate_count": 1
+          }
+        ],
+        "rejection_category_counts": {
+          "crossing": 105,
+          "row_pair+crossing": 11,
+          "row_pair+witness_pair": 32,
+          "row_pair+witness_pair+crossing": 4704,
+          "survive": 8,
+          "witness_pair+crossing": 180
+        },
+        "survivors": [
+          {
+            "dropped_center": 0,
+            "dropped_center_class": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 1,
+            "dropped_center_class": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 2,
+            "dropped_center_class": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 3,
+            "dropped_center_class": [
+              0,
+              2,
+              5,
+              6
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 4,
+            "dropped_center_class": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 5,
+            "dropped_center_class": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 6,
+            "dropped_center_class": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          },
+          {
+            "dropped_center": 7,
+            "dropped_center_class": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "dropped_center_class_is_original": true,
+            "target_center_class": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "target_center_class_is_original": true,
+            "target_row_key": "151:8"
+          }
+        ]
+      },
+      "one_row_drop_candidate_count": 5040,
+      "one_row_drop_centers": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "one_row_drop_non_original_target_row_survivor_count": 0,
+      "one_row_drop_rejection_category_counts": {
+        "crossing": 105,
+        "row_pair+crossing": 11,
+        "row_pair+witness_pair": 32,
+        "row_pair+witness_pair+crossing": 4704,
+        "survive": 8,
+        "witness_pair+crossing": 180
+      },
+      "one_row_drop_replacement_count_per_center": 70,
+      "one_row_drop_surviving_candidate_count": 8,
+      "one_row_drop_survivors_all_original_rows": true,
+      "original_target_center_class": [
+        1,
+        2,
+        5,
+        7
+      ],
+      "singleton_support_labels": [
+        5,
+        7
+      ],
+      "source_one_outside_record": {
+        "bootstrap_core_witnesses": [
+          1,
+          2
+        ],
+        "outside_witnesses": [
+          5,
+          7
+        ],
+        "pressure_class": "NEEDS_ONE_OUTSIDE_LABEL_AND_PRIVATE_CENTER",
+        "row_center": 8,
+        "row_center_private_in_all_deletion_closures": true,
+        "source_record_id": 151,
+        "support_label_modes": {
+          "INTERNAL_TO_ONE_DELETION_CLOSURE": 1,
+          "PRIVATE_IN_ALL_DELETION_HALOS": 1
+        },
+        "support_labels": [
+          5,
+          7
+        ],
+        "witnesses": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center": 8,
+      "target_center_candidate_classes": [
+        [
+          0,
+          1,
+          2,
+          5
+        ],
+        [
+          0,
+          1,
+          2,
+          7
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          2,
+          6,
+          7
+        ]
+      ],
+      "target_center_candidate_count": 9,
+      "target_row_key": "151:8"
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-151-singleton-support-audit.md
+++ b/docs/bootstrap-t12-151-singleton-support-audit.md
@@ -1,0 +1,94 @@
+# Bootstrap T12 151 Singleton-Support Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet follows the one-outside-label ledger for the two source-`151`
+singleton-support targets:
+
+```text
+151:5
+151:8
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_151_singleton_support_audit.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_151_singleton_support_audit.json`.
+
+## Scan Scope
+
+For row `151:5`, the scan enumerates every center-`5` selected row containing
+bootstrap-core witnesses `[2,4]` and at least one singleton support from
+`[7,8]`.
+
+For row `151:8`, the scan enumerates every center-`8` selected row containing
+bootstrap-core witnesses `[1,2]` and at least one singleton support from
+`[5,7]`.
+
+Each target has nine activation rows.
+
+First, the scan replaces only the target row and preserves the other eight
+source-`151` selected rows.
+
+Second, it performs a one-row-drop relaxation: for each dropped non-target
+center, the dropped row may be any of its `70` possible selected 4-sets while
+the target row uses one of its nine singleton-support activation rows. This
+gives:
+
+```text
+151:5: 9 * 8 * 70 = 5040
+151:8: 9 * 8 * 70 = 5040
+```
+
+Both scans use only the basic selected-row filters:
+
+- row-pair cap;
+- witness-pair cap;
+- two-overlap crossing.
+
+No Euclidean realization, exact distance equation, minimality hypothesis, or
+rich-class forcing hypothesis is used.
+
+## Result
+
+In the fixed-neighborhood scan, each target has exactly one survivor: its
+original source-`151` row.
+
+```text
+151:5 -> [2,4,7,8]
+151:8 -> [1,2,5,7]
+```
+
+In the one-row-drop relaxation, each target has eight survivors. All are the
+trivial original-neighborhood survivors: the target row is original, and the
+dropped row is also equal to its original source-`151` row.
+
+The checked scan status is:
+
+```text
+ONLY_ORIGINAL_SOURCE151_SINGLETON_ROWS_SURVIVE_SUPPORT_AUDITS
+```
+
+## Remaining Gap
+
+This closes a narrow local escape route for the two source-`151`
+singleton-support targets under a fixed source-`151` neighborhood and a
+one-row-drop stress test. It does not prove that singleton support labels are
+forced by a genuine rich-class catalogue, does not allow two or more other rows
+to move, and does not model additional auxiliary rich supports.
+
+## What This Does Not Prove
+
+This artifact does not prove singleton support existence, row forcing, `n=9`,
+the bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining
+diagnostic for two T12 row targets.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -651,6 +651,15 @@ This remains a finite proof-mining diagnostic only, not a proof of outside-pair
 support existence, row forcing, `n=9`, the bootstrap bridge, or Erdos Problem
 #97.
 
+The source-`151` singleton-support audit in
+`docs/bootstrap-t12-151-singleton-support-audit.md` covers rows `151:5` and
+`151:8`. In both fixed source-`151` neighborhoods, only the original target row
+survives among the nine singleton-support activation rows; in the one-row-drop
+relaxations, the only survivors also keep the dropped row equal to its
+original source-`151` row. This remains a finite proof-mining diagnostic only,
+not a proof of singleton support existence, row forcing, `n=9`, the bootstrap
+bridge, or Erdos Problem #97.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -132,7 +132,10 @@ Use this queue when no more specific issue is selected.
    for the remaining relation-sufficient row target: no non-original row-`6`
    activation survivor appears in the fixed source-`151` neighborhood or a
    one-row-drop relaxation, but genuine outside-pair support existence and row
-   forcing remain open.
+   forcing remain open. The source-`151` singleton-support audit in
+   `docs/bootstrap-t12-151-singleton-support-audit.md` applies the same local
+   audit shape to rows `151:5` and `151:8`; it also leaves the genuine
+   support-existence and row-forcing bridge questions open.
 5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
    certificates and emit verifier-backed template records.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker

--- a/docs/index.md
+++ b/docs/index.md
@@ -200,6 +200,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-151-6-outside-pair-audit.md`](bootstrap-t12-151-6-outside-pair-audit.md):
   source-`151` row-`6` outside-pair audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.
+- [`bootstrap-t12-151-singleton-support-audit.md`](bootstrap-t12-151-singleton-support-audit.md):
+  source-`151` singleton-support audit covering rows `151:5` and `151:8`.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -395,6 +395,12 @@ condition that the surviving multi-block family does not automatically satisfy:
   row-`6` activation survivor under basic incidence/crossing filters. The
   remaining target is still genuine outside-pair support or row-forcing
   geometry, not a proof that row `6` is forced.
+- bootstrap/T12 focused source-`151` singleton-support evidence, as recorded
+  in `docs/bootstrap-t12-151-singleton-support-audit.md`, showing that rows
+  `151:5` and `151:8` have no non-original activation survivor in the fixed
+  source-`151` neighborhood or one-row-drop relaxation. The remaining target
+  is still genuine singleton-support or row-forcing geometry, not a proof that
+  either row is forced.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -263,6 +263,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_151_6_outside_pair_audit.json"
       verifier: "scripts/check_bootstrap_t12_151_6_outside_pair_audit.py"
       claim_scope: "proof-mining diagnostic only; enumerates the thirteen center-6 rows containing bootstrap-core witness [0] and outside support pair [3,5], [3,8], or [5,8], and finds no non-original row-6 survivor in the fixed source-151 neighborhood or one-row-drop relaxation, but does not prove outside-pair support existence, row forcing, n=9, or the bridge"
+    - pattern: "bootstrap_t12_151_singleton_support_audit"
+      status: "singleton-support activation-row audit for source 151 rows 5 and 8"
+      artifact: "data/certificates/bootstrap_t12_151_singleton_support_audit.json"
+      verifier: "scripts/check_bootstrap_t12_151_singleton_support_audit.py"
+      claim_scope: "proof-mining diagnostic only; enumerates singleton-support activation rows for source 151 rows 5 and 8 and finds no non-original target-row survivor in the fixed source-151 neighborhood or one-row-drop relaxation, but does not prove singleton support existence, row forcing, n=9, or the bridge"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3572,6 +3572,71 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_151_singleton_support_audit
+    path: data/certificates/bootstrap_t12_151_singleton_support_audit.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_151_singleton_support_audit.py
+    command: python scripts/check_bootstrap_t12_151_singleton_support_audit.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_151_singleton_support_audit.py
+    check_command: python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-151 singleton-support activation-row audit for rows 5 and 8; no non-original target-row activation survivor exists in the fixed source-151 neighborhood or one-row-drop relaxation under basic incidence/crossing filters, but this is not singleton-support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_151_singleton_support_audit.v1
+      status: BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 151
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.target_row_keys:
+        - "151:5"
+        - "151:8"
+      summary.target_centers:
+        - 5
+        - 8
+      summary.target_count: 2
+      summary.target_center_candidate_count_by_key.151:5: 9
+      summary.target_center_candidate_count_by_key.151:8: 9
+      summary.fixed_neighborhood_candidate_count: 18
+      summary.fixed_neighborhood_surviving_candidate_count: 2
+      summary.fixed_neighborhood_non_original_survivor_count: 0
+      summary.one_row_drop_candidate_count: 10080
+      summary.one_row_drop_surviving_candidate_count: 16
+      summary.one_row_drop_non_original_target_row_survivor_count: 0
+      summary.one_row_drop_survivors_all_original_rows: true
+      summary.scan_status: ONLY_ORIGINAL_SOURCE151_SINGLETON_ROWS_SURVIVE_SUPPORT_AUDITS
+      source_one_outside_packet.schema: erdos97.bootstrap_t12_one_outside.v1
+      source_overlay_packet.schema: erdos97.bootstrap_vertex_circle_overlay.v1
+      provenance.generator: scripts/check_bootstrap_t12_151_singleton_support_audit.py
+      provenance.command: python scripts/check_bootstrap_t12_151_singleton_support_audit.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - singleton support proves row-center forcing
+      - source 151 singleton rows are forced
+      - source 151 singleton support exists
+      - the source 151 singleton audit proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_151_singleton_support_audit.py
+++ b/scripts/check_bootstrap_t12_151_singleton_support_audit.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 source-151 singleton-support audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_151_singleton_support_audit import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_151_singleton_support_audit_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 source-151 singleton-support audit")
+    print(f"target rows: {summary['target_row_keys']}")
+    print(
+        "fixed-neighborhood survivors: "
+        f"{summary['fixed_neighborhood_surviving_candidate_count']}"
+    )
+    print(
+        "one-row-drop survivors: "
+        f"{summary['one_row_drop_surviving_candidate_count']}"
+    )
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_151_singleton_support_audit_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 source-151 singleton artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 source-151 singleton expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/bootstrap_t12_151_singleton_support_audit.py
+++ b/src/erdos97/bootstrap_t12_151_singleton_support_audit.py
@@ -1,0 +1,581 @@
+"""Singleton-support audit for the bootstrap/T12 source-151 targets.
+
+Rows 151:5 and 151:8 are the source-151 one-outside-label targets.  This audit
+asks whether either target can use a singleton-support activation row different
+from its fixed source-151 row while the surrounding source-151 selected rows
+are preserved, or while one additional row is allowed to move.
+
+The answer is no under the basic selected-row incidence and crossing filters.
+This is not a Euclidean realizability theorem and not a proof of row forcing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CYCLIC_ORDER,
+    _crossing_violations,
+    _row_pair_cap_violations,
+    _witness_pair_cap_violations,
+)
+from erdos97.bootstrap_t12_one_outside import (
+    DEFAULT_ARTIFACT as ONE_OUTSIDE_ARTIFACT,
+    SCHEMA as ONE_OUTSIDE_SCHEMA,
+    STATUS as ONE_OUTSIDE_STATUS,
+    build_t12_one_outside_payload,
+)
+from erdos97.bootstrap_vertex_circle_overlay import (
+    SCHEMA as OVERLAY_SCHEMA,
+    STATUS as OVERLAY_STATUS,
+    build_overlay_payload,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_151_singleton_support_audit.v1"
+STATUS = "BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "ONLY_ORIGINAL_SOURCE151_SINGLETON_ROWS_SURVIVE_SUPPORT_AUDITS"
+CLAIM_SCOPE = (
+    "Fixed selected-row-neighborhood singleton-support audit for source 151 "
+    "rows 5 and 8. It enumerates activation rows containing each target's "
+    "bootstrap-core witnesses plus one singleton support label, then checks "
+    "the fixed source-151 neighborhood and a one-row-drop relaxation by "
+    "row-pair, witness-pair, and crossing filters. The only survivors keep the "
+    "original target row and, in the one-row-drop scans, also keep the dropped "
+    "row equal to its original source-151 row. This does not prove singleton "
+    "support existence, row forcing, does not prove n=9, does not prove the "
+    "bridge, and is not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_singleton_support_audit.json"
+)
+
+SOURCE_RECORD_ID = 151
+TARGET_SPECS: dict[int, dict[str, object]] = {
+    5: {
+        "target_row_key": "151:5",
+        "bootstrap_core_witnesses": [2, 4],
+        "singleton_support_labels": [7, 8],
+        "original_row": [2, 4, 7, 8],
+        "fixed_counts": {
+            "row_pair+witness_pair+crossing": 6,
+            "survive": 1,
+            "witness_pair+crossing": 2,
+        },
+        "one_row_drop_counts": {
+            "crossing": 47,
+            "row_pair+crossing": 11,
+            "row_pair+witness_pair": 36,
+            "row_pair+witness_pair+crossing": 4692,
+            "survive": 8,
+            "witness_pair+crossing": 246,
+        },
+    },
+    8: {
+        "target_row_key": "151:8",
+        "bootstrap_core_witnesses": [1, 2],
+        "singleton_support_labels": [5, 7],
+        "original_row": [1, 2, 5, 7],
+        "fixed_counts": {
+            "crossing": 2,
+            "row_pair+witness_pair+crossing": 6,
+            "survive": 1,
+        },
+        "one_row_drop_counts": {
+            "crossing": 105,
+            "row_pair+crossing": 11,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 4704,
+            "survive": 8,
+            "witness_pair+crossing": 180,
+        },
+    },
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _source_151_rows() -> list[list[int]]:
+    overlay = build_overlay_payload()
+    records = overlay.get("records")
+    if not isinstance(records, Sequence):
+        raise AssertionError("overlay records must be a sequence")
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise AssertionError("overlay records must be mappings")
+        if int(record["source_record_id"]) == SOURCE_RECORD_ID:
+            return [_int_list(row) for row in record["selected_rows"]]
+    raise AssertionError("could not find source 151 in overlay packet")
+
+
+def _target_one_outside_records() -> dict[int, dict[str, object]]:
+    one_outside = build_t12_one_outside_payload()
+    records = one_outside.get("records")
+    if not isinstance(records, Sequence):
+        raise AssertionError("one-outside packet records must be a sequence")
+    target_records: dict[int, dict[str, object]] = {}
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise AssertionError("one-outside records must be mappings")
+        if int(record["source_record_id"]) != SOURCE_RECORD_ID:
+            continue
+        row_center = int(record["row_center"])
+        if row_center not in TARGET_SPECS:
+            continue
+        support_labels = [
+            int(option["support_label"]) for option in record["support_options"]
+        ]
+        target_records[row_center] = {
+            "source_record_id": int(record["source_record_id"]),
+            "row_center": row_center,
+            "witnesses": _int_list(record["witnesses"]),
+            "bootstrap_core_witnesses": _int_list(
+                record["bootstrap_core_witnesses"]
+            ),
+            "outside_witnesses": _int_list(record["outside_witnesses"]),
+            "support_labels": sorted(support_labels),
+            "support_label_modes": record["support_label_modes"],
+            "pressure_class": str(record["pressure_class"]),
+            "row_center_private_in_all_deletion_closures": bool(
+                record["row_center_private_in_all_deletion_closures"]
+            ),
+        }
+    missing = sorted(set(TARGET_SPECS) - set(target_records))
+    if missing:
+        raise AssertionError(f"missing source-151 one-outside rows: {missing}")
+    return target_records
+
+
+def _target_row_key(center: int) -> str:
+    return str(TARGET_SPECS[center]["target_row_key"])
+
+
+def _bootstrap_core_witnesses(center: int) -> list[int]:
+    return _int_list(TARGET_SPECS[center]["bootstrap_core_witnesses"])
+
+
+def _singleton_support_labels(center: int) -> list[int]:
+    return _int_list(TARGET_SPECS[center]["singleton_support_labels"])
+
+
+def _original_row(center: int) -> list[int]:
+    return _int_list(TARGET_SPECS[center]["original_row"])
+
+
+def _target_row_candidates(center: int) -> list[list[int]]:
+    candidates: set[tuple[int, ...]] = set()
+    core = set(_bootstrap_core_witnesses(center))
+    for support_label in _singleton_support_labels(center):
+        required = core | {support_label}
+        for fourth in CYCLIC_ORDER:
+            if fourth != center and fourth not in required:
+                candidates.add(tuple(sorted(required | {fourth})))
+    return [list(candidate) for candidate in sorted(candidates)]
+
+
+def _all_replacement_rows(center: int) -> list[list[int]]:
+    labels = [label for label in CYCLIC_ORDER if label != center]
+    return [list(row) for row in combinations(labels, 4)]
+
+
+def _rejection_data(rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    row_pair_violations = _row_pair_cap_violations(rows)
+    witness_pair_violations = _witness_pair_cap_violations(rows)
+    crossing_violations = _crossing_violations(rows)
+    reasons = []
+    if row_pair_violations:
+        reasons.append("row_pair")
+    if witness_pair_violations:
+        reasons.append("witness_pair")
+    if crossing_violations:
+        reasons.append("crossing")
+    return {
+        "row_pair_cap_violations": row_pair_violations,
+        "witness_pair_cap_violations": witness_pair_violations,
+        "crossing_violations": crossing_violations,
+        "rejection_reasons": reasons,
+        "rejection_category": "+".join(reasons) if reasons else "survive",
+        "passes_basic_incidence_crossing_filters": not reasons,
+    }
+
+
+def _fixed_candidate_records(
+    base_rows: Sequence[Sequence[int]],
+    center: int,
+) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for candidate in _target_row_candidates(center):
+        rows = [list(row) for row in base_rows]
+        rows[center] = list(candidate)
+        rejection = _rejection_data(rows)
+        records.append(
+            {
+                "target_row_key": _target_row_key(center),
+                "target_center": center,
+                "target_center_class": candidate,
+                "is_original_row": candidate == _original_row(center),
+                **rejection,
+            }
+        )
+    return records
+
+
+def _scan_one_row_drop(
+    base_rows: Sequence[Sequence[int]],
+    center: int,
+) -> dict[str, object]:
+    total_counts: Counter[str] = Counter()
+    per_dropped_counts: dict[int, Counter[str]] = {
+        dropped: Counter() for dropped in CYCLIC_ORDER if dropped != center
+    }
+    survivors: list[dict[str, object]] = []
+
+    for target_row in _target_row_candidates(center):
+        for dropped_center in [label for label in CYCLIC_ORDER if label != center]:
+            for replacement_row in _all_replacement_rows(dropped_center):
+                rows = [list(row) for row in base_rows]
+                rows[center] = list(target_row)
+                rows[dropped_center] = list(replacement_row)
+                category = str(_rejection_data(rows)["rejection_category"])
+                total_counts[category] += 1
+                per_dropped_counts[dropped_center][category] += 1
+                if category == "survive":
+                    survivors.append(
+                        {
+                            "target_row_key": _target_row_key(center),
+                            "target_center_class": list(target_row),
+                            "target_center_class_is_original": (
+                                target_row == _original_row(center)
+                            ),
+                            "dropped_center": dropped_center,
+                            "dropped_center_class": list(replacement_row),
+                            "dropped_center_class_is_original": (
+                                replacement_row == list(base_rows[dropped_center])
+                            ),
+                        }
+                    )
+
+    return {
+        "candidate_count": sum(total_counts.values()),
+        "rejection_category_counts": _json_counter(total_counts),
+        "per_dropped_center": [
+            {
+                "dropped_center": dropped_center,
+                "source_row": list(base_rows[dropped_center]),
+                "replacement_row_count": len(_all_replacement_rows(dropped_center)),
+                "candidate_count": sum(per_dropped_counts[dropped_center].values()),
+                "surviving_candidate_count": per_dropped_counts[dropped_center].get(
+                    "survive", 0
+                ),
+                "rejection_category_counts": _json_counter(
+                    per_dropped_counts[dropped_center]
+                ),
+            }
+            for dropped_center in CYCLIC_ORDER
+            if dropped_center != center
+        ],
+        "survivors": survivors,
+    }
+
+
+def _target_audit_record(
+    base_rows: Sequence[Sequence[int]],
+    one_outside_record: Mapping[str, object],
+    center: int,
+) -> dict[str, object]:
+    fixed_records = _fixed_candidate_records(base_rows, center)
+    fixed_counts = Counter(str(record["rejection_category"]) for record in fixed_records)
+    fixed_survivors = [
+        record
+        for record in fixed_records
+        if record["passes_basic_incidence_crossing_filters"]
+    ]
+    one_row_drop = _scan_one_row_drop(base_rows, center)
+    one_row_drop_survivors = one_row_drop["survivors"]
+    if not isinstance(one_row_drop_survivors, Sequence):
+        raise AssertionError("one-row-drop survivors must be a sequence")
+    non_original_one_drop_survivors = [
+        survivor
+        for survivor in one_row_drop_survivors
+        if not survivor["target_center_class_is_original"]
+    ]
+
+    return {
+        "target_row_key": _target_row_key(center),
+        "target_center": center,
+        "bootstrap_core_witnesses": _bootstrap_core_witnesses(center),
+        "singleton_support_labels": _singleton_support_labels(center),
+        "original_target_center_class": _original_row(center),
+        "target_center_candidate_classes": _target_row_candidates(center),
+        "target_center_candidate_count": len(_target_row_candidates(center)),
+        "fixed_neighborhood_candidate_count": len(fixed_records),
+        "fixed_neighborhood_surviving_candidate_count": len(fixed_survivors),
+        "fixed_neighborhood_non_original_survivor_count": sum(
+            1 for survivor in fixed_survivors if not survivor["is_original_row"]
+        ),
+        "fixed_neighborhood_rejection_category_counts": _json_counter(fixed_counts),
+        "one_row_drop_centers": [
+            dropped_center for dropped_center in CYCLIC_ORDER if dropped_center != center
+        ],
+        "one_row_drop_replacement_count_per_center": 70,
+        "one_row_drop_candidate_count": one_row_drop["candidate_count"],
+        "one_row_drop_surviving_candidate_count": len(one_row_drop_survivors),
+        "one_row_drop_non_original_target_row_survivor_count": len(
+            non_original_one_drop_survivors
+        ),
+        "one_row_drop_survivors_all_original_rows": all(
+            survivor["target_center_class_is_original"]
+            and survivor["dropped_center_class_is_original"]
+            for survivor in one_row_drop_survivors
+        ),
+        "one_row_drop_rejection_category_counts": one_row_drop[
+            "rejection_category_counts"
+        ],
+        "source_one_outside_record": dict(one_outside_record),
+        "fixed_neighborhood_candidates": fixed_records,
+        "one_row_drop": one_row_drop,
+    }
+
+
+def build_t12_151_singleton_support_audit_payload() -> dict[str, object]:
+    """Return the deterministic source-151 singleton-support audit."""
+
+    base_rows = _source_151_rows()
+    target_records = _target_one_outside_records()
+    audit_records = []
+    for center in sorted(TARGET_SPECS):
+        one_outside_record = target_records[center]
+        if (
+            one_outside_record["bootstrap_core_witnesses"]
+            != _bootstrap_core_witnesses(center)
+        ):
+            raise AssertionError(f"source one-outside core drifted for {center}")
+        if one_outside_record["support_labels"] != _singleton_support_labels(center):
+            raise AssertionError(f"source one-outside supports drifted for {center}")
+        if base_rows[center] != _original_row(center):
+            raise AssertionError(f"source-151 row {center} drifted")
+        audit_records.append(_target_audit_record(base_rows, one_outside_record, center))
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This audit preserves the source-151 selected-row neighborhood, or drops exactly one non-target row in each relaxation.",
+            "A row containing bootstrap-core witnesses plus a singleton support is activation bookkeeping, not a proof that a genuine rich class exists.",
+            "The audit uses incidence and crossing filters only, not Euclidean realizability.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "source_record_ids": [SOURCE_RECORD_ID],
+            "cyclic_order": CYCLIC_ORDER,
+            "target_row_keys": [_target_row_key(center) for center in sorted(TARGET_SPECS)],
+            "target_centers": sorted(TARGET_SPECS),
+            "target_count": len(audit_records),
+            "target_center_candidate_count_by_key": {
+                record["target_row_key"]: record["target_center_candidate_count"]
+                for record in audit_records
+            },
+            "fixed_neighborhood_candidate_count": sum(
+                int(record["fixed_neighborhood_candidate_count"])
+                for record in audit_records
+            ),
+            "fixed_neighborhood_surviving_candidate_count": sum(
+                int(record["fixed_neighborhood_surviving_candidate_count"])
+                for record in audit_records
+            ),
+            "fixed_neighborhood_non_original_survivor_count": sum(
+                int(record["fixed_neighborhood_non_original_survivor_count"])
+                for record in audit_records
+            ),
+            "one_row_drop_candidate_count": sum(
+                int(record["one_row_drop_candidate_count"]) for record in audit_records
+            ),
+            "one_row_drop_surviving_candidate_count": sum(
+                int(record["one_row_drop_surviving_candidate_count"])
+                for record in audit_records
+            ),
+            "one_row_drop_non_original_target_row_survivor_count": sum(
+                int(record["one_row_drop_non_original_target_row_survivor_count"])
+                for record in audit_records
+            ),
+            "one_row_drop_survivors_all_original_rows": all(
+                bool(record["one_row_drop_survivors_all_original_rows"])
+                for record in audit_records
+            ),
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not prove singleton support existence, does not "
+                "prove the rows are forced by minimal or rich-class geometry, "
+                "does not allow two or more other rows to move, and does not "
+                "model additional auxiliary rich supports."
+            ),
+        },
+        "source_rows": {str(center): base_rows[center] for center in CYCLIC_ORDER},
+        "target_audits": audit_records,
+        "source_one_outside_packet": {
+            "path": ONE_OUTSIDE_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": ONE_OUTSIDE_SCHEMA,
+            "status": ONE_OUTSIDE_STATUS,
+        },
+        "source_overlay_packet": {
+            "path": "data/certificates/bootstrap_vertex_circle_overlay.json",
+            "schema": OVERLAY_SCHEMA,
+            "status": OVERLAY_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_151_singleton_support_audit.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_151_singleton_support_audit.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "source_record_ids": [SOURCE_RECORD_ID],
+        "cyclic_order": CYCLIC_ORDER,
+        "target_row_keys": ["151:5", "151:8"],
+        "target_centers": [5, 8],
+        "target_count": 2,
+        "target_center_candidate_count_by_key": {"151:5": 9, "151:8": 9},
+        "fixed_neighborhood_candidate_count": 18,
+        "fixed_neighborhood_surviving_candidate_count": 2,
+        "fixed_neighborhood_non_original_survivor_count": 0,
+        "one_row_drop_candidate_count": 10080,
+        "one_row_drop_surviving_candidate_count": 16,
+        "one_row_drop_non_original_target_row_survivor_count": 0,
+        "one_row_drop_survivors_all_original_rows": True,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    records = payload.get("target_audits")
+    if not isinstance(records, Sequence) or len(records) != 2:
+        raise AssertionError("expected two source-151 singleton target audits")
+    by_key = {
+        str(record["target_row_key"]): record
+        for record in records
+        if isinstance(record, Mapping)
+    }
+    if sorted(by_key) != ["151:5", "151:8"]:
+        raise AssertionError("unexpected source-151 singleton audit keys")
+
+    for center in sorted(TARGET_SPECS):
+        key = _target_row_key(center)
+        record = by_key[key]
+        spec = TARGET_SPECS[center]
+        if record.get("bootstrap_core_witnesses") != spec["bootstrap_core_witnesses"]:
+            raise AssertionError(f"{key} bootstrap core drifted")
+        if record.get("singleton_support_labels") != spec["singleton_support_labels"]:
+            raise AssertionError(f"{key} support labels drifted")
+        if record.get("original_target_center_class") != spec["original_row"]:
+            raise AssertionError(f"{key} original row drifted")
+        if record.get("target_center_candidate_count") != 9:
+            raise AssertionError(f"{key} candidate count drifted")
+        if record.get("fixed_neighborhood_candidate_count") != 9:
+            raise AssertionError(f"{key} fixed candidate count drifted")
+        if record.get("fixed_neighborhood_surviving_candidate_count") != 1:
+            raise AssertionError(f"{key} fixed survivor count drifted")
+        if record.get("fixed_neighborhood_non_original_survivor_count") != 0:
+            raise AssertionError(f"{key} fixed non-original survivor drifted")
+        if record.get("fixed_neighborhood_rejection_category_counts") != spec[
+            "fixed_counts"
+        ]:
+            raise AssertionError(f"{key} fixed rejection counts drifted")
+        if record.get("one_row_drop_candidate_count") != 5040:
+            raise AssertionError(f"{key} one-row-drop candidate count drifted")
+        if record.get("one_row_drop_surviving_candidate_count") != 8:
+            raise AssertionError(f"{key} one-row-drop survivor count drifted")
+        if record.get("one_row_drop_non_original_target_row_survivor_count") != 0:
+            raise AssertionError(f"{key} one-row-drop non-original drifted")
+        if record.get("one_row_drop_survivors_all_original_rows") is not True:
+            raise AssertionError(f"{key} one-row-drop survivors drifted")
+        if record.get("one_row_drop_rejection_category_counts") != spec[
+            "one_row_drop_counts"
+        ]:
+            raise AssertionError(f"{key} one-row-drop counts drifted")
+
+        fixed_candidates = record.get("fixed_neighborhood_candidates")
+        if not isinstance(fixed_candidates, Sequence) or len(fixed_candidates) != 9:
+            raise AssertionError(f"{key} fixed-neighborhood candidates malformed")
+        fixed_survivors = [
+            candidate
+            for candidate in fixed_candidates
+            if isinstance(candidate, Mapping)
+            and candidate.get("passes_basic_incidence_crossing_filters")
+        ]
+        if len(fixed_survivors) != 1:
+            raise AssertionError(f"{key} fixed survivor list drifted")
+        if fixed_survivors[0].get("target_center_class") != spec["original_row"]:
+            raise AssertionError(f"{key} fixed survivor should be original")
+
+        one_row_drop = record.get("one_row_drop")
+        if not isinstance(one_row_drop, Mapping):
+            raise AssertionError(f"{key} one_row_drop must be a mapping")
+        survivors = one_row_drop.get("survivors")
+        if not isinstance(survivors, Sequence) or len(survivors) != 8:
+            raise AssertionError(f"{key} should have eight one-row-drop survivors")
+        if any(
+            not isinstance(survivor, Mapping)
+            or not survivor.get("target_center_class_is_original")
+            or not survivor.get("dropped_center_class_is_original")
+            for survivor in survivors
+        ):
+            raise AssertionError(f"{key} one-row-drop survivors should be original")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_151_singleton_support_audit.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_151_singleton_support_audit.py
+++ b/tests/test_bootstrap_t12_151_singleton_support_audit.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_151_singleton_support_audit import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_151_singleton_support_audit_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_151_singleton_support_audit_payload()
+
+
+def test_151_singleton_support_audit_counts_and_scope(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "singleton-support audit" in claim_scope
+    assert "does not prove singleton support existence" in claim_scope
+    assert "does not prove n=9" in claim_scope
+    assert "counterexample" in claim_scope
+
+
+def test_151_singleton_support_audit_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["source_record_ids"] == [151]
+    assert summary["target_row_keys"] == ["151:5", "151:8"]
+    assert summary["target_centers"] == [5, 8]
+    assert summary["target_count"] == 2
+    assert summary["target_center_candidate_count_by_key"] == {
+        "151:5": 9,
+        "151:8": 9,
+    }
+    assert summary["fixed_neighborhood_candidate_count"] == 18
+    assert summary["fixed_neighborhood_surviving_candidate_count"] == 2
+    assert summary["fixed_neighborhood_non_original_survivor_count"] == 0
+    assert summary["one_row_drop_candidate_count"] == 10080
+    assert summary["one_row_drop_surviving_candidate_count"] == 16
+    assert summary["one_row_drop_non_original_target_row_survivor_count"] == 0
+    assert summary["one_row_drop_survivors_all_original_rows"] is True
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_151_singleton_support_audit_target_details(
+    payload: dict[str, object],
+) -> None:
+    records = {
+        record["target_row_key"]: record for record in payload["target_audits"]
+    }
+
+    assert records["151:5"]["bootstrap_core_witnesses"] == [2, 4]
+    assert records["151:5"]["singleton_support_labels"] == [7, 8]
+    assert records["151:5"]["original_target_center_class"] == [2, 4, 7, 8]
+    assert records["151:5"]["target_center_candidate_classes"] == [
+        [0, 2, 4, 7],
+        [0, 2, 4, 8],
+        [1, 2, 4, 7],
+        [1, 2, 4, 8],
+        [2, 3, 4, 7],
+        [2, 3, 4, 8],
+        [2, 4, 6, 7],
+        [2, 4, 6, 8],
+        [2, 4, 7, 8],
+    ]
+
+    assert records["151:8"]["bootstrap_core_witnesses"] == [1, 2]
+    assert records["151:8"]["singleton_support_labels"] == [5, 7]
+    assert records["151:8"]["original_target_center_class"] == [1, 2, 5, 7]
+    assert records["151:8"]["target_center_candidate_classes"] == [
+        [0, 1, 2, 5],
+        [0, 1, 2, 7],
+        [1, 2, 3, 5],
+        [1, 2, 3, 7],
+        [1, 2, 4, 5],
+        [1, 2, 4, 7],
+        [1, 2, 5, 6],
+        [1, 2, 5, 7],
+        [1, 2, 6, 7],
+    ]
+
+
+def test_151_singleton_support_audit_rejection_counts(
+    payload: dict[str, object],
+) -> None:
+    records = {
+        record["target_row_key"]: record for record in payload["target_audits"]
+    }
+
+    assert records["151:5"]["fixed_neighborhood_rejection_category_counts"] == {
+        "row_pair+witness_pair+crossing": 6,
+        "survive": 1,
+        "witness_pair+crossing": 2,
+    }
+    assert records["151:5"]["one_row_drop_rejection_category_counts"] == {
+        "crossing": 47,
+        "row_pair+crossing": 11,
+        "row_pair+witness_pair": 36,
+        "row_pair+witness_pair+crossing": 4692,
+        "survive": 8,
+        "witness_pair+crossing": 246,
+    }
+
+    assert records["151:8"]["fixed_neighborhood_rejection_category_counts"] == {
+        "crossing": 2,
+        "row_pair+witness_pair+crossing": 6,
+        "survive": 1,
+    }
+    assert records["151:8"]["one_row_drop_rejection_category_counts"] == {
+        "crossing": 105,
+        "row_pair+crossing": 11,
+        "row_pair+witness_pair": 32,
+        "row_pair+witness_pair+crossing": 4704,
+        "survive": 8,
+        "witness_pair+crossing": 180,
+    }
+
+
+def test_151_singleton_support_audit_survivors_are_original(
+    payload: dict[str, object],
+) -> None:
+    for record in payload["target_audits"]:
+        fixed_survivors = [
+            candidate
+            for candidate in record["fixed_neighborhood_candidates"]
+            if candidate["passes_basic_incidence_crossing_filters"]
+        ]
+        assert len(fixed_survivors) == 1
+        assert fixed_survivors[0]["is_original_row"] is True
+
+        survivors = record["one_row_drop"]["survivors"]
+        assert len(survivors) == 8
+        assert all(
+            survivor["target_center_class_is_original"]
+            and survivor["dropped_center_class_is_original"]
+            for survivor in survivors
+        )
+
+
+def test_151_singleton_support_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_151_singleton_support_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_151_singleton_support_audit.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert (
+        payload["summary"]["one_row_drop_non_original_target_row_survivor_count"]
+        == 0
+    )
+
+
+def test_151_singleton_support_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["one_row_drop_non_original_target_row_survivor_count"] = 1
+
+    with pytest.raises(
+        AssertionError,
+        match="one_row_drop_non_original_target_row_survivor_count",
+    ):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- Add a generator-backed source-151 singleton-support audit covering rows `151:5` and `151:8`.
- Enumerate activation rows containing each target's bootstrap-core witnesses plus one singleton support label.
- Record that fixed-neighborhood scans keep only the original target rows, and one-row-drop relaxations have only trivial original-neighborhood survivors.
- Keep the scope diagnostic: this does not prove singleton-support existence, row forcing, `n=9`, the bridge, or a counterexample.

## Verification

- `python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected`
- `python -m pytest tests/test_bootstrap_t12_151_singleton_support_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check --cached`
- `python -m ruff check .`
- `python -m pytest -q`