### PR TITLE
Add focused T08 self-edge packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t06_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t07_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_local_lemmas.json
+++ b/data/certificates/n9_vertex_circle_local_lemmas.json
@@ -186,6 +186,28 @@
     },
     {
       "check_status": "checked",
+      "covered_assignment_count": 18,
+      "crosscheck_mode": "alternate_self_edge_certificate",
+      "families_checked": [
+        {
+          "assignment_count": 18,
+          "family_id": "F02",
+          "orbit_size": 18
+        }
+      ],
+      "family_ids": [
+        "F02"
+      ],
+      "interpretation": "Aggregate scan family rows match the focused packet, and the focused packet supplies a valid alternate reflexive self-edge certificate for the same family. The aggregate nested-spoke strict edge is not required to be the same strict edge as the proof-facing note; this remains a packet consistency check, not an independent n=9 completeness proof.",
+      "lemma_id": "nested_spoke_quotient_self_edge",
+      "packet_key": "T08",
+      "packet_path": "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json",
+      "proof_note_path": "docs/n9-vertex-circle-t08-self-edge-lemma.md",
+      "source_kind": "focused_packet",
+      "template_id": "T08"
+    },
+    {
+      "check_status": "checked",
       "covered_assignment_count": 40,
       "families_checked": [
         {

--- a/data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json
+++ b/data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json
@@ -1,0 +1,945 @@
+{
+  "assignment_count": 18,
+  "assignment_ids": [
+    "A002",
+    "A012",
+    "A043",
+    "A050",
+    "A067",
+    "A084",
+    "A085",
+    "A086",
+    "A096",
+    "A106",
+    "A109",
+    "A122",
+    "A132",
+    "A134",
+    "A143",
+    "A149",
+    "A150",
+    "A159"
+  ],
+  "claim_scope": "Focused T08/F02 self-edge local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "core_size": 6,
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "family_assignment_counts": {
+    "F02": 18
+  },
+  "family_count": 1,
+  "family_ids": [
+    "F02"
+  ],
+  "family_orbit_sizes": {
+    "F02": 18
+  },
+  "family_packets": [
+    {
+      "assignment_count": 18,
+      "core_selected_rows": [
+        [
+          0,
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          1,
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          2,
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          5,
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          6,
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          7,
+          0,
+          1,
+          4,
+          6
+        ]
+      ],
+      "core_size": 6,
+      "distance_equality": {
+        "end_pair": [
+          1,
+          2
+        ],
+        "path": [
+          {
+            "next_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "next_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "next_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "next_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "next_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "start_pair": [
+          1,
+          3
+        ]
+      },
+      "equality_chain": [
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          7
+        ],
+        [
+          6,
+          7
+        ],
+        [
+          5,
+          6
+        ],
+        [
+          2,
+          5
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "family_id": "F02",
+      "local_lemma": {
+        "contradiction": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "equality_statement": "Rows [1, 7, 6, 5, 2] identify [1, 3] with [1, 2] in the selected-distance quotient.",
+        "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the four listed selected rows; no claim is made about other n=9 templates.",
+        "packet_name": "T08/F02 self-edge local lemma packet",
+        "review_status": "review_pending",
+        "selected_distance_equalities": [
+          {
+            "left_pair": [
+              1,
+              3
+            ],
+            "right_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              1,
+              7
+            ],
+            "right_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "left_pair": [
+              6,
+              7
+            ],
+            "right_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "left_pair": [
+              5,
+              6
+            ],
+            "right_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "left_pair": [
+              2,
+              5
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_inequality_statement": "Row 0 has witness order [1, 2, 3, 8], so the outer pair [1, 3] strictly contains the inner pair [1, 2] in that row's vertex-circle order."
+      },
+      "orbit_size": 18,
+      "replay": {
+        "cycle_edge_count": 0,
+        "primary_self_edge_conflict": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        "selected_row_count": 6,
+        "self_edge_conflict_count": 9,
+        "self_edge_conflicts": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "row": 0,
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              4,
+              7
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "row": 1,
+            "witness_order": [
+              3,
+              4,
+              7,
+              0
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              0,
+              7
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "row": 1,
+            "witness_order": [
+              3,
+              4,
+              7,
+              0
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              5,
+              6
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "row": 2,
+            "witness_order": [
+              3,
+              5,
+              6,
+              1
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              2,
+              3
+            ],
+            "inner_pair": [
+              1,
+              6
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "row": 2,
+            "witness_order": [
+              3,
+              5,
+              6,
+              1
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              6,
+              7
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              6
+            ],
+            "row": 5,
+            "witness_order": [
+              6,
+              7,
+              2,
+              4
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              0,
+              2
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              5,
+              7
+            ],
+            "row": 6,
+            "witness_order": [
+              7,
+              8,
+              1,
+              5
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_interval": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              1,
+              4
+            ],
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_interval": [
+              1,
+              3
+            ],
+            "outer_pair": [
+              1,
+              6
+            ],
+            "row": 7,
+            "witness_order": [
+              0,
+              1,
+              4,
+              6
+            ]
+          }
+        ],
+        "status": "self_edge",
+        "strict_edge_count": 54
+      },
+      "source_family_record": {
+        "assignment_count": 18,
+        "core_size": 6,
+        "distance_equality": {
+          "end_pair": [
+            1,
+            2
+          ],
+          "path": [
+            {
+              "next_pair": [
+                1,
+                7
+              ],
+              "row": 1
+            },
+            {
+              "next_pair": [
+                6,
+                7
+              ],
+              "row": 7
+            },
+            {
+              "next_pair": [
+                5,
+                6
+              ],
+              "row": 6
+            },
+            {
+              "next_pair": [
+                2,
+                5
+              ],
+              "row": 5
+            },
+            {
+              "next_pair": [
+                1,
+                2
+              ],
+              "row": 2
+            }
+          ],
+          "start_pair": [
+            1,
+            3
+          ]
+        },
+        "equality_chain": [
+          [
+            1,
+            3
+          ],
+          [
+            1,
+            7
+          ],
+          [
+            6,
+            7
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        "family_id": "F02",
+        "orbit_size": 18,
+        "path_length": 5,
+        "status": "self_edge",
+        "strict_inequality": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        "template_id": "T08"
+      },
+      "strict_inequality": {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          3,
+          8
+        ]
+      }
+    }
+  ],
+  "interpretation": [
+    "This packet isolates the T08/F02 self-edge motif from existing review-pending n=9 diagnostics.",
+    "The family record has four local rows that force the displayed equality chain.",
+    "The family record has a vertex-circle strict inequality between the same quotient class.",
+    "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+    "No proof of the n=9 case is claimed."
+  ],
+  "n": 9,
+  "orbit_size_sum": 18,
+  "path_length_counts": {
+    "5": 18
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py"
+  },
+  "row_size": 4,
+  "schema": "erdos97.n9_vertex_circle_t08_self_edge_lemma_packet.v1",
+  "selected_path_shape_counts": {
+    "2:1:1:path=5": 18
+  },
+  "shared_endpoint_counts": {
+    "1": 18
+  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "source T08/F02 self-edge template record",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+      "role": "catalog crosswalk confirming T08 coverage and shape summary",
+      "schema": "erdos97.n9_vertex_circle_template_lemma_catalog.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "source_catalog_record": {
+    "conclusion_shape": {
+      "certificate_fields": [
+        "strict_inequality",
+        "distance_equality"
+      ],
+      "kind": "self_edge",
+      "strict_graph_obstruction": "reflexive strict edge after selected-distance quotienting"
+    },
+    "coverage": {
+      "assignment_count": 18,
+      "assignment_ids": [
+        "A002",
+        "A012",
+        "A043",
+        "A050",
+        "A067",
+        "A084",
+        "A085",
+        "A086",
+        "A096",
+        "A106",
+        "A109",
+        "A122",
+        "A132",
+        "A134",
+        "A143",
+        "A149",
+        "A150",
+        "A159"
+      ],
+      "families": [
+        "F02"
+      ],
+      "family_count": 1,
+      "orbit_size_sum": 18
+    },
+    "family_summaries": [
+      {
+        "assignment_count": 18,
+        "contradiction_kind": "self_edge",
+        "core_size": 6,
+        "equality_path_length": 5,
+        "family_id": "F02",
+        "inner_pair": [
+          1,
+          2
+        ],
+        "inner_span": 1,
+        "orbit_size": 18,
+        "outer_pair": [
+          1,
+          3
+        ],
+        "outer_span": 2,
+        "path_length": 5,
+        "status": "self_edge",
+        "template_id": "T08"
+      }
+    ],
+    "hypothesis_shape": {
+      "core_size": 6,
+      "path_length_counts": {
+        "5": 18
+      },
+      "selected_path_shape_counts": {
+        "2:1:1:path=5": 18
+      },
+      "self_edge_shape_counts": [
+        {
+          "count": 4,
+          "inner_span": 1,
+          "outer_span": 2,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 0
+        },
+        {
+          "count": 2,
+          "inner_span": 1,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        },
+        {
+          "count": 1,
+          "inner_span": 2,
+          "outer_span": 3,
+          "shared_endpoint_count": 1
+        }
+      ],
+      "shared_endpoint_counts": {
+        "1": 18
+      },
+      "strict_edge_count": 54
+    },
+    "status": "self_edge",
+    "template_id": "T08",
+    "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+  },
+  "source_template_record": {
+    "assignment_count": 18,
+    "assignment_ids": [
+      "A002",
+      "A012",
+      "A043",
+      "A050",
+      "A067",
+      "A084",
+      "A085",
+      "A086",
+      "A096",
+      "A106",
+      "A109",
+      "A122",
+      "A132",
+      "A134",
+      "A143",
+      "A149",
+      "A150",
+      "A159"
+    ],
+    "core_size": 6,
+    "families": [
+      "F02"
+    ],
+    "family_count": 1,
+    "orbit_size_sum": 18,
+    "path_length_counts": {
+      "5": 18
+    },
+    "selected_path_shape_counts": {
+      "2:1:1:path=5": 18
+    },
+    "self_edge_shape_counts": [
+      {
+        "count": 4,
+        "inner_span": 1,
+        "outer_span": 2,
+        "shared_endpoint_count": 1
+      },
+      {
+        "count": 2,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoint_count": 0
+      },
+      {
+        "count": 2,
+        "inner_span": 1,
+        "outer_span": 3,
+        "shared_endpoint_count": 1
+      },
+      {
+        "count": 1,
+        "inner_span": 2,
+        "outer_span": 3,
+        "shared_endpoint_count": 1
+      }
+    ],
+    "shared_endpoint_counts": {
+      "1": 18
+    },
+    "status": "self_edge",
+    "strict_edge_count": 54,
+    "template_id": "T08",
+    "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+  },
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_edge_count": 54,
+  "template_id": "T08",
+  "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -18,7 +18,7 @@ that justifies doing it anyway.
 Use this queue when no more specific issue is selected.
 
 1. Review the aggregate `n=9` vertex-circle local-lemma scan against the
-   focused T01/T02/T03/T04/T05/T06/T07 self-edge packets and the focused T10/T11/T12
+   focused T01/T02/T03/T04/T05/T06/T07/T08 self-edge packets and the focused T10/T11/T12
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
    than an `n=9` proof.
 2. Audit whether the aggregate local-template coverage can be checked from the

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -514,12 +514,13 @@ T04/F13     -> docs/n9-vertex-circle-t04-self-edge-lemma.md
 T05/F10     -> docs/n9-vertex-circle-t05-self-edge-lemma.md
 T06/F11     -> docs/n9-vertex-circle-t06-self-edge-lemma.md
 T07/F06     -> docs/n9-vertex-circle-t07-self-edge-lemma.md
+T08/F02     -> docs/n9-vertex-circle-t08-self-edge-lemma.md
 T10/F12     -> docs/n9-vertex-circle-t10-strict-cycle-lemma.md
 T11/F07     -> docs/n9-vertex-circle-t11-strict-cycle-lemma.md
 T12/F16     -> docs/n9-vertex-circle-t12-strict-cycle-lemma.md
 ```
 
-For T01, T02, T03, T04, T05, T06, T07, T10, T11, and T12 the scan loads the focused JSON
+For T01, T02, T03, T04, T05, T06, T07, T08, T10, T11, and T12 the scan loads the focused JSON
 packets and checks that the aggregate family rows, strict inequalities,
 equality paths, cycle steps, and assignment counts match the focused packet
 used by the note.

--- a/docs/n9-vertex-circle-t08-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t08-self-edge-lemma.md
@@ -9,12 +9,11 @@ checker, and does not update the official/global status.
 
 ## Packet scope
 
-The checked source artifact is
-`data/certificates/n9_vertex_circle_self_edge_template_packet.json`, whose
-`T08` record is derived from:
+The checked focused artifact is
+`data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json`. It is
+derived from:
 
-- `data/certificates/n9_vertex_circle_self_edge_path_join.json`
-- `data/certificates/n9_vertex_circle_core_templates.json`
+- `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
 
 The template covers 18 assignment ids:
@@ -129,15 +128,14 @@ a selected-distance quotient class back to itself.
 
 ## Commands
 
-Check the source packet and the combined template catalog:
+Generate and check the packet:
 
 ```bash
-python scripts/check_n9_vertex_circle_self_edge_template_packet.py \
-  --check \
+python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py \
   --assert-expected \
-  --json
+  --write
 
-python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
+python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py \
   --check \
   --assert-expected \
   --json
@@ -146,7 +144,7 @@ python scripts/check_n9_vertex_circle_template_lemma_catalog.py \
 Run the targeted artifact tests:
 
 ```bash
-python -m pytest tests/test_n9_vertex_circle_self_edge_template_packet.py -q -m "artifact"
+python -m pytest tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py -q
 ```
 
 ## Review standard

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -170,13 +170,16 @@ Next steps:
 - use `data/certificates/n9_vertex_circle_t07_self_edge_lemma_packet.json` to
   replay the focused review-pending T07/F06 nested-spoke alternate self-edge
   proof note;
+- use `data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json` to
+  replay the focused review-pending T08/F02 nested-spoke alternate self-edge
+  proof note;
 - use `data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T10/F12 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T11/F07 strict-cycle local lemma packet;
 - use `data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json`
   to replay the focused review-pending T12/F16 strict-cycle local lemma packet;
-- review the aggregate local-lemma scan after the T01/T02/T03/T04/T05/T06/T07
+- review the aggregate local-lemma scan after the T01/T02/T03/T04/T05/T06/T07/T08
   self-edge and T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
   coverage of stored packets rather than an independent `n=9` proof;
 - test whether the same motifs appear in the P18 obstruction and fail in the

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1103,6 +1103,50 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_t08_self_edge_lemma_packet
+    path: data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py
+    command: python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py
+    check_command: python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Focused T08/F02 self-edge local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_t08_self_edge_lemma_packet.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: Focused T08/F02 self-edge local lemma packet for eighteen n=9 frontier assignments; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      n: 9
+      row_size: 4
+      template_id: T08
+      template_key: self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1
+      assignment_count: 18
+      family_count: 1
+      family_ids:
+        - F02
+      family_assignment_counts.F02: 18
+      family_orbit_sizes.F02: 18
+      orbit_size_sum: 18
+      core_size: 6
+      strict_edge_count: 54
+      path_length_counts.5: 18
+      shared_endpoint_counts.1: 18
+      "selected_path_shape_counts.2:1:1:path=5": 18
+      provenance.command: python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - T08 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the local lemma packet is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t10_strict_cycle_lemma_packet
     path: data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_vertex_circle_local_lemmas.py
+++ b/scripts/check_n9_vertex_circle_local_lemmas.py
@@ -52,6 +52,9 @@ DEFAULT_T06_PACKET = (
 DEFAULT_T07_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t07_self_edge_lemma_packet.json"
 )
+DEFAULT_T08_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t08_self_edge_lemma_packet.json"
+)
 DEFAULT_T10_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_t10_strict_cycle_lemma_packet.json"
 )
@@ -96,6 +99,7 @@ def scan_payload(
     t05_packet_path: Path = DEFAULT_T05_PACKET,
     t06_packet_path: Path = DEFAULT_T06_PACKET,
     t07_packet_path: Path = DEFAULT_T07_PACKET,
+    t08_packet_path: Path = DEFAULT_T08_PACKET,
     t10_packet_path: Path = DEFAULT_T10_PACKET,
     t11_packet_path: Path = DEFAULT_T11_PACKET,
     t12_packet_path: Path = DEFAULT_T12_PACKET,
@@ -113,6 +117,7 @@ def scan_payload(
             "T05": load_artifact(t05_packet_path),
             "T06": load_artifact(t06_packet_path),
             "T07": load_artifact(t07_packet_path),
+            "T08": load_artifact(t08_packet_path),
             "T10": load_artifact(t10_packet_path),
             "T11": load_artifact(t11_packet_path),
             "T12": load_artifact(t12_packet_path),
@@ -277,6 +282,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to focused T07 self-edge lemma packet JSON.",
     )
     parser.add_argument(
+        "--t08-packet",
+        type=Path,
+        default=DEFAULT_T08_PACKET,
+        help="Path to focused T08 self-edge lemma packet JSON.",
+    )
+    parser.add_argument(
         "--t11-packet",
         type=Path,
         default=DEFAULT_T11_PACKET,
@@ -317,6 +328,7 @@ def main(argv: list[str] | None = None) -> int:
         t05_packet_path=_resolve(args.t05_packet),
         t06_packet_path=_resolve(args.t06_packet),
         t07_packet_path=_resolve(args.t07_packet),
+        t08_packet_path=_resolve(args.t08_packet),
         t10_packet_path=_resolve(args.t10_packet),
         t11_packet_path=_resolve(args.t11_packet),
         t12_packet_path=_resolve(args.t12_packet),

--- a/scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Generate or check the focused T08/F02 n=9 self-edge local lemma packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_vertex_circle_self_edge_template_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_SELF_EDGE_PACKET,
+    validate_payload as validate_self_edge_packet,
+)
+from check_n9_vertex_circle_template_lemma_catalog import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_TEMPLATE_CATALOG,
+    validate_payload as validate_template_catalog,
+)
+from erdos97.n9_vertex_circle_t08_self_edge_lemma_packet import (  # noqa: E402
+    CLAIM_SCOPE,
+    EXPECTED_ASSIGNMENT_IDS,
+    EXPECTED_CORE_SIZE,
+    EXPECTED_CORE_SELECTED_ROWS,
+    EXPECTED_DISTANCE_EQUALITIES,
+    EXPECTED_EQUALITY_CHAINS,
+    EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+    EXPECTED_FAMILY_IDS,
+    EXPECTED_FAMILY_ORBIT_SIZES,
+    EXPECTED_PATH_LENGTH_COUNTS,
+    EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+    EXPECTED_SELF_EDGE_CONFLICT_COUNT,
+    EXPECTED_SHARED_ENDPOINT_COUNTS,
+    EXPECTED_STRICT_EDGE_COUNT,
+    EXPECTED_STRICT_INEQUALITIES,
+    EXPECTED_TEMPLATE_KEY,
+    PROVENANCE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    assert_expected_t08_self_edge_lemma_packet,
+    source_artifacts,
+    t08_self_edge_lemma_packet_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t08_self_edge_lemma_packet.json"
+)
+EXPECTED_TOP_LEVEL_KEYS = {
+    "assignment_count",
+    "assignment_ids",
+    "claim_scope",
+    "core_size",
+    "cyclic_order",
+    "family_assignment_counts",
+    "family_count",
+    "family_ids",
+    "family_orbit_sizes",
+    "family_packets",
+    "interpretation",
+    "n",
+    "orbit_size_sum",
+    "path_length_counts",
+    "provenance",
+    "row_size",
+    "schema",
+    "selected_path_shape_counts",
+    "shared_endpoint_counts",
+    "source_artifacts",
+    "source_catalog_record",
+    "source_template_record",
+    "status",
+    "strict_edge_count",
+    "template_id",
+    "template_key",
+    "trust",
+}
+EXPECTED_FAMILY_PACKET_KEYS = {
+    "assignment_count",
+    "core_selected_rows",
+    "core_size",
+    "distance_equality",
+    "equality_chain",
+    "family_id",
+    "local_lemma",
+    "orbit_size",
+    "replay",
+    "source_family_record",
+    "strict_inequality",
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    """Append a mismatch error when values differ."""
+
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_source_payloads(
+    *,
+    self_edge_packet_path: Path = DEFAULT_SELF_EDGE_PACKET,
+    template_catalog_path: Path = DEFAULT_TEMPLATE_CATALOG,
+) -> dict[str, Any]:
+    """Load the source artifacts used by the focused T08 packet."""
+
+    return {
+        "self_edge_packet": load_artifact(_resolve(self_edge_packet_path)),
+        "template_catalog": load_artifact(_resolve(template_catalog_path)),
+    }
+
+
+def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
+    self_edge = source_payloads.get("self_edge_packet")
+    catalog = source_payloads.get("template_catalog")
+    if not isinstance(self_edge, dict):
+        errors.append("source self-edge template packet must be an object")
+    else:
+        errors.extend(
+            f"source self-edge template packet invalid: {error}"
+            for error in validate_self_edge_packet(self_edge, recompute=False)
+        )
+    if not isinstance(catalog, dict):
+        errors.append("source template lemma catalog must be an object")
+    else:
+        errors.extend(
+            f"source template lemma catalog invalid: {error}"
+            for error in validate_template_catalog(catalog, recompute=False)
+        )
+
+
+def _expected_payload(
+    source_payloads: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any] | None:
+    try:
+        return t08_self_edge_lemma_packet_payload(
+            source_payloads["self_edge_packet"],
+            source_payloads["template_catalog"],
+        )
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"source-bound T08 self-edge lemma packet failed: {exc}")
+        return None
+
+
+def _family_packets_by_id(payload: dict[str, Any], errors: list[str]) -> dict[str, dict[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        errors.append("family_packets must be a list")
+        return {}
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, "
+            f"got {len(packets)}"
+        )
+    by_id: dict[str, dict[str, Any]] = {}
+    for packet in packets:
+        if not isinstance(packet, dict):
+            errors.append("family_packets entries must be objects")
+            continue
+        family_id = str(packet.get("family_id"))
+        if family_id in by_id:
+            errors.append(f"duplicate family packet id: {family_id}")
+        by_id[family_id] = packet
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        errors.append(
+            f"family packet ids mismatch: expected {list(EXPECTED_FAMILY_IDS)!r}, "
+            f"got {sorted(by_id)!r}"
+        )
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS if family_id in by_id}
+
+
+def _validate_local_lemma(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    lemma = packet.get("local_lemma")
+    if not isinstance(lemma, dict):
+        errors.append(f"{family_id} local_lemma must be an object")
+        return
+    expect_equal(errors, f"{family_id} local_lemma review_status", lemma.get("review_status"), "review_pending")
+    selected_equalities = lemma.get("selected_distance_equalities")
+    expected_steps = len(EXPECTED_DISTANCE_EQUALITIES[family_id]["path"])
+    if not isinstance(selected_equalities, list) or len(selected_equalities) != expected_steps:
+        errors.append(
+            f"{family_id} local_lemma selected_distance_equalities must have "
+            f"{expected_steps} steps"
+        )
+    strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+    statement = str(lemma.get("strict_inequality_statement", ""))
+    for pair_value in (strict["outer_pair"], strict["inner_pair"]):
+        if str(pair_value) not in statement:
+            errors.append(f"{family_id} strict inequality statement must name {pair_value}")
+    hypothesis = str(lemma.get("hypothesis_scope", ""))
+    if "four listed selected rows" not in hypothesis:
+        errors.append(f"{family_id} local_lemma hypothesis must mention four selected rows")
+    contradiction = str(lemma.get("contradiction", ""))
+    if "reflexive strict edge" not in contradiction:
+        errors.append(f"{family_id} local_lemma contradiction must mention a reflexive strict edge")
+
+
+def _validate_replay(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    replay = packet.get("replay")
+    if not isinstance(replay, dict):
+        errors.append(f"{family_id} replay must be an object")
+        return
+    expect_equal(errors, f"{family_id} replay status", replay.get("status"), "self_edge")
+    expect_equal(
+        errors,
+        f"{family_id} replay selected_row_count",
+        replay.get("selected_row_count"),
+        EXPECTED_CORE_SIZE,
+    )
+    expect_equal(
+        errors,
+        f"{family_id} replay strict_edge_count",
+        replay.get("strict_edge_count"),
+        EXPECTED_STRICT_EDGE_COUNT,
+    )
+    expect_equal(
+        errors,
+        f"{family_id} replay self_edge_conflict_count",
+        replay.get("self_edge_conflict_count"),
+        EXPECTED_SELF_EDGE_CONFLICT_COUNT,
+    )
+    expect_equal(errors, f"{family_id} replay cycle_edge_count", replay.get("cycle_edge_count"), 0)
+    primary = replay.get("primary_self_edge_conflict")
+    if not isinstance(primary, dict):
+        errors.append(f"{family_id} replay primary_self_edge_conflict must be an object")
+        return
+    strict = EXPECTED_STRICT_INEQUALITIES[family_id]
+    for key in ("row", "witness_order", "outer_pair", "inner_pair", "outer_interval", "inner_interval"):
+        expect_equal(errors, f"{family_id} primary {key}", primary.get(key), strict[key])
+
+
+def _validate_family_packet(family_id: str, packet: dict[str, Any], errors: list[str]) -> None:
+    if set(packet) != EXPECTED_FAMILY_PACKET_KEYS:
+        errors.append(
+            f"{family_id} keys mismatch: expected {sorted(EXPECTED_FAMILY_PACKET_KEYS)!r}, "
+            f"got {sorted(packet)!r}"
+        )
+    expect_equal(errors, f"{family_id} family_id", packet.get("family_id"), family_id)
+    expect_equal(
+        errors,
+        f"{family_id} assignment_count",
+        packet.get("assignment_count"),
+        EXPECTED_FAMILY_ASSIGNMENT_COUNTS[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} orbit_size",
+        packet.get("orbit_size"),
+        EXPECTED_FAMILY_ORBIT_SIZES[family_id],
+    )
+    expect_equal(errors, f"{family_id} core_size", packet.get("core_size"), EXPECTED_CORE_SIZE)
+    expect_equal(
+        errors,
+        f"{family_id} core_selected_rows",
+        packet.get("core_selected_rows"),
+        [list(row) for row in EXPECTED_CORE_SELECTED_ROWS[family_id]],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} strict_inequality",
+        packet.get("strict_inequality"),
+        EXPECTED_STRICT_INEQUALITIES[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} distance_equality",
+        packet.get("distance_equality"),
+        EXPECTED_DISTANCE_EQUALITIES[family_id],
+    )
+    expect_equal(
+        errors,
+        f"{family_id} equality_chain",
+        packet.get("equality_chain"),
+        [list(item) for item in EXPECTED_EQUALITY_CHAINS[family_id]],
+    )
+    _validate_local_lemma(family_id, packet, errors)
+    _validate_replay(family_id, packet, errors)
+
+
+def validate_payload(
+    payload: Any,
+    *,
+    source_payloads: dict[str, Any] | None = None,
+    recompute: bool = True,
+) -> list[str]:
+    """Return validation errors for a focused T08/F02 local lemma packet."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+
+    if source_payloads is None:
+        try:
+            source_payloads = load_source_payloads()
+        except (OSError, json.JSONDecodeError) as exc:
+            return [f"could not load source artifacts: {exc}"]
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "cyclic_order": list(range(9)),
+        "template_id": "T08",
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": 18,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": 1,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": 18,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        expect_equal(errors, key, payload.get(key), expected)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list) or not all(
+        isinstance(item, str) for item in interpretation
+    ):
+        errors.append("interpretation must be a list of strings")
+    else:
+        if "No proof of the n=9 case is claimed." not in interpretation:
+            errors.append("interpretation must preserve the no-proof statement")
+        if not any("proof mining" in item for item in interpretation):
+            errors.append("interpretation must preserve the proof-mining scope")
+
+    for family_id, packet in _family_packets_by_id(payload, errors).items():
+        _validate_family_packet(family_id, packet, errors)
+
+    _validate_sources(source_payloads, errors)
+    expected_payload = None if errors else _expected_payload(source_payloads, errors)
+    if expected_payload is not None:
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            source_artifacts(
+                source_payloads["self_edge_packet"],
+                source_payloads["template_catalog"],
+            ),
+        )
+        expect_equal(
+            errors,
+            "source_template_record",
+            payload.get("source_template_record"),
+            expected_payload["source_template_record"],
+        )
+        expect_equal(
+            errors,
+            "source_catalog_record",
+            payload.get("source_catalog_record"),
+            expected_payload["source_catalog_record"],
+        )
+
+    try:
+        assert_expected_t08_self_edge_lemma_packet(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected T08 self-edge lemma packet counts failed: {exc}")
+
+    if recompute and expected_payload is not None and not errors:
+        expect_equal(errors, "T08 self-edge lemma packet", payload, expected_payload)
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    family_packets = object_payload.get("family_packets")
+    family_packets = family_packets if isinstance(family_packets, list) else []
+    replay_statuses = [
+        packet.get("replay", {}).get("status")
+        for packet in family_packets
+        if isinstance(packet, dict) and isinstance(packet.get("replay"), dict)
+    ]
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "template_id": object_payload.get("template_id"),
+        "assignment_count": object_payload.get("assignment_count"),
+        "family_count": object_payload.get("family_count"),
+        "family_ids": object_payload.get("family_ids"),
+        "core_size": object_payload.get("core_size"),
+        "replay_statuses": replay_statuses,
+        "strict_edge_count": object_payload.get("strict_edge_count"),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
+    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--self-edge-packet", type=Path, default=DEFAULT_SELF_EDGE_PACKET)
+    parser.add_argument("--template-catalog", type=Path, default=DEFAULT_TEMPLATE_CATALOG)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        sources = load_source_payloads(
+            self_edge_packet_path=args.self_edge_packet,
+            template_catalog_path=args.template_catalog,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        payload = t08_self_edge_lemma_packet_payload(
+            sources["self_edge_packet"],
+            sources["template_catalog"],
+        )
+        if args.assert_expected:
+            assert_expected_t08_self_edge_lemma_packet(payload)
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    try:
+        payload = load_artifact(artifact)
+        errors = validate_payload(
+            payload,
+            source_payloads=sources,
+            recompute=args.check or args.assert_expected,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        payload = {}
+        errors = [str(exc)]
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+    else:
+        print("n=9 vertex-circle T08/F02 self-edge local lemma packet")
+        print(f"artifact: {summary['artifact']}")
+        print(f"assignments: {summary['assignment_count']}")
+        print(f"families: {summary['family_ids']}")
+        print(f"core size: {summary['core_size']}")
+        if args.check or args.assert_expected:
+            print("OK: T08/F02 self-edge local lemma packet checks passed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -351,6 +351,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_t08_self_edge_lemma_packet",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused T08/F02 n=9 self-edge local lemma packet; "
+            "proof-mining scaffolding only, not a proof of n=9, "
+            "counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t10_strict_cycle_lemma_packet",
         command=(
             "python",

--- a/src/erdos97/n9_vertex_circle_local_lemmas.py
+++ b/src/erdos97/n9_vertex_circle_local_lemmas.py
@@ -134,6 +134,18 @@ EXPECTED_FOCUSED_NOTE_CROSSCHECK = (
         ),
     },
     {
+        "lemma_id": NESTED_SPOKE_LEMMA,
+        "template_id": "T08",
+        "family_ids": ["F02"],
+        "proof_note_path": "docs/n9-vertex-circle-t08-self-edge-lemma.md",
+        "source_kind": "focused_packet",
+        "crosscheck_mode": "alternate_self_edge_certificate",
+        "packet_key": "T08",
+        "packet_path": (
+            "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json"
+        ),
+    },
+    {
         "lemma_id": SHARED_ENDPOINT_LEMMA,
         "template_id": "T02",
         "family_ids": ["F01", "F04", "F08", "F14"],
@@ -694,8 +706,8 @@ def _assert_alternate_self_edge_certificate_match(
     ):
         if primary.get(key) != packet_strict.get(key):
             raise AssertionError(f"{family_id} focused packet primary conflict mismatch")
-    if template_id not in {"T01", "T05", "T06", "T07"}:
-        raise AssertionError("alternate self-edge certificate mode is currently T01/T05/T06/T07-only")
+    if template_id not in {"T01", "T05", "T06", "T07", "T08"}:
+        raise AssertionError("alternate self-edge certificate mode is currently T01/T05/T06/T07/T08-only")
 
 
 def _assert_packet_equality_path(

--- a/src/erdos97/n9_vertex_circle_t08_self_edge_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t08_self_edge_lemma_packet.py
@@ -1,0 +1,556 @@
+"""Build a focused T08/F02 n=9 self-edge local lemma packet.
+
+This module is proof-mining scaffolding. It does not prove the full n=9 case,
+does not claim a counterexample, and does not promote the review-pending n=9
+checker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.n9_vertex_circle_self_edge_path_join import validate_equality_path
+from erdos97.n9_vertex_circle_self_edge_template_packet import (
+    SCHEMA as SELF_EDGE_TEMPLATE_PACKET_SCHEMA,
+)
+from erdos97.n9_vertex_circle_template_lemma_catalog import (
+    SCHEMA as TEMPLATE_LEMMA_CATALOG_SCHEMA,
+)
+from erdos97.vertex_circle_quotient_replay import (
+    pair,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_t08_self_edge_lemma_packet.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Focused T08/F02 self-edge local lemma packet for eighteen n=9 frontier "
+    "assignments; proof-mining scaffolding only, not a proof of n=9, not a "
+    "counterexample, not an independent review of the exhaustive checker, and "
+    "not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py "
+        "--assert-expected --write"
+    ),
+}
+
+EXPECTED_TEMPLATE_ID = "T08"
+EXPECTED_TEMPLATE_KEY = "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+EXPECTED_FAMILY_ID = "F02"
+EXPECTED_FAMILY_IDS = (EXPECTED_FAMILY_ID,)
+EXPECTED_ASSIGNMENT_IDS = (
+    "A002",
+    "A012",
+    "A043",
+    "A050",
+    "A067",
+    "A084",
+    "A085",
+    "A086",
+    "A096",
+    "A106",
+    "A109",
+    "A122",
+    "A132",
+    "A134",
+    "A143",
+    "A149",
+    "A150",
+    "A159",
+)
+EXPECTED_ASSIGNMENT_COUNT = 18
+EXPECTED_FAMILY_COUNT = 1
+EXPECTED_ORBIT_SIZE_SUM = 18
+EXPECTED_CORE_SIZE = 6
+EXPECTED_STRICT_EDGE_COUNT = 54
+EXPECTED_SELF_EDGE_CONFLICT_COUNT = 9
+EXPECTED_CYCLE_EDGE_COUNT = 0
+EXPECTED_FAMILY_ASSIGNMENT_COUNTS = {"F02": 18}
+EXPECTED_FAMILY_ORBIT_SIZES = {"F02": 18}
+EXPECTED_PATH_LENGTH_COUNTS = {"5": 18}
+EXPECTED_SHARED_ENDPOINT_COUNTS = {"1": 18}
+EXPECTED_SELECTED_PATH_SHAPE_COUNTS = {"2:1:1:path=5": 18}
+EXPECTED_CORE_SELECTED_ROWS = {
+    "F02": (
+        (0, 1, 2, 3, 8),
+        (1, 0, 3, 4, 7),
+        (2, 1, 3, 5, 6),
+        (5, 2, 4, 6, 7),
+        (6, 1, 5, 7, 8),
+        (7, 0, 1, 4, 6),
+    ),
+}
+EXPECTED_STRICT_INEQUALITIES: dict[str, dict[str, Any]] = {
+    "F02": {
+        "row": 0,
+        "witness_order": [1, 2, 3, 8],
+        "outer_interval": [0, 2],
+        "inner_interval": [0, 1],
+        "outer_pair": [1, 3],
+        "inner_pair": [1, 2],
+        "outer_class": [0, 1],
+        "inner_class": [0, 1],
+        "outer_span": 2,
+        "inner_span": 1,
+    },
+}
+EXPECTED_DISTANCE_EQUALITIES: dict[str, dict[str, Any]] = {
+    "F02": {
+        "start_pair": [1, 3],
+        "end_pair": [1, 2],
+        "path": [
+            {"row": 1, "next_pair": [1, 7]},
+            {"row": 7, "next_pair": [6, 7]},
+            {"row": 6, "next_pair": [5, 6]},
+            {"row": 5, "next_pair": [2, 5]},
+            {"row": 2, "next_pair": [1, 2]},
+        ],
+    },
+}
+EXPECTED_EQUALITY_CHAINS = {
+    "F02": ([1, 3], [1, 7], [6, 7], [5, 6], [2, 5], [1, 2]),
+}
+
+
+def _template_record(packet: dict[str, Any]) -> dict[str, Any]:
+    templates = packet.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("self-edge template packet must contain templates")
+    for template in templates:
+        if isinstance(template, dict) and template.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return template
+    raise ValueError(f"missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _family_records_by_id(template: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    records = template.get("family_records")
+    if not isinstance(records, list):
+        raise ValueError(f"{EXPECTED_TEMPLATE_ID} must contain family_records")
+    by_id = {
+        str(record["family_id"]): record
+        for record in records
+        if isinstance(record, dict) and "family_id" in record
+    }
+    missing = [family_id for family_id in EXPECTED_FAMILY_IDS if family_id not in by_id]
+    if missing:
+        raise ValueError(f"missing T08 families: {missing!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def _catalog_record(catalog: dict[str, Any]) -> dict[str, Any]:
+    templates = catalog.get("templates")
+    if not isinstance(templates, list):
+        raise ValueError("template lemma catalog must contain templates")
+    for record in templates:
+        if isinstance(record, dict) and record.get("template_id") == EXPECTED_TEMPLATE_ID:
+            return record
+    raise ValueError(f"catalog missing template {EXPECTED_TEMPLATE_ID}")
+
+
+def _normalize_rows(rows: Sequence[Sequence[int]]) -> list[list[int]]:
+    return [[int(value) for value in row] for row in rows]
+
+
+def equality_chain(equality: Mapping[str, Any]) -> list[list[int]]:
+    """Return the pair chain traversed by a selected-distance equality path."""
+
+    chain = [[int(value) for value in pair(*equality["start_pair"])]]
+    for step in equality["path"]:
+        chain.append([int(value) for value in pair(*step["next_pair"])])
+    return chain
+
+
+def equality_steps(equality: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return row-labelled equality steps for the local lemma packet."""
+
+    current = [int(value) for value in pair(*equality["start_pair"])]
+    steps = []
+    for step in equality["path"]:
+        next_pair = [int(value) for value in pair(*step["next_pair"])]
+        steps.append(
+            {
+                "row": int(step["row"]),
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+    return steps
+
+
+def source_artifacts(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return embedded source-artifact metadata for the T08 packet."""
+
+    return [
+        {
+            "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+            "role": "source T08/F02 self-edge template record",
+            "schema": self_edge_packet.get("schema"),
+            "status": self_edge_packet.get("status"),
+            "trust": self_edge_packet.get("trust"),
+        },
+        {
+            "path": "data/certificates/n9_vertex_circle_template_lemma_catalog.json",
+            "role": "catalog crosswalk confirming T08 coverage and shape summary",
+            "schema": template_catalog.get("schema"),
+            "status": template_catalog.get("status"),
+            "trust": template_catalog.get("trust"),
+        },
+    ]
+
+
+def _primary_conflict(replay: dict[str, Any], strict: Mapping[str, Any]) -> dict[str, Any]:
+    for conflict in replay["self_edge_conflicts"]:
+        if (
+            conflict["row"] == strict["row"]
+            and conflict["outer_pair"] == strict["outer_pair"]
+            and conflict["inner_pair"] == strict["inner_pair"]
+        ):
+            return {
+                **conflict,
+                "outer_span": strict["outer_span"],
+                "inner_span": strict["inner_span"],
+            }
+    raise AssertionError("primary T08 self-edge conflict not found in replay")
+
+
+def _source_template_summary(template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_id": str(template["template_id"]),
+        "template_key": str(template["template_key"]),
+        "status": str(template["status"]),
+        "assignment_count": int(template["assignment_count"]),
+        "assignment_ids": list(template["assignment_ids"]),
+        "family_count": int(template["family_count"]),
+        "families": list(template["families"]),
+        "orbit_size_sum": int(template["orbit_size_sum"]),
+        "core_size": int(template["core_size"]),
+        "strict_edge_count": int(template["strict_edge_count"]),
+        "path_length_counts": template["path_length_counts"],
+        "shared_endpoint_counts": template["shared_endpoint_counts"],
+        "selected_path_shape_counts": template["selected_path_shape_counts"],
+        "self_edge_shape_counts": template["self_edge_shape_counts"],
+    }
+
+
+def _family_source_summary(family: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "family_id": str(family["family_id"]),
+        "template_id": str(family["template_id"]),
+        "status": str(family["status"]),
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "path_length": int(family["path_length"]),
+        "strict_inequality": family["strict_inequality"],
+        "distance_equality": family["distance_equality"],
+        "equality_chain": equality_chain(family["distance_equality"]),
+    }
+
+
+def _assert_source_records(
+    template: dict[str, Any],
+    families: Mapping[str, dict[str, Any]],
+    catalog_record: dict[str, Any],
+) -> None:
+    if template["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected template id")
+    if template["template_key"] != EXPECTED_TEMPLATE_KEY:
+        raise AssertionError("unexpected T08 template key")
+    if template["status"] != "self_edge":
+        raise AssertionError("T08 must remain a self-edge template")
+    if template["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("unexpected T08 assignment ids")
+    if template["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("unexpected T08 assignment count")
+    if template["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("unexpected T08 family list")
+    if template["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("unexpected T08 family count")
+    if template["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("unexpected T08 orbit-size sum")
+    if template["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected T08 core size")
+    if template["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("unexpected T08 strict-edge count")
+    if template["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("unexpected T08 path-length counts")
+    if template["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("unexpected T08 shared-endpoint counts")
+    if template["selected_path_shape_counts"] != EXPECTED_SELECTED_PATH_SHAPE_COUNTS:
+        raise AssertionError("unexpected T08 selected-path shape counts")
+
+    family = families[EXPECTED_FAMILY_ID]
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    strict = family["strict_inequality"]
+    validate_equality_path(rows, equality)
+    if family["family_id"] != EXPECTED_FAMILY_ID:
+        raise AssertionError("unexpected family id")
+    if family["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("family/template mismatch")
+    if family["status"] != "self_edge":
+        raise AssertionError("F02 must remain a self-edge record")
+    if family["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F02 assignment count")
+    if family["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F02 orbit size")
+    if family["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("unexpected F02 core size")
+    if rows != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS[EXPECTED_FAMILY_ID]):
+        raise AssertionError("unexpected F02 core rows")
+    if strict != EXPECTED_STRICT_INEQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F02 strict inequality")
+    if equality != EXPECTED_DISTANCE_EQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("unexpected F02 equality path")
+    expected_chain = [list(item) for item in EXPECTED_EQUALITY_CHAINS[EXPECTED_FAMILY_ID]]
+    if equality_chain(equality) != expected_chain:
+        raise AssertionError("unexpected F02 equality chain")
+    if strict["outer_pair"] != equality["start_pair"]:
+        raise AssertionError("F02 strict outer pair must start equality path")
+    if strict["inner_pair"] != equality["end_pair"]:
+        raise AssertionError("F02 strict inner pair must end equality path")
+
+    if catalog_record["template_id"] != EXPECTED_TEMPLATE_ID:
+        raise AssertionError("unexpected catalog template id")
+    if catalog_record["status"] != "self_edge":
+        raise AssertionError("unexpected catalog T08 status")
+    coverage = catalog_record["coverage"]
+    if coverage["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        raise AssertionError("catalog T08 assignment count mismatch")
+    if coverage["assignment_ids"] != list(EXPECTED_ASSIGNMENT_IDS):
+        raise AssertionError("catalog T08 assignment ids mismatch")
+    if coverage["families"] != list(EXPECTED_FAMILY_IDS):
+        raise AssertionError("catalog T08 family mismatch")
+    if coverage["family_count"] != EXPECTED_FAMILY_COUNT:
+        raise AssertionError("catalog T08 family count mismatch")
+    if coverage["orbit_size_sum"] != EXPECTED_ORBIT_SIZE_SUM:
+        raise AssertionError("catalog T08 orbit-size sum mismatch")
+    hypothesis = catalog_record["hypothesis_shape"]
+    if hypothesis["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("catalog T08 core-size mismatch")
+    if hypothesis["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("catalog T08 strict-edge mismatch")
+    if hypothesis["path_length_counts"] != EXPECTED_PATH_LENGTH_COUNTS:
+        raise AssertionError("catalog T08 path-length mismatch")
+    if hypothesis["shared_endpoint_counts"] != EXPECTED_SHARED_ENDPOINT_COUNTS:
+        raise AssertionError("catalog T08 shared-endpoint mismatch")
+    if hypothesis["selected_path_shape_counts"] != EXPECTED_SELECTED_PATH_SHAPE_COUNTS:
+        raise AssertionError("catalog T08 selected-path shape mismatch")
+
+
+def _family_local_lemma(strict: Mapping[str, Any], equality: Mapping[str, Any]) -> dict[str, Any]:
+    path_rows = [int(step["row"]) for step in equality["path"]]
+    return {
+        "packet_name": "T08/F02 self-edge local lemma packet",
+        "review_status": "review_pending",
+        "hypothesis_scope": (
+            "Natural cyclic order on labels 0..8 plus the four listed selected "
+            "rows; no claim is made about other n=9 templates."
+        ),
+        "selected_distance_equalities": equality_steps(equality),
+        "strict_inequality_statement": (
+            f"Row {strict['row']} has witness order {strict['witness_order']}, "
+            f"so the outer pair {strict['outer_pair']} strictly contains the "
+            f"inner pair {strict['inner_pair']} in that row's vertex-circle order."
+        ),
+        "equality_statement": (
+            f"Rows {path_rows} identify {equality['start_pair']} with "
+            f"{equality['end_pair']} in the selected-distance quotient."
+        ),
+        "contradiction": (
+            "The strict graph has a reflexive strict edge after selected-distance "
+            "quotienting."
+        ),
+    }
+
+
+def _family_packet(family: dict[str, Any]) -> dict[str, Any]:
+    rows = _normalize_rows(family["core_selected_rows"])
+    equality = family["distance_equality"]
+    strict = family["strict_inequality"]
+    replay_result = replay_vertex_circle_quotient(
+        n9.N,
+        list(n9.ORDER),
+        parse_selected_rows(rows),
+    )
+    replay = result_to_json(replay_result)
+    primary = _primary_conflict(replay, strict)
+    return {
+        "family_id": EXPECTED_FAMILY_ID,
+        "assignment_count": int(family["assignment_count"]),
+        "orbit_size": int(family["orbit_size"]),
+        "core_size": int(family["core_size"]),
+        "core_selected_rows": rows,
+        "strict_inequality": strict,
+        "distance_equality": equality,
+        "equality_chain": equality_chain(equality),
+        "local_lemma": _family_local_lemma(strict, equality),
+        "replay": {
+            "status": replay["status"],
+            "selected_row_count": replay["selected_row_count"],
+            "strict_edge_count": replay["strict_edge_count"],
+            "self_edge_conflict_count": len(replay["self_edge_conflicts"]),
+            "cycle_edge_count": len(replay["cycle_edges"]),
+            "primary_self_edge_conflict": primary,
+            "self_edge_conflicts": replay["self_edge_conflicts"],
+        },
+        "source_family_record": _family_source_summary(family),
+    }
+
+
+def t08_self_edge_lemma_packet_payload(
+    self_edge_packet: dict[str, Any],
+    template_catalog: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the focused review-pending T08/F02 local lemma packet."""
+
+    if self_edge_packet.get("schema") != SELF_EDGE_TEMPLATE_PACKET_SCHEMA:
+        raise ValueError("unexpected self-edge template packet schema")
+    if template_catalog.get("schema") != TEMPLATE_LEMMA_CATALOG_SCHEMA:
+        raise ValueError("unexpected template lemma catalog schema")
+
+    template = _template_record(self_edge_packet)
+    families = _family_records_by_id(template)
+    catalog_record = _catalog_record(template_catalog)
+    _assert_source_records(template, families, catalog_record)
+    family_packets = [_family_packet(families[EXPECTED_FAMILY_ID])]
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "family_packets": family_packets,
+        "source_template_record": _source_template_summary(template),
+        "source_catalog_record": catalog_record,
+        "interpretation": [
+            "This packet isolates the T08/F02 self-edge motif from existing review-pending n=9 diagnostics.",
+            "The family record has four local rows that force the displayed equality chain.",
+            "The family record has a vertex-circle strict inequality between the same quotient class.",
+            "The packet is intended for local lemma review and proof mining, not as a theorem name.",
+            "No proof of the n=9 case is claimed.",
+        ],
+        "source_artifacts": source_artifacts(self_edge_packet, template_catalog),
+        "provenance": PROVENANCE,
+    }
+    assert_expected_t08_self_edge_lemma_packet(payload)
+    return payload
+
+
+def _family_packets_by_id(payload: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    packets = payload.get("family_packets")
+    if not isinstance(packets, list):
+        raise AssertionError("family_packets must be a list")
+    if len(packets) != len(EXPECTED_FAMILY_IDS):
+        raise AssertionError(
+            f"family_packets length mismatch: expected {len(EXPECTED_FAMILY_IDS)}, got {len(packets)}"
+        )
+    by_id = {
+        str(packet["family_id"]): packet
+        for packet in packets
+        if isinstance(packet, dict) and "family_id" in packet
+    }
+    if len(by_id) != len(packets):
+        raise AssertionError("family_packets must not contain duplicate family ids")
+    if set(by_id) != set(EXPECTED_FAMILY_IDS):
+        raise AssertionError(f"unexpected family packet ids: {sorted(by_id)!r}")
+    return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS}
+
+
+def assert_expected_t08_self_edge_lemma_packet(payload: Mapping[str, Any]) -> None:
+    """Assert stable constants for the focused T08/F02 local lemma packet."""
+
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "cyclic_order": list(n9.ORDER),
+        "template_id": EXPECTED_TEMPLATE_ID,
+        "template_key": EXPECTED_TEMPLATE_KEY,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_ids": list(EXPECTED_ASSIGNMENT_IDS),
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "family_ids": list(EXPECTED_FAMILY_IDS),
+        "family_assignment_counts": EXPECTED_FAMILY_ASSIGNMENT_COUNTS,
+        "family_orbit_sizes": EXPECTED_FAMILY_ORBIT_SIZES,
+        "orbit_size_sum": EXPECTED_ORBIT_SIZE_SUM,
+        "core_size": EXPECTED_CORE_SIZE,
+        "strict_edge_count": EXPECTED_STRICT_EDGE_COUNT,
+        "path_length_counts": EXPECTED_PATH_LENGTH_COUNTS,
+        "shared_endpoint_counts": EXPECTED_SHARED_ENDPOINT_COUNTS,
+        "selected_path_shape_counts": EXPECTED_SELECTED_PATH_SHAPE_COUNTS,
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}")
+
+    packet = _family_packets_by_id(payload)[EXPECTED_FAMILY_ID]
+    if packet["assignment_count"] != EXPECTED_FAMILY_ASSIGNMENT_COUNTS[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F02 assignment count mismatch")
+    if packet["orbit_size"] != EXPECTED_FAMILY_ORBIT_SIZES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F02 orbit size mismatch")
+    if packet["core_size"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("F02 core size mismatch")
+    if packet["core_selected_rows"] != _normalize_rows(EXPECTED_CORE_SELECTED_ROWS[EXPECTED_FAMILY_ID]):
+        raise AssertionError("F02 core rows mismatch")
+    if packet["strict_inequality"] != EXPECTED_STRICT_INEQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F02 strict inequality mismatch")
+    if packet["distance_equality"] != EXPECTED_DISTANCE_EQUALITIES[EXPECTED_FAMILY_ID]:
+        raise AssertionError("F02 equality path mismatch")
+    if packet["equality_chain"] != [list(item) for item in EXPECTED_EQUALITY_CHAINS[EXPECTED_FAMILY_ID]]:
+        raise AssertionError("F02 equality chain mismatch")
+
+    replay = packet["replay"]
+    if replay["status"] != "self_edge":
+        raise AssertionError("F02 replay status mismatch")
+    if replay["selected_row_count"] != EXPECTED_CORE_SIZE:
+        raise AssertionError("F02 selected row count mismatch")
+    if replay["strict_edge_count"] != EXPECTED_STRICT_EDGE_COUNT:
+        raise AssertionError("F02 strict-edge count mismatch")
+    if replay["self_edge_conflict_count"] != EXPECTED_SELF_EDGE_CONFLICT_COUNT:
+        raise AssertionError("F02 self-edge conflict count mismatch")
+    if replay["cycle_edge_count"] != EXPECTED_CYCLE_EDGE_COUNT:
+        raise AssertionError("F02 cycle-edge count mismatch")
+    primary = replay["primary_self_edge_conflict"]
+    strict = EXPECTED_STRICT_INEQUALITIES[EXPECTED_FAMILY_ID]
+    for key in ("row", "witness_order", "outer_pair", "inner_pair", "outer_interval", "inner_interval"):
+        if primary[key] != strict[key]:
+            raise AssertionError(f"F02 primary conflict {key} mismatch")
+    lemma = packet["local_lemma"]
+    if lemma["review_status"] != "review_pending":
+        raise AssertionError("F02 local lemma review status mismatch")
+
+    if "No proof of the n=9 case is claimed." not in payload.get("interpretation", []):
+        raise AssertionError("interpretation must preserve the no-proof statement")

--- a/tests/test_n9_vertex_circle_local_lemmas.py
+++ b/tests/test_n9_vertex_circle_local_lemmas.py
@@ -28,6 +28,7 @@ from scripts.check_n9_vertex_circle_local_lemmas import (
     DEFAULT_T05_PACKET,
     DEFAULT_T06_PACKET,
     DEFAULT_T07_PACKET,
+    DEFAULT_T08_PACKET,
     DEFAULT_T10_PACKET,
     DEFAULT_T11_PACKET,
     DEFAULT_T12_PACKET,
@@ -195,6 +196,31 @@ def test_local_lemma_scan_counts_and_scope(payload: dict[str, object]) -> None:
             "check_status": "checked",
             "families_checked": [
                 {"family_id": "F06", "assignment_count": 18, "orbit_size": 18},
+            ],
+            "covered_assignment_count": 18,
+            "interpretation": (
+                "Aggregate scan family rows match the focused packet, and the "
+                "focused packet supplies a valid alternate reflexive self-edge "
+                "certificate for the same family. The aggregate nested-spoke "
+                "strict edge is not required to be the same strict edge as the "
+                "proof-facing note; this remains a packet consistency check, not "
+                "an independent n=9 completeness proof."
+            ),
+        },
+        {
+            "lemma_id": NESTED_SPOKE_LEMMA,
+            "template_id": "T08",
+            "family_ids": ["F02"],
+            "proof_note_path": "docs/n9-vertex-circle-t08-self-edge-lemma.md",
+            "source_kind": "focused_packet",
+            "crosscheck_mode": "alternate_self_edge_certificate",
+            "packet_key": "T08",
+            "packet_path": (
+                "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json"
+            ),
+            "check_status": "checked",
+            "families_checked": [
+                {"family_id": "F02", "assignment_count": 18, "orbit_size": 18},
             ],
             "covered_assignment_count": 18,
             "interpretation": (
@@ -603,6 +629,7 @@ def test_focused_packet_crosscheck_rejects_t01_path_drift() -> None:
                 "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T06": load_artifact(DEFAULT_T06_PACKET),
                 "T07": load_artifact(DEFAULT_T07_PACKET),
+                "T08": load_artifact(DEFAULT_T08_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -628,6 +655,7 @@ def test_focused_packet_crosscheck_rejects_t05_path_drift() -> None:
                 "T05": t05_packet,
                 "T06": load_artifact(DEFAULT_T06_PACKET),
                 "T07": load_artifact(DEFAULT_T07_PACKET),
+                "T08": load_artifact(DEFAULT_T08_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -653,6 +681,7 @@ def test_focused_packet_crosscheck_rejects_t06_path_drift() -> None:
                 "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T06": t06_packet,
                 "T07": load_artifact(DEFAULT_T07_PACKET),
+                "T08": load_artifact(DEFAULT_T08_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -678,6 +707,33 @@ def test_focused_packet_crosscheck_rejects_t07_path_drift() -> None:
                 "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T06": load_artifact(DEFAULT_T06_PACKET),
                 "T07": t07_packet,
+                "T08": load_artifact(DEFAULT_T08_PACKET),
+                "T10": load_artifact(DEFAULT_T10_PACKET),
+                "T11": load_artifact(DEFAULT_T11_PACKET),
+                "T12": load_artifact(DEFAULT_T12_PACKET),
+            },
+        )
+
+
+def test_focused_packet_crosscheck_rejects_t08_path_drift() -> None:
+    self_edge_packet = load_artifact(DEFAULT_SELF_EDGE_PACKET)
+    strict_cycle_packet = load_artifact(DEFAULT_STRICT_CYCLE_PACKET)
+    t08_packet = load_artifact(DEFAULT_T08_PACKET)
+    t08_packet["family_packets"][0]["distance_equality"]["path"][0]["next_pair"] = [0, 1]
+
+    with pytest.raises(AssertionError, match="F02 focused packet equality path step mismatch"):
+        local_lemma_scan_payload(
+            self_edge_packet,
+            strict_cycle_packet,
+            focused_packets={
+                "T01": load_artifact(DEFAULT_T01_PACKET),
+                "T02": load_artifact(DEFAULT_T02_PACKET),
+                "T03": load_artifact(DEFAULT_T03_PACKET),
+                "T04": load_artifact(DEFAULT_T04_PACKET),
+                "T05": load_artifact(DEFAULT_T05_PACKET),
+                "T06": load_artifact(DEFAULT_T06_PACKET),
+                "T07": load_artifact(DEFAULT_T07_PACKET),
+                "T08": t08_packet,
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -703,6 +759,7 @@ def test_focused_packet_crosscheck_rejects_t02_path_drift() -> None:
                 "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T06": load_artifact(DEFAULT_T06_PACKET),
                 "T07": load_artifact(DEFAULT_T07_PACKET),
+                "T08": load_artifact(DEFAULT_T08_PACKET),
                 "T10": load_artifact(DEFAULT_T10_PACKET),
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),
@@ -753,6 +810,7 @@ def test_focused_packet_crosscheck_rejects_t10_replay_status_drift() -> None:
                 "T05": load_artifact(DEFAULT_T05_PACKET),
                 "T06": load_artifact(DEFAULT_T06_PACKET),
                 "T07": load_artifact(DEFAULT_T07_PACKET),
+                "T08": load_artifact(DEFAULT_T08_PACKET),
                 "T10": t10_packet,
                 "T11": load_artifact(DEFAULT_T11_PACKET),
                 "T12": load_artifact(DEFAULT_T12_PACKET),

--- a/tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import copy
+
+from erdos97.n9_vertex_circle_t08_self_edge_lemma_packet import (
+    assert_expected_t08_self_edge_lemma_packet,
+)
+from scripts.check_n9_vertex_circle_t08_self_edge_lemma_packet import (
+    DEFAULT_ARTIFACT,
+    load_artifact,
+    load_source_payloads,
+    summary_payload,
+    validate_payload,
+)
+
+
+def _family_packet(payload: dict[str, object]) -> dict[str, object]:
+    packets = payload["family_packets"]  # type: ignore[index]
+    assert isinstance(packets, list)
+    assert len(packets) == 1
+    return packets[0]  # type: ignore[return-value]
+
+
+def _template_record(source_payloads: dict[str, object]) -> dict[str, object]:
+    for template in source_payloads["self_edge_packet"]["templates"]:  # type: ignore[index]
+        if template["template_id"] == "T08":
+            return template
+    raise AssertionError("missing T08 template")
+
+
+def test_t08_self_edge_lemma_packet_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_t08_self_edge_lemma_packet(payload)
+    assert payload["status"] == "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "proof-mining scaffolding only" in payload["claim_scope"]
+    assert "not a proof of n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not an independent review" in payload["claim_scope"]
+    assert payload["template_id"] == "T08"
+    assert payload["template_key"] == "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+    assert payload["assignment_count"] == 18
+    assert payload["assignment_ids"] == [
+        "A002",
+        "A012",
+        "A043",
+        "A050",
+        "A067",
+        "A084",
+        "A085",
+        "A086",
+        "A096",
+        "A106",
+        "A109",
+        "A122",
+        "A132",
+        "A134",
+        "A143",
+        "A149",
+        "A150",
+        "A159",
+    ]
+    assert payload["family_count"] == 1
+    assert payload["family_ids"] == ["F02"]
+    assert payload["family_assignment_counts"] == {"F02": 18}
+    assert payload["family_orbit_sizes"] == {"F02": 18}
+    assert payload["orbit_size_sum"] == 18
+    assert payload["core_size"] == 6
+    assert payload["strict_edge_count"] == 54
+    assert payload["path_length_counts"] == {"5": 18}
+    assert payload["shared_endpoint_counts"] == {"1": 18}
+    assert payload["selected_path_shape_counts"] == {"2:1:1:path=5": 18}
+
+
+def test_t08_self_edge_lemma_packet_records_expected_local_shape() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+
+    assert packet["family_id"] == "F02"
+    assert packet["core_selected_rows"] == [
+        [0, 1, 2, 3, 8],
+        [1, 0, 3, 4, 7],
+        [2, 1, 3, 5, 6],
+        [5, 2, 4, 6, 7],
+        [6, 1, 5, 7, 8],
+        [7, 0, 1, 4, 6],
+    ]
+    assert packet["strict_inequality"]["row"] == 0  # type: ignore[index]
+    assert packet["strict_inequality"]["witness_order"] == [1, 2, 3, 8]  # type: ignore[index]
+    assert packet["strict_inequality"]["outer_pair"] == [1, 3]  # type: ignore[index]
+    assert packet["strict_inequality"]["inner_pair"] == [1, 2]  # type: ignore[index]
+    assert packet["strict_inequality"]["inner_interval"] == [0, 1]  # type: ignore[index]
+    assert packet["equality_chain"] == [[1, 3], [1, 7], [6, 7], [5, 6], [2, 5], [1, 2]]
+    assert packet["local_lemma"]["review_status"] == "review_pending"  # type: ignore[index]
+    assert "four listed selected rows" in packet["local_lemma"]["hypothesis_scope"]  # type: ignore[index]
+    assert packet["replay"]["status"] == "self_edge"  # type: ignore[index]
+    assert packet["replay"]["selected_row_count"] == 6  # type: ignore[index]
+    assert packet["replay"]["strict_edge_count"] == 54  # type: ignore[index]
+    assert packet["replay"]["self_edge_conflict_count"] == 9  # type: ignore[index]
+    assert packet["replay"]["cycle_edge_count"] == 0  # type: ignore[index]
+    assert packet["replay"]["primary_self_edge_conflict"]["row"] == 0  # type: ignore[index]
+
+
+def test_t08_self_edge_lemma_packet_checker_passes_lightweight() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload, recompute=False)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["template_id"] == "T08"
+    assert summary["family_count"] == 1
+    assert summary["assignment_count"] == 18
+    assert summary["replay_statuses"] == ["self_edge"]
+
+
+def test_t08_self_edge_lemma_packet_rejects_tampered_equality_path() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+    packet["distance_equality"]["path"][0]["next_pair"] = [3, 6]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F02 distance_equality mismatch" in error for error in errors)
+    assert any("expected T08 self-edge lemma packet" in error for error in errors)
+
+
+def test_t08_self_edge_lemma_packet_rejects_tampered_strict_row() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+    packet["strict_inequality"]["row"] = 1  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F02 strict_inequality mismatch" in error for error in errors)
+
+
+def test_t08_self_edge_lemma_packet_rejects_wrong_conflict_count() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _family_packet(payload)
+    packet["replay"]["self_edge_conflict_count"] = 1  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("F02 replay self_edge_conflict_count mismatch" in error for error in errors)
+
+
+def test_t08_self_edge_lemma_packet_rejects_missing_no_proof_note() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["interpretation"] = [
+        item for item in payload["interpretation"] if item != "No proof of the n=9 case is claimed."
+    ]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("no-proof" in error for error in errors)
+
+
+def test_t08_self_edge_lemma_packet_detects_source_packet_mismatch() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    sources = copy.deepcopy(load_source_payloads())
+    template = _template_record(sources)
+    template["family_records"][0]["strict_inequality"]["row"] = 1
+
+    errors = validate_payload(payload, source_payloads=sources, recompute=False)
+
+    assert any(
+        "source self-edge template packet invalid" in error
+        or "source-bound T08 self-edge lemma packet failed" in error
+        for error in errors
+    )


### PR DESCRIPTION
## Summary

- add a focused review-pending T08/F02 self-edge local lemma packet, checker, tests, and generated JSON artifact
- wire the T08 packet into the aggregate n=9 local-lemma scan as an alternate nested-spoke self-edge certificate for F02
- update audit wiring, provenance metadata, and proof-mining docs without changing the repo/global Erdos #97 status

## Verification

- `python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --assert-expected --write --check --json`
- `python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemmas.py --assert-expected --write --check --json`
- `python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py tests/test_n9_vertex_circle_local_lemmas.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (879 passed, 285 deselected)

`make verify-n9-review` could not be run locally because this Windows shell does not have `make` installed; the new underlying T08 and aggregate local-lemma artifact commands passed directly.