### PR TITLE
Add block6 vertex-circle extension audit artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ verify-n9-review:
 
 verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+	$(PYTHON) scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json
 
 verify-n10-review:
 	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For a partial bridge theorem from minimality to fragile-cover witness
   systems, read
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
+- For the first stored geometric gate on the block-6 fragile-cover negative
+  control, read
+  [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).
 - For the rich-triple closure / bootstrap-core bridge fork, read
   [`docs/bootstrap-core-bridge.md`](docs/bootstrap-core-bridge.md).
 - For the bootstrap-core rank/capacity crosswalk on current fixed-row
@@ -463,6 +466,8 @@ python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json
 python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json
 python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
 python scripts/check_n9_base_apex_d3_artifact_join.py --check --json
+python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+python scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json
 ```

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -121,6 +121,14 @@ block-6 fragile cover but still permits two disjoint blocks, so this is a
 necessary structural bridge only, not a contradiction and not the open
 ear-orderable bridge. See `docs/minimal-fragile-cover-bridge.md`.
 
+The stored block-6 vertex-circle full-extension audit adds a stronger geometric
+gate for that same two-block negative control in the natural cyclic order: all
+full selected-row extensions are closed by vertex-circle quotient self-edge or
+strict-cycle obstructions. This rejects one abstract family that passes the
+fragile-cover hypergraph and full-extension checks, but it is still not an
+all-order/all-extension bridge proof. See
+`docs/block6-fragile-vertex-circle-extension-audit.md`.
+
 ### Bootstrap-core bridge
 
 Status: `LEMMA` / bridge fork.

--- a/STATE.md
+++ b/STATE.md
@@ -44,6 +44,13 @@ from exact critical 4-ties. This is necessary structure only; the block-6
 abstract family shows that fragile-cover hypergraph constraints alone are too
 weak. See `docs/minimal-fragile-cover-bridge.md`.
 
+A stored block-6 vertex-circle full-extension audit adds one geometric gate to
+that negative control: in the natural cyclic order, the two-block block-6
+family has no full selected-row extension surviving the vertex-circle quotient
+self-edge / strict-cycle filter. This is still a natural-order diagnostic, not
+an all-order/all-extension bridge proof. See
+`docs/block6-fragile-vertex-circle-extension-audit.md`.
+
 A separate rich-triple closure bridge records that ear-orderability is
 equivalent to bootstrap rank at most 3. Failure of that rank condition yields
 inclusion-minimal generating cores with deletion closures, private halos, and a

--- a/data/certificates/block6_fragile_vertex_circle_extension_audit.json
+++ b/data/certificates/block6_fragile_vertex_circle_extension_audit.json
@@ -1,0 +1,66 @@
+{
+  "claim_scope": "Two-block block-6 fragile-cover extension audit in the natural cyclic order; not a proof of Erdos Problem #97 and not a counterexample.",
+  "cyclic_order": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11
+  ],
+  "fixed_rows": {
+    "0": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "3": [
+      0,
+      2,
+      4,
+      5
+    ],
+    "6": [
+      7,
+      8,
+      9,
+      10
+    ],
+    "9": [
+      6,
+      8,
+      10,
+      11
+    ]
+  },
+  "n": 12,
+  "pair_cap": 2,
+  "provenance": {
+    "command": "python scripts/check_block6_fragile_vertex_circle_extension.py --assert-expected --write",
+    "generator": "scripts/check_block6_fragile_vertex_circle_extension.py"
+  },
+  "pruned_search": {
+    "initial_vc": "ok",
+    "max_nodes": 2000000,
+    "nodes": 1752,
+    "result": "closed",
+    "solutions": 0,
+    "vc_prunes": {
+      "self_edge": 645,
+      "strict_cycle": 768
+    },
+    "zero_option_prunes": 37
+  },
+  "row_size": 4,
+  "schema": "erdos97.block6_fragile_vertex_circle_extension_audit.v1",
+  "selected_indegree_cap": 7,
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/block6-fragile-vertex-circle-extension-audit.md
+++ b/docs/block6-fragile-vertex-circle-extension-audit.md
@@ -80,8 +80,23 @@ Reproduce the pruned audit with:
 
 ```bash
 python scripts/check_block6_fragile_vertex_circle_extension.py \
+  --check \
   --assert-expected \
   --json
+```
+
+The checked artifact is:
+
+```text
+data/certificates/block6_fragile_vertex_circle_extension_audit.json
+```
+
+Rewrite it after an intentional generator change with:
+
+```bash
+python scripts/check_block6_fragile_vertex_circle_extension.py \
+  --assert-expected \
+  --write
 ```
 
 The audit reported:

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -26,8 +26,13 @@ Use this queue when no more specific issue is selected.
    reviewer-facing input for the aggregate local-template coverage. The replay
    checks the packet JSON without sharing the main quotient-replay helper, but
    it is still a packet audit rather than an `n=9` proof.
-3. Strengthen the minimal fragile-cover bridge with one geometric necessary
-   condition and test it against the block-6 negative controls.
+3. Continue the minimal fragile-cover bridge after the stored block-6
+   vertex-circle full-extension audit
+   `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.
+   The current geometric gate rejects the two-block block-6 control in the
+   natural cyclic order, so the next useful widening is all compatible cyclic
+   orders, all full extensions, or a minimal/rich-class hypothesis that avoids
+   fixing one selected row at each center too early.
 4. Use the bootstrap-core crosswalk and the bootstrap / vertex-circle overlay
    in `docs/bootstrap-core-crosswalk.md` and
    `docs/bootstrap-vertex-circle-overlay.md` to design a sharper condition.

--- a/docs/minimal-fragile-cover-bridge.md
+++ b/docs/minimal-fragile-cover-bridge.md
@@ -401,6 +401,16 @@ orders by Kalmanson certificates. The same payload also points to the older
 natural-order all-extension vertex-circle audit, where the pruned search closes
 with zero clean full extensions.
 
+That natural-order all-extension audit is now stored as a checked artifact:
+
+```bash
+python scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json
+```
+
+```text
+data/certificates/block6_fragile_vertex_circle_extension_audit.json
+```
+
 This is bookkeeping, not a new global obstruction. The remaining block-6 bridge
 gap is still all full extensions across all compatible cyclic orders, or a
 genuine minimal/rich-class geometric reduction that avoids fixing one selected

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -419,6 +419,14 @@ condition that the surviving multi-block family does not automatically satisfy:
   source-`151` neighborhood or one-row-drop relaxation. The remaining target
   is still genuine singleton-support or row-forcing geometry, not a proof that
   either row is forced.
+- block-6 vertex-circle full-extension evidence, as recorded in
+  `data/certificates/block6_fragile_vertex_circle_extension_audit.json` and
+  `docs/block6-fragile-vertex-circle-extension-audit.md`, showing that the
+  two-block block-6 negative control has no natural-order full selected-row
+  extension surviving the vertex-circle quotient self-edge / strict-cycle
+  gate. This rejects one abstract family that passes fragile-cover hypergraph
+  checks, but it remains natural-order and all-order/all-extension bridge work
+  is still open.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2316,6 +2316,46 @@ artifacts:
       - official/global status update
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
+
+  - id: block6_fragile_vertex_circle_extension_audit
+    path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_block6_fragile_vertex_circle_extension.py
+    command: python scripts/check_block6_fragile_vertex_circle_extension.py --assert-expected --write
+    checker: scripts/check_block6_fragile_vertex_circle_extension.py
+    check_command: python scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Two-block block-6 fragile-cover full-extension vertex-circle audit in the natural cyclic order; not a proof of the fragile bridge, not a proof of Erdos Problem #97, not a counterexample, and not an official/global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.block6_fragile_vertex_circle_extension_audit.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      n: 12
+      row_size: 4
+      pair_cap: 2
+      selected_indegree_cap: 7
+      pruned_search.initial_vc: ok
+      pruned_search.result: closed
+      pruned_search.nodes: 1752
+      pruned_search.zero_option_prunes: 37
+      pruned_search.vc_prunes.self_edge: 645
+      pruned_search.vc_prunes.strict_cycle: 768
+      pruned_search.solutions: 0
+      provenance.generator: scripts/check_block6_fragile_vertex_circle_extension.py
+      provenance.command: python scripts/check_block6_fragile_vertex_circle_extension.py --assert-expected --write
+    forbidden_claims:
+      - fragile covers prove the theorem
+      - vertex-circle full-extension gate proves the fragile bridge
+      - all block-6 cyclic orders are obstructed
+      - all fragile-cover extensions are obstructed
+      - minimal counterexamples are ruled out
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
   - id: speculative_circulant_frontier_obstructions
     path: data/certificates/speculative_circulant_frontier_obstructions.json
     kind: certificate_artifact

--- a/scripts/check_block6_fragile_vertex_circle_extension.py
+++ b/scripts/check_block6_fragile_vertex_circle_extension.py
@@ -28,11 +28,24 @@ from erdos97.vertex_circle_order_filter import (  # noqa: E402
 )
 
 
+DEFAULT_OUT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "block6_fragile_vertex_circle_extension_audit.json"
+)
 N = 12
 ROW_SIZE = 4
 ORDER = list(range(N))
 PAIR_CAP = 2
 INDEGREE_CAP = (2 * (N - 1)) // (ROW_SIZE - 1)
+PROVENANCE = {
+    "generator": "scripts/check_block6_fragile_vertex_circle_extension.py",
+    "command": (
+        "python scripts/check_block6_fragile_vertex_circle_extension.py "
+        "--assert-expected --write"
+    ),
+}
 EXPECTED_PRUNED = {
     "result": "closed",
     "nodes": 1752,
@@ -348,10 +361,12 @@ def audit_payload(*, include_terminal: bool, max_nodes: int = 2_000_000) -> dict
     payload: dict[str, Any] = {
         "schema": "erdos97.block6_fragile_vertex_circle_extension_audit.v1",
         "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
         "claim_scope": (
             "Two-block block-6 fragile-cover extension audit in the natural "
             "cyclic order; not a proof of Erdos Problem #97 and not a counterexample."
         ),
+        "provenance": PROVENANCE,
         "n": N,
         "row_size": ROW_SIZE,
         "cyclic_order": ORDER,
@@ -365,11 +380,38 @@ def audit_payload(*, include_terminal: bool, max_nodes: int = 2_000_000) -> dict
     return payload
 
 
+def _resolve_repo_path(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: Mapping[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def compare_artifact(payload: Mapping[str, Any], path: Path) -> None:
+    checked = load_json(path)
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
 def assert_expected(payload: Mapping[str, Any], *, include_terminal: bool) -> None:
     if payload["status"] != "REVIEW_PENDING_DIAGNOSTIC_ONLY":
         raise AssertionError("unexpected status")
+    if payload["trust"] != "REVIEW_PENDING_DIAGNOSTIC":
+        raise AssertionError("unexpected trust label")
     if "not a proof" not in payload["claim_scope"]:
         raise AssertionError("claim scope lost no-proof note")
+    if payload["provenance"] != PROVENANCE:
+        raise AssertionError("unexpected provenance")
     pruned = dict(payload["pruned_search"])
     pruned_subset = {key: pruned[key] for key in EXPECTED_PRUNED}
     if pruned_subset != EXPECTED_PRUNED:
@@ -396,12 +438,29 @@ def main() -> int:
         action="store_true",
         help="assert the current expected audit counts",
     )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help="artifact path for --write or --check",
+    )
+    parser.add_argument("--write", action="store_true", help="write the checked artifact")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare the regenerated payload against the checked artifact",
+    )
     parser.add_argument("--max-nodes", type=int, default=2_000_000)
     args = parser.parse_args()
 
     payload = audit_payload(include_terminal=args.terminal, max_nodes=args.max_nodes)
     if args.assert_expected:
         assert_expected(payload, include_terminal=args.terminal)
+    artifact_path = _resolve_repo_path(args.out)
+    if args.write:
+        write_json(payload, artifact_path)
+    if args.check:
+        compare_artifact(payload, artifact_path)
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -692,6 +692,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="block6_fragile_vertex_circle_extension",
+        command=(
+            "python",
+            "scripts/check_block6_fragile_vertex_circle_extension.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Two-block block-6 fragile-cover full-extension vertex-circle "
+            "audit in the natural cyclic order; not a proof of the fragile "
+            "bridge, Erdos Problem #97, or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/tests/test_block6_fragile_vertex_circle_extension.py
+++ b/tests/test_block6_fragile_vertex_circle_extension.py
@@ -31,6 +31,7 @@ def test_block6_checker_cli_json() -> None:
         [
             sys.executable,
             "scripts/check_block6_fragile_vertex_circle_extension.py",
+            "--check",
             "--assert-expected",
             "--json",
         ],


### PR DESCRIPTION
## Summary

- add a stored checked JSON artifact for the two-block block-6 fragile-cover vertex-circle full-extension audit
- extend the audit CLI with `--write`, `--out`, and stored-artifact `--check` support, and wire it into `verify-bridge-frontier`, artifact audit, provenance metadata, and tests
- update bridge docs/backlog/status ledgers to record the geometric gate while keeping the all-order/all-extension bridge gap explicit

## Verification

- `python scripts/check_block6_fragile_vertex_circle_extension.py --assert-expected --write --check --json`
- `python scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json`
- `python scripts/check_fragile_hypergraph.py --blocks 2 --assert-ok --check-full-extension --assert-full-extension --json`
- `python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json`
- `python scripts/check_block6_fragile_filter_crosswalk.py --assert-expected --json`
- `python -m pytest tests/test_block6_fragile_vertex_circle_extension.py tests/test_fragile_hypergraph.py tests/test_block6_fragile_filter_crosswalk.py -q` (11 passed)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (888 passed, 285 deselected)

This remains a review-pending bridge diagnostic only: it does not prove the fragile bridge, `n=9`, Erdos Problem #97, or a counterexample.