### PR TITLE
[codex] Add sparse frontier Kalmanson template availability diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ verify-kalmanson:
 	$(PYTHON) scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 	$(PYTHON) scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 	$(PYTHON) scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
+	$(PYTHON) scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 
 verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
+python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -184,8 +184,9 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-151-singleton-support-audit.md` applies the same local
    audit shape to rows `151:5` and `151:8`; it also leaves the genuine
    support-existence and row-forcing bridge questions open.
-5. Classify Kalmanson inverse-pair templates from the C13/C19 all-order
-   certificates and emit verifier-backed template records.
+5. Extend the Kalmanson template diagnostics toward order-search coverage:
+   C13/C19 template records and C25/C29 availability records now exist, but
+   they are not cyclic-order coverage or obstructions for the larger frontier.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
    with an independent input-data replay.
 
@@ -352,6 +353,7 @@ python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalma
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 python scripts/analyze_kalmanson_certificates.py
 python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
+python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 ```
 
 Expected artifacts:
@@ -365,6 +367,9 @@ Expected artifacts:
 - optional C13/C19 coefficient-template diagnostics such as
   `scripts/analyze_kalmanson_inverse_pair_templates.py`, kept separate from
   any transfer claim to other selected-witness patterns.
+- optional C25/C29 sparse-frontier template-availability diagnostics such as
+  `scripts/analyze_kalmanson_sparse_frontier_templates.py`, kept separate from
+  cyclic-order coverage or all-order obstruction claims.
 
 Acceptance criteria:
 

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -135,6 +135,26 @@ This is reusable-template guidance for future searches. It does not search new
 orders, certify any new pattern, or transfer either all-order obstruction to
 arbitrary selected-witness systems.
 
+## C25/C29 Sparse-Frontier Template Availability
+
+The sparse-frontier availability diagnostic
+
+```bash
+python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
+```
+
+checks the registered `C25_sidon_2_5_9_14` and
+`C29_sidon_1_3_7_15` fixed abstract selected-witness patterns. It recomputes
+their selected-distance quotient vector tables and records that both expose
+the same two coefficient-template shapes found in the checked C13/C19 pilots:
+one selected-distance class against one selected-distance class, and two
+selected-distance classes against two selected-distance classes.
+
+This is availability only. It does not search cyclic orders, does not prove
+that every order contains such a pair, does not obstruct C25 or C29, and does
+not transfer either C13/C19 all-order obstruction to the larger sparse
+frontier.
+
 ## Interpretation
 
 Safe claim:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -310,8 +310,11 @@ benchmarks for the larger frontier:
   as the current C13/C19 coefficient-template diagnostic: both fixed pilots
   expose only the one-class-vs-one-class and two-classes-vs-two-classes
   quotient-vector inverse templates;
-- test whether the same templates appear in newly mined sparse incidence
-  patterns;
+- use
+  `scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json`
+  as the current C25/C29 sparse-frontier template-availability diagnostic:
+  both larger Sidon patterns expose the same two quotient-vector inverse
+  templates, but this is not cyclic-order coverage or an obstruction;
 - use the recorded C29 fixed-order certificate
   `data/certificates/c29_sidon_fixed_order_kalmanson_165_unsat.json` as the
   benchmark for full-cone Kalmanson/Farkas certificates that are not visible to

--- a/docs/sparse-frontier-diagnostic.md
+++ b/docs/sparse-frontier-diagnostic.md
@@ -310,6 +310,20 @@ inverse-pair filter on this instance. It still proves only this fixed
 selected-witness pattern plus this fixed cyclic order, not all cyclic orders of
 the abstract C29 pattern.
 
+The command
+
+```bash
+python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
+```
+
+adds a pattern-level template-availability diagnostic for the C25 and C29
+abstract sparse-frontier entries. It records that both patterns expose the same
+two selected-distance quotient coefficient templates seen in the checked
+C13/C19 all-order Kalmanson pilots. This is not branch coverage and not an
+obstruction: it only says the relevant inverse-pair vocabulary exists in the
+fixed abstract patterns, not that any cyclic order must realize one of those
+pairs.
+
 The first constrained numerical run on the registered `C13` sparse-filter order
 is:
 

--- a/scripts/analyze_kalmanson_sparse_frontier_templates.py
+++ b/scripts/analyze_kalmanson_sparse_frontier_templates.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Check Kalmanson inverse-pair template availability in sparse frontier patterns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from analyze_kalmanson_inverse_pair_templates import (  # noqa: E402
+    coefficient_template_row,
+    cross_pattern_summary,
+    pattern_template_summary,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+SCHEMA = "erdos97.kalmanson_sparse_frontier_templates.v1"
+STATUS = "KALMANSON_SPARSE_FRONTIER_TEMPLATE_AVAILABILITY_DIAGNOSTIC"
+TRUST = "EXACT_CERTIFICATE_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Exact coefficient-template availability diagnostic for the registered "
+    "C25_sidon_2_5_9_14 and C29_sidon_1_3_7_15 sparse-frontier selected-witness "
+    "patterns. It only classifies quotient-vector inverse pairs available to "
+    "these fixed abstract patterns. It does not search cyclic orders, does not "
+    "prove an all-order obstruction, does not prove Erdos Problem #97, does not "
+    "claim a counterexample, and does not transfer the obstruction to arbitrary "
+    "selected-witness systems."
+)
+PROVENANCE = {
+    "generator": "scripts/analyze_kalmanson_sparse_frontier_templates.py",
+    "command": (
+        "python scripts/analyze_kalmanson_sparse_frontier_templates.py "
+        "--assert-expected --json"
+    ),
+}
+DEFAULT_CATALOG = ROOT / "data" / "patterns" / "candidate_patterns.json"
+FRONTIER_PATTERNS = (
+    ("C25_sidon_2_5_9_14", 25, (2, 5, 9, 14)),
+    ("C29_sidon_1_3_7_15", 29, (1, 3, 7, 15)),
+)
+CHECKED_PILOT_TEMPLATE_ROWS = [
+    coefficient_template_row("one_class_equals_one_class", 0),
+    coefficient_template_row("two_classes_equal_two_classes", 0),
+]
+CHECKED_PILOT_TEMPLATE_SET = [
+    "one_class_equals_one_class",
+    "two_classes_equal_two_classes",
+]
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def catalog_entries(catalog_path: Path) -> dict[str, Mapping[str, Any]]:
+    raw = load_json(catalog_path)
+    if not isinstance(raw, list):
+        raise TypeError("candidate pattern catalog must be a JSON list")
+    entries: dict[str, Mapping[str, Any]] = {}
+    for entry in raw:
+        if not isinstance(entry, Mapping):
+            raise TypeError("candidate pattern catalog entries must be JSON objects")
+        name = str(entry.get("name"))
+        entries[name] = entry
+    return entries
+
+
+def diagnostic_payload(*, catalog_path: Path = DEFAULT_CATALOG, top: int = 4) -> dict[str, Any]:
+    """Return the sparse-frontier inverse-pair template availability diagnostic."""
+
+    catalog = catalog_entries(catalog_path)
+    summaries = []
+    source_patterns = []
+    for name, n, offsets in FRONTIER_PATTERNS:
+        catalog_entry = catalog.get(name)
+        if catalog_entry is None:
+            raise ValueError(f"candidate pattern catalog is missing {name}")
+        if int(catalog_entry.get("n", -1)) != n:
+            raise ValueError(f"candidate pattern catalog has wrong n for {name}")
+        source_patterns.append(
+            {
+                "name": name,
+                "n": n,
+                "formula": catalog_entry.get("formula"),
+                "status": catalog_entry.get("status"),
+                "trust": catalog_entry.get("trust"),
+                "lifecycle": catalog_entry.get("lifecycle"),
+            }
+        )
+        summaries.append(
+            pattern_template_summary(
+                {
+                    "name": name,
+                    "n": n,
+                    "circulant_offsets": list(offsets),
+                },
+                top=top,
+            )
+        )
+
+    cross = cross_pattern_summary(summaries)
+    frontier_templates = cross["all_coefficient_templates"]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "source_catalog": display_path(catalog_path, ROOT),
+        "source_catalog_patterns": source_patterns,
+        "frontier_pattern_summaries": summaries,
+        "frontier_cross_pattern_summary": cross,
+        "checked_pilot_template_rows": CHECKED_PILOT_TEMPLATE_ROWS,
+        "comparison_to_checked_c13_c19_pilots": {
+            "checked_pilot_template_set": CHECKED_PILOT_TEMPLATE_SET,
+            "frontier_template_set": frontier_templates,
+            "frontier_exposes_only_checked_pilot_templates": (
+                frontier_templates == CHECKED_PILOT_TEMPLATE_SET
+            ),
+            "frontier_exposes_all_checked_pilot_templates": (
+                set(CHECKED_PILOT_TEMPLATE_SET).issubset(set(frontier_templates))
+            ),
+        },
+        "interpretation": (
+            "The larger Sidon frontier exposes the same two quotient coefficient "
+            "template shapes seen in the checked C13/C19 all-order pilots, but "
+            "this is only availability. It does not say that every cyclic order "
+            "contains such a pair, and it does not obstruct C25 or C29."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def assert_expected(payload: Mapping[str, Any]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not search cyclic orders",
+        "does not prove an all-order obstruction",
+        "does not prove Erdos Problem #97",
+        "does not claim a counterexample",
+        "does not transfer the obstruction",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+
+    summaries = payload.get("frontier_pattern_summaries")
+    if not isinstance(summaries, list) or len(summaries) != 2:
+        raise AssertionError("expected exactly two frontier pattern summaries")
+    expected_by_name = {
+        "C25_sidon_2_5_9_14": {
+            "ordered_quad_table_size": 303600,
+            "vector_id_count": 74950,
+            "inverse_vector_pair_count": 37475,
+            "selected_distance_class_count": 225,
+            "selected_distance_class_size_histogram": {"1": 200, "4": 25},
+            "inverse_pair_support_size_distribution": {"2": 2850, "4": 34625},
+            "potential_ordered_quad_pair_count_by_template": {
+                "one_class_equals_one_class": 284800,
+                "two_classes_equal_two_classes": 2220800,
+            },
+            "vector_occurrence_count_min": 8,
+            "vector_occurrence_count_max": 32,
+            "template_counts": {
+                "one_class_equals_one_class": 2850,
+                "two_classes_equal_two_classes": 34625,
+            },
+        },
+        "C29_sidon_1_3_7_15": {
+            "ordered_quad_table_size": 570024,
+            "vector_id_count": 141404,
+            "inverse_vector_pair_count": 70702,
+            "selected_distance_class_count": 319,
+            "selected_distance_class_size_histogram": {"1": 290, "4": 29},
+            "inverse_pair_support_size_distribution": {"2": 3973, "4": 66729},
+            "potential_ordered_quad_pair_count_by_template": {
+                "one_class_equals_one_class": 389760,
+                "two_classes_equal_two_classes": 4270656,
+            },
+            "vector_occurrence_count_min": 8,
+            "vector_occurrence_count_max": 32,
+            "template_counts": {
+                "one_class_equals_one_class": 3973,
+                "two_classes_equal_two_classes": 66729,
+            },
+        },
+    }
+    for summary in summaries:
+        if not isinstance(summary, Mapping):
+            raise AssertionError("frontier pattern summaries must be objects")
+        pattern = summary.get("pattern")
+        if not isinstance(pattern, Mapping):
+            raise AssertionError("summary pattern must be an object")
+        name = str(pattern.get("name"))
+        expected = expected_by_name.pop(name)
+        for key, value in expected.items():
+            if key == "template_counts":
+                continue
+            if summary.get(key) != value:
+                raise AssertionError(
+                    f"{name} {key} mismatch: expected {value!r}, got {summary.get(key)!r}"
+                )
+        rows = summary.get("coefficient_template_distribution")
+        if not isinstance(rows, list):
+            raise AssertionError(f"{name} coefficient_template_distribution must be a list")
+        observed_counts = {
+            str(row["template"]): int(row["inverse_vector_pair_count"])
+            for row in rows
+            if isinstance(row, Mapping)
+        }
+        if observed_counts != expected["template_counts"]:
+            raise AssertionError(f"{name} coefficient template counts changed: {observed_counts}")
+    if expected_by_name:
+        raise AssertionError(f"missing frontier summaries for {sorted(expected_by_name)}")
+
+    if payload.get("frontier_cross_pattern_summary") != {
+        "shared_coefficient_templates": CHECKED_PILOT_TEMPLATE_SET,
+        "all_coefficient_templates": CHECKED_PILOT_TEMPLATE_SET,
+        "patterns_have_same_template_set": True,
+    }:
+        raise AssertionError(
+            f"frontier cross summary changed: {payload.get('frontier_cross_pattern_summary')!r}"
+        )
+    if payload.get("comparison_to_checked_c13_c19_pilots") != {
+        "checked_pilot_template_set": CHECKED_PILOT_TEMPLATE_SET,
+        "frontier_template_set": CHECKED_PILOT_TEMPLATE_SET,
+        "frontier_exposes_only_checked_pilot_templates": True,
+        "frontier_exposes_all_checked_pilot_templates": True,
+    }:
+        raise AssertionError(
+            "comparison to checked C13/C19 pilots changed: "
+            f"{payload.get('comparison_to_checked_c13_c19_pilots')!r}"
+        )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--top", type=int, default=4)
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.top <= 0:
+        raise SystemExit("--top must be positive")
+    catalog = args.catalog if args.catalog.is_absolute() else ROOT / args.catalog
+    payload = diagnostic_payload(catalog_path=catalog, top=args.top)
+    if args.assert_expected:
+        assert_expected(payload)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("Kalmanson sparse-frontier template availability diagnostic")
+        for summary in payload["frontier_pattern_summaries"]:
+            pattern = summary["pattern"]
+            print(
+                f"{pattern['name']}: inverse pairs={summary['inverse_vector_pair_count']} "
+                f"templates={summary['inverse_pair_support_size_distribution']}"
+            )
+        if args.assert_expected:
+            print("OK: sparse-frontier template availability matches expected values")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -122,6 +122,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="kalmanson_sparse_frontier_templates",
+        command=(
+            "python",
+            "scripts/analyze_kalmanson_sparse_frontier_templates.py",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Coefficient-template availability diagnostic for registered "
+            "C25/C29 sparse-frontier patterns; not a cyclic-order search, "
+            "proof of Erdos Problem #97, counterexample, or all-order "
+            "obstruction."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_review_pending",
         command=("python", "scripts/check_n9_vertex_circle_exhaustive.py", "--assert-expected", "--json"),
         claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",

--- a/tests/test_kalmanson_sparse_frontier_templates.py
+++ b/tests/test_kalmanson_sparse_frontier_templates.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.analyze_kalmanson_sparse_frontier_templates import (
+    CHECKED_PILOT_TEMPLATE_SET,
+    assert_expected,
+    diagnostic_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_kalmanson_sparse_frontier_template_availability_expected_counts() -> None:
+    payload = diagnostic_payload(top=2)
+
+    assert_expected(payload)
+    assert payload["frontier_cross_pattern_summary"] == {
+        "shared_coefficient_templates": CHECKED_PILOT_TEMPLATE_SET,
+        "all_coefficient_templates": CHECKED_PILOT_TEMPLATE_SET,
+        "patterns_have_same_template_set": True,
+    }
+    assert payload["comparison_to_checked_c13_c19_pilots"] == {
+        "checked_pilot_template_set": CHECKED_PILOT_TEMPLATE_SET,
+        "frontier_template_set": CHECKED_PILOT_TEMPLATE_SET,
+        "frontier_exposes_only_checked_pilot_templates": True,
+        "frontier_exposes_all_checked_pilot_templates": True,
+    }
+
+    by_name = {
+        summary["pattern"]["name"]: summary
+        for summary in payload["frontier_pattern_summaries"]
+    }
+    assert by_name["C25_sidon_2_5_9_14"]["inverse_vector_pair_count"] == 37475
+    assert by_name["C25_sidon_2_5_9_14"][
+        "potential_ordered_quad_pair_count_by_template"
+    ] == {
+        "one_class_equals_one_class": 284800,
+        "two_classes_equal_two_classes": 2220800,
+    }
+    assert by_name["C29_sidon_1_3_7_15"]["inverse_vector_pair_count"] == 70702
+    assert by_name["C29_sidon_1_3_7_15"][
+        "inverse_pair_support_size_distribution"
+    ] == {"2": 3973, "4": 66729}
+
+
+def test_kalmanson_sparse_frontier_template_claim_scope_is_guarded() -> None:
+    payload = diagnostic_payload(top=1)
+
+    claim_scope = payload["claim_scope"]
+    assert "does not search cyclic orders" in claim_scope
+    assert "does not prove an all-order obstruction" in claim_scope
+    assert "does not prove Erdos Problem #97" in claim_scope
+    assert "does not claim a counterexample" in claim_scope
+    assert "availability" in payload["interpretation"]
+    assert "does not obstruct C25 or C29" in payload["interpretation"]
+
+
+def test_kalmanson_sparse_frontier_template_rejects_tampering() -> None:
+    payload = diagnostic_payload(top=1)
+    payload["frontier_pattern_summaries"][0]["inverse_vector_pair_count"] = 37474
+
+    try:
+        assert_expected(payload)
+    except AssertionError as exc:
+        assert "C25_sidon_2_5_9_14 inverse_vector_pair_count mismatch" in str(exc)
+    else:  # pragma: no cover - defensive assertion shape
+        raise AssertionError("tampered sparse-frontier diagnostic unexpectedly passed")
+
+
+def test_kalmanson_sparse_frontier_template_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/analyze_kalmanson_sparse_frontier_templates.py",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "KALMANSON_SPARSE_FRONTIER_TEMPLATE_AVAILABILITY_DIAGNOSTIC"
+    assert [
+        summary["pattern"]["name"]
+        for summary in payload["frontier_pattern_summaries"]
+    ] == ["C25_sidon_2_5_9_14", "C29_sidon_1_3_7_15"]

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -42,6 +42,15 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json"
+    )
+    assert (
         "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected "
         "--check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json"
         in command_texts


### PR DESCRIPTION
## Summary

- Add `scripts/analyze_kalmanson_sparse_frontier_templates.py` to classify quotient-vector inverse-pair coefficient templates for the registered `C25_sidon_2_5_9_14` and `C29_sidon_1_3_7_15` sparse-frontier patterns.
- Wire the diagnostic into `verify-kalmanson`, artifact audit metadata, README command listings, and review/backlog docs.
- Add tests for expected counts, claim-scope guardrails, tamper rejection, CLI JSON, and artifact-audit registration.

## Scope / non-claim

This is a template-availability diagnostic only. It does not search cyclic orders, prove an all-order obstruction for C25/C29, prove Erdos Problem #97, claim a counterexample, or transfer the C13/C19 fixed-pattern obstructions to arbitrary selected-witness systems.

## Validation

- `python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json`
- `python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json`
- `python -m pytest tests/test_kalmanson_sparse_frontier_templates.py tests/test_run_artifact_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`946 passed, 285 deselected`)