### PR TITLE
Add focused T05 self-edge packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_local_lemmas.json
+++ b/data/certificates/n9_vertex_circle_local_lemmas.json
@@ -119,6 +119,28 @@
     },
     {
       "check_status": "checked",
+      "covered_assignment_count": 18,
+      "crosscheck_mode": "alternate_self_edge_certificate",
+      "families_checked": [
+        {
+          "assignment_count": 18,
+          "family_id": "F10",
+          "orbit_size": 18
+        }
+      ],
+      "family_ids": [
+        "F10"
+      ],
+      "interpretation": "Aggregate scan family rows match the focused packet, and the focused packet supplies a valid alternate reflexive self-edge certificate for the same family. The aggregate nested-spoke strict edge is not required to be the same strict edge as the proof-facing note; this remains a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "nested_spoke_quotient_self_edge",
+      "packet_key": "T05",
+      "packet_path": "data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t05-self-edge-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T05"
+    },
+    {
+      "check_status": "checked",
       "covered_assignment_count": 40,
       "families_checked": [
         {

--- a/data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json
+++ b/data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json
@@ -1,0 +1,610 @@
+{
+  "assignment_count": 18,
+  "assignment_ids": [
+    "A013",
+    "A029",
+    "A036",
+    "A038",
+    "A053",
+    "A057",
+    "A059",
+    "A062",
+    "A072",
+    "A088",
+    "A090",
+    "A100",
+    "A105",
+    "A120",
+    "A129",
+    "A133",
+    "A162",
+    "A170"
+  ],
+  "claim_scope": "Focused T05/F10 self-edge local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "core_size": 4,
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "family_assignment_counts": {
+    "F10": 18
+  },
+  "family_count": 1,
+  "family_ids": [
+    "F10"
+  ],
+  "family_orbit_sizes": {
+    "F10": 18
+  },
+  "family_packets": [
+    {
+      "assignment_count": 18,
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          7,
+          2,
+          5,
+          6,
+          8
+        ],
+        [
+          8,
+          0,
+          1,
+          6,
+          7
+        ]
+      ],
+      "core_size": 4,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "next_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          8
+        ]
+      },
+      "equality_chain": [
+        [
+          1,
+          8
+        ],
+        [
+          7,
+          8
+        ],
+        [
+          2,
+          7
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "family_id": "F10",
+      "local_lemma": {
+        "contradiction": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "equality_statement": "Rows [8, 7, 2] identify [1, 8] with [1, 2] in the selected-distance quotient.",
+        "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the four listed selected rows; no claim is made about other n=9 templates.",
+        "packet_name": "T05/F10 self-edge local lemma packet",
+        "review_status": "review_pending",
+        "selected_distance_equalities": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              7,
+              8
+            ],
+            "right_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "left_pair": [
+              2,
+              7
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_inequality_statement": "Row 0 has witness order [1, 2, 4, 8], so the outer pair [1, 8] strictly contains the inner pair [1, 2] in that row's vertex-circle order."
+      },
+      "orbit_size": 18,
+      "replay": {
+        "cycle_edge_count": 0,
+        "primary_self_edge_conflict": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        "selected_row_count": 4,
+        "self_edge_conflict_count": 2,
+        "self_edge_conflicts": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              4
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          }
+        ],
+        "status": "self_edge",
+        "strict_edge_count": 36
+      },
+      "source_family_record": {
+        "assignment_count": 18,
+        "core_size": 4,
+        "distance_equality": {
+          "end_pair": [
+            1,
+            2
+          ],
+          "path": [
+            {
+              "next_pair": [
+                7,
+                8
+              ],
+              "row": 8
+            },
+            {
+              "next_pair": [
+                2,
+                7
+              ],
+              "row": 7
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "start_pair": [
+            1,
+            8
+          ]
+        },
+        "equality_chain": [
+          [
+            1,
+            8
+          ],
+          [
+            7,
+            8
+          ],
+          [
+            2,
+            7
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        "family_id": "F10",
+        "orbit_size": 18,
+        "path_length": 3,
+        "status": "self_edge",
+        "strict_inequality": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        "template_id": "T05"
+      },
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          8
+        ]
+      }
+    }
+  ],
+  "interpretation": [
+    "This packet isolates the T05/F10 self-edge motif from existing review-pending n=9 diagnostics.",
+    "The family record has four local rows that force the displayed equality chain.",
+    "The family record has a vertex-circle strict inequality between the same quotient class.",
+    "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "orbit_size_sum": 18,
+  "path_length_counts": {
+    "3": 18
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_t05_self_edge_lemma_packet.v1",
+  "selected_path_shape_counts": {
+    "3:1:1:path=3": 18
+  },
+  "shared_endpoint_counts": {
+    "1": 18
+  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "source T05/F10 self-edge template record",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+      "role": "catalog crosswalk confirming T05 coverage and shape summary",
+      "schema": "erdos97.n9_vertex_circle_template_lemma_catalog.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_catalog_record": {
+    "conclusion_shape": {
+      "certificate_fields": [
+        "strict_inequality",
+        "distance_equality"
+      ],
+      "kind": "self_edge",
+      "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+    },
+    "coverage": {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A013",
+        "A029",
+        "A036",
+        "A038",
+        "A053",
+        "A057",
+        "A059",
+        "A062",
+        "A072",
+        "A088",
+        "A090",
+        "A100",
+        "A105",
+        "A120",
+        "A129",
+        "A133",
+        "A162",
+        "A170"
+      ],
+      "families": [
+        "F10"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18
+    },
+    "family_summaries": [
+      {
+        "assignment_count": 18,
+        "contradiction_kind": "self_edge",
+        "core_size": 4,
+        "equality_path_length": 3,
+        "family_id": "F10",
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "orbit_size": 18,
+        "outer_pair": [
+          1,
+          8
+        ],
+        "outer_span": 3,
+        "path_length": 3,
+        "status": "self_edge",
+        "template_id": "T05"
+      }
+    ],
+    "hypothesis_shape": {
+      "core_size": 4,
+      "path_length_counts": {
+        "3": 18
+      },
+      "selected_path_shape_counts": {
+        "3:1:1:path=3": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 1,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "strict_edge_count": 36
+    },
+    "status": "self_edge",
+    "template_id": "T05",
+    "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+  },
+  "source_template_record": {
+    "assignment_count": 18,
+    "assignment_ids": [
+      "A013",
+      "A029",
+      "A036",
+      "A038",
+      "A053",
+      "A057",
+      "A059",
+      "A062",
+      "A072",
+      "A088",
+      "A090",
+      "A100",
+      "A105",
+      "A120",
+      "A129",
+      "A133",
+      "A162",
+      "A170"
+    ],
+    "core_size": 4,
+    "families": [
+      "F10"
+    ],
+    "family_count": 1,
+    "orbit_size_sum": 18,
+    "path_length_counts": {
+      "3": 18
+    },
+    "selected_path_shape_counts": {
+      "3:1:1:path=3": 18
+    },
+    "self_edge_shape_counts": [
+      {
+        "count": 1,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoint_count": 0
+      },
+      {
+        "count": 1,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoint_count": 1
+      }
+    ],
+    "shared_endpoint_counts": {
+      "1": 18
+    },
+    "status": "self_edge",
+    "strict_edge_count": 36,
+    "template_id": "T05",
+    "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_edge_count": 36,
+  "template_id": "T05",
+  "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -18,7 +18,7 @@ that justifies doing it anyway.
 Use this queue when no more specific issue is selected.
 
 1. Review the aggregate `n=9` vertex-circle local-lemma scan against the
-   focused T01/T02/T03/T04 self-edge packets and the focused T10/T11/T12
+   focused T01/T02/T03/T04/T05 self-edge packets and the focused T10/T11/T12
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
    than an `n=9` proof.
 2. Audit whether the aggregate local-template coverage can be checked from the

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -511,12 +511,13 @@ T01/F09 -> docs/n9-vertex-circle-t01-self-edge-lemma.md
 T02/F01,F04,F08,F14 -> docs/n9-vertex-circle-t02-self-edge-lemma.md
 T03/F05,F15 -> docs/n9-vertex-circle-t03-self-edge-lemma.md
 T04/F13     -> docs/n9-vertex-circle-t04-self-edge-lemma.md
+T05/F10     -> docs/n9-vertex-circle-t05-self-edge-lemma.md
 T10/F12     -> docs/n9-vertex-circle-t10-strict-cycle-lemma.md
 T11/F07     -> docs/n9-vertex-circle-t11-strict-cycle-lemma.md
 T12/F16     -> docs/n9-vertex-circle-t12-strict-cycle-lemma.md
 ```
 
-For T01, T02, T03, T04, T10, T11, and T12 the scan loads the focused JSON
+For T01, T02, T03, T04, T05, T10, T11, and T12 the scan loads the focused JSON
 packets and checks that the aggregate family rows, strict inequalities,
 equality paths, cycle steps, and assignment counts match the focused packet
 used by the note.

--- a/docs/n9-vertex-circle-t05-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t05-self-edge-lemma.md
@@ -9,12 +9,11 @@ checker, and does not update the official/global status.
 
 ## Packet scope
 
-The checked source artifact is
-`data/certificates/n9_vertex_circle_self_edge_template_packet.json`, whose
-`T05` record is derived from:
+The checked focused artifact is
+`data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json`. It is
+derived from:
 
-- `data/certificates/n9_vertex_circle_self_edge_path_join.json`
-- `data/certificates/n9_vertex_circle_core_templates.json`
+- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
 
 The template covers 18 assignment ids:
@@ -121,15 +120,14 @@ a selected-distance quotient class back to itself.
 
 ## Commands
 
-Check the source packet and the combined template catalog:
+Generate and check the packet:
 
 ```bash
-python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
-  --check \
+python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py \
   --assert-expected \
-  --json
+  --write
 
-python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py \
   --check \
   --assert-expected \
   --json
@@ -138,7 +136,7 @@ python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
 Run the targeted artifact tests:
 
 ```bash
-python -m pytest tests/test_n9_vertex_circle_self_edge_template_packet.py -q -m "artifact"
+python -m pytest tests/test_n9_vertex_circle_t05_self_edge_lemma_packet.py -q
 ```
 
 ## Review standard

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -161,14 +161,17 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json` to
   replay the focused review-pending T04/F13 four-row selected-path self-edge
   proof note;
+- use `data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json` to
+  replay the focused review-pending T05/F10 nested-spoke alternate self-edge
+  proof note;
 - use `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T10/F12 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T11/F07 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T12/F16 strict-cycle local lemma packet;
-- review the aggregate local-lemma scan after the T01/T02/T03/T04 self-edge and
-  T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
+- review the aggregate local-lemma scan after the T01/T02/T03/T04/T05 self-edge
+  and T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
   coverage of stored packets rather than an independent `n=9` proof;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -971,6 +971,50 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_t05_self_edge_lemma_packet
+    path: data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py
+    command: python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py
+    check_command: python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused T05/F10 self-edge local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_t05_self_edge_lemma_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Focused T05/F10 self-edge local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      template_id: T05
+      template_key: self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1
+      assignment_count: 18
+      family_count: 1
+      family_ids:
+        - F10
+      family_assignment_counts.F10: 18
+      family_orbit_sizes.F10: 18
+      orbit_size_sum: 18
+      core_size: 4
+      strict_edge_count: 36
+      path_length_counts.3: 18
+      shared_endpoint_counts.1: 18
+      "selected_path_shape_counts.3:1:1:path=3": 18
+      provenance.command: python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - T05 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the local lemma packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t10_strict_cycle_lemma_packet
     path: data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -43,6 +43,9 @@ DEFAULT_T03_PACKET = (
 DEFAULT_T04_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t04_self_edge_lemma_packet.json"
 )
+DEFAULT_T05_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t05_self_edge_lemma_packet.json"
+)
 DEFAULT_T10_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
 )
@@ -84,6 +87,7 @@ def scan_payload(
     t02_packet_path: Path = DEFAULT_T02_PACKET,
     t03_packet_path: Path = DEFAULT_T03_PACKET,
     t04_packet_path: Path = DEFAULT_T04_PACKET,
+    t05_packet_path: Path = DEFAULT_T05_PACKET,
     t10_packet_path: Path = DEFAULT_T10_PACKET,
     t11_packet_path: Path = DEFAULT_T11_PACKET,
     t12_packet_path: Path = DEFAULT_T12_PACKET,
@@ -98,6 +102,7 @@ def scan_payload(
             "T02": load_artifact(t02_packet_path),
             "T03": load_artifact(t03_packet_path),
             "T04": load_artifact(t04_packet_path),
+            "T05": load_artifact(t05_packet_path),
             "T10": load_artifact(t10_packet_path),
             "T11": load_artifact(t11_packet_path),
             "T12": load_artifact(t12_packet_path),
@@ -244,6 +249,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to focused T04 self-edge lemma packet JSON.",
     )
     parser.add_argument(
+        "--t05-packet",
+        type=Path,
+        default=DEFAULT_T05_PACKET,
+        help="Path to focused T05 self-edge lemma packet JSON.",
+    )
+    parser.add_argument(
         "--t11-packet",
         type=Path,
         default=DEFAULT_T11_PACKET,
@@ -281,6 +292,7 @@ def main(argv: list[str] | None = None) -> int:
         t02_packet_path=_resolve(args.t02_packet),
         t03_packet_path=_resolve(args.t03_packet),
         t04_packet_path=_resolve(args.t04_packet),
+        t05_packet_path=_resolve(args.t05_packet),
         t10_packet_path=_resolve(args.t10_packet),
         t11_packet_path=_resolve(args.t11_packet),
         t12_packet_path=_resolve(args.t12_packet),

--- a/scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Generate or check the focused T05/F10 n=9 self-edge local lemma packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_self_edge_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_SELF_EDGE_PACKET,
+    validate_payload as validate_self_edge_packet,
+)
+from check_n9_vertex_circle_template_lemma_catalog import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATE_CATALOG,
+    validate_payload as validate_template_catalog,
+)
+from erdos97.n9_vertex_circle_t05_self_edge_lemma_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    EXPECTED_ASSIGNMENT_IDS,
+    EXPECTED_CORE_SELECTED_ROWS,
+    EXPECTED_DISTANCE_EQUALITIES,
+    EXPECTED_EQUALITY_CHAINS,
+    EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+    EXPECTED_FAMILY_IDS,
+    EXPECTED_FAMILY_ORBIT_SIZES,
+    EXPECTED_PATH_LENGTH_COUNTS,
+    EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+    EXPECTED_SELF_EDGE_CONFLICT_COUNT,
+    EXPECTED_SHARED_ENDPOINT_COUNTS,
+    EXPECTED_STRICT_INEQUALITIES,
+    EXPECTED_TEMPLATE_KEY,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_t05_self_edge_lemma_packet,
+    source_artifacts,
+    t05_self_edge_lemma_packet_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t05_self_edge_lemma_packet.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_count",
+    "assignment_ids",
+    "claim_scope",
+    "core_size",
+    "cyclic_order",
+    "family_assignment_counts",
+    "family_count",
+    "family_ids",
+    "family_orbit_sizes",
+    "family_packets",
+    "interpretation",
+    "n",
+    "orbit_size_sum",
+    "path_length_counts",
+    "provenance",
+    "row_size",
+    "schema",
+    "selected_path_shape_counts",
+    "shared_endpoint_counts",
+    "source_artifacts",
+    "source_catalog_record",
+    "source_template_record",
+    "status",
+    "strict_edge_count",
+    "template_id",
+    "template_key",
+    "trust",
+}
+EXPECTED_FAMILY_PACKET_KEYS = {
+    "assignment_count",
+    "core_selected_rows",
+    "core_size",
+    "distance_equality",
+    "equality_chain",
+    "family_id",
+    "local_lemma",
+    "orbit_size",
+    "replay",
+    "source_family_record",
+    "strict_inequality",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
+    template_catalog_path: Path = DEFAULT_TEMPLATE_CATALOG,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the focused T05 packet."""
+
+    return {
+        "self_edge_packet": load_artifact(_resolve(self_edge_packet_path)),
+        "template_catalog": load_artifact(_resolve(template_catalog_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    self_edge = source_payloads.get("self_edge_packet")
+    catalog = source_payloads.get("template_catalog")
+    if not isinstance(self_edge, dict):
+        errors.append("source self-edge template packet must be an object")
+    else:
+        errors.extend(
+            f"source self-edge template packet invalid: {error}"
+            for error in validate_self_edge_packet(self_edge, recompute=False)
+        )
+    if not isinstance(catalog, dict):
+        errors.append("source template lemma catalog must be an object")
+    else:
+        errors.extend(
+            f"source template lemma catalog invalid: {error}"
+            for error in validate_template_catalog(catalog, recompute=False)
+        )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return t05_self_edge_lemma_packet_payload(
+            source_payloads["self_edge_packet"],
+            source_payloads["template_catalog"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound T05 self-edge lemma packet failed: {exc}")
+        return None
+
+
+def _family_packets_by_id(payload: dict[str, Any], errors: list[str]) -> dict[str, dict[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        errors.append("family_packets must be a list")
+        return {}
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, "
+            f"got {len(packets)}"
+        )
+    by_id: dict[str, dict[str, Any]] = {}
+    for packet in packets:
+        if not isinstance(packet, dict):
+            errors.append("family_packets entries must be objects")
+            continue
+        family_id = str(packet.get("family_id"))
+        if family_id in by_id:
+            errors.append(f"duplicate family packet id: {family_id}")
+        by_id[family_id] = packet
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family packet ids mismatch: expected {list(EXPECTED_FAMILY_IDS)!r}, "
+            f"got {sorted(by_id)!r}"
+        )
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS if family_id in by_id}
+
+
+def _validate_local_lemma(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    lemma = packet.get("local_lemma")
+    if not isinstance(lemma, dict):
+        errors.append(f"{family_id} local_lemma must be an object")
+        return
+    expect_equal(errors, f"{family_id} local_lemma review_status", lemma.get("review_status"), "review_pending")
+    selected_equalities = lemma.get("selected_distance_equalities")
+    if not isinstance(selected_equalities, list) or len(selected_equalities) != 3:
+        errors.append(f"{family_id} local_lemma selected_distance_equalities must have three steps")
+    strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+    statement = str(lemma.get("strict_inequality_statement", ""))
+    for pair_value in (strict["outer_pair"], strict["inner_pair"]):
+        if str(pair_value) not in statement:
+            errors.append(f"{family_id} strict inequality statement must name {pair_value}")
+    hypothesis = str(lemma.get("hypothesis_scope", ""))
+    if "four listed selected rows" not in hypothesis:
+        errors.append(f"{family_id} local_lemma hypothesis must mention four selected rows")
+    contradiction = str(lemma.get("contradiction", ""))
+    if "reflexive strict edge" not in contradiction:
+        errors.append(f"{family_id} local_lemma contradiction must mention a reflexive strict edge")
+
+
+def _validate_replay(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    replay = packet.get("replay")
+    if not isinstance(replay, dict):
+        errors.append(f"{family_id} replay must be an object")
+        return
+    expect_equal(errors, f"{family_id} replay status", replay.get("status"), "self_edge")
+    expect_equal(errors, f"{family_id} replay selected_row_count", replay.get("selected_row_count"), 4)
+    expect_equal(errors, f"{family_id} replay strict_edge_count", replay.get("strict_edge_count"), 36)
+    expect_equal(
+        errors,
+        f"{family_id} replay self_edge_conflict_count",
+        replay.get("self_edge_conflict_count"),
+        EXPECTED_SELF_EDGE_CONFLICT_COUNT,
+    )
+    expect_equal(errors, f"{family_id} replay cycle_edge_count", replay.get("cycle_edge_count"), 0)
+    primary = replay.get("primary_self_edge_conflict")
+    if not isinstance(primary, dict):
+        errors.append(f"{family_id} replay primary_self_edge_conflict must be an object")
+        return
+    strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+    for key in ("row", "witness_order", "outer_pair", "inner_pair", "outer_interval", "inner_interval"):
+        expect_equal(errors, f"{family_id} primary {key}", primary.get(key), strict[key])
+
+
+def _validate_family_packet(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    if set(packet) != EXPECTED_FAMILY_PACKET_KEYS:
+        errors.append(
+            f"{family_id} keys mismatch: expected {sorted(EXPECTED_FAMILY_PACKET_KEYS)!r}, "
+            f"got {sorted(packet)!r}"
+        )
+    expect_equal(errors, f"{family_id} family_id", packet.get("family_id"), family_id)
+    expect_equal(
+        errors,
+        f"{family_id} assignment_count",
+        packet.get("assignment_count"),
+        EXPECTED_FAMILY_ASSIGNMENT_COUNTS[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} orbit_size",
+        packet.get("orbit_size"),
+        EXPECTED_FAMILY_ORBIT_SIZES[family_id],
+    )
+    expect_equal(errors, f"{family_id} core_size", packet.get("core_size"), 4)
+    expect_equal(
+        errors,
+        f"{family_id} core_selected_rows",
+        packet.get("core_selected_rows"),
+        [list(row) for row in EXPECTED_CORE_SELECTED_ROWS[family_id]],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} strict_inequality",
+        packet.get("strict_inequality"),
+        EXPECTED_STRICT_INEQUALITIES[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} distance_equality",
+        packet.get("distance_equality"),
+        EXPECTED_DISTANCE_EQUALITIES[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} equality_chain",
+        packet.get("equality_chain"),
+        [list(item) for item in EXPECTED_EQUALITY_CHAINS[family_id]],
+    )
+    _validate_local_lemma(family_id, packet, errors)
+    _validate_replay(family_id, packet, errors)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a focused T05/F10 local lemma packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "template_id": "T05",
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": 18,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": 1,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": 18,
+        "core_size": 4,
+        "strict_edge_count": 36,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the no-proof statement")
+        if not any("proof mining" in item for item in interpretation):
+            errors.append("interpretation must preserve the proof-mining scope")
+
+    for family_id, packet in _family_packets_by_id(payload, errors).items():
+        _validate_family_packet(family_id, packet, errors)
+
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            source_artifacts(
+                source_payloads["self_edge_packet"],
+                source_payloads["template_catalog"],
+            ),
+        )
+        expect_equal(
+            errors,
+            "source_template_record",
+            payload.get("source_template_record"),
+            expected_payload["source_template_record"],
+        )
+        expect_equal(
+            errors,
+            "source_catalog_record",
+            payload.get("source_catalog_record"),
+            expected_payload["source_catalog_record"],
+        )
+
+    try:
+        assert_expected_t05_self_edge_lemma_packet(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected T05 self-edge lemma packet counts failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "T05 self-edge lemma packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    family_packets = object_payload.get("family_packets")
+    family_packets = family_packets if isinstance(family_packets, list) else []
+    replay_statuses = [
+        packet.get("replay", {}).get("status")
+        for packet in family_packets
+        if isinstance(packet, dict) and isinstance(packet.get("replay"), dict)
+    ]
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "template_id": object_payload.get("template_id"),
+        "assignment_count": object_payload.get("assignment_count"),
+        "family_count": object_payload.get("family_count"),
+        "family_ids": object_payload.get("family_ids"),
+        "core_size": object_payload.get("core_size"),
+        "replay_statuses": replay_statuses,
+        "strict_edge_count": object_payload.get("strict_edge_count"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--self-edge-packet", type=Path, default=DEFAULT_SELF_EDGE_PACKET)
+    parser.add_argument("--template-catalog", type=Path, default=DEFAULT_TEMPLATE_CATALOG)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            self_edge_packet_path=args.self_edge_packet,
+            template_catalog_path=args.template_catalog,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = t05_self_edge_lemma_packet_payload(
+            sources["self_edge_packet"],
+            sources["template_catalog"],
+        )
+        if args.assert_expected:
+            assert_expected_t05_self_edge_lemma_packet(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle T05/F10 self-edge local lemma packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"assignments: {summary['assignment_count']}")
+        print(f"families: {summary['family_ids']}")
+        print(f"core size: {summary['core_size']}")
+        if args.check or args.assert_expected:
+            print("OK: T05/F10 self-edge local lemma packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -306,6 +306,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_t05_self_edge_lemma_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused T05/F10 n=9 self-edge local lemma packet; "
+            "proof-mining scaffolding only, not a proof of n=9, "
+            "counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t10_strict_cycle_lemma_packet",
         command=(
             "python",

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -83,8 +83,9 @@ EXPECTED_SUMMARY = {
     },
 }
 EXPECTED_DIRECT_TWO_ROW_INSTANCE_COUNT = 0
-EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
-    NESTED_SPOKE_LEMMA: {
+EXPECTED_FOCUSED_NOTE_CROSSCHECK = (
+    {
+        "lemma_id": NESTED_SPOKE_LEMMA,
         "template_id": "T01",
         "family_ids": ["F09"],
         "proof_note_path": "docs/n9-vertex-circle-t01-self-edge-lemma.md",
@@ -95,7 +96,20 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json"
         ),
     },
-    SHARED_ENDPOINT_LEMMA: {
+    {
+        "lemma_id": NESTED_SPOKE_LEMMA,
+        "template_id": "T05",
+        "family_ids": ["F10"],
+        "proof_note_path": "docs/n9-vertex-circle-t05-self-edge-lemma.md",
+        "source_kind": "focused_packet",
+        "crosscheck_mode": "alternate_self_edge_certificate",
+        "packet_key": "T05",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json"
+        ),
+    },
+    {
+        "lemma_id": SHARED_ENDPOINT_LEMMA,
         "template_id": "T02",
         "family_ids": ["F01", "F04", "F08", "F14"],
         "proof_note_path": "docs/n9-vertex-circle-t02-self-edge-lemma.md",
@@ -105,7 +119,8 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json"
         ),
     },
-    T03_SELECTED_PATH_SELF_EDGE: {
+    {
+        "lemma_id": T03_SELECTED_PATH_SELF_EDGE,
         "template_id": "T03",
         "family_ids": ["F05", "F15"],
         "proof_note_path": "docs/n9-vertex-circle-t03-self-edge-lemma.md",
@@ -115,7 +130,8 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json"
         ),
     },
-    T04_SELECTED_PATH_SELF_EDGE: {
+    {
+        "lemma_id": T04_SELECTED_PATH_SELF_EDGE,
         "template_id": "T04",
         "family_ids": ["F13"],
         "proof_note_path": "docs/n9-vertex-circle-t04-self-edge-lemma.md",
@@ -125,7 +141,8 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json"
         ),
     },
-    T10_STRICT_CYCLE_LEMMA: {
+    {
+        "lemma_id": T10_STRICT_CYCLE_LEMMA,
         "template_id": "T10",
         "family_ids": ["F12"],
         "proof_note_path": "docs/n9-vertex-circle-t10-strict-cycle-lemma.md",
@@ -135,7 +152,8 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
         ),
     },
-    T11_STRICT_CYCLE_LEMMA: {
+    {
+        "lemma_id": T11_STRICT_CYCLE_LEMMA,
         "template_id": "T11",
         "family_ids": ["F07"],
         "proof_note_path": "docs/n9-vertex-circle-t11-strict-cycle-lemma.md",
@@ -145,7 +163,8 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json"
         ),
     },
-    T12_STRICT_CYCLE_LEMMA: {
+    {
+        "lemma_id": T12_STRICT_CYCLE_LEMMA,
         "template_id": "T12",
         "family_ids": ["F16"],
         "proof_note_path": "docs/n9-vertex-circle-t12-strict-cycle-lemma.md",
@@ -155,7 +174,7 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = {
             "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json"
         ),
     },
-}
+)
 
 
 def local_lemma_scan_payload(
@@ -354,7 +373,8 @@ def _focused_note_crosscheck(
     """Cross-check aggregate records against focused proof-note packets."""
 
     records = []
-    for lemma_id, expected in EXPECTED_FOCUSED_NOTE_CROSSCHECK.items():
+    for expected in EXPECTED_FOCUSED_NOTE_CROSSCHECK:
+        lemma_id = str(expected["lemma_id"])
         family_ids = list(expected["family_ids"])
         aggregate_instances = _instances_by_family(
             lemma_instances.get(lemma_id, ()),
@@ -366,7 +386,6 @@ def _focused_note_crosscheck(
             if focused_packet is None:
                 records.append(
                     {
-                        "lemma_id": lemma_id,
                         **expected,
                         "check_status": "not_loaded",
                         "families_checked": [],
@@ -392,7 +411,6 @@ def _focused_note_crosscheck(
             )
         records.append(
             {
-                "lemma_id": lemma_id,
                 **expected,
                 "check_status": "checked",
                 **check_summary,
@@ -640,8 +658,8 @@ def _assert_alternate_self_edge_certificate_match(
     ):
         if primary.get(key) != packet_strict.get(key):
             raise AssertionError(f"{family_id} focused packet primary conflict mismatch")
-    if template_id != "T01":
-        raise AssertionError("alternate self-edge certificate mode is currently T01-only")
+    if template_id not in {"T01", "T05"}:
+        raise AssertionError("alternate self-edge certificate mode is currently T01/T05-only")
 
 
 def _assert_packet_equality_path(
@@ -806,16 +824,22 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
     crosscheck = payload.get("focused_note_crosscheck")
     if not isinstance(crosscheck, list):
         raise AssertionError("focused_note_crosscheck must be a list")
-    by_lemma = {
-        str(item.get("lemma_id")): item
-        for item in crosscheck
-        if isinstance(item, dict) and "lemma_id" in item
+    expected_by_key = {
+        (str(item["lemma_id"]), str(item["template_id"])): item
+        for item in EXPECTED_FOCUSED_NOTE_CROSSCHECK
     }
-    if set(by_lemma) != set(EXPECTED_FOCUSED_NOTE_CROSSCHECK):
-        raise AssertionError(f"focused-note lemma ids mismatch: {sorted(by_lemma)!r}")
-    for lemma_id, expected in EXPECTED_FOCUSED_NOTE_CROSSCHECK.items():
-        item = by_lemma[lemma_id]
+    by_key = {
+        (str(item.get("lemma_id")), str(item.get("template_id"))): item
+        for item in crosscheck
+        if isinstance(item, dict) and "lemma_id" in item and "template_id" in item
+    }
+    if set(by_key) != set(expected_by_key):
+        raise AssertionError(f"focused-note keys mismatch: {sorted(by_key)!r}")
+    for key_tuple, expected in expected_by_key.items():
+        item = by_key[key_tuple]
+        label = "/".join(key_tuple)
         for key in (
+            "lemma_id",
             "template_id",
             "family_ids",
             "proof_note_path",
@@ -824,18 +848,18 @@ def assert_expected_local_lemma_scan(payload: dict[str, Any]) -> None:
         ):
             if item.get(key) != expected[key]:
                 raise AssertionError(
-                    f"{lemma_id} focused-note {key} mismatch: "
+                    f"{label} focused-note {key} mismatch: "
                     f"expected {expected[key]!r}, got {item.get(key)!r}"
                 )
         if item.get("check_status") != "checked":
-            raise AssertionError(f"{lemma_id} focused-note crosscheck was not checked")
+            raise AssertionError(f"{label} focused-note crosscheck was not checked")
         checked_families = [
             str(checked.get("family_id"))
             for checked in item.get("families_checked", [])
             if isinstance(checked, dict)
         ]
         if checked_families != expected["family_ids"]:
-            raise AssertionError(f"{lemma_id} checked family ids mismatch")
+            raise AssertionError(f"{label} checked family ids mismatch")
 
 
 def _order_from_packet(packet: dict[str, Any]) -> tuple[int, ...]:

--- a/src/erdos97/n9_vertex_circle_t05_self_edge_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t05_self_edge_lemma_packet.py
@@ -1,0 +1,552 @@
+"""Build a focused T05/F10 n=9 self-edge local lemma packet.
+
+This module is proof-mining scaffolding. It does not prove the full n=9 case,
+does not claim a counterexample, and does not promote the review-pending n=9
+checker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path
+from erdos97.n9_vertex_circle_self_edge_template_packet import (
+    SCHEMA as SELF_EDGE_TEMPLATE_PACKET_SCHEMA,
+)
+from erdos97.n9_vertex_circle_template_lemma_catalog import (
+    SCHEMA as TEMPLATE_LEMMA_CATALOG_SCHEMA,
+)
+from erdos97.vertex_circle_quotient_replay import (
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_t05_self_edge_lemma_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused T05/F10 self-edge local lemma packet for eighteen n=9 frontier "
+    "assignments; proof-mining scaffolding only, not a proof of n=9, not a "
+    "counterexample, not an independent review of the exhaustive checker, and "
+    "not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py "
+        "--assert-expected --write"
+    ),
+}
+
+EXPECTED_TEMPLATE_ID = "T05"
+EXPECTED_TEMPLATE_KEY = "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+EXPECTED_FAMILY_ID = "F10"
+EXPECTED_FAMILY_IDS = (EXPECTED_FAMILY_ID,)
+EXPECTED_ASSIGNMENT_IDS = (
+    "A013",
+    "A029",
+    "A036",
+    "A038",
+    "A053",
+    "A057",
+    "A059",
+    "A062",
+    "A072",
+    "A088",
+    "A090",
+    "A100",
+    "A105",
+    "A120",
+    "A129",
+    "A133",
+    "A162",
+    "A170",
+)
+EXPECTED_ASSIGNMENT_COUNT = 18
+EXPECTED_FAMILY_COUNT = 1
+EXPECTED_ORBIT_SIZE_SUM = 18
+EXPECTED_CORE_SIZE = 4
+EXPECTED_STRICT_EDGE_COUNT = 36
+EXPECTED_SELF_EDGE_CONFLICT_COUNT = 2
+EXPECTED_CYCLE_EDGE_COUNT = 0
+EXPECTED_FAMILY_ASSIGNMENT_COUNTS = {"F10": 18}
+EXPECTED_FAMILY_ORBIT_SIZES = {"F10": 18}
+EXPECTED_PATH_LENGTH_COUNTS = {"3": 18}
+EXPECTED_SHARED_ENDPOINT_COUNTS = {"1": 18}
+EXPECTED_SELECTED_PATH_SHAPE_COUNTS = {"3:1:1:path=3": 18}
+EXPECTED_CORE_SELECTED_ROWS = {
+    "F10": (
+        (0, 1, 2, 4, 8),
+        (2, 1, 3, 4, 7),
+        (7, 2, 5, 6, 8),
+        (8, 0, 1, 6, 7),
+    ),
+}
+EXPECTED_STRICT_INEQUALITIES: dict[str, dict[str, Any]] = {
+    "F10": {
+        "row": 0,
+        "witness_order": [1, 2, 4, 8],
+        "outer_interval": [0, 3],
+        "inner_interval": [0, 1],
+        "outer_pair": [1, 8],
+        "inner_pair": [1, 2],
+        "outer_class": [0, 1],
+        "inner_class": [0, 1],
+        "outer_span": 3,
+        "inner_span": 1,
+    },
+}
+EXPECTED_DISTANCE_EQUALITIES: dict[str, dict[str, Any]] = {
+    "F10": {
+        "start_pair": [1, 8],
+        "end_pair": [1, 2],
+        "path": [
+            {"row": 8, "next_pair": [7, 8]},
+            {"row": 7, "next_pair": [2, 7]},
+            {"row": 2, "next_pair": [1, 2]},
+        ],
+    },
+}
+EXPECTED_EQUALITY_CHAINS = {
+    "F10": ([1, 8], [7, 8], [2, 7], [1, 2]),
+}
+
+
+def _template_record(packet: dict[str, Any]) -> dict[str, Any]:
+    templates = packet.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("self-edge template packet must contain templates")
+    for template in templates:
+        if isinstance(template, dict) and template.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return template
+    raise ValueError(f"missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _family_records_by_id(template: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    records = template.get("family_records")
+    if not isinstance(records, list):
+        raise ValueError(f"{EXPECTED_TEMPLATE_ID} must contain family_records")
+    by_id = {
+        str(record["family_id"]): record
+        for record in records
+        if isinstance(record, dict) and "family_id" in record
+    }
+    missing = [family_id for family_id in EXPECTED_FAMILY_IDS if family_id not in by_id]
+    if missing:
+        raise ValueError(f"missing T05 families: {missing!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def _catalog_record(catalog: dict[str, Any]) -> dict[str, Any]:
+    templates = catalog.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template lemma catalog must contain templates")
+    for record in templates:
+        if isinstance(record, dict) and record.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return record
+    raise ValueError(f"catalog missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _normalize_rows(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    return [[int(value) for value in row] for row in rows]
+
+
+def equality_chain(equality: Mapping[str, Any]) -> list[list[int]]:
+    """Return the pair chain traversed by a selected-distance equality path."""
+
+    chain = [[int(value) for value in pair(*equality["start_pair"])]]
+    for step in equality["path"]:
+        chain.append([int(value) for value in pair(*step["next_pair"])])
+    return chain
+
+
+def equality_steps(equality: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return row-labelled equality steps for the local lemma packet."""
+
+    current = [int(value) for value in pair(*equality["start_pair"])]
+    steps = []
+    for step in equality["path"]:
+        next_pair = [int(value) for value in pair(*step["next_pair"])]
+        steps.append(
+            {
+                "row": int(step["row"]),
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+    return steps
+
+
+def source_artifacts(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the T05 packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+            "role": "source T05/F10 self-edge template record",
+            "schema": self_edge_packet.get("schema"),
+            "status": self_edge_packet.get("status"),
+            "trust": self_edge_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+            "role": "catalog crosswalk confirming T05 coverage and shape summary",
+            "schema": template_catalog.get("schema"),
+            "status": template_catalog.get("status"),
+            "trust": template_catalog.get("trust"),
+        },
+    ]
+
+
+def _primary_conflict(replay: dict[str, Any], strict: Mapping[str, Any]) -> dict[str, Any]:
+    for conflict in replay["self_edge_conflicts"]:
+        if (
+            conflict["row"] == strict["row"]
+            and conflict["outer_pair"] == strict["outer_pair"]
+            and conflict["inner_pair"] == strict["inner_pair"]
+        ):
+            return {
+                **conflict,
+                "outer_span": strict["outer_span"],
+                "inner_span": strict["inner_span"],
+            }
+    raise AssertionError("primary T05 self-edge conflict not found in replay")
+
+
+def _source_template_summary(template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_id": str(template["template_id"]),
+        "template_key": str(template["template_key"]),
+        "status": str(template["status"]),
+        "assignment_count": int(template["assignment_count"]),
+        "assignment_ids": list(template["assignment_ids"]),
+        "family_count": int(template["family_count"]),
+        "families": list(template["families"]),
+        "orbit_size_sum": int(template["orbit_size_sum"]),
+        "core_size": int(template["core_size"]),
+        "strict_edge_count": int(template["strict_edge_count"]),
+        "path_length_counts": template["path_length_counts"],
+        "shared_endpoint_counts": template["shared_endpoint_counts"],
+        "selected_path_shape_counts": template["selected_path_shape_counts"],
+        "self_edge_shape_counts": template["self_edge_shape_counts"],
+    }
+
+
+def _family_source_summary(family: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "family_id": str(family["family_id"]),
+        "template_id": str(family["template_id"]),
+        "status": str(family["status"]),
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "path_length": int(family["path_length"]),
+        "strict_inequality": family["strict_inequality"],
+        "distance_equality": family["distance_equality"],
+        "equality_chain": equality_chain(family["distance_equality"]),
+    }
+
+
+def _assert_source_records(
+    template: dict[str, Any],
+    families: Mapping[str, dict[str, Any]],
+    catalog_record: dict[str, Any],
+) -> None:
+    if template["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected template id")
+    if template["template_key"] != EXPECTED_TEMPLATE_KEY:
+        raise AssertionError("unexpected T05 template key")
+    if template["status"] != "self_edge":
+        raise AssertionError("T05 must remain a self-edge template")
+    if template["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("unexpected T05 assignment ids")
+    if template["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected T05 assignment count")
+    if template["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("unexpected T05 family list")
+    if template["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("unexpected T05 family count")
+    if template["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("unexpected T05 orbit-size sum")
+    if template["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected T05 core size")
+    if template["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("unexpected T05 strict-edge count")
+    if template["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected T05 path-length counts")
+    if template["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("unexpected T05 shared-endpoint counts")
+    if template["selected_path_shape_counts"] != EXPECTED_SELECTED_PATH_SHAPE_COUNTS:
+        raise AssertionError("unexpected T05 selected-path shape counts")
+
+    family = families[EXPECTED_FAMILY_ID]
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    strict = family["strict_inequality"]
+    validate_equality_path(rows, equality)
+    if family["family_id"] != EXPECTED_FAMILY_ID:
+        raise AssertionError("unexpected family id")
+    if family["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("family/template mismatch")
+    if family["status"] != "self_edge":
+        raise AssertionError("F10 must remain a self-edge record")
+    if family["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F10 assignment count")
+    if family["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F10 orbit size")
+    if family["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected F10 core size")
+    if rows != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS[EXPECTED_FAMILY_ID]):
+        raise AssertionError("unexpected F10 core rows")
+    if strict != EXPECTED_STRICT_INEQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F10 strict inequality")
+    if equality != EXPECTED_DISTANCE_EQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F10 equality path")
+    expected_chain = [list(item) for item in EXPECTED_EQUALITY_CHAINS[EXPECTED_FAMILY_ID]]
+    if equality_chain(equality) != expected_chain:
+        raise AssertionError("unexpected F10 equality chain")
+    if strict["outer_pair"] != equality["start_pair"]:
+        raise AssertionError("F10 strict outer pair must start equality path")
+    if strict["inner_pair"] != equality["end_pair"]:
+        raise AssertionError("F10 strict inner pair must end equality path")
+
+    if catalog_record["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected catalog template id")
+    if catalog_record["status"] != "self_edge":
+        raise AssertionError("unexpected catalog T05 status")
+    coverage = catalog_record["coverage"]
+    if coverage["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("catalog T05 assignment count mismatch")
+    if coverage["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("catalog T05 assignment ids mismatch")
+    if coverage["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("catalog T05 family mismatch")
+    if coverage["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("catalog T05 family count mismatch")
+    if coverage["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("catalog T05 orbit-size sum mismatch")
+    hypothesis = catalog_record["hypothesis_shape"]
+    if hypothesis["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("catalog T05 core-size mismatch")
+    if hypothesis["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("catalog T05 strict-edge mismatch")
+    if hypothesis["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("catalog T05 path-length mismatch")
+    if hypothesis["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("catalog T05 shared-endpoint mismatch")
+    if hypothesis["selected_path_shape_counts"] != EXPECTED_SELECTED_PATH_SHAPE_COUNTS:
+        raise AssertionError("catalog T05 selected-path shape mismatch")
+
+
+def _family_local_lemma(strict: Mapping[str, Any], equality: Mapping[str, Any]) -> dict[str, Any]:
+    path_rows = [int(step["row"]) for step in equality["path"]]
+    return {
+        "packet_name": "T05/F10 self-edge local lemma packet",
+        "review_status": "review_pending",
+        "hypothesis_scope": (
+            "Natural cyclic order on labels 0..8 plus the four listed selected "
+            "rows; no claim is made about other n=9 templates."
+        ),
+        "selected_distance_equalities": equality_steps(equality),
+        "strict_inequality_statement": (
+            f"Row {strict['row']} has witness order {strict['witness_order']}, "
+            f"so the outer pair {strict['outer_pair']} strictly contains the "
+            f"inner pair {strict['inner_pair']} in that row's vertex-circle order."
+        ),
+        "equality_statement": (
+            f"Rows {path_rows} identify {equality['start_pair']} with "
+            f"{equality['end_pair']} in the selected-distance quotient."
+        ),
+        "contradiction": (
+            "The strict graph has a reflexive strict edge after selected-distance "
+            "quotienting."
+        ),
+    }
+
+
+def _family_packet(family: dict[str, Any]) -> dict[str, Any]:
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    strict = family["strict_inequality"]
+    replay_result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parse_selected_rows(rows),
+    )
+    replay = result_to_json(replay_result)
+    primary = _primary_conflict(replay, strict)
+    return {
+        "family_id": EXPECTED_FAMILY_ID,
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "core_selected_rows": rows,
+        "strict_inequality": strict,
+        "distance_equality": equality,
+        "equality_chain": equality_chain(equality),
+        "local_lemma": _family_local_lemma(strict, equality),
+        "replay": {
+            "status": replay["status"],
+            "selected_row_count": replay["selected_row_count"],
+            "strict_edge_count": replay["strict_edge_count"],
+            "self_edge_conflict_count": len(replay["self_edge_conflicts"]),
+            "cycle_edge_count": len(replay["cycle_edges"]),
+            "primary_self_edge_conflict": primary,
+            "self_edge_conflicts": replay["self_edge_conflicts"],
+        },
+        "source_family_record": _family_source_summary(family),
+    }
+
+
+def t05_self_edge_lemma_packet_payload(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the focused review-pending T05/F10 local lemma packet."""
+
+    if self_edge_packet.get("schema") != SELF_EDGE_TEMPLATE_PACKET_SCHEMA:
+        raise ValueError("unexpected self-edge template packet schema")
+    if template_catalog.get("schema") != TEMPLATE_LEMMA_CATALOG_SCHEMA:
+        raise ValueError("unexpected template lemma catalog schema")
+
+    template = _template_record(self_edge_packet)
+    families = _family_records_by_id(template)
+    catalog_record = _catalog_record(template_catalog)
+    _assert_source_records(template, families, catalog_record)
+    family_packets = [_family_packet(families[EXPECTED_FAMILY_ID])]
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "family_packets": family_packets,
+        "source_template_record": _source_template_summary(template),
+        "source_catalog_record": catalog_record,
+        "interpretation": [
+            "This packet isolates the T05/F10 self-edge motif from existing review-pending n=9 diagnostics.",
+            "The family record has four local rows that force the displayed equality chain.",
+            "The family record has a vertex-circle strict inequality between the same quotient class.",
+            "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": source_artifacts(self_edge_packet, template_catalog),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_t05_self_edge_lemma_packet(payload)
+    return payload
+
+
+def _family_packets_by_id(payload: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        raise AssertionError("family_packets must be a list")
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        raise AssertionError(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, got {len(packets)}"
+        )
+    by_id = {
+        str(packet["family_id"]): packet
+        for packet in packets
+        if isinstance(packet, dict) and "family_id" in packet
+    }
+    if len(by_id) != len(packets):
+        raise AssertionError("family_packets must not contain duplicate family ids")
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        raise AssertionError(f"unexpected family packet ids: {sorted(by_id)!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def assert_expected_t05_self_edge_lemma_packet(payload: Mapping[str, Any]) -> None:
+    """Assert stable constants for the focused T05/F10 local lemma packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}")
+
+    packet = _family_packets_by_id(payload)[EXPECTED_FAMILY_ID]
+    if packet["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F10 assignment count mismatch")
+    if packet["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F10 orbit size mismatch")
+    if packet["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("F10 core size mismatch")
+    if packet["core_selected_rows"] != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS[EXPECTED_FAMILY_ID]):
+        raise AssertionError("F10 core rows mismatch")
+    if packet["strict_inequality"] != EXPECTED_STRICT_INEQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F10 strict inequality mismatch")
+    if packet["distance_equality"] != EXPECTED_DISTANCE_EQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F10 equality path mismatch")
+    if packet["equality_chain"] != [list(item) for item in EXPECTED_EQUALITY_CHAINS[EXPECTED_FAMILY_ID]]:
+        raise AssertionError("F10 equality chain mismatch")
+
+    replay = packet["replay"]
+    if replay["status"] != "self_edge":
+        raise AssertionError("F10 replay status mismatch")
+    if replay["selected_row_count"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("F10 selected row count mismatch")
+    if replay["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("F10 strict-edge count mismatch")
+    if replay["self_edge_conflict_count"] != EXPECTED_SELF_EDGE_CONFLICT_COUNT:
+        raise AssertionError("F10 self-edge conflict count mismatch")
+    if replay["cycle_edge_count"] != EXPECTED_CYCLE_EDGE_COUNT:
+        raise AssertionError("F10 cycle-edge count mismatch")
+    primary = replay["primary_self_edge_conflict"]
+    strict = EXPECTED_STRICT_INEQUALITIES[EXPECTED_FAMILY_ID]
+    for key in ("row", "witness_order", "outer_pair", "inner_pair", "outer_interval", "inner_interval"):
+        if primary[key] != strict[key]:
+            raise AssertionError(f"F10 primary conflict {key} mismatch")
+    lemma = packet["local_lemma"]
+    if lemma["review_status"] != "review_pending":
+        raise AssertionError("F10 local lemma review status mismatch")
+
+    if "No proof of the n=9 case is claimed." not in payload.get("interpretation", []):
+        raise AssertionError("interpretation must preserve the no-proof statement")

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -25,6 +25,7 @@ from scripts.check_n9_vertex_circle_local_lemmas import (
     DEFAULT_T02_PACKET,
     DEFAULT_T03_PACKET,
     DEFAULT_T04_PACKET,
+    DEFAULT_T05_PACKET,
     DEFAULT_T10_PACKET,
     DEFAULT_T11_PACKET,
     DEFAULT_T12_PACKET,
@@ -117,6 +118,31 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
                 {"family_id": "F09", "assignment_count": 6, "orbit_size": 6},
             ],
             "covered_assignment_count": 6,
+            "interpretation": (
+                "Aggregate scan family rows match the focused packet, and the "
+                "focused packet supplies a valid alternate reflexive self-edge "
+                "certificate for the same family. The aggregate nested-spoke "
+                "strict edge is not required to be the same strict edge as the "
+                "proof-facing note; this remains a packet consistency check, not "
+                "an independent n=9 completeness proof."
+            ),
+        },
+        {
+            "lemma_id": NESTED_SPOKE_LEMMA,
+            "template_id": "T05",
+            "family_ids": ["F10"],
+            "proof_note_path": "docs/n9-vertex-circle-t05-self-edge-lemma.md",
+            "source_kind": "focused_packet",
+            "crosscheck_mode": "alternate_self_edge_certificate",
+            "packet_key": "T05",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F10", "assignment_count": 18, "orbit_size": 18},
+            ],
+            "covered_assignment_count": 18,
             "interpretation": (
                 "Aggregate scan family rows match the focused packet, and the "
                 "focused packet supplies a valid alternate reflexive self-edge "
@@ -520,6 +546,30 @@ def test_focused_packet_crosscheck_rejects_t01_path_drift() -> None:
                 "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": load_artifact(DEFAULT_T03_PACKET),
                 "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T05": load_artifact(DEFAULT_T05_PACKET),
+                "T10": load_artifact(DEFAULT_T10_PACKET),
+                "T11": load_artifact(DEFAULT_T11_PACKET),
+                "T12": load_artifact(DEFAULT_T12_PACKET),
+            },
+        )
+
+
+def test_focused_packet_crosscheck_rejects_t05_path_drift() -> None:
+    self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
+    strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
+    t05_packet = load_artifact(DEFAULT_T05_PACKET)
+    t05_packet["family_packets"][0]["distance_equality"]["path"][0]["next_pair"] = [0, 8]
+
+    with pytest.raises(AssertionError, match="F10 focused packet equality path step mismatch"):
+        local_lemma_scan_payload(
+            self_edge_packet,
+            strict_cycle_packet,
+            focused_packets={
+                "T01": load_artifact(DEFAULT_T01_PACKET),
+                "T02": load_artifact(DEFAULT_T02_PACKET),
+                "T03": load_artifact(DEFAULT_T03_PACKET),
+                "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T05": t05_packet,
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -542,6 +592,7 @@ def test_focused_packet_crosscheck_rejects_t02_path_drift() -> None:
                 "T02": t02_packet,
                 "T03": load_artifact(DEFAULT_T03_PACKET),
                 "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -564,6 +615,7 @@ def test_focused_packet_crosscheck_rejects_t03_row_drift() -> None:
                 "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": t03_packet,
                 "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -586,6 +638,7 @@ def test_focused_packet_crosscheck_rejects_t10_replay_status_drift() -> None:
                 "T02": load_artifact(DEFAULT_T02_PACKET),
                 "T03": load_artifact(DEFAULT_T03_PACKET),
                 "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T10": t10_packet,
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),

--- a/tests/test_n9_vertex_circle_t05_self_edge_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t05_self_edge_lemma_packet.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import copy
+
+from erdos97.n9_vertex_circle_t05_self_edge_lemma_packet import (
+    assert_expected_t05_self_edge_lemma_packet,
+)
+from scripts.check_n9_vertex_circle_t05_self_edge_lemma_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+def _family_packet(payload: dict[str, object]) -> dict[str, object]:
+    packets = payload["family_packets"]  # type: ignore[index]
+    assert isinstance(packets, list)
+    assert len(packets) == 1
+    return packets[0]  # type: ignore[return-value]
+
+
+def _template_record(source_payloads: dict[str, object]) -> dict[str, object]:
+    for template in source_payloads["self_edge_packet"]["templates"]:  # type: ignore[index]
+        if template["template_id"] == "T05":
+            return template
+    raise AssertionError("missing T05 template")
+
+
+def test_t05_self_edge_lemma_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_t05_self_edge_lemma_packet(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "proof-mining scaffolding only" in payload["claim_scope"]
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["template_id"] == "T05"
+    assert payload["template_key"] == "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+    assert payload["assignment_count"] == 18
+    assert payload["assignment_ids"] == [
+        "A013",
+        "A029",
+        "A036",
+        "A038",
+        "A053",
+        "A057",
+        "A059",
+        "A062",
+        "A072",
+        "A088",
+        "A090",
+        "A100",
+        "A105",
+        "A120",
+        "A129",
+        "A133",
+        "A162",
+        "A170",
+    ]
+    assert payload["family_count"] == 1
+    assert payload["family_ids"] == ["F10"]
+    assert payload["family_assignment_counts"] == {"F10": 18}
+    assert payload["family_orbit_sizes"] == {"F10": 18}
+    assert payload["orbit_size_sum"] == 18
+    assert payload["core_size"] == 4
+    assert payload["strict_edge_count"] == 36
+    assert payload["path_length_counts"] == {"3": 18}
+    assert payload["shared_endpoint_counts"] == {"1": 18}
+    assert payload["selected_path_shape_counts"] == {"3:1:1:path=3": 18}
+
+
+def test_t05_self_edge_lemma_packet_records_expected_local_shape() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+
+    assert packet["family_id"] == "F10"
+    assert packet["core_selected_rows"] == [
+        [0, 1, 2, 4, 8],
+        [2, 1, 3, 4, 7],
+        [7, 2, 5, 6, 8],
+        [8, 0, 1, 6, 7],
+    ]
+    assert packet["strict_inequality"]["row"] == 0  # type: ignore[index]
+    assert packet["strict_inequality"]["witness_order"] == [1, 2, 4, 8]  # type: ignore[index]
+    assert packet["strict_inequality"]["outer_pair"] == [1, 8]  # type: ignore[index]
+    assert packet["strict_inequality"]["inner_pair"] == [1, 2]  # type: ignore[index]
+    assert packet["strict_inequality"]["inner_interval"] == [0, 1]  # type: ignore[index]
+    assert packet["equality_chain"] == [[1, 8], [7, 8], [2, 7], [1, 2]]
+    assert packet["local_lemma"]["review_status"] == "review_pending"  # type: ignore[index]
+    assert "four listed selected rows" in packet["local_lemma"]["hypothesis_scope"]  # type: ignore[index]
+    assert packet["replay"]["status"] == "self_edge"  # type: ignore[index]
+    assert packet["replay"]["selected_row_count"] == 4  # type: ignore[index]
+    assert packet["replay"]["strict_edge_count"] == 36  # type: ignore[index]
+    assert packet["replay"]["self_edge_conflict_count"] == 2  # type: ignore[index]
+    assert packet["replay"]["cycle_edge_count"] == 0  # type: ignore[index]
+    assert packet["replay"]["primary_self_edge_conflict"]["row"] == 0  # type: ignore[index]
+
+
+def test_t05_self_edge_lemma_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["template_id"] == "T05"
+    assert summary["family_count"] == 1
+    assert summary["assignment_count"] == 18
+    assert summary["replay_statuses"] == ["self_edge"]
+
+
+def test_t05_self_edge_lemma_packet_rejects_tampered_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+    packet["distance_equality"]["path"][0]["next_pair"] = [3, 6]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F10 distance_equality mismatch" in error for error in errors)
+    assert any("expected T05 self-edge lemma packet" in error for error in errors)
+
+
+def test_t05_self_edge_lemma_packet_rejects_tampered_strict_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+    packet["strict_inequality"]["row"] = 1  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F10 strict_inequality mismatch" in error for error in errors)
+
+
+def test_t05_self_edge_lemma_packet_rejects_wrong_conflict_count() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+    packet["replay"]["self_edge_conflict_count"] = 1  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F10 replay self_edge_conflict_count mismatch" in error for error in errors)
+
+
+def test_t05_self_edge_lemma_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_t05_self_edge_lemma_packet_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    template = _template_record(sources)
+    template["family_records"][0]["strict_inequality"]["row"] = 1
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source self-edge template packet invalid" in error
+        or "source-bound T05 self-edge lemma packet failed" in error
+        for error in errors
+    )


### PR DESCRIPTION
## Summary

- add a focused review-pending T05/F10 self-edge local lemma packet, checker, tests, and generated JSON artifact
- wire the T05 packet into the aggregate n=9 local-lemma scan as an alternate nested-spoke self-edge certificate for F10
- update audit wiring, provenance metadata, and proof-mining docs without changing the repo/global Erdos #97 status

## Verification

- `python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --assert-expected --write --check --json`
- `python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write --check --json`
- `python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemmas.py tests/test_n9_vertex_circle_t05_self_edge_lemma_packet.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (852 passed, 285 deselected)

`make verify-n9-review` could not be run locally because this Windows shell does not have `make` installed; the new underlying T05 and aggregate local-lemma artifact commands passed directly.