### PR TITLE
Cross-check T01 alternate self-edge certificate

### DIFF
--- a/data/certificates/n9_vertex_circle_local_lemmas.json
+++ b/data/certificates/n9_vertex_circle_local_lemmas.json
@@ -97,6 +97,28 @@
   "focused_note_crosscheck": [
     {
       "check_status": "checked",
+      "covered_assignment_count": 6,
+      "crosscheck_mode": "alternate_self_edge_certificate",
+      "families_checked": [
+        {
+          "assignment_count": 6,
+          "family_id": "F09",
+          "orbit_size": 6
+        }
+      ],
+      "family_ids": [
+        "F09"
+      ],
+      "interpretation": "Aggregate scan family rows match the focused packet, and the focused packet supplies a valid alternate reflexive self-edge certificate for the same family. The aggregate nested-spoke strict edge is not required to be the same strict edge as the proof-facing note; this remains a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "nested_spoke_quotient_self_edge",
+      "packet_key": "T01",
+      "packet_path": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t01-self-edge-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T01"
+    },
+    {
+      "check_status": "checked",
       "covered_assignment_count": 40,
       "families_checked": [
         {

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -18,7 +18,7 @@ that justifies doing it anyway.
 Use this queue when no more specific issue is selected.
 
 1. Review the aggregate `n=9` vertex-circle local-lemma scan against the
-   focused T02/T03/T04 self-edge packets and the focused T10/T11/T12
+   focused T01/T02/T03/T04 self-edge packets and the focused T10/T11/T12
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
    than an `n=9` proof.
 2. Audit whether the aggregate local-template coverage can be checked from the

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -507,6 +507,7 @@ The aggregate checker also cross-checks the proof-facing focused notes that
 have already been extracted from the packet catalog:
 
 ```text
+T01/F09 -> docs/n9-vertex-circle-t01-self-edge-lemma.md
 T02/F01,F04,F08,F14 -> docs/n9-vertex-circle-t02-self-edge-lemma.md
 T03/F05,F15 -> docs/n9-vertex-circle-t03-self-edge-lemma.md
 T04/F13     -> docs/n9-vertex-circle-t04-self-edge-lemma.md
@@ -515,9 +516,10 @@ T11/F07     -> docs/n9-vertex-circle-t11-strict-cycle-lemma.md
 T12/F16     -> docs/n9-vertex-circle-t12-strict-cycle-lemma.md
 ```
 
-For T02, T03, T04, T10, T11, and T12 the scan loads the focused JSON packets and
-checks that the aggregate family rows, strict inequalities, equality paths,
-cycle steps, and assignment counts match the focused packet used by the note.
+For T01, T02, T03, T04, T10, T11, and T12 the scan loads the focused JSON
+packets and checks that the aggregate family rows, strict inequalities,
+equality paths, cycle steps, and assignment counts match the focused packet
+used by the note.
 
 This crosscheck is intentionally modest. It says the aggregate proof-mining
 summary agrees with the focused proof-note packets and source template record.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -167,7 +167,7 @@ Next steps:
   to replay the focused review-pending T11/F07 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T12/F16 strict-cycle local lemma packet;
-- review the aggregate local-lemma scan after the T02/T03/T04 self-edge and
+- review the aggregate local-lemma scan after the T01/T02/T03/T04 self-edge and
   T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
   coverage of stored packets rather than an independent `n=9` proof;
 - test whether the same motifs appear in the P18 obstruction and fail in the

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -31,6 +31,9 @@ DEFAULT_SELF_EDGE_PACKET = (
 DEFAULT_STRICT_CYCLE_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
 )
+DEFAULT_T01_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t01_self_edge_lemma_packet.json"
+)
 DEFAULT_T02_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t02_self_edge_lemma_packet.json"
 )
@@ -77,6 +80,7 @@ def scan_payload(
     *,
     self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
     strict_cycle_packet_path: Path = DEFAULT_STRICT_CYCLE_PACKET,
+    t01_packet_path: Path = DEFAULT_T01_PACKET,
     t02_packet_path: Path = DEFAULT_T02_PACKET,
     t03_packet_path: Path = DEFAULT_T03_PACKET,
     t04_packet_path: Path = DEFAULT_T04_PACKET,
@@ -90,6 +94,7 @@ def scan_payload(
         load_artifact(self_edge_packet_path),
         load_artifact(strict_cycle_packet_path),
         focused_packets={
+            "T01": load_artifact(t01_packet_path),
             "T02": load_artifact(t02_packet_path),
             "T03": load_artifact(t03_packet_path),
             "T04": load_artifact(t04_packet_path),
@@ -209,6 +214,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to n9 strict-cycle template packet JSON.",
     )
     parser.add_argument(
+        "--t01-packet",
+        type=Path,
+        default=DEFAULT_T01_PACKET,
+        help="Path to focused T01 self-edge lemma packet JSON.",
+    )
+    parser.add_argument(
         "--t02-packet",
         type=Path,
         default=DEFAULT_T02_PACKET,
@@ -266,6 +277,7 @@ def main(argv: list[str] | None = None) -> int:
     payload = scan_payload(
         self_edge_packet_path=_resolve(args.self_edge_packet),
         strict_cycle_packet_path=_resolve(args.strict_cycle_packet),
+        t01_packet_path=_resolve(args.t01_packet),
         t02_packet_path=_resolve(args.t02_packet),
         t03_packet_path=_resolve(args.t03_packet),
         t04_packet_path=_resolve(args.t04_packet),

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -84,6 +84,17 @@ EXPECTED_SUMMARY = {
 }
 EXPECTED_DIRECT_TWO_ROW_INSTANCE_COUNT = 0
 EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
+    NESTED_SPOKE_LEMMA: {
+        "template_id": "T01",
+        "family_ids": ["F09"],
+        "proof_note_path": "docs/n9-vertex-circle-t01-self-edge-lemma.md",
+        "source_kind": "focused_packet",
+        "crosscheck_mode": "alternate_self_edge_certificate",
+        "packet_key": "T01",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json"
+        ),
+    },
     SHARED_ENDPOINT_LEMMA: {
         "template_id": "T02",
         "family_ids": ["F01", "F04", "F08", "F14"],
@@ -425,9 +436,7 @@ def _check_focused_packet(
                 f"{template_id} focused packet must explicitly reject {forbidden!r}"
             )
 
-    family_packets = focused_packet.get("family_packets")
-    if not isinstance(family_packets, list):
-        raise AssertionError(f"{template_id} focused packet must contain family_packets")
+    family_packets = _focused_family_packets(template_id, focused_packet)
     packets_by_family = {
         str(packet["family_id"]): packet
         for packet in family_packets
@@ -435,12 +444,20 @@ def _check_focused_packet(
     }
 
     checked = []
+    crosscheck_mode = str(expected.get("crosscheck_mode", "same_instance"))
     for family_id, aggregate in aggregate_instances.items():
         packet = packets_by_family.get(family_id)
         if packet is None:
             raise AssertionError(f"{template_id} focused packet missing {family_id}")
         _assert_family_common_fields(template_id, family_id, aggregate, packet)
-        if lemma_id in {
+        if crosscheck_mode == "alternate_self_edge_certificate":
+            _assert_alternate_self_edge_certificate_match(
+                template_id,
+                family_id,
+                aggregate,
+                packet,
+            )
+        elif lemma_id in {
             SHARED_ENDPOINT_LEMMA,
             T03_SELECTED_PATH_SELF_EDGE,
             T04_SELECTED_PATH_SELF_EDGE,
@@ -460,11 +477,21 @@ def _check_focused_packet(
         "families_checked": checked,
         "covered_assignment_count": sum(item["assignment_count"] for item in checked),
         "interpretation": (
-            "Aggregate scan instance matches the focused packet used by the "
-            "proof-facing note; this is a packet consistency check, not an "
-            "independent n=9 completeness proof."
+            _focused_packet_interpretation(crosscheck_mode)
         ),
     }
+
+
+def _focused_family_packets(
+    template_id: str,
+    focused_packet: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    family_packets = focused_packet.get("family_packets")
+    if isinstance(family_packets, list):
+        return [packet for packet in family_packets if isinstance(packet, Mapping)]
+    if "family_id" in focused_packet:
+        return [focused_packet]
+    raise AssertionError(f"{template_id} focused packet must contain family packet data")
 
 
 def _check_t04_template_record(
@@ -566,6 +593,110 @@ def _assert_self_edge_family_match(
         variant = aggregate.get("direct_conditions", {}).get("variant")
         if template_id in {"T03", "T04"} or variant == "selected_path_self_edge":
             raise AssertionError(f"{family_id} selected-path conditions must hold")
+
+
+def _assert_alternate_self_edge_certificate_match(
+    template_id: str,
+    family_id: str,
+    aggregate: Mapping[str, Any],
+    packet: Mapping[str, Any],
+) -> None:
+    aggregate_strict = aggregate.get("strict_inequality")
+    packet_strict = packet.get("strict_inequality")
+    equality = packet.get("distance_equality")
+    if not isinstance(aggregate_strict, Mapping) or not isinstance(packet_strict, Mapping):
+        raise AssertionError(f"{family_id} focused packet strict_inequality mismatch")
+    if not isinstance(equality, Mapping):
+        raise AssertionError(f"{family_id} focused packet distance_equality mismatch")
+    if packet_strict.get("outer_class") != packet_strict.get("inner_class"):
+        raise AssertionError(f"{family_id} focused packet strict edge must be reflexive")
+    if aggregate_strict.get("outer_class") != aggregate_strict.get("inner_class"):
+        raise AssertionError(f"{family_id} aggregate strict edge must be reflexive")
+    if packet_strict.get("outer_pair") != equality.get("start_pair"):
+        raise AssertionError(f"{family_id} focused strict/equality start mismatch")
+    if packet_strict.get("inner_pair") != equality.get("end_pair"):
+        raise AssertionError(f"{family_id} focused strict/equality end mismatch")
+    _assert_packet_equality_path(family_id, packet, equality)
+    if aggregate_strict.get("outer_pair") != packet_strict.get("outer_pair"):
+        raise AssertionError(f"{family_id} alternate certificate outer-pair mismatch")
+    if aggregate.get("distance_equality", {}).get("start_pair") != equality.get("start_pair"):
+        raise AssertionError(f"{family_id} alternate certificate equality-start mismatch")
+
+    replay = packet.get("replay")
+    if not isinstance(replay, Mapping) or replay.get("status") != "self_edge":
+        raise AssertionError(f"{family_id} focused packet replay status mismatch")
+    if replay.get("selected_row_count") != packet.get("core_size"):
+        raise AssertionError(f"{family_id} focused packet replay row count mismatch")
+    primary = replay.get("primary_self_edge_conflict")
+    if not isinstance(primary, Mapping):
+        raise AssertionError(f"{family_id} focused packet primary conflict mismatch")
+    for key in (
+        "row",
+        "witness_order",
+        "outer_interval",
+        "inner_interval",
+        "outer_pair",
+        "inner_pair",
+    ):
+        if primary.get(key) != packet_strict.get(key):
+            raise AssertionError(f"{family_id} focused packet primary conflict mismatch")
+    if template_id != "T01":
+        raise AssertionError("alternate self-edge certificate mode is currently T01-only")
+
+
+def _assert_packet_equality_path(
+    family_id: str,
+    packet: Mapping[str, Any],
+    equality: Mapping[str, Any],
+) -> None:
+    rows = packet.get("core_selected_rows")
+    if not isinstance(rows, Sequence) or isinstance(rows, str):
+        raise AssertionError(f"{family_id} focused packet rows mismatch")
+    row_map: dict[int, set[int]] = {}
+    for raw_row in rows:
+        if not isinstance(raw_row, Sequence) or isinstance(raw_row, str) or len(raw_row) != 5:
+            raise AssertionError(f"{family_id} focused packet rows mismatch")
+        center = int(raw_row[0])
+        row_map[center] = {int(value) for value in raw_row[1:]}
+
+    current = [int(value) for value in equality.get("start_pair", [])]
+    steps = equality.get("path")
+    if not isinstance(steps, Sequence) or isinstance(steps, str):
+        raise AssertionError(f"{family_id} focused packet equality path mismatch")
+    for step in steps:
+        if not isinstance(step, Mapping):
+            raise AssertionError(f"{family_id} focused packet equality path mismatch")
+        row = int(step["row"])
+        next_pair = [int(value) for value in step["next_pair"]]
+        witnesses = row_map.get(row)
+        if witnesses is None:
+            raise AssertionError(f"{family_id} focused packet equality path row mismatch")
+        if row not in current or row not in next_pair:
+            raise AssertionError(f"{family_id} focused packet equality path step mismatch")
+        left_other = next(value for value in current if value != row)
+        right_other = next(value for value in next_pair if value != row)
+        if left_other not in witnesses or right_other not in witnesses:
+            raise AssertionError(f"{family_id} focused packet equality path witness mismatch")
+        current = next_pair
+    if current != equality.get("end_pair"):
+        raise AssertionError(f"{family_id} focused packet equality path end mismatch")
+
+
+def _focused_packet_interpretation(crosscheck_mode: str) -> str:
+    if crosscheck_mode == "alternate_self_edge_certificate":
+        return (
+            "Aggregate scan family rows match the focused packet, and the "
+            "focused packet supplies a valid alternate reflexive self-edge "
+            "certificate for the same family. The aggregate nested-spoke "
+            "strict edge is not required to be the same strict edge as the "
+            "proof-facing note; this remains a packet consistency check, not "
+            "an independent n=9 completeness proof."
+        )
+    return (
+        "Aggregate scan instance matches the focused packet used by the "
+        "proof-facing note; this is a packet consistency check, not an "
+        "independent n=9 completeness proof."
+    )
 
 
 def _assert_strict_cycle_family_match(

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -21,6 +21,7 @@ from erdos97.n9_vertex_circle_local_lemmas import (
 from scripts.check_n9_vertex_circle_local_lemmas import (
     DEFAULT_SELF_EDGE_PACKET,
     DEFAULT_STRICT_CYCLE_PACKET,
+    DEFAULT_T01_PACKET,
     DEFAULT_T02_PACKET,
     DEFAULT_T03_PACKET,
     DEFAULT_T04_PACKET,
@@ -100,6 +101,31 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
         },
     }
     assert payload["focused_note_crosscheck"] == [  # type: ignore[index]
+        {
+            "lemma_id": NESTED_SPOKE_LEMMA,
+            "template_id": "T01",
+            "family_ids": ["F09"],
+            "proof_note_path": "docs/n9-vertex-circle-t01-self-edge-lemma.md",
+            "source_kind": "focused_packet",
+            "crosscheck_mode": "alternate_self_edge_certificate",
+            "packet_key": "T01",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F09", "assignment_count": 6, "orbit_size": 6},
+            ],
+            "covered_assignment_count": 6,
+            "interpretation": (
+                "Aggregate scan family rows match the focused packet, and the "
+                "focused packet supplies a valid alternate reflexive self-edge "
+                "certificate for the same family. The aggregate nested-spoke "
+                "strict edge is not required to be the same strict edge as the "
+                "proof-facing note; this remains a packet consistency check, not "
+                "an independent n=9 completeness proof."
+            ),
+        },
         {
             "lemma_id": SHARED_ENDPOINT_LEMMA,
             "template_id": "T02",
@@ -479,6 +505,28 @@ def test_payload_provenance_is_not_shared_mutable_state() -> None:
     )
 
 
+def test_focused_packet_crosscheck_rejects_t01_path_drift() -> None:
+    self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
+    strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
+    t01_packet = load_artifact(DEFAULT_T01_PACKET)
+    t01_packet["distance_equality"]["path"][0]["next_pair"] = [0, 3]
+
+    with pytest.raises(AssertionError, match="F09 focused packet equality path step mismatch"):
+        local_lemma_scan_payload(
+            self_edge_packet,
+            strict_cycle_packet,
+            focused_packets={
+                "T01": t01_packet,
+                "T02": load_artifact(DEFAULT_T02_PACKET),
+                "T03": load_artifact(DEFAULT_T03_PACKET),
+                "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T10": load_artifact(DEFAULT_T10_PACKET),
+                "T11": load_artifact(DEFAULT_T11_PACKET),
+                "T12": load_artifact(DEFAULT_T12_PACKET),
+            },
+        )
+
+
 def test_focused_packet_crosscheck_rejects_t02_path_drift() -> None:
     self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
     strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
@@ -490,6 +538,7 @@ def test_focused_packet_crosscheck_rejects_t02_path_drift() -> None:
             self_edge_packet,
             strict_cycle_packet,
             focused_packets={
+                "T01": load_artifact(DEFAULT_T01_PACKET),
                 "T02": t02_packet,
                 "T03": load_artifact(DEFAULT_T03_PACKET),
                 "T04": load_artifact(DEFAULT_T04_PACKET),
@@ -511,6 +560,7 @@ def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
             self_edge_packet,
             strict_cycle_packet,
             focused_packets={
+                "T01": load_artifact(DEFAULT_T01_PACKET),
                 "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": t03_packet,
                 "T04": load_artifact(DEFAULT_T04_PACKET),
@@ -532,6 +582,7 @@ def test_focused_packet_crosscheck_rejects_t10_replay_status_drift() -> None:
             self_edge_packet,
             strict_cycle_packet,
             focused_packets={
+                "T01": load_artifact(DEFAULT_T01_PACKET),
                 "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": load_artifact(DEFAULT_T03_PACKET),
                 "T04": load_artifact(DEFAULT_T04_PACKET),


### PR DESCRIPTION
## Summary

- load the focused T01/F09 self-edge packet in the aggregate n=9 local-lemma scan
- record it as an alternate self-edge certificate for the same F09 core, since its strict edge differs from the aggregate nested-spoke instance
- regenerate the local-lemma artifact and update proof-mining docs/tests

## Verification

- `python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write --check --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemmas.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (843 passed, 285 deselected)