### PR TITLE
Cross-check T02 local lemma packet

### DIFF
--- a/data/certificates/n9_vertex_circle_local_lemmas.json
+++ b/data/certificates/n9_vertex_circle_local_lemmas.json
@@ -97,6 +97,45 @@
   "focused_note_crosscheck": [
     {
       "check_status": "checked",
+      "covered_assignment_count": 40,
+      "families_checked": [
+        {
+          "assignment_count": 18,
+          "family_id": "F01",
+          "orbit_size": 18
+        },
+        {
+          "assignment_count": 18,
+          "family_id": "F04",
+          "orbit_size": 18
+        },
+        {
+          "assignment_count": 2,
+          "family_id": "F08",
+          "orbit_size": 2
+        },
+        {
+          "assignment_count": 2,
+          "family_id": "F14",
+          "orbit_size": 2
+        }
+      ],
+      "family_ids": [
+        "F01",
+        "F04",
+        "F08",
+        "F14"
+      ],
+      "interpretation": "Aggregate scan instance matches the focused packet used by the proof-facing note; this is a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "shared_endpoint_nested_self_edge",
+      "packet_key": "T02",
+      "packet_path": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t02-self-edge-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T02"
+    },
+    {
+      "check_status": "checked",
       "covered_assignment_count": 20,
       "families_checked": [
         {

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -18,9 +18,9 @@ that justifies doing it anyway.
 Use this queue when no more specific issue is selected.
 
 1. Review the aggregate `n=9` vertex-circle local-lemma scan against the
-   focused T03/T04 self-edge packets and the focused T10/T11/T12 strict-cycle
-   packets, keeping it scoped as proof-mining scaffolding rather than an `n=9`
-   proof.
+   focused T02/T03/T04 self-edge packets and the focused T10/T11/T12
+   strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
+   than an `n=9` proof.
 2. Audit whether the aggregate local-template coverage can be checked from the
    stored packet JSON by a second, simpler replay that does not share the
    current quotient-replay helper.

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -507,6 +507,7 @@ The aggregate checker also cross-checks the proof-facing focused notes that
 have already been extracted from the packet catalog:
 
 ```text
+T02/F01,F04,F08,F14 -> docs/n9-vertex-circle-t02-self-edge-lemma.md
 T03/F05,F15 -> docs/n9-vertex-circle-t03-self-edge-lemma.md
 T04/F13     -> docs/n9-vertex-circle-t04-self-edge-lemma.md
 T10/F12     -> docs/n9-vertex-circle-t10-strict-cycle-lemma.md
@@ -514,7 +515,7 @@ T11/F07     -> docs/n9-vertex-circle-t11-strict-cycle-lemma.md
 T12/F16     -> docs/n9-vertex-circle-t12-strict-cycle-lemma.md
 ```
 
-For T03, T04, T10, T11, and T12 the scan loads the focused JSON packets and
+For T02, T03, T04, T10, T11, and T12 the scan loads the focused JSON packets and
 checks that the aggregate family rows, strict inequalities, equality paths,
 cycle steps, and assignment counts match the focused packet used by the note.
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -167,7 +167,7 @@ Next steps:
   to replay the focused review-pending T11/F07 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T12/F16 strict-cycle local lemma packet;
-- review the aggregate local-lemma scan after the T03/T04 self-edge and
+- review the aggregate local-lemma scan after the T02/T03/T04 self-edge and
   T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
   coverage of stored packets rather than an independent `n=9` proof;
 - test whether the same motifs appear in the P18 obstruction and fail in the

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -31,6 +31,9 @@ DEFAULT_SELF_EDGE_PACKET = (
 DEFAULT_STRICT_CYCLE_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
 )
+DEFAULT_T02_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t02_self_edge_lemma_packet.json"
+)
 DEFAULT_T03_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t03_self_edge_lemma_packet.json"
 )
@@ -74,6 +77,7 @@ def scan_payload(
     *,
     self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
     strict_cycle_packet_path: Path = DEFAULT_STRICT_CYCLE_PACKET,
+    t02_packet_path: Path = DEFAULT_T02_PACKET,
     t03_packet_path: Path = DEFAULT_T03_PACKET,
     t04_packet_path: Path = DEFAULT_T04_PACKET,
     t10_packet_path: Path = DEFAULT_T10_PACKET,
@@ -86,6 +90,7 @@ def scan_payload(
         load_artifact(self_edge_packet_path),
         load_artifact(strict_cycle_packet_path),
         focused_packets={
+            "T02": load_artifact(t02_packet_path),
             "T03": load_artifact(t03_packet_path),
             "T04": load_artifact(t04_packet_path),
             "T10": load_artifact(t10_packet_path),
@@ -204,6 +209,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to n9 strict-cycle template packet JSON.",
     )
     parser.add_argument(
+        "--t02-packet",
+        type=Path,
+        default=DEFAULT_T02_PACKET,
+        help="Path to focused T02 self-edge lemma packet JSON.",
+    )
+    parser.add_argument(
         "--t03-packet",
         type=Path,
         default=DEFAULT_T03_PACKET,
@@ -255,6 +266,7 @@ def main(argv: list[str] | None = None) -> int:
     payload = scan_payload(
         self_edge_packet_path=_resolve(args.self_edge_packet),
         strict_cycle_packet_path=_resolve(args.strict_cycle_packet),
+        t02_packet_path=_resolve(args.t02_packet),
         t03_packet_path=_resolve(args.t03_packet),
         t04_packet_path=_resolve(args.t04_packet),
         t10_packet_path=_resolve(args.t10_packet),

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -84,6 +84,16 @@ EXPECTED_SUMMARY = {
 }
 EXPECTED_DIRECT_TWO_ROW_INSTANCE_COUNT = 0
 EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
+    SHARED_ENDPOINT_LEMMA: {
+        "template_id": "T02",
+        "family_ids": ["F01", "F04", "F08", "F14"],
+        "proof_note_path": "docs/n9-vertex-circle-t02-self-edge-lemma.md",
+        "source_kind": "focused_packet",
+        "packet_key": "T02",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json"
+        ),
+    },
     T03_SELECTED_PATH_SELF_EDGE: {
         "template_id": "T03",
         "family_ids": ["F05", "F15"],
@@ -430,7 +440,11 @@ def _check_focused_packet(
         if packet is None:
             raise AssertionError(f"{template_id} focused packet missing {family_id}")
         _assert_family_common_fields(template_id, family_id, aggregate, packet)
-        if lemma_id in {T03_SELECTED_PATH_SELF_EDGE, T04_SELECTED_PATH_SELF_EDGE}:
+        if lemma_id in {
+            SHARED_ENDPOINT_LEMMA,
+            T03_SELECTED_PATH_SELF_EDGE,
+            T04_SELECTED_PATH_SELF_EDGE,
+        }:
             _assert_self_edge_family_match(template_id, family_id, aggregate, packet)
         else:
             _assert_strict_cycle_family_match(template_id, family_id, aggregate, packet)

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -21,6 +21,7 @@ from erdos97.n9_vertex_circle_local_lemmas import (
 from scripts.check_n9_vertex_circle_local_lemmas import (
     DEFAULT_SELF_EDGE_PACKET,
     DEFAULT_STRICT_CYCLE_PACKET,
+    DEFAULT_T02_PACKET,
     DEFAULT_T03_PACKET,
     DEFAULT_T04_PACKET,
     DEFAULT_T10_PACKET,
@@ -99,6 +100,30 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
         },
     }
     assert payload["focused_note_crosscheck"] == [  # type: ignore[index]
+        {
+            "lemma_id": SHARED_ENDPOINT_LEMMA,
+            "template_id": "T02",
+            "family_ids": ["F01", "F04", "F08", "F14"],
+            "proof_note_path": "docs/n9-vertex-circle-t02-self-edge-lemma.md",
+            "source_kind": "focused_packet",
+            "packet_key": "T02",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F01", "assignment_count": 18, "orbit_size": 18},
+                {"family_id": "F04", "assignment_count": 18, "orbit_size": 18},
+                {"family_id": "F08", "assignment_count": 2, "orbit_size": 2},
+                {"family_id": "F14", "assignment_count": 2, "orbit_size": 2},
+            ],
+            "covered_assignment_count": 40,
+            "interpretation": (
+                "Aggregate scan instance matches the focused packet used by the "
+                "proof-facing note; this is a packet consistency check, not an "
+                "independent n=9 completeness proof."
+            ),
+        },
         {
             "lemma_id": T03_SELECTED_PATH_SELF_EDGE,
             "template_id": "T03",
@@ -454,6 +479,27 @@ def test_payload_provenance_is_not_shared_mutable_state() -> None:
     )
 
 
+def test_focused_packet_crosscheck_rejects_t02_path_drift() -> None:
+    self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
+    strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
+    t02_packet = load_artifact(DEFAULT_T02_PACKET)
+    t02_packet["family_packets"][0]["distance_equality"]["path"][0]["next_pair"] = [0, 7]
+
+    with pytest.raises(AssertionError, match="F01 focused packet distance_equality mismatch"):
+        local_lemma_scan_payload(
+            self_edge_packet,
+            strict_cycle_packet,
+            focused_packets={
+                "T02": t02_packet,
+                "T03": load_artifact(DEFAULT_T03_PACKET),
+                "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T10": load_artifact(DEFAULT_T10_PACKET),
+                "T11": load_artifact(DEFAULT_T11_PACKET),
+                "T12": load_artifact(DEFAULT_T12_PACKET),
+            },
+        )
+
+
 def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
     self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
     strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
@@ -465,6 +511,7 @@ def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
             self_edge_packet,
             strict_cycle_packet,
             focused_packets={
+                "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": t03_packet,
                 "T04": load_artifact(DEFAULT_T04_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
@@ -485,6 +532,7 @@ def test_focused_packet_crosscheck_rejects_t10_replay_status_drift() -> None:
             self_edge_packet,
             strict_cycle_packet,
             focused_packets={
+                "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": load_artifact(DEFAULT_T03_PACKET),
                 "T04": load_artifact(DEFAULT_T04_PACKET),
                 "T10": t10_packet,


### PR DESCRIPTION
## Summary

- load the focused T02 self-edge packet in the aggregate n=9 local-lemma scan
- cross-check the shared-endpoint families F01/F04/F08/F14 against that focused packet
- regenerate the local-lemma summary artifact and update proof-mining docs/tests

## Verification

- `python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write --check --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemmas.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (842 passed, 285 deselected)