### PR TITLE
[codex] Replay reversed block escape artifact checks

### DIFF
--- a/scripts/check_block6_reversed_block_shuffle_vertex_circle_escape.py
+++ b/scripts/check_block6_reversed_block_shuffle_vertex_circle_escape.py
@@ -414,6 +414,15 @@ def _resolve_repo_path(path: Path) -> Path:
     return path if path.is_absolute() else ROOT / path
 
 
+def check_artifact(path: Path = OUT) -> dict[str, Any]:
+    """Replay the stored artifact without regenerating the full sweep."""
+
+    artifact_path = _resolve_repo_path(path)
+    data = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert_expected(data)
+    return data
+
+
 def _parse_indices(raw_indices: Sequence[str]) -> list[int] | None:
     if not raw_indices:
         return None
@@ -427,7 +436,14 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print full JSON payload")
     parser.add_argument("--write", action="store_true", help="write the artifact")
-    parser.add_argument("--check", action="store_true", help="compare with artifact")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "replay the stored artifact; when combined with --write, compare "
+            "the regenerated payload with the artifact"
+        ),
+    )
     parser.add_argument("--out", type=Path, default=OUT, help="artifact path")
     parser.add_argument(
         "--assert-expected",
@@ -450,16 +466,19 @@ def main() -> int:
     if indices is not None and (args.write or args.check or args.assert_expected):
         parser.error("--indices is incompatible with --write, --check, and --assert-expected")
 
-    data = payload(indices=indices)
-    if args.assert_expected:
-        assert_expected(data)
     artifact_path = _resolve_repo_path(args.out)
-    if args.write:
-        write_json(data, artifact_path)
-    if args.check:
+    if args.check and not args.write:
+        data = check_artifact(artifact_path)
+    else:
+        data = payload(indices=indices)
+        if args.write:
+            write_json(data, artifact_path)
+    if args.check and args.write:
         checked = json.loads(artifact_path.read_text(encoding="utf-8"))
         if checked != data:
             raise AssertionError(f"artifact differs from generated payload: {artifact_path}")
+    if args.assert_expected:
+        assert_expected(data)
 
     if args.json:
         print(json.dumps(data, indent=2, sort_keys=True))

--- a/tests/test_block6_reversed_block_shuffle_vertex_circle_escape.py
+++ b/tests/test_block6_reversed_block_shuffle_vertex_circle_escape.py
@@ -9,6 +9,7 @@ from scripts.check_block6_reversed_block_shuffle_vertex_circle_escape import (
     EXPECTED_CLEAN_INDICES,
     OUT,
     assert_expected,
+    check_artifact,
     payload,
     reversed_second_block_shuffle_orders,
 )
@@ -44,6 +45,15 @@ def test_reversed_block_shuffle_escape_artifact() -> None:
     assert "not a counterexample" in data["claim_scope"]
 
 
+def test_reversed_block_shuffle_escape_check_artifact_replay() -> None:
+    data = check_artifact()
+
+    assert data["summary"]["orders_with_clean_pruned_solution"] == 16
+    assert [record["index"] for record in data["clean_order_records"]] == (
+        EXPECTED_CLEAN_INDICES
+    )
+
+
 def test_reversed_block_shuffle_escape_cli_partial() -> None:
     result = subprocess.run(
         [
@@ -51,6 +61,25 @@ def test_reversed_block_shuffle_escape_cli_partial() -> None:
             "scripts/check_block6_reversed_block_shuffle_vertex_circle_escape.py",
             "--indices",
             "0,13",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_reversed_block_shuffle_escape_cli_check_replays_artifact() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_block6_reversed_block_shuffle_vertex_circle_escape.py",
+            "--check",
+            "--assert-expected",
             "--json",
         ],
         cwd=ROOT,


### PR DESCRIPTION
## Summary

- Make `scripts/check_block6_reversed_block_shuffle_vertex_circle_escape.py --check` replay the stored JSON artifact instead of regenerating the full 462-order sweep.
- Preserve full regeneration under `--write`, and keep `--write --check` as the regenerated-payload comparison path.
- Add focused tests for the direct replay helper and the CLI `--check --assert-expected --json` path.

## Research status

This is an artifact-checker speedup only. It does not change the repository's mathematical status: no general proof and no counterexample are claimed.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`921 passed, 285 deselected`)
- `python scripts/check_block6_reversed_block_shuffle_vertex_circle_escape.py --check --assert-expected`