### PR TITLE
Add simple local-lemma replay artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -431,9 +431,17 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t06_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t07_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/data/certificates/n9_vertex_circle_local_lemma_simple_replay.json
+++ b/data/certificates/n9_vertex_circle_local_lemma_simple_replay.json
@@ -1,0 +1,224 @@
+{
+  "claim_scope": "Second-source packet-level audit for the aggregate n=9 vertex-circle local-lemma coverage. This is not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "coverage_summary": {
+    "covered_assignment_count": 184,
+    "covered_family_count": 16,
+    "expected_assignment_count": 184,
+    "expected_family_count": 16,
+    "self_edge_assignment_count": 158,
+    "self_edge_family_count": 13,
+    "strict_cycle_assignment_count": 26,
+    "strict_cycle_family_count": 3
+  },
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ],
+  "interpretation": "A passed audit says the stored local packet records contain enough data to replay their local reflexive strict-edge or strict-cycle contradictions without the quotient-replay helper. It does not certify that the packet family list is complete for n=9.",
+  "method": "Packet-level replay from selected rows, stored equality paths, and stored cyclic interval strict inequalities; this module does not call the quotient-replay helper or enumerate assignments.",
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_local_lemma_simple_replay.py"
+  },
+  "schema": "erdos97.n9_vertex_circle_local_lemma_simple_replay.v1",
+  "self_edge": {
+    "assignment_count": 158,
+    "family_count": 13,
+    "records": [
+      {
+        "assignment_count": 6,
+        "core_size": 3,
+        "family_id": "F09",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 6,
+        "replayed_step_count": 3,
+        "template_id": "T01",
+        "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:0x1,3:1:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 3,
+        "family_id": "F01",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 3,
+        "template_id": "T02",
+        "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 3,
+        "family_id": "F04",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 3,
+        "template_id": "T02",
+        "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+      },
+      {
+        "assignment_count": 2,
+        "core_size": 3,
+        "family_id": "F08",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 2,
+        "replayed_step_count": 3,
+        "template_id": "T02",
+        "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+      },
+      {
+        "assignment_count": 2,
+        "core_size": 3,
+        "family_id": "F14",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 2,
+        "replayed_step_count": 3,
+        "template_id": "T02",
+        "template_key": "self_edge|rows=3|strict_edges=27|conflicts=3:1:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 4,
+        "family_id": "F05",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 3,
+        "template_id": "T03",
+        "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+      },
+      {
+        "assignment_count": 2,
+        "core_size": 4,
+        "family_id": "F15",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 2,
+        "replayed_step_count": 3,
+        "template_id": "T03",
+        "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x1"
+      },
+      {
+        "assignment_count": 2,
+        "core_size": 4,
+        "family_id": "F13",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 2,
+        "replayed_step_count": 3,
+        "template_id": "T04",
+        "template_key": "self_edge|rows=4|strict_edges=36|conflicts=2:1:1x2"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 4,
+        "family_id": "F10",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 3,
+        "template_id": "T05",
+        "template_key": "self_edge|rows=4|strict_edges=36|conflicts=3:1:0x1,3:1:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 5,
+        "family_id": "F11",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 4,
+        "template_id": "T06",
+        "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x1,3:1:0x1,3:1:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 5,
+        "family_id": "F06",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 4,
+        "template_id": "T07",
+        "template_key": "self_edge|rows=5|strict_edges=45|conflicts=2:1:1x3,3:1:0x1,3:1:1x1,3:2:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 6,
+        "family_id": "F02",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 5,
+        "template_id": "T08",
+        "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x4,3:1:0x2,3:1:1x2,3:2:1x1"
+      },
+      {
+        "assignment_count": 18,
+        "core_size": 6,
+        "family_id": "F03",
+        "obstruction_kind": "reflexive_strict_edge",
+        "orbit_size": 18,
+        "replayed_step_count": 6,
+        "template_id": "T09",
+        "template_key": "self_edge|rows=6|strict_edges=54|conflicts=2:1:1x5,3:1:0x2,3:1:1x4,3:2:1x2"
+      }
+    ]
+  },
+  "source_artifacts": [
+    {
+      "path": "data/certificates/n9_vertex_circle_self_edge_template_packet.json",
+      "role": "source self-edge template packet",
+      "schema": "erdos97.n9_vertex_circle_self_edge_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_strict_cycle_template_packet.json",
+      "role": "source strict-cycle template packet",
+      "schema": "erdos97.n9_vertex_circle_strict_cycle_template_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "REVIEW_PENDING_PACKET_AUDIT",
+  "strict_cycle": {
+    "assignment_count": 26,
+    "family_count": 3,
+    "records": [
+      {
+        "assignment_count": 18,
+        "core_size": 4,
+        "family_id": "F12",
+        "obstruction_kind": "directed_strict_cycle",
+        "orbit_size": 18,
+        "replayed_step_count": 2,
+        "template_id": "T10",
+        "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=2|spans=2:1x2"
+      },
+      {
+        "assignment_count": 6,
+        "core_size": 4,
+        "family_id": "F07",
+        "obstruction_kind": "directed_strict_cycle",
+        "orbit_size": 6,
+        "replayed_step_count": 3,
+        "template_id": "T11",
+        "template_key": "strict_cycle|rows=4|strict_edges=36|cycle=3|spans=2:1x1,3:1x1,3:2x1"
+      },
+      {
+        "assignment_count": 2,
+        "core_size": 6,
+        "family_id": "F16",
+        "obstruction_kind": "directed_strict_cycle",
+        "orbit_size": 2,
+        "replayed_step_count": 3,
+        "template_id": "T12",
+        "template_key": "strict_cycle|rows=6|strict_edges=54|cycle=3|spans=3:1x3"
+      }
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": [],
+  "validation_status": "passed"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -21,9 +21,11 @@ Use this queue when no more specific issue is selected.
    focused T01/T02/T03/T04/T05/T06/T07/T08/T09 self-edge packets and the focused T10/T11/T12
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
    than an `n=9` proof.
-2. Audit whether the aggregate local-template coverage can be checked from the
-   stored packet JSON by a second, simpler replay that does not share the
-   current quotient-replay helper.
+2. Use the stored simple replay artifact
+   `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` as a
+   reviewer-facing input for the aggregate local-template coverage. The replay
+   checks the packet JSON without sharing the main quotient-replay helper, but
+   it is still a packet audit rather than an `n=9` proof.
 3. Strengthen the minimal fragile-cover bridge with one geometric necessary
    condition and test it against the block-6 negative controls.
 4. Use the bootstrap-core crosswalk and the bootstrap / vertex-circle overlay

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -546,6 +546,15 @@ strict-cycle records: each strict edge + equality path to the next outer pair
 coverage counts:     13 self-edge families and 3 strict-cycle families
 ```
 
+The stored audit artifact is
+`data/certificates/n9_vertex_circle_local_lemma_simple_replay.json`; regenerate
+and check it with:
+
+```bash
+python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --assert-expected --write
+python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
+```
+
 For a self-edge family, the replay verifies that every equality-path step is a
 selected-distance equality in the named row, that the stored outer and inner
 pairs are the endpoints of nested intervals in the row's cyclic witness order,

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -185,6 +185,9 @@ Next steps:
 - review the aggregate local-lemma scan after the T01/T02/T03/T04/T05/T06/T07/T08/T09
   self-edge and T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
   coverage of stored packets rather than an independent `n=9` proof;
+- use `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` to
+  replay the aggregate local-template coverage from stored packet JSON without
+  sharing the main quotient-replay helper;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -722,6 +722,42 @@ artifacts:
       - the local-lemma scan is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_local_lemma_simple_replay
+    path: data/certificates/n9_vertex_circle_local_lemma_simple_replay.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_local_lemma_simple_replay.py
+    command: python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_local_lemma_simple_replay.py
+    check_command: python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Second-source packet-level audit for aggregate n=9 vertex-circle local-lemma coverage; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_local_lemma_simple_replay.v1
+      status: REVIEW_PENDING_PACKET_AUDIT
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      n: 9
+      validation_status: passed
+      coverage_summary.covered_family_count: 16
+      coverage_summary.covered_assignment_count: 184
+      coverage_summary.self_edge_family_count: 13
+      coverage_summary.self_edge_assignment_count: 158
+      coverage_summary.strict_cycle_family_count: 3
+      coverage_summary.strict_cycle_assignment_count: 26
+      coverage_summary.expected_family_count: 16
+      coverage_summary.expected_assignment_count: 184
+      provenance.command: python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --assert-expected --write
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the simple replay audit is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t01_self_edge_lemma_packet
     path: data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_vertex_circle_local_lemma_simple_replay.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_simple_replay.py
@@ -25,11 +25,29 @@ DEFAULT_SELF_EDGE_PACKET = (
 DEFAULT_STRICT_CYCLE_PACKET = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
 )
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_local_lemma_simple_replay.json"
+)
 
 
 def load_artifact(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
 
 
 def replay_payload(
@@ -41,6 +59,45 @@ def replay_payload(
         load_artifact(self_edge_packet_path),
         load_artifact(strict_cycle_packet_path),
     )
+
+
+def validate_artifact_payload(payload: Any, expected_payload: dict[str, Any]) -> list[str]:
+    """Return validation errors for a stored simple-replay artifact."""
+
+    if not isinstance(payload, dict):
+        return ["artifact top level must be a JSON object"]
+    errors: list[str] = []
+    try:
+        assert_expected_simple_packet_replay(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"expected simple-replay payload failed: {exc}")
+    if payload != expected_payload:
+        errors.append("simple-replay payload mismatch")
+    return errors
+
+
+def summary_payload(path: Path, payload: Any, errors: list[str]) -> dict[str, Any]:
+    """Return a compact checker summary."""
+
+    object_payload = payload if isinstance(payload, dict) else {}
+    coverage = object_payload.get("coverage_summary", {})
+    if not isinstance(coverage, dict):
+        coverage = {}
+    return {
+        "ok": not errors,
+        "artifact": str(path.relative_to(ROOT)) if path.is_relative_to(ROOT) else str(path),
+        "schema": object_payload.get("schema"),
+        "status": object_payload.get("status"),
+        "trust": object_payload.get("trust"),
+        "validation_status": object_payload.get("validation_status"),
+        "covered_family_count": coverage.get("covered_family_count"),
+        "covered_assignment_count": coverage.get("covered_assignment_count"),
+        "self_edge_family_count": coverage.get("self_edge_family_count"),
+        "self_edge_assignment_count": coverage.get("self_edge_assignment_count"),
+        "strict_cycle_family_count": coverage.get("strict_cycle_family_count"),
+        "strict_cycle_assignment_count": coverage.get("strict_cycle_assignment_count"),
+        "validation_errors": list(errors),
+    }
 
 
 def summary_lines(payload: dict[str, Any]) -> list[str]:
@@ -86,10 +143,13 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_STRICT_CYCLE_PACKET,
         help="Path to n9 strict-cycle template packet JSON.",
     )
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true", help="Write generated artifact.")
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Exit nonzero when packet-level replay validation fails.",
+        help="Validate the stored artifact against freshly replayed packet data.",
     )
     parser.add_argument(
         "--assert-expected",
@@ -99,12 +159,52 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
     args = parser.parse_args(argv)
 
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
     payload = replay_payload(
-        self_edge_packet_path=args.self_edge_packet,
-        strict_cycle_packet_path=args.strict_cycle_packet,
+        self_edge_packet_path=_resolve(args.self_edge_packet),
+        strict_cycle_packet_path=_resolve(args.strict_cycle_packet),
     )
     if args.assert_expected:
         assert_expected_simple_packet_replay(payload)
+
+    if args.write:
+        write_json(payload, out)
+        if not args.check:
+            if args.json:
+                print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
+            else:
+                print(f"wrote {out.relative_to(ROOT)}")
+            return 0
+
+    if args.check:
+        try:
+            stored_payload = load_artifact(artifact)
+            errors = validate_artifact_payload(stored_payload, payload)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            stored_payload = {}
+            errors = [str(exc)]
+
+        if args.json:
+            print(json.dumps(summary_payload(artifact, stored_payload, errors), indent=2, sort_keys=True))
+        elif errors:
+            print(f"FAILED: {artifact}", file=sys.stderr)
+            for error in errors:
+                print(f"- {error}", file=sys.stderr)
+        else:
+            for line in summary_lines(stored_payload):
+                print(line)
+            print("OK: simple packet replay artifact checks passed")
+        return 1 if errors else 0
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -114,8 +214,6 @@ def main(argv: list[str] | None = None) -> int:
         for error in payload["validation_errors"]:
             print(f"error[{error['scope']}]: {error['error']}")
 
-    if args.check and payload["validation_status"] != "passed":
-        return 1
     return 0
 
 

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -246,6 +246,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_local_lemma_simple_replay",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_local_lemma_simple_replay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Second-source packet-level audit for aggregate n=9 vertex-circle "
+            "local-lemma coverage; not a proof of n=9, counterexample, or "
+            "independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t01_self_edge_lemma_packet",
         command=(
             "python",

--- a/src/erdos97/n9_vertex_circle_local_lemma_simple_replay.py
+++ b/src/erdos97/n9_vertex_circle_local_lemma_simple_replay.py
@@ -19,6 +19,13 @@ CLAIM_SCOPE = (
     "not an independent review of the exhaustive checker, and not a global "
     "status update."
 )
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_local_lemma_simple_replay.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py "
+        "--assert-expected --write"
+    ),
+}
 
 EXPECTED_SELF_EDGE_ASSIGNMENT_COUNT = 158
 EXPECTED_SELF_EDGE_FAMILY_COUNT = 13
@@ -133,6 +140,7 @@ def simple_packet_replay_payload(
             "contradictions without the quotient-replay helper. It does not "
             "certify that the packet family list is complete for n=9."
         ),
+        "provenance": dict(PROVENANCE),
     }
 
 
@@ -145,6 +153,8 @@ def assert_expected_simple_packet_replay(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"status mismatch: {payload.get('status')!r}")
     if payload.get("trust") != TRUST:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
     claim_scope = str(payload.get("claim_scope", ""))
     for forbidden in ("proof of n=9", "counterexample", "global status update"):
         if f"not a {forbidden}" not in claim_scope and f"not an {forbidden}" not in claim_scope:


### PR DESCRIPTION
## Summary

- add a stored second-source simple replay JSON artifact for the aggregate n=9 vertex-circle local-lemma packets
- extend the simple replay CLI with `--write`, `--out`, and stored-artifact `--check` support while keeping it independent of the quotient replay helper
- wire the audit into `verify-n9-review`, artifact audit, provenance metadata, and review/backlog docs without changing repo/global status

## Verification

- `python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --assert-expected --write --check --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_simple_replay.py -q` (6 passed)
- `python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python -m pytest -q` (888 passed, 285 deselected)

`make verify-n9-review` could not be run locally because this Windows shell does not have `make` installed; the newly added simple replay command and its neighboring aggregate local-lemma command passed directly.