### PR TITLE
[codex] Expand n=9 relation skeleton catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository is a public research log and reproducibility workspace for Erdő
   read [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 - For the derived `n=9` vertex-circle template lemma-candidate catalog, read
   [`docs/n9-vertex-circle-template-lemma-catalog.md`](docs/n9-vertex-circle-template-lemma-catalog.md).
-- For the first relation-skeleton extraction from focused `n=9`
+- For the relation-skeleton extraction from focused `n=9`
   vertex-circle local packets, read
   [`docs/relation-skeleton-catalog.md`](docs/relation-skeleton-catalog.md).
 - For the review-pending `n=10` singleton-slice finite-case draft, read

--- a/data/certificates/relation_skeleton_catalog.json
+++ b/data/certificates/relation_skeleton_catalog.json
@@ -1,9 +1,9 @@
 {
   "catalog_scope": "vertex-circle selected-distance quotient skeletons",
-  "claim_scope": "Two-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "claim_scope": "Seven-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
   "contradiction_type_counts": {
-    "strict_directed_cycle": 1,
-    "strict_self_edge": 1
+    "strict_directed_cycle": 3,
+    "strict_self_edge": 4
   },
   "cyclic_order": [
     0,
@@ -17,7 +17,7 @@
     8
   ],
   "interpretation": [
-    "This catalog extracts relation skeletons from two focused local lemma packets.",
+    "This catalog extracts relation skeletons from focused local lemma packets.",
     "Each entry separates selected-distance quotient equalities from vertex-circle strict inequalities.",
     "The catalog is intended to support reusable local-lemma review and bridge proof mining.",
     "No proof of the n=9 case is claimed.",
@@ -30,10 +30,15 @@
   },
   "row_size": 4,
   "schema": "erdos97.relation_skeleton_catalog.v1",
-  "skeleton_count": 2,
+  "skeleton_count": 7,
   "skeleton_ids": [
     "VC-T01-F09-strict-self-edge",
-    "VC-T10-F12-strict-directed-cycle"
+    "VC-T03-F05-strict-self-edge",
+    "VC-T03-F15-strict-self-edge",
+    "VC-T04-F13-strict-self-edge",
+    "VC-T10-F12-strict-directed-cycle",
+    "VC-T11-F07-strict-directed-cycle",
+    "VC-T12-F16-strict-directed-cycle"
   ],
   "skeletons": [
     {
@@ -212,6 +217,537 @@
       "source_family_id": "F09",
       "source_packet": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
       "source_template_id": "T01",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          3
+        ],
+        "strict_from_pair": [
+          3,
+          7
+        ],
+        "strict_to_pair": [
+          1,
+          7
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F05"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 4 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          [
+            2,
+            1,
+            3,
+            4,
+            8
+          ],
+          [
+            3,
+            0,
+            2,
+            4,
+            7
+          ],
+          [
+            6,
+            1,
+            3,
+            5,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              3,
+              7
+            ],
+            [
+              2,
+              3
+            ],
+            [
+              1,
+              2
+            ],
+            [
+              1,
+              7
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              3,
+              7
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "left_pair": [
+              2,
+              3
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          },
+          {
+            "left_pair": [
+              1,
+              2
+            ],
+            "right_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_pair": [
+              1,
+              7
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              3,
+              7
+            ],
+            "outer_span": 2,
+            "row": 6,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              7,
+              1,
+              3,
+              5
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T03-F05-strict-self-edge",
+      "source_family_id": "F05",
+      "source_packet": "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
+      "source_template_id": "T03",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          4
+        ],
+        "strict_to_pair": [
+          3,
+          4
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "families": [
+          "F15"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 4 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            3,
+            4,
+            8
+          ],
+          [
+            1,
+            0,
+            2,
+            4,
+            5
+          ],
+          [
+            2,
+            1,
+            3,
+            5,
+            6
+          ],
+          [
+            3,
+            2,
+            4,
+            6,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              4
+            ],
+            [
+              1,
+              2
+            ],
+            [
+              2,
+              3
+            ],
+            [
+              3,
+              4
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              4
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              1,
+              2
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          },
+          {
+            "left_pair": [
+              2,
+              3
+            ],
+            "right_pair": [
+              3,
+              4
+            ],
+            "row": 3
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              3,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              3,
+              4,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T03-F15-strict-self-edge",
+      "source_family_id": "F15",
+      "source_packet": "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
+      "source_template_id": "T03",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          5
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "families": [
+          "F13"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 4 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            5,
+            7
+          ],
+          [
+            1,
+            2,
+            3,
+            6,
+            8
+          ],
+          [
+            3,
+            1,
+            4,
+            5,
+            8
+          ],
+          [
+            5,
+            1,
+            3,
+            6,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              5
+            ],
+            [
+              3,
+              5
+            ],
+            [
+              1,
+              3
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              5
+            ],
+            "right_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "left_pair": [
+              3,
+              5
+            ],
+            "right_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "left_pair": [
+              1,
+              3
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              5
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              5,
+              7
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T04-F13-strict-self-edge",
+      "source_family_id": "F13",
+      "source_packet": "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
+      "source_template_id": "T04",
       "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
     },
     {
@@ -499,6 +1035,690 @@
       "source_packet": "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
       "source_template_id": "T10",
       "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a directed strict cycle of length 3 after selected-distance quotienting.",
+        "cycle_length": 3,
+        "kind": "strict_directed_cycle",
+        "obstruction": "directed strict cycle in the quotient graph",
+        "quotient_cycle": [
+          {
+            "cycle_step": 0,
+            "equality_chain_to_next_outer_pair": [
+              [
+                0,
+                3
+              ]
+            ],
+            "next_outer_pair": [
+              0,
+              3
+            ],
+            "strict_from_pair": [
+              0,
+              2
+            ],
+            "strict_to_pair": [
+              0,
+              3
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "equality_chain_to_next_outer_pair": [
+              [
+                0,
+                5
+              ],
+              [
+                5,
+                7
+              ]
+            ],
+            "next_outer_pair": [
+              5,
+              7
+            ],
+            "strict_from_pair": [
+              0,
+              3
+            ],
+            "strict_to_pair": [
+              0,
+              5
+            ]
+          },
+          {
+            "cycle_step": 2,
+            "equality_chain_to_next_outer_pair": [
+              [
+                1,
+                5
+              ],
+              [
+                0,
+                1
+              ],
+              [
+                0,
+                2
+              ]
+            ],
+            "next_outer_pair": [
+              0,
+              2
+            ],
+            "strict_from_pair": [
+              5,
+              7
+            ],
+            "strict_to_pair": [
+              1,
+              5
+            ]
+          }
+        ]
+      },
+      "contradiction_type": "strict_directed_cycle",
+      "coverage": {
+        "assignment_count": 6,
+        "families": [
+          "F07"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 6
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 4 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            1,
+            0,
+            2,
+            3,
+            5
+          ],
+          [
+            5,
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            6,
+            1,
+            5,
+            7,
+            8
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              0,
+              3
+            ]
+          ],
+          [
+            [
+              0,
+              5
+            ],
+            [
+              5,
+              7
+            ]
+          ],
+          [
+            [
+              1,
+              5
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "cycle_step": 0,
+            "equality_steps": []
+          },
+          {
+            "cycle_step": 1,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  0,
+                  5
+                ],
+                "right_pair": [
+                  5,
+                  7
+                ],
+                "row": 5
+              }
+            ]
+          },
+          {
+            "cycle_step": 2,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  1,
+                  5
+                ],
+                "right_pair": [
+                  0,
+                  1
+                ],
+                "row": 1
+              },
+              {
+                "left_pair": [
+                  0,
+                  1
+                ],
+                "right_pair": [
+                  0,
+                  2
+                ],
+                "row": 0
+              }
+            ]
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              3
+            ],
+            "inner_pair": [
+              0,
+              3
+            ],
+            "inner_span": 2,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_pair": [
+              0,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              3
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_pair": [
+              5,
+              7
+            ],
+            "outer_span": 3,
+            "row": 6,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              7,
+              8,
+              1,
+              5
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T11-F07-strict-directed-cycle",
+      "source_family_id": "F07",
+      "source_packet": "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json",
+      "source_template_id": "T11",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a directed strict cycle of length 3 after selected-distance quotienting.",
+        "cycle_length": 3,
+        "kind": "strict_directed_cycle",
+        "obstruction": "directed strict cycle in the quotient graph",
+        "quotient_cycle": [
+          {
+            "cycle_step": 0,
+            "equality_chain_to_next_outer_pair": [
+              [
+                0,
+                8
+              ],
+              [
+                2,
+                8
+              ]
+            ],
+            "next_outer_pair": [
+              2,
+              8
+            ],
+            "strict_from_pair": [
+              0,
+              3
+            ],
+            "strict_to_pair": [
+              0,
+              8
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "equality_chain_to_next_outer_pair": [
+              [
+                2,
+                4
+              ],
+              [
+                1,
+                4
+              ],
+              [
+                1,
+                7
+              ]
+            ],
+            "next_outer_pair": [
+              1,
+              7
+            ],
+            "strict_from_pair": [
+              2,
+              8
+            ],
+            "strict_to_pair": [
+              2,
+              4
+            ]
+          },
+          {
+            "cycle_step": 2,
+            "equality_chain_to_next_outer_pair": [
+              [
+                1,
+                3
+              ],
+              [
+                0,
+                3
+              ]
+            ],
+            "next_outer_pair": [
+              0,
+              3
+            ],
+            "strict_from_pair": [
+              1,
+              7
+            ],
+            "strict_to_pair": [
+              1,
+              3
+            ]
+          }
+        ]
+      },
+      "contradiction_type": "strict_directed_cycle",
+      "coverage": {
+        "assignment_count": 2,
+        "families": [
+          "F16"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 6 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          [
+            1,
+            2,
+            4,
+            7,
+            8
+          ],
+          [
+            2,
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            3,
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            4,
+            1,
+            2,
+            5,
+            7
+          ],
+          [
+            8,
+            0,
+            2,
+            5,
+            6
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              0,
+              8
+            ],
+            [
+              2,
+              8
+            ]
+          ],
+          [
+            [
+              2,
+              4
+            ],
+            [
+              1,
+              4
+            ],
+            [
+              1,
+              7
+            ]
+          ],
+          [
+            [
+              1,
+              3
+            ],
+            [
+              0,
+              3
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "cycle_step": 0,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  0,
+                  8
+                ],
+                "right_pair": [
+                  2,
+                  8
+                ],
+                "row": 8
+              }
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  2,
+                  4
+                ],
+                "right_pair": [
+                  1,
+                  4
+                ],
+                "row": 4
+              },
+              {
+                "left_pair": [
+                  1,
+                  4
+                ],
+                "right_pair": [
+                  1,
+                  7
+                ],
+                "row": 1
+              }
+            ]
+          },
+          {
+            "cycle_step": 2,
+            "equality_steps": [
+              {
+                "left_pair": [
+                  1,
+                  3
+                ],
+                "right_pair": [
+                  0,
+                  3
+                ],
+                "row": 3
+              }
+            ]
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              2
+            ],
+            "inner_pair": [
+              0,
+              8
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              0,
+              3
+            ],
+            "outer_span": 3,
+            "row": 2,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          },
+          {
+            "inner_class": [
+              1,
+              2
+            ],
+            "inner_pair": [
+              2,
+              4
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              2
+            ],
+            "outer_pair": [
+              2,
+              8
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              2,
+              4,
+              7,
+              8
+            ]
+          },
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              1,
+              2
+            ],
+            "outer_pair": [
+              1,
+              7
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              3,
+              6,
+              7
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T12-F16-strict-directed-cycle",
+      "source_family_id": "F16",
+      "source_packet": "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
+      "source_template_id": "T12",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
     }
   ],
   "source_artifacts": [
@@ -510,9 +1730,37 @@
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     },
     {
+      "path": "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
+      "role": "focused T03 self-edge local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t03_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
+      "role": "focused T04/F13 self-edge local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t04_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
       "path": "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
       "role": "focused T10/F12 strict-cycle local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json",
+      "role": "focused T11/F07 strict-cycle local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t11_strict_cycle_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
+      "role": "focused T12/F16 strict-cycle local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t12_strict_cycle_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,9 +51,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`turn-inequality-lemma.md`](turn-inequality-lemma.md): proof-facing note for
   the candidate exterior-turn inequalities used in the review-pending `n=9`
   turn-frontier replay.
-- [`relation-skeleton-catalog.md`](relation-skeleton-catalog.md): first
-  review-pending relation-skeleton extraction for T01 self-edge and T10
-  strict-cycle vertex-circle quotient motifs; proof-mining aid only.
+- [`relation-skeleton-catalog.md`](relation-skeleton-catalog.md):
+  review-pending relation-skeleton extraction for selected T01/T03/T04
+  self-edge and T10/T11/T12 strict-cycle vertex-circle quotient motifs;
+  proof-mining aid only.
 - [`reciprocal-radial-budget.md`](reciprocal-radial-budget.md): local
   middle-witness reciprocal-radial budget packet; a research packet, not a
   global obstruction.

--- a/docs/relation-skeleton-catalog.md
+++ b/docs/relation-skeleton-catalog.md
@@ -2,26 +2,31 @@
 
 Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
 
-This note records a first narrow relation-skeleton extraction for proof
-mining. It does not claim a proof of `n=9`, does not claim a counterexample,
+This note records a focused relation-skeleton extraction for proof mining. It
+does not claim a proof of `n=9`, does not claim a counterexample,
 does not complete independent review of the exhaustive checker, and does not
 update the official/global status of Erdos Problem #97.
 
 ## Scope
 
 The checked artifact is
-`data/certificates/relation_skeleton_catalog.json`. It currently contains two
+`data/certificates/relation_skeleton_catalog.json`. It currently contains seven
 vertex-circle selected-distance quotient skeletons extracted from focused
 local lemma packets:
 
 ```text
 VC-T01-F09-strict-self-edge
+VC-T03-F05-strict-self-edge
+VC-T03-F15-strict-self-edge
+VC-T04-F13-strict-self-edge
 VC-T10-F12-strict-directed-cycle
+VC-T11-F07-strict-directed-cycle
+VC-T12-F16-strict-directed-cycle
 ```
 
-This is intentionally smaller than the full 12-template `n=9` catalog. The
-goal is to give reviewers a reusable object shape before adding Kalmanson,
-row-Ptolemy, or additional vertex-circle templates.
+This is still smaller than the full 12-template `n=9` catalog. The goal is to
+give reviewers a reusable object shape before adding Kalmanson, row-Ptolemy,
+or all remaining vertex-circle templates.
 
 ## Skeleton Fields
 
@@ -75,6 +80,43 @@ The row-0 vertex-circle order `[1,2,4,8]` gives the strict inequality
 
 Thus the selected-distance quotient strict graph has a strict self-edge.
 
+### T03/F05 And T03/F15 Self-edges
+
+The two T03 family packets are recorded as separate skeletons because their
+local rows and equality chains differ. Both have four selected rows and one
+vertex-circle strict edge whose endpoints are identified by a length-3
+selected-distance path.
+
+The skeletons record the equality chains:
+
+```text
+F05: [3,7] = [2,3] = [1,2] = [1,7]
+F15: [1,4] = [1,2] = [2,3] = [3,4]
+```
+
+In each case the listed vertex-circle strict edge returns to the same quotient
+class, giving a strict self-edge.
+
+### T04/F13 Self-edge
+
+The T04/F13 local core is recorded as:
+
+```text
+0: {1,2,5,7}
+1: {2,3,6,8}
+3: {1,4,5,8}
+5: {1,3,6,7}
+```
+
+The selected-distance path gives:
+
+```text
+[1,5] = [3,5] = [1,3] = [1,2]
+```
+
+Row `0` has witness order `[1,2,5,7]`, so vertex-circle monotonicity gives
+`[1,5] > [1,2]`. Thus the quotient graph has a strict self-edge.
+
 ### T10/F12 Strict Cycle
 
 The four selected rows
@@ -95,6 +137,21 @@ force the quotient cycle
 
 Thus the selected-distance quotient strict graph has a directed strict cycle
 of length two.
+
+### T11/F07 And T12/F16 Strict Cycles
+
+The T11 and T12 skeletons record three-edge directed strict cycles. They are
+the same local arguments as the focused lemma notes, normalized into the common
+relation-skeleton schema:
+
+```text
+T11/F07: [0,2] > [0,3] > [5,7] > [0,2]
+T12/F16: [0,3] > [2,8] > [1,7] > [0,3]
+```
+
+The skeleton entries keep the selected rows, equality chains, strict
+vertex-circle edges, and quotient-cycle steps separate so a reviewer can check
+the local lemma without reading the exhaustive `n=9` brancher.
 
 ## Commands
 
@@ -120,10 +177,9 @@ python -m pytest tests/test_relation_skeleton_catalog.py -q -m "artifact"
 ## Review Standard
 
 A reviewer should be able to restate each skeleton as a local lemma without
-using `T01`, `T10`, `F09`, or `F12` as theorem names. The proof obligation is
-to check that the listed selected rows force the displayed quotient equalities
-and that the listed vertex-circle order forces the displayed strict edge or
-cycle.
+using template or family ids as theorem names. The proof obligation is to check
+that the listed selected rows force the displayed quotient equalities and that
+the listed vertex-circle order forces the displayed strict edge or cycle.
 
 This catalog is a proof-mining aid. It is not an independent proof of the
 `n=9` finite case, not a global theorem, and not evidence for a counterexample.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1322,22 +1322,27 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Two-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    claim_scope: Seven-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
     json_top_level_type: object
     expected_json:
       schema: erdos97.relation_skeleton_catalog.v1
       status: REVIEW_PENDING_DIAGNOSTIC_ONLY
       trust: REVIEW_PENDING_DIAGNOSTIC
-      claim_scope: Two-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      claim_scope: Seven-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
       catalog_scope: vertex-circle selected-distance quotient skeletons
       n: 9
       row_size: 4
-      skeleton_count: 2
-      contradiction_type_counts.strict_directed_cycle: 1
-      contradiction_type_counts.strict_self_edge: 1
+      skeleton_count: 7
+      contradiction_type_counts.strict_directed_cycle: 3
+      contradiction_type_counts.strict_self_edge: 4
       skeleton_ids:
         - VC-T01-F09-strict-self-edge
+        - VC-T03-F05-strict-self-edge
+        - VC-T03-F15-strict-self-edge
+        - VC-T04-F13-strict-self-edge
         - VC-T10-F12-strict-directed-cycle
+        - VC-T11-F07-strict-directed-cycle
+        - VC-T12-F16-strict-directed-cycle
       provenance.command: python scripts/check_relation_skeleton_catalog.py --assert-expected --write
     forbidden_claims:
       - n=9 is proved

--- a/scripts/check_relation_skeleton_catalog.py
+++ b/scripts/check_relation_skeleton_catalog.py
@@ -22,10 +22,30 @@ from check_n9_vertex_circle_t01_self_edge_lemma_packet import (  # noqa: E402
     load_source_payloads as load_t01_sources,
     validate_payload as validate_t01_packet,
 )
+from check_n9_vertex_circle_t03_self_edge_lemma_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_T03_PACKET,
+    load_source_payloads as load_t03_sources,
+    validate_payload as validate_t03_packet,
+)
+from check_n9_vertex_circle_t04_self_edge_lemma_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_T04_PACKET,
+    load_source_payloads as load_t04_sources,
+    validate_payload as validate_t04_packet,
+)
 from check_n9_vertex_circle_t10_strict_cycle_lemma_packet import (  # noqa: E402
     DEFAULT_ARTIFACT as DEFAULT_T10_PACKET,
     load_source_payloads as load_t10_sources,
     validate_payload as validate_t10_packet,
+)
+from check_n9_vertex_circle_t11_strict_cycle_lemma_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_T11_PACKET,
+    load_source_payloads as load_t11_sources,
+    validate_payload as validate_t11_packet,
+)
+from check_n9_vertex_circle_t12_strict_cycle_lemma_packet import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_T12_PACKET,
+    load_source_payloads as load_t12_sources,
+    validate_payload as validate_t12_packet,
 )
 from erdos97.path_display import display_path  # noqa: E402
 from erdos97.relation_skeleton_catalog import (  # noqa: E402
@@ -108,51 +128,47 @@ def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> N
 def load_source_payloads(
     *,
     t01_packet_path: Path = DEFAULT_T01_PACKET,
+    t03_packet_path: Path = DEFAULT_T03_PACKET,
+    t04_packet_path: Path = DEFAULT_T04_PACKET,
     t10_packet_path: Path = DEFAULT_T10_PACKET,
+    t11_packet_path: Path = DEFAULT_T11_PACKET,
+    t12_packet_path: Path = DEFAULT_T12_PACKET,
 ) -> dict[str, Any]:
     """Load source packets used by the relation-skeleton catalog."""
 
     return {
         "t01_packet": load_artifact(_resolve(t01_packet_path)),
+        "t03_packet": load_artifact(_resolve(t03_packet_path)),
+        "t04_packet": load_artifact(_resolve(t04_packet_path)),
         "t10_packet": load_artifact(_resolve(t10_packet_path)),
+        "t11_packet": load_artifact(_resolve(t11_packet_path)),
+        "t12_packet": load_artifact(_resolve(t12_packet_path)),
     }
 
 
 def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
-    t01_packet = source_payloads.get("t01_packet")
-    t10_packet = source_payloads.get("t10_packet")
-    if not isinstance(t01_packet, dict):
-        errors.append("source T01 packet must be an object")
-    else:
+    validators = (
+        ("T01", "t01_packet", load_t01_sources, validate_t01_packet),
+        ("T03", "t03_packet", load_t03_sources, validate_t03_packet),
+        ("T04", "t04_packet", load_t04_sources, validate_t04_packet),
+        ("T10", "t10_packet", load_t10_sources, validate_t10_packet),
+        ("T11", "t11_packet", load_t11_sources, validate_t11_packet),
+        ("T12", "t12_packet", load_t12_sources, validate_t12_packet),
+    )
+    for label, key, load_sources, validate in validators:
+        packet = source_payloads.get(key)
+        if not isinstance(packet, dict):
+            errors.append(f"source {label} packet must be an object")
+            continue
         try:
-            t01_sources = load_t01_sources()
+            packet_sources = load_sources()
         except (OSError, json.JSONDecodeError) as exc:
-            errors.append(f"could not load T01 source packets: {exc}")
-        else:
-            errors.extend(
-                f"source T01 packet invalid: {error}"
-                for error in validate_t01_packet(
-                    t01_packet,
-                    source_payloads=t01_sources,
-                    recompute=False,
-                )
-            )
-    if not isinstance(t10_packet, dict):
-        errors.append("source T10 packet must be an object")
-    else:
-        try:
-            t10_sources = load_t10_sources()
-        except (OSError, json.JSONDecodeError) as exc:
-            errors.append(f"could not load T10 source packets: {exc}")
-        else:
-            errors.extend(
-                f"source T10 packet invalid: {error}"
-                for error in validate_t10_packet(
-                    t10_packet,
-                    source_payloads=t10_sources,
-                    recompute=False,
-                )
-            )
+            errors.append(f"could not load {label} source packets: {exc}")
+            continue
+        errors.extend(
+            f"source {label} packet invalid: {error}"
+            for error in validate(packet, source_payloads=packet_sources, recompute=False)
+        )
 
 
 def _expected_payload(
@@ -162,7 +178,11 @@ def _expected_payload(
     try:
         return relation_skeleton_catalog_payload(
             source_payloads["t01_packet"],
+            source_payloads["t03_packet"],
+            source_payloads["t04_packet"],
             source_payloads["t10_packet"],
+            source_payloads["t11_packet"],
+            source_payloads["t12_packet"],
         )
     except (AssertionError, KeyError, TypeError, ValueError) as exc:
         errors.append(f"source-bound relation skeleton catalog failed: {exc}")
@@ -216,6 +236,7 @@ def _validate_source_artifacts(payload: dict[str, Any], errors: list[str]) -> No
 
 def _validate_t01_skeleton(skeleton: dict[str, Any], errors: list[str]) -> None:
     expect_equal(errors, "T01 contradiction_type", skeleton.get("contradiction_type"), "strict_self_edge")
+    expect_equal(errors, "T01 source_packet", skeleton.get("source_packet"), EXPECTED_SOURCE_ARTIFACTS[0])
     expect_equal(errors, "T01 source_template_id", skeleton.get("source_template_id"), "T01")
     expect_equal(errors, "T01 source_family_id", skeleton.get("source_family_id"), "F09")
     coverage = skeleton.get("coverage")
@@ -254,6 +275,7 @@ def _validate_t10_skeleton(skeleton: dict[str, Any], errors: list[str]) -> None:
         skeleton.get("contradiction_type"),
         "strict_directed_cycle",
     )
+    expect_equal(errors, "T10 source_packet", skeleton.get("source_packet"), EXPECTED_SOURCE_ARTIFACTS[3])
     expect_equal(errors, "T10 source_template_id", skeleton.get("source_template_id"), "T10")
     expect_equal(errors, "T10 source_family_id", skeleton.get("source_family_id"), "F12")
     coverage = skeleton.get("coverage")
@@ -290,8 +312,57 @@ def _validate_skeletons(payload: dict[str, Any], errors: list[str]) -> None:
     skeletons = _skeletons_by_id(payload, errors)
     if EXPECTED_SKELETON_IDS[0] in skeletons:
         _validate_t01_skeleton(skeletons[EXPECTED_SKELETON_IDS[0]], errors)
-    if EXPECTED_SKELETON_IDS[1] in skeletons:
-        _validate_t10_skeleton(skeletons[EXPECTED_SKELETON_IDS[1]], errors)
+    if EXPECTED_SKELETON_IDS[4] in skeletons:
+        _validate_t10_skeleton(skeletons[EXPECTED_SKELETON_IDS[4]], errors)
+    expected_family_counts = {
+        "VC-T03-F05-strict-self-edge": (EXPECTED_SOURCE_ARTIFACTS[1], "T03", "F05", "strict_self_edge", 18, 1),
+        "VC-T03-F15-strict-self-edge": (EXPECTED_SOURCE_ARTIFACTS[1], "T03", "F15", "strict_self_edge", 2, 1),
+        "VC-T04-F13-strict-self-edge": (EXPECTED_SOURCE_ARTIFACTS[2], "T04", "F13", "strict_self_edge", 2, 1),
+        "VC-T11-F07-strict-directed-cycle": (
+            EXPECTED_SOURCE_ARTIFACTS[4],
+            "T11",
+            "F07",
+            "strict_directed_cycle",
+            6,
+            3,
+        ),
+        "VC-T12-F16-strict-directed-cycle": (
+            EXPECTED_SOURCE_ARTIFACTS[5],
+            "T12",
+            "F16",
+            "strict_directed_cycle",
+            2,
+            3,
+        ),
+    }
+    for skeleton_id, (
+        source_packet,
+        template_id,
+        family_id,
+        contradiction_type,
+        assignment_count,
+        strict_edge_count,
+    ) in expected_family_counts.items():
+        skeleton = skeletons.get(skeleton_id)
+        if skeleton is None:
+            continue
+        expect_equal(errors, f"{skeleton_id} source_packet", skeleton.get("source_packet"), source_packet)
+        expect_equal(errors, f"{skeleton_id} source_template_id", skeleton.get("source_template_id"), template_id)
+        expect_equal(errors, f"{skeleton_id} source_family_id", skeleton.get("source_family_id"), family_id)
+        expect_equal(errors, f"{skeleton_id} contradiction_type", skeleton.get("contradiction_type"), contradiction_type)
+        coverage = skeleton.get("coverage")
+        if not isinstance(coverage, dict):
+            errors.append(f"{skeleton_id} coverage must be an object")
+        else:
+            expect_equal(errors, f"{skeleton_id} assignment_count", coverage.get("assignment_count"), assignment_count)
+            expect_equal(errors, f"{skeleton_id} families", coverage.get("families"), [family_id])
+        relation = skeleton.get("relation_quotient")
+        if not isinstance(relation, dict):
+            errors.append(f"{skeleton_id} relation_quotient must be an object")
+        else:
+            strict_edges = relation.get("strict_edges")
+            if not isinstance(strict_edges, list) or len(strict_edges) != strict_edge_count:
+                errors.append(f"{skeleton_id} strict edge count must be {strict_edge_count}")
     for skeleton_id, skeleton in skeletons.items():
         expect_equal(errors, f"{skeleton_id} review_status", skeleton.get("review_status"), "review_pending")
         expect_equal(
@@ -337,7 +408,7 @@ def validate_payload(
         "n": 9,
         "row_size": 4,
         "cyclic_order": list(range(9)),
-        "skeleton_count": 2,
+        "skeleton_count": 7,
         "skeleton_ids": list(EXPECTED_SKELETON_IDS),
         "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
         "provenance": PROVENANCE,
@@ -361,7 +432,12 @@ def validate_payload(
     _validate_sources(source_payloads, errors)
     expected_payload = None if errors else _expected_payload(source_payloads, errors)
     if expected_payload is not None:
-        expect_equal(errors, "source_artifacts", payload.get("source_artifacts"), expected_payload["source_artifacts"])
+        expect_equal(
+            errors,
+            "source_artifacts",
+            payload.get("source_artifacts"),
+            expected_payload["source_artifacts"],
+        )
 
     try:
         assert_expected_relation_skeleton_catalog(payload)
@@ -399,7 +475,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--json", action="store_true", help="print stable JSON summary")
     parser.add_argument("--assert-expected", action="store_true")
     parser.add_argument("--t01-packet", type=Path, default=DEFAULT_T01_PACKET)
+    parser.add_argument("--t03-packet", type=Path, default=DEFAULT_T03_PACKET)
+    parser.add_argument("--t04-packet", type=Path, default=DEFAULT_T04_PACKET)
     parser.add_argument("--t10-packet", type=Path, default=DEFAULT_T10_PACKET)
+    parser.add_argument("--t11-packet", type=Path, default=DEFAULT_T11_PACKET)
+    parser.add_argument("--t12-packet", type=Path, default=DEFAULT_T12_PACKET)
     return parser.parse_args(argv)
 
 
@@ -419,14 +499,25 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         sources = load_source_payloads(
             t01_packet_path=args.t01_packet,
+            t03_packet_path=args.t03_packet,
+            t04_packet_path=args.t04_packet,
             t10_packet_path=args.t10_packet,
+            t11_packet_path=args.t11_packet,
+            t12_packet_path=args.t12_packet,
         )
     except (OSError, json.JSONDecodeError) as exc:
         print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
         return 1
 
     if args.write:
-        payload = relation_skeleton_catalog_payload(sources["t01_packet"], sources["t10_packet"])
+        payload = relation_skeleton_catalog_payload(
+            sources["t01_packet"],
+            sources["t03_packet"],
+            sources["t04_packet"],
+            sources["t10_packet"],
+            sources["t11_packet"],
+            sources["t12_packet"],
+        )
         if args.assert_expected:
             assert_expected_relation_skeleton_catalog(payload)
         write_json(payload, out)

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -479,7 +479,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--json",
         ),
         claim_scope=(
-            "Two-entry relation-skeleton catalog for focused n=9 "
+            "Seven-entry relation-skeleton catalog for focused n=9 "
             "vertex-circle quotient motifs; proof-mining scaffolding only, "
             "not a proof of n=9, counterexample, or independent review "
             "completion."

--- a/src/erdos97/relation_skeleton_catalog.py
+++ b/src/erdos97/relation_skeleton_catalog.py
@@ -1,7 +1,7 @@
 """Build a small relation-skeleton catalog from focused local lemma packets.
 
 This module is proof-mining scaffolding. It extracts a common typed view of
-two existing vertex-circle quotient obstructions. It does not prove the full
+focused vertex-circle quotient obstructions. It does not prove the full
 n=9 case, does not claim a counterexample, and does not update the global
 status of Erdos Problem #97.
 """
@@ -15,7 +15,7 @@ SCHEMA = "erdos97.relation_skeleton_catalog.v1"
 STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 CLAIM_SCOPE = (
-    "Two-entry relation-skeleton catalog for focused n=9 vertex-circle "
+    "Seven-entry relation-skeleton catalog for focused n=9 vertex-circle "
     "selected-distance quotient obstructions; proof-mining scaffolding only, "
     "not a proof of n=9, not a counterexample, not an independent review of "
     "the exhaustive checker, and not a global status update."
@@ -27,15 +27,24 @@ PROVENANCE = {
 
 EXPECTED_SKELETON_IDS = (
     "VC-T01-F09-strict-self-edge",
+    "VC-T03-F05-strict-self-edge",
+    "VC-T03-F15-strict-self-edge",
+    "VC-T04-F13-strict-self-edge",
     "VC-T10-F12-strict-directed-cycle",
+    "VC-T11-F07-strict-directed-cycle",
+    "VC-T12-F16-strict-directed-cycle",
 )
 EXPECTED_CONTRADICTION_TYPE_COUNTS = {
-    "strict_directed_cycle": 1,
-    "strict_self_edge": 1,
+    "strict_directed_cycle": 3,
+    "strict_self_edge": 4,
 }
 EXPECTED_SOURCE_ARTIFACTS = (
     "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
     "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
 )
 DOES_NOT_PROVE = (
     "n=9",
@@ -45,22 +54,31 @@ DOES_NOT_PROVE = (
 )
 
 
-def _source_artifacts(t01_packet: Mapping[str, Any], t10_packet: Mapping[str, Any]) -> list[dict[str, Any]]:
+def _source_artifact(path: str, role: str, packet: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": path,
+        "role": role,
+        "schema": packet.get("schema"),
+        "status": packet.get("status"),
+        "trust": packet.get("trust"),
+    }
+
+
+def _source_artifacts(
+    t01_packet: Mapping[str, Any],
+    t03_packet: Mapping[str, Any],
+    t04_packet: Mapping[str, Any],
+    t10_packet: Mapping[str, Any],
+    t11_packet: Mapping[str, Any],
+    t12_packet: Mapping[str, Any],
+) -> list[dict[str, Any]]:
     return [
-        {
-            "path": EXPECTED_SOURCE_ARTIFACTS[0],
-            "role": "focused T01/F09 self-edge local lemma packet",
-            "schema": t01_packet.get("schema"),
-            "status": t01_packet.get("status"),
-            "trust": t01_packet.get("trust"),
-        },
-        {
-            "path": EXPECTED_SOURCE_ARTIFACTS[1],
-            "role": "focused T10/F12 strict-cycle local lemma packet",
-            "schema": t10_packet.get("schema"),
-            "status": t10_packet.get("status"),
-            "trust": t10_packet.get("trust"),
-        },
+        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[0], "focused T01/F09 self-edge local lemma packet", t01_packet),
+        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[1], "focused T03 self-edge local lemma packet", t03_packet),
+        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[2], "focused T04/F13 self-edge local lemma packet", t04_packet),
+        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[3], "focused T10/F12 strict-cycle local lemma packet", t10_packet),
+        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[4], "focused T11/F07 strict-cycle local lemma packet", t11_packet),
+        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[5], "focused T12/F16 strict-cycle local lemma packet", t12_packet),
     ]
 
 
@@ -158,6 +176,86 @@ def _t01_skeleton(packet: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _family_packets(packet: Mapping[str, Any], *, expected_template: str) -> list[Mapping[str, Any]]:
+    family_packets = packet["family_packets"]
+    if not isinstance(family_packets, list):
+        raise ValueError(f"{expected_template} packet family_packets must be a list")
+    if str(packet.get("template_id")) != expected_template:
+        raise ValueError(f"expected template {expected_template}, got {packet.get('template_id')!r}")
+    out = []
+    for family_packet in family_packets:
+        if not isinstance(family_packet, Mapping):
+            raise ValueError(f"{expected_template} family packets must be mappings")
+        out.append(family_packet)
+    return out
+
+
+def _coverage_from_family(family_packet: Mapping[str, Any]) -> dict[str, Any]:
+    family_id = str(family_packet["family_id"])
+    return {
+        "assignment_count": int(family_packet["assignment_count"]),
+        "family_count": 1,
+        "families": [family_id],
+        "orbit_size_sum": int(family_packet["orbit_size"]),
+    }
+
+
+def _strict_edge_from_self_edge_family(family_packet: Mapping[str, Any]) -> dict[str, Any]:
+    strict = family_packet["strict_inequality"]
+    return {
+        "source": "vertex_circle_chord_monotonicity",
+        "row": int(strict["row"]),
+        "witness_order": list(strict["witness_order"]),
+        "outer_pair": list(strict["outer_pair"]),
+        "inner_pair": list(strict["inner_pair"]),
+        "outer_class": list(strict["outer_class"]),
+        "inner_class": list(strict["inner_class"]),
+        "outer_span": int(strict["outer_span"]),
+        "inner_span": int(strict["inner_span"]),
+    }
+
+
+def _self_edge_family_skeleton(
+    *,
+    packet: Mapping[str, Any],
+    family_packet: Mapping[str, Any],
+    source_packet: str,
+) -> dict[str, Any]:
+    template_id = str(packet["template_id"])
+    family_id = str(family_packet["family_id"])
+    strict_edge = _strict_edge_from_self_edge_family(family_packet)
+    return {
+        "skeleton_id": f"VC-{template_id}-{family_id}-strict-self-edge",
+        "source_packet": source_packet,
+        "source_template_id": template_id,
+        "source_family_id": family_id,
+        "obstruction_system": "vertex_circle_selected_distance_quotient",
+        "contradiction_type": "strict_self_edge",
+        "review_status": "review_pending",
+        "coverage": _coverage_from_family(family_packet),
+        "hypotheses": {
+            "cyclic_order": list(packet["cyclic_order"]),
+            "selected_rows": list(family_packet["core_selected_rows"]),
+            "minimal_local_hypotheses": _minimal_hypotheses(int(family_packet["core_size"])),
+        },
+        "relation_quotient": {
+            "equality_steps": list(family_packet["local_lemma"]["selected_distance_equalities"]),
+            "equality_chains": [list(family_packet["equality_chain"])],
+            "strict_edges": [strict_edge],
+        },
+        "conclusion": {
+            "kind": "strict_self_edge",
+            "quotient_class": strict_edge["outer_class"],
+            "strict_from_pair": strict_edge["outer_pair"],
+            "strict_to_pair": strict_edge["inner_pair"],
+            "obstruction": "strict edge from a quotient class to itself",
+            "contradiction_statement": str(family_packet["local_lemma"]["contradiction"]),
+        },
+        "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json",
+        "does_not_prove": list(DOES_NOT_PROVE),
+    }
+
+
 def _t10_family_packet(packet: Mapping[str, Any]) -> Mapping[str, Any]:
     family_packets = packet["family_packets"]
     if not isinstance(family_packets, Sequence) or len(family_packets) != 1:
@@ -199,8 +297,8 @@ def _t10_skeleton(packet: Mapping[str, Any]) -> dict[str, Any]:
     steps = _cycle_steps(family_packet)
     strict_edges = [_strict_edge_from_cycle_step(step) for step in steps]
     return {
-        "skeleton_id": EXPECTED_SKELETON_IDS[1],
-        "source_packet": EXPECTED_SOURCE_ARTIFACTS[1],
+        "skeleton_id": EXPECTED_SKELETON_IDS[4],
+        "source_packet": EXPECTED_SOURCE_ARTIFACTS[3],
         "source_template_id": str(packet["template_id"]),
         "source_family_id": str(family_packet["family_id"]),
         "obstruction_system": "vertex_circle_selected_distance_quotient",
@@ -232,13 +330,96 @@ def _t10_skeleton(packet: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _strict_cycle_family_skeleton(
+    *,
+    packet: Mapping[str, Any],
+    family_packet: Mapping[str, Any],
+    source_packet: str,
+) -> dict[str, Any]:
+    template_id = str(packet["template_id"])
+    family_id = str(family_packet["family_id"])
+    steps = _cycle_steps(family_packet)
+    strict_edges = [_strict_edge_from_cycle_step(step) for step in steps]
+    return {
+        "skeleton_id": f"VC-{template_id}-{family_id}-strict-directed-cycle",
+        "source_packet": source_packet,
+        "source_template_id": template_id,
+        "source_family_id": family_id,
+        "obstruction_system": "vertex_circle_selected_distance_quotient",
+        "contradiction_type": "strict_directed_cycle",
+        "review_status": "review_pending",
+        "coverage": _coverage_from_family(family_packet),
+        "hypotheses": {
+            "cyclic_order": list(packet["cyclic_order"]),
+            "selected_rows": list(family_packet["core_selected_rows"]),
+            "minimal_local_hypotheses": _minimal_hypotheses(int(family_packet["core_size"])),
+        },
+        "relation_quotient": {
+            "equality_steps": list(family_packet["local_lemma"]["selected_distance_equalities"]),
+            "equality_chains": [
+                list(item["equality_chain_to_next_outer_pair"])
+                for item in family_packet["cycle_pair_chain"]
+            ],
+            "strict_edges": strict_edges,
+        },
+        "conclusion": {
+            "kind": "strict_directed_cycle",
+            "cycle_length": int(family_packet["cycle_length"]),
+            "quotient_cycle": _t10_quotient_cycle(family_packet),
+            "obstruction": "directed strict cycle in the quotient graph",
+            "contradiction_statement": str(family_packet["local_lemma"]["contradiction"]),
+        },
+        "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json",
+        "does_not_prove": list(DOES_NOT_PROVE),
+    }
+
+
 def relation_skeleton_catalog_payload(
     t01_packet: Mapping[str, Any],
+    t03_packet: Mapping[str, Any],
+    t04_packet: Mapping[str, Any],
     t10_packet: Mapping[str, Any],
+    t11_packet: Mapping[str, Any],
+    t12_packet: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Return the two-entry relation-skeleton catalog."""
+    """Return the expanded relation-skeleton catalog."""
 
-    skeletons = [_t01_skeleton(t01_packet), _t10_skeleton(t10_packet)]
+    skeletons = [
+        _t01_skeleton(t01_packet),
+        *(
+            _self_edge_family_skeleton(
+                packet=t03_packet,
+                family_packet=family_packet,
+                source_packet=EXPECTED_SOURCE_ARTIFACTS[1],
+            )
+            for family_packet in _family_packets(t03_packet, expected_template="T03")
+        ),
+        *(
+            _self_edge_family_skeleton(
+                packet=t04_packet,
+                family_packet=family_packet,
+                source_packet=EXPECTED_SOURCE_ARTIFACTS[2],
+            )
+            for family_packet in _family_packets(t04_packet, expected_template="T04")
+        ),
+        _t10_skeleton(t10_packet),
+        *(
+            _strict_cycle_family_skeleton(
+                packet=t11_packet,
+                family_packet=family_packet,
+                source_packet=EXPECTED_SOURCE_ARTIFACTS[4],
+            )
+            for family_packet in _family_packets(t11_packet, expected_template="T11")
+        ),
+        *(
+            _strict_cycle_family_skeleton(
+                packet=t12_packet,
+                family_packet=family_packet,
+                source_packet=EXPECTED_SOURCE_ARTIFACTS[5],
+            )
+            for family_packet in _family_packets(t12_packet, expected_template="T12")
+        ),
+    ]
     payload = {
         "schema": SCHEMA,
         "status": STATUS,
@@ -253,13 +434,20 @@ def relation_skeleton_catalog_payload(
         "skeleton_ids": list(EXPECTED_SKELETON_IDS),
         "skeletons": skeletons,
         "interpretation": [
-            "This catalog extracts relation skeletons from two focused local lemma packets.",
+            "This catalog extracts relation skeletons from focused local lemma packets.",
             "Each entry separates selected-distance quotient equalities from vertex-circle strict inequalities.",
             "The catalog is intended to support reusable local-lemma review and bridge proof mining.",
             "No proof of the n=9 case is claimed.",
             "No proof of Erdos Problem #97 and no counterexample are claimed.",
         ],
-        "source_artifacts": _source_artifacts(t01_packet, t10_packet),
+        "source_artifacts": _source_artifacts(
+            t01_packet,
+            t03_packet,
+            t04_packet,
+            t10_packet,
+            t11_packet,
+            t12_packet,
+        ),
         "provenance": PROVENANCE,
     }
     assert_expected_relation_skeleton_catalog(payload)
@@ -292,7 +480,7 @@ def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> Non
         "n": 9,
         "row_size": 4,
         "cyclic_order": list(range(9)),
-        "skeleton_count": 2,
+        "skeleton_count": 7,
         "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
         "skeleton_ids": list(EXPECTED_SKELETON_IDS),
         "provenance": PROVENANCE,
@@ -303,7 +491,7 @@ def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> Non
 
     skeletons = _skeletons_by_id(payload)
     t01 = skeletons[EXPECTED_SKELETON_IDS[0]]
-    t10 = skeletons[EXPECTED_SKELETON_IDS[1]]
+    t10 = skeletons[EXPECTED_SKELETON_IDS[4]]
 
     if t01["contradiction_type"] != "strict_self_edge":
         raise AssertionError("T01 skeleton must be a strict self-edge")
@@ -330,6 +518,43 @@ def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> Non
         raise AssertionError("T10 skeleton cycle length changed")
     if len(t10["relation_quotient"]["strict_edges"]) != 2:
         raise AssertionError("T10 skeleton must have two displayed strict edges")
+
+    expected_source_packets = {
+        "VC-T01-F09-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[0],
+        "VC-T03-F05-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[1],
+        "VC-T03-F15-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[1],
+        "VC-T04-F13-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[2],
+        "VC-T10-F12-strict-directed-cycle": EXPECTED_SOURCE_ARTIFACTS[3],
+        "VC-T11-F07-strict-directed-cycle": EXPECTED_SOURCE_ARTIFACTS[4],
+        "VC-T12-F16-strict-directed-cycle": EXPECTED_SOURCE_ARTIFACTS[5],
+    }
+    for skeleton_id, source_packet in expected_source_packets.items():
+        if skeletons[skeleton_id]["source_packet"] != source_packet:
+            raise AssertionError(f"{skeleton_id} source packet changed")
+
+    expected_family_counts = {
+        "VC-T03-F05-strict-self-edge": ("T03", "F05", "strict_self_edge", 18, 1),
+        "VC-T03-F15-strict-self-edge": ("T03", "F15", "strict_self_edge", 2, 1),
+        "VC-T04-F13-strict-self-edge": ("T04", "F13", "strict_self_edge", 2, 1),
+        "VC-T11-F07-strict-directed-cycle": ("T11", "F07", "strict_directed_cycle", 6, 3),
+        "VC-T12-F16-strict-directed-cycle": ("T12", "F16", "strict_directed_cycle", 2, 3),
+    }
+    for skeleton_id, (
+        template_id,
+        family_id,
+        contradiction_type,
+        assignment_count,
+        strict_edge_count,
+    ) in expected_family_counts.items():
+        skeleton = skeletons[skeleton_id]
+        if skeleton["source_template_id"] != template_id or skeleton["source_family_id"] != family_id:
+            raise AssertionError(f"{skeleton_id} source ids changed")
+        if skeleton["contradiction_type"] != contradiction_type:
+            raise AssertionError(f"{skeleton_id} contradiction type changed")
+        if skeleton["coverage"]["assignment_count"] != assignment_count:
+            raise AssertionError(f"{skeleton_id} assignment count changed")
+        if len(skeleton["relation_quotient"]["strict_edges"]) != strict_edge_count:
+            raise AssertionError(f"{skeleton_id} strict edge count changed")
 
     for skeleton in skeletons.values():
         if skeleton["review_status"] != "review_pending":

--- a/tests/test_relation_skeleton_catalog.py
+++ b/tests/test_relation_skeleton_catalog.py
@@ -10,6 +10,7 @@ import pytest
 
 from erdos97.relation_skeleton_catalog import (
     EXPECTED_SKELETON_IDS,
+    EXPECTED_SOURCE_ARTIFACTS,
     assert_expected_relation_skeleton_catalog,
     relation_skeleton_catalog_payload,
 )
@@ -39,11 +40,11 @@ def test_relation_skeleton_catalog_counts_and_scope() -> None:
     assert "not a proof of n=9" in payload["claim_scope"]
     assert "not a counterexample" in payload["claim_scope"]
     assert "not an independent review" in payload["claim_scope"]
-    assert payload["skeleton_count"] == 2
+    assert payload["skeleton_count"] == 7
     assert payload["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
     assert payload["contradiction_type_counts"] == {
-        "strict_directed_cycle": 1,
-        "strict_self_edge": 1,
+        "strict_directed_cycle": 3,
+        "strict_self_edge": 4,
     }
 
 
@@ -51,6 +52,7 @@ def test_relation_skeleton_catalog_records_t01_self_edge() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     skeleton = _skeletons_by_id(payload)["VC-T01-F09-strict-self-edge"]
 
+    assert skeleton["source_packet"] == EXPECTED_SOURCE_ARTIFACTS[0]
     assert skeleton["source_template_id"] == "T01"
     assert skeleton["source_family_id"] == "F09"
     assert skeleton["contradiction_type"] == "strict_self_edge"
@@ -84,6 +86,7 @@ def test_relation_skeleton_catalog_records_t10_strict_cycle() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     skeleton = _skeletons_by_id(payload)["VC-T10-F12-strict-directed-cycle"]
 
+    assert skeleton["source_packet"] == EXPECTED_SOURCE_ARTIFACTS[3]
     assert skeleton["source_template_id"] == "T10"
     assert skeleton["source_family_id"] == "F12"
     assert skeleton["contradiction_type"] == "strict_directed_cycle"
@@ -118,6 +121,65 @@ def test_relation_skeleton_catalog_records_t10_strict_cycle() -> None:
     ]
 
 
+def test_relation_skeleton_catalog_records_new_self_edge_families() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    skeletons = _skeletons_by_id(payload)
+
+    expected = {
+        "VC-T03-F05-strict-self-edge": (
+            EXPECTED_SOURCE_ARTIFACTS[1],
+            "T03",
+            "F05",
+            18,
+            [[3, 7], [2, 3], [1, 2], [1, 7]],
+        ),
+        "VC-T03-F15-strict-self-edge": (
+            EXPECTED_SOURCE_ARTIFACTS[1],
+            "T03",
+            "F15",
+            2,
+            [[1, 4], [1, 2], [2, 3], [3, 4]],
+        ),
+        "VC-T04-F13-strict-self-edge": (
+            EXPECTED_SOURCE_ARTIFACTS[2],
+            "T04",
+            "F13",
+            2,
+            [[1, 5], [3, 5], [1, 3], [1, 2]],
+        ),
+    }
+    for skeleton_id, (source_packet, template_id, family_id, assignment_count, equality_chain) in expected.items():
+        skeleton = skeletons[skeleton_id]
+        assert skeleton["source_packet"] == source_packet
+        assert skeleton["source_template_id"] == template_id
+        assert skeleton["source_family_id"] == family_id
+        assert skeleton["contradiction_type"] == "strict_self_edge"
+        assert skeleton["coverage"]["assignment_count"] == assignment_count  # type: ignore[index]
+        assert skeleton["relation_quotient"]["equality_chains"] == [equality_chain]  # type: ignore[index]
+        assert len(skeleton["relation_quotient"]["strict_edges"]) == 1  # type: ignore[index]
+        assert skeleton["conclusion"]["kind"] == "strict_self_edge"  # type: ignore[index]
+
+
+def test_relation_skeleton_catalog_records_new_strict_cycle_families() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    skeletons = _skeletons_by_id(payload)
+
+    expected = {
+        "VC-T11-F07-strict-directed-cycle": (EXPECTED_SOURCE_ARTIFACTS[4], "T11", "F07", 6, 3),
+        "VC-T12-F16-strict-directed-cycle": (EXPECTED_SOURCE_ARTIFACTS[5], "T12", "F16", 2, 3),
+    }
+    for skeleton_id, (source_packet, template_id, family_id, assignment_count, cycle_length) in expected.items():
+        skeleton = skeletons[skeleton_id]
+        assert skeleton["source_packet"] == source_packet
+        assert skeleton["source_template_id"] == template_id
+        assert skeleton["source_family_id"] == family_id
+        assert skeleton["contradiction_type"] == "strict_directed_cycle"
+        assert skeleton["coverage"]["assignment_count"] == assignment_count  # type: ignore[index]
+        assert skeleton["conclusion"]["kind"] == "strict_directed_cycle"  # type: ignore[index]
+        assert skeleton["conclusion"]["cycle_length"] == cycle_length  # type: ignore[index]
+        assert len(skeleton["relation_quotient"]["strict_edges"]) == cycle_length  # type: ignore[index]
+
+
 def test_relation_skeleton_catalog_checker_passes_lightweight() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     errors = validate_payload(payload, recompute=False)
@@ -125,7 +187,7 @@ def test_relation_skeleton_catalog_checker_passes_lightweight() -> None:
 
     assert errors == []
     assert summary["ok"] is True
-    assert summary["skeleton_count"] == 2
+    assert summary["skeleton_count"] == 7
     assert summary["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
 
 
@@ -179,7 +241,11 @@ def test_relation_skeleton_catalog_artifact_matches_generator() -> None:
 
     assert checked_in == relation_skeleton_catalog_payload(
         sources["t01_packet"],
+        sources["t03_packet"],
+        sources["t04_packet"],
         sources["t10_packet"],
+        sources["t11_packet"],
+        sources["t12_packet"],
     )
 
 
@@ -203,7 +269,7 @@ def test_relation_skeleton_catalog_checker_cli_json() -> None:
     assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
-    assert payload["skeleton_count"] == 2
+    assert payload["skeleton_count"] == 7
     assert payload["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
 
 


### PR DESCRIPTION
## Summary
- expand the relation-skeleton catalog from two to seven focused n=9 vertex-circle local entries
- regenerate `data/certificates/relation_skeleton_catalog.json` from T01/T03/T04/T10/T11/T12 packets
- update checker validation, provenance metadata, audit wiring, docs, and tests for the expanded catalog

## Scope / non-claim
- review-pending proof-mining scaffold only
- not a proof of n=9
- not a counterexample
- not an independent review of the exhaustive checker
- no global status update

## Validation
- `python scripts/check_relation_skeleton_catalog.py --assert-expected --write`
- `python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json`
- `python -m ruff check src\erdos97\relation_skeleton_catalog.py scripts\check_relation_skeleton_catalog.py tests\test_relation_skeleton_catalog.py`
- `python -m pytest tests\test_relation_skeleton_catalog.py -q`
- `python -m pytest tests\test_relation_skeleton_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`948 passed, 285 deselected`)