### PR TITLE
[codex] Expand relation skeletons to local lemma coverage

### DIFF
--- a/data/certificates/relation_skeleton_catalog.json
+++ b/data/certificates/relation_skeleton_catalog.json
@@ -1,9 +1,9 @@
 {
   "catalog_scope": "vertex-circle selected-distance quotient skeletons",
-  "claim_scope": "Seven-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
+  "claim_scope": "Sixteen-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.",
   "contradiction_type_counts": {
     "strict_directed_cycle": 3,
-    "strict_self_edge": 4
+    "strict_self_edge": 13
   },
   "cyclic_order": [
     0,
@@ -30,12 +30,21 @@
   },
   "row_size": 4,
   "schema": "erdos97.relation_skeleton_catalog.v1",
-  "skeleton_count": 7,
+  "skeleton_count": 16,
   "skeleton_ids": [
     "VC-T01-F09-strict-self-edge",
+    "VC-T02-F01-strict-self-edge",
+    "VC-T02-F04-strict-self-edge",
+    "VC-T02-F08-strict-self-edge",
+    "VC-T02-F14-strict-self-edge",
     "VC-T03-F05-strict-self-edge",
     "VC-T03-F15-strict-self-edge",
     "VC-T04-F13-strict-self-edge",
+    "VC-T05-F10-strict-self-edge",
+    "VC-T06-F11-strict-self-edge",
+    "VC-T07-F06-strict-self-edge",
+    "VC-T08-F02-strict-self-edge",
+    "VC-T09-F03-strict-self-edge",
     "VC-T10-F12-strict-directed-cycle",
     "VC-T11-F07-strict-directed-cycle",
     "VC-T12-F16-strict-directed-cycle"
@@ -217,6 +226,686 @@
       "source_family_id": "F09",
       "source_packet": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
       "source_template_id": "T01",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          8
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F01"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 3 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            1,
+            0,
+            2,
+            4,
+            7
+          ],
+          [
+            8,
+            0,
+            1,
+            4,
+            5
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              8
+            ],
+            [
+              0,
+              8
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T02-F01-strict-self-edge",
+      "source_family_id": "F01",
+      "source_packet": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+      "source_template_id": "T02",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          0,
+          2
+        ],
+        "strict_to_pair": [
+          2,
+          3
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F04"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 3 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          [
+            1,
+            0,
+            2,
+            3,
+            5
+          ],
+          [
+            2,
+            1,
+            3,
+            4,
+            8
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              0,
+              2
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              1,
+              2
+            ],
+            [
+              2,
+              3
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              0,
+              2
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              1,
+              2
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              2,
+              3
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              0,
+              2
+            ],
+            "outer_span": 3,
+            "row": 1,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              2,
+              3,
+              5,
+              0
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T02-F04-strict-self-edge",
+      "source_family_id": "F04",
+      "source_packet": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+      "source_template_id": "T02",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          8
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "families": [
+          "F08"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 3 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            1,
+            0,
+            2,
+            3,
+            5
+          ],
+          [
+            8,
+            0,
+            1,
+            3,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              8
+            ],
+            [
+              0,
+              8
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T02-F08-strict-self-edge",
+      "source_family_id": "F08",
+      "source_packet": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+      "source_template_id": "T02",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          8
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "families": [
+          "F14"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 2
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 3 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          [
+            1,
+            0,
+            2,
+            3,
+            7
+          ],
+          [
+            8,
+            0,
+            1,
+            5,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              8
+            ],
+            [
+              0,
+              8
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              6,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T02-F14-strict-self-edge",
+      "source_family_id": "F14",
+      "source_packet": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+      "source_template_id": "T02",
       "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
     },
     {
@@ -748,6 +1437,1038 @@
       "source_family_id": "F13",
       "source_packet": "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
       "source_template_id": "T04",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          8
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F10"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 4 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            4,
+            8
+          ],
+          [
+            2,
+            1,
+            3,
+            4,
+            7
+          ],
+          [
+            7,
+            2,
+            5,
+            6,
+            8
+          ],
+          [
+            8,
+            0,
+            1,
+            6,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              8
+            ],
+            [
+              7,
+              8
+            ],
+            [
+              2,
+              7
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              7,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              7,
+              8
+            ],
+            "right_pair": [
+              2,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "left_pair": [
+              2,
+              7
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              8
+            ],
+            "outer_span": 3,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              4,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T05-F10-strict-self-edge",
+      "source_family_id": "F10",
+      "source_packet": "data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json",
+      "source_template_id": "T05",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          5
+        ],
+        "strict_from_pair": [
+          3,
+          8
+        ],
+        "strict_to_pair": [
+          3,
+          5
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F11"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 5 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            1,
+            0,
+            3,
+            5,
+            8
+          ],
+          [
+            5,
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            6,
+            2,
+            5,
+            7,
+            8
+          ],
+          [
+            7,
+            0,
+            1,
+            5,
+            6
+          ],
+          [
+            8,
+            2,
+            3,
+            6,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              3,
+              8
+            ],
+            [
+              6,
+              8
+            ],
+            [
+              6,
+              7
+            ],
+            [
+              5,
+              7
+            ],
+            [
+              3,
+              5
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              3,
+              8
+            ],
+            "right_pair": [
+              6,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              6,
+              8
+            ],
+            "right_pair": [
+              6,
+              7
+            ],
+            "row": 6
+          },
+          {
+            "left_pair": [
+              6,
+              7
+            ],
+            "right_pair": [
+              5,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "left_pair": [
+              5,
+              7
+            ],
+            "right_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              5
+            ],
+            "inner_pair": [
+              3,
+              5
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              5
+            ],
+            "outer_pair": [
+              3,
+              8
+            ],
+            "outer_span": 2,
+            "row": 1,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              3,
+              5,
+              8,
+              0
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T06-F11-strict-self-edge",
+      "source_family_id": "F11",
+      "source_packet": "data/certificates/n9_vertex_circle_t06_self_edge_lemma_packet.json",
+      "source_template_id": "T06",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          4
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F06"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 5 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            4,
+            7
+          ],
+          [
+            2,
+            0,
+            1,
+            4,
+            6
+          ],
+          [
+            4,
+            1,
+            3,
+            5,
+            7
+          ],
+          [
+            5,
+            3,
+            4,
+            6,
+            8
+          ],
+          [
+            6,
+            0,
+            2,
+            5,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              4
+            ],
+            [
+              4,
+              5
+            ],
+            [
+              5,
+              6
+            ],
+            [
+              2,
+              6
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              4
+            ],
+            "right_pair": [
+              4,
+              5
+            ],
+            "row": 4
+          },
+          {
+            "left_pair": [
+              4,
+              5
+            ],
+            "right_pair": [
+              5,
+              6
+            ],
+            "row": 5
+          },
+          {
+            "left_pair": [
+              5,
+              6
+            ],
+            "right_pair": [
+              2,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "left_pair": [
+              2,
+              6
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              4
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              4,
+              7
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T07-F06-strict-self-edge",
+      "source_family_id": "F06",
+      "source_packet": "data/certificates/n9_vertex_circle_t07_self_edge_lemma_packet.json",
+      "source_template_id": "T07",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          3
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F02"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 6 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            1,
+            0,
+            3,
+            4,
+            7
+          ],
+          [
+            2,
+            1,
+            3,
+            5,
+            6
+          ],
+          [
+            5,
+            2,
+            4,
+            6,
+            7
+          ],
+          [
+            6,
+            1,
+            5,
+            7,
+            8
+          ],
+          [
+            7,
+            0,
+            1,
+            4,
+            6
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              3
+            ],
+            [
+              1,
+              7
+            ],
+            [
+              6,
+              7
+            ],
+            [
+              5,
+              6
+            ],
+            [
+              2,
+              5
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              3
+            ],
+            "right_pair": [
+              1,
+              7
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              1,
+              7
+            ],
+            "right_pair": [
+              6,
+              7
+            ],
+            "row": 7
+          },
+          {
+            "left_pair": [
+              6,
+              7
+            ],
+            "right_pair": [
+              5,
+              6
+            ],
+            "row": 6
+          },
+          {
+            "left_pair": [
+              5,
+              6
+            ],
+            "right_pair": [
+              2,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "left_pair": [
+              2,
+              5
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T08-F02-strict-self-edge",
+      "source_family_id": "F02",
+      "source_packet": "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json",
+      "source_template_id": "T08",
+      "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
+    },
+    {
+      "conclusion": {
+        "contradiction_statement": "The strict graph has a reflexive strict edge after selected-distance quotienting.",
+        "kind": "strict_self_edge",
+        "obstruction": "strict edge from a quotient class to itself",
+        "quotient_class": [
+          0,
+          1
+        ],
+        "strict_from_pair": [
+          1,
+          3
+        ],
+        "strict_to_pair": [
+          1,
+          2
+        ]
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "families": [
+          "F03"
+        ],
+        "family_count": 1,
+        "orbit_size_sum": 18
+      },
+      "does_not_prove": [
+        "n=9",
+        "Erdos Problem #97",
+        "a counterexample",
+        "independent review of the n=9 exhaustive checker"
+      ],
+      "hypotheses": {
+        "cyclic_order": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "minimal_local_hypotheses": [
+          "natural cyclic order on labels 0..8",
+          "the listed 6 selected rows are exact equidistant 4-tie rows",
+          "strict convexity makes vertex-circle chord monotonicity applicable",
+          "only the displayed local rows and quotient relations are used"
+        ],
+        "selected_rows": [
+          [
+            0,
+            1,
+            2,
+            3,
+            8
+          ],
+          [
+            1,
+            0,
+            3,
+            5,
+            7
+          ],
+          [
+            2,
+            1,
+            3,
+            4,
+            6
+          ],
+          [
+            3,
+            2,
+            4,
+            5,
+            8
+          ],
+          [
+            4,
+            0,
+            3,
+            6,
+            8
+          ],
+          [
+            8,
+            0,
+            1,
+            4,
+            7
+          ]
+        ]
+      },
+      "obstruction_system": "vertex_circle_selected_distance_quotient",
+      "relation_quotient": {
+        "equality_chains": [
+          [
+            [
+              1,
+              3
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              8
+            ],
+            [
+              4,
+              8
+            ],
+            [
+              3,
+              4
+            ],
+            [
+              2,
+              3
+            ],
+            [
+              1,
+              2
+            ]
+          ]
+        ],
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              3
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              4,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              4,
+              8
+            ],
+            "right_pair": [
+              3,
+              4
+            ],
+            "row": 4
+          },
+          {
+            "left_pair": [
+              3,
+              4
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "left_pair": [
+              2,
+              3
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 2
+          }
+        ],
+        "strict_edges": [
+          {
+            "inner_class": [
+              0,
+              1
+            ],
+            "inner_pair": [
+              1,
+              2
+            ],
+            "inner_span": 1,
+            "outer_class": [
+              0,
+              1
+            ],
+            "outer_pair": [
+              1,
+              3
+            ],
+            "outer_span": 2,
+            "row": 0,
+            "source": "vertex_circle_chord_monotonicity",
+            "witness_order": [
+              1,
+              2,
+              3,
+              8
+            ]
+          }
+        ]
+      },
+      "review_status": "review_pending",
+      "skeleton_id": "VC-T09-F03-strict-self-edge",
+      "source_family_id": "F03",
+      "source_packet": "data/certificates/n9_vertex_circle_t09_self_edge_lemma_packet.json",
+      "source_template_id": "T09",
       "verifier": "python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json"
     },
     {
@@ -1724,42 +3445,84 @@
   "source_artifacts": [
     {
       "path": "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
-      "role": "focused T01/F09 self-edge local lemma packet",
+      "role": "focused T01 local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     },
     {
+      "path": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+      "role": "focused T02 local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t02_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
       "path": "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
-      "role": "focused T03 self-edge local lemma packet",
+      "role": "focused T03 local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t03_self_edge_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     },
     {
       "path": "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
-      "role": "focused T04/F13 self-edge local lemma packet",
+      "role": "focused T04 local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t04_self_edge_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     },
     {
+      "path": "data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json",
+      "role": "focused T05 local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t05_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t06_self_edge_lemma_packet.json",
+      "role": "focused T06 local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t06_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t07_self_edge_lemma_packet.json",
+      "role": "focused T07 local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t07_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json",
+      "role": "focused T08 local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t08_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_t09_self_edge_lemma_packet.json",
+      "role": "focused T09 local lemma packet",
+      "schema": "erdos97.n9_vertex_circle_t09_self_edge_lemma_packet.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
       "path": "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
-      "role": "focused T10/F12 strict-cycle local lemma packet",
+      "role": "focused T10 local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     },
     {
       "path": "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json",
-      "role": "focused T11/F07 strict-cycle local lemma packet",
+      "role": "focused T11 local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t11_strict_cycle_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"
     },
     {
       "path": "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
-      "role": "focused T12/F16 strict-cycle local lemma packet",
+      "role": "focused T12 local lemma packet",
       "schema": "erdos97.n9_vertex_circle_t12_strict_cycle_lemma_packet.v1",
       "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
       "trust": "REVIEW_PENDING_DIAGNOSTIC"

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,8 +52,8 @@ put detailed reconciliation in the canonical synthesis.
   the candidate exterior-turn inequalities used in the review-pending `n=9`
   turn-frontier replay.
 - [`relation-skeleton-catalog.md`](relation-skeleton-catalog.md):
-  review-pending relation-skeleton extraction for selected T01/T03/T04
-  self-edge and T10/T11/T12 strict-cycle vertex-circle quotient motifs;
+  review-pending relation-skeleton extraction for the focused T01-T09
+  self-edge and T10-T12 strict-cycle vertex-circle quotient motifs;
   proof-mining aid only.
 - [`reciprocal-radial-budget.md`](reciprocal-radial-budget.md): local
   middle-witness reciprocal-radial budget packet; a research packet, not a

--- a/docs/relation-skeleton-catalog.md
+++ b/docs/relation-skeleton-catalog.md
@@ -10,23 +10,34 @@ update the official/global status of Erdos Problem #97.
 ## Scope
 
 The checked artifact is
-`data/certificates/relation_skeleton_catalog.json`. It currently contains seven
-vertex-circle selected-distance quotient skeletons extracted from focused
-local lemma packets:
+`data/certificates/relation_skeleton_catalog.json`. It currently contains
+sixteen vertex-circle selected-distance quotient skeletons extracted from the
+focused local lemma packets:
 
 ```text
 VC-T01-F09-strict-self-edge
+VC-T02-F01-strict-self-edge
+VC-T02-F04-strict-self-edge
+VC-T02-F08-strict-self-edge
+VC-T02-F14-strict-self-edge
 VC-T03-F05-strict-self-edge
 VC-T03-F15-strict-self-edge
 VC-T04-F13-strict-self-edge
+VC-T05-F10-strict-self-edge
+VC-T06-F11-strict-self-edge
+VC-T07-F06-strict-self-edge
+VC-T08-F02-strict-self-edge
+VC-T09-F03-strict-self-edge
 VC-T10-F12-strict-directed-cycle
 VC-T11-F07-strict-directed-cycle
 VC-T12-F16-strict-directed-cycle
 ```
 
-This is still smaller than the full 12-template `n=9` catalog. The goal is to
-give reviewers a reusable object shape before adding Kalmanson, row-Ptolemy,
-or all remaining vertex-circle templates.
+This matches the family-level coverage of the stored aggregate local-lemma
+packet layer: 13 strict self-edge families and 3 strict-cycle families, covering
+184 labelled pre-vertex-circle frontier assignments in that review-pending
+packet accounting. It is still a proof-mining catalog, not an independent
+review of that packet layer or the exhaustive `n=9` checker.
 
 ## Skeleton Fields
 
@@ -80,6 +91,21 @@ The row-0 vertex-circle order `[1,2,4,8]` gives the strict inequality
 
 Thus the selected-distance quotient strict graph has a strict self-edge.
 
+### T02 Shared-endpoint Self-edges
+
+The T02 packet contributes four shared-endpoint self-edge skeletons:
+
+```text
+F01: [1,8] = [0,8] = [0,1] = [1,2]
+F04: [0,2] = [0,1] = [1,2] = [2,3]
+F08: [1,8] = [0,8] = [0,1] = [1,2]
+F14: [1,8] = [0,8] = [0,1] = [1,2]
+```
+
+Each skeleton records one vertex-circle strict edge whose outer and inner
+ordinary pair distances are identified by the displayed selected-distance
+chain, producing a reflexive strict edge in the quotient graph.
+
 ### T03/F05 And T03/F15 Self-edges
 
 The two T03 family packets are recorded as separate skeletons because their
@@ -116,6 +142,21 @@ The selected-distance path gives:
 
 Row `0` has witness order `[1,2,5,7]`, so vertex-circle monotonicity gives
 `[1,5] > [1,2]`. Thus the quotient graph has a strict self-edge.
+
+### T05-T09 Selected-path Self-edges
+
+The T05 through T09 packets add five more selected-path self-edge skeletons:
+
+```text
+T05/F10: [1,8] = [7,8] = [2,7] = [1,2]
+T06/F11: [3,8] = [6,8] = [6,7] = [5,7] = [3,5]
+T07/F06: [1,4] = [4,5] = [5,6] = [2,6] = [1,2]
+T08/F02: [1,3] = [1,7] = [6,7] = [5,6] = [2,5] = [1,2]
+T09/F03: [1,3] = [0,1] = [0,8] = [4,8] = [3,4] = [2,3] = [1,2]
+```
+
+As with T03 and T04, each selected path identifies the endpoints of a stored
+vertex-circle strict inequality, yielding a strict self-edge after quotienting.
 
 ### T10/F12 Strict Cycle
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1322,31 +1322,40 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Seven-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    claim_scope: Sixteen-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
     json_top_level_type: object
     expected_json:
       schema: erdos97.relation_skeleton_catalog.v1
       status: REVIEW_PENDING_DIAGNOSTIC_ONLY
       trust: REVIEW_PENDING_DIAGNOSTIC
-      claim_scope: Seven-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+      claim_scope: Sixteen-entry relation-skeleton catalog for focused n=9 vertex-circle selected-distance quotient obstructions; proof-mining scaffolding only, not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
       catalog_scope: vertex-circle selected-distance quotient skeletons
       n: 9
       row_size: 4
-      skeleton_count: 7
+      skeleton_count: 16
       contradiction_type_counts.strict_directed_cycle: 3
-      contradiction_type_counts.strict_self_edge: 4
+      contradiction_type_counts.strict_self_edge: 13
       skeleton_ids:
         - VC-T01-F09-strict-self-edge
+        - VC-T02-F01-strict-self-edge
+        - VC-T02-F04-strict-self-edge
+        - VC-T02-F08-strict-self-edge
+        - VC-T02-F14-strict-self-edge
         - VC-T03-F05-strict-self-edge
         - VC-T03-F15-strict-self-edge
         - VC-T04-F13-strict-self-edge
+        - VC-T05-F10-strict-self-edge
+        - VC-T06-F11-strict-self-edge
+        - VC-T07-F06-strict-self-edge
+        - VC-T08-F02-strict-self-edge
+        - VC-T09-F03-strict-self-edge
         - VC-T10-F12-strict-directed-cycle
         - VC-T11-F07-strict-directed-cycle
         - VC-T12-F16-strict-directed-cycle
       provenance.command: python scripts/check_relation_skeleton_catalog.py --assert-expected --write
     forbidden_claims:
       - n=9 is proved
-      - T01 or T10 proves n=9
+      - any relation skeleton proves n=9
       - independent review of the exhaustive checker is complete
       - source-of-truth strongest result
       - official/global status update

--- a/scripts/check_relation_skeleton_catalog.py
+++ b/scripts/check_relation_skeleton_catalog.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sys
 from pathlib import Path
-from typing import Any, Sequence
+from types import ModuleType
+from typing import Any, Mapping, Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -17,42 +19,14 @@ SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-from check_n9_vertex_circle_t01_self_edge_lemma_packet import (  # noqa: E402
-    DEFAULT_ARTIFACT as DEFAULT_T01_PACKET,
-    load_source_payloads as load_t01_sources,
-    validate_payload as validate_t01_packet,
-)
-from check_n9_vertex_circle_t03_self_edge_lemma_packet import (  # noqa: E402
-    DEFAULT_ARTIFACT as DEFAULT_T03_PACKET,
-    load_source_payloads as load_t03_sources,
-    validate_payload as validate_t03_packet,
-)
-from check_n9_vertex_circle_t04_self_edge_lemma_packet import (  # noqa: E402
-    DEFAULT_ARTIFACT as DEFAULT_T04_PACKET,
-    load_source_payloads as load_t04_sources,
-    validate_payload as validate_t04_packet,
-)
-from check_n9_vertex_circle_t10_strict_cycle_lemma_packet import (  # noqa: E402
-    DEFAULT_ARTIFACT as DEFAULT_T10_PACKET,
-    load_source_payloads as load_t10_sources,
-    validate_payload as validate_t10_packet,
-)
-from check_n9_vertex_circle_t11_strict_cycle_lemma_packet import (  # noqa: E402
-    DEFAULT_ARTIFACT as DEFAULT_T11_PACKET,
-    load_source_payloads as load_t11_sources,
-    validate_payload as validate_t11_packet,
-)
-from check_n9_vertex_circle_t12_strict_cycle_lemma_packet import (  # noqa: E402
-    DEFAULT_ARTIFACT as DEFAULT_T12_PACKET,
-    load_source_payloads as load_t12_sources,
-    validate_payload as validate_t12_packet,
-)
 from erdos97.path_display import display_path  # noqa: E402
 from erdos97.relation_skeleton_catalog import (  # noqa: E402
     CLAIM_SCOPE,
     EXPECTED_CONTRADICTION_TYPE_COUNTS,
+    EXPECTED_FAMILY_DETAILS,
     EXPECTED_SKELETON_IDS,
     EXPECTED_SOURCE_ARTIFACTS,
+    FOCUSED_TEMPLATE_IDS,
     PROVENANCE,
     SCHEMA,
     STATUS,
@@ -62,6 +36,19 @@ from erdos97.relation_skeleton_catalog import (  # noqa: E402
 )
 
 DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "relation_skeleton_catalog.json"
+FOCUSED_CHECKERS: dict[str, ModuleType] = {
+    template_id: importlib.import_module(
+        "check_n9_vertex_circle_"
+        f"t{int(template_id[1:]):02d}_"
+        f"{'self_edge' if int(template_id[1:]) < 10 else 'strict_cycle'}"
+        "_lemma_packet"
+    )
+    for template_id in FOCUSED_TEMPLATE_IDS
+}
+DEFAULT_FOCUSED_PACKET_PATHS = {
+    template_id: checker.DEFAULT_ARTIFACT
+    for template_id, checker in FOCUSED_CHECKERS.items()
+}
 
 EXPECTED_TOP_LEVEL_KEYS = {
     "catalog_scope",
@@ -127,35 +114,25 @@ def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> N
 
 def load_source_payloads(
     *,
-    t01_packet_path: Path = DEFAULT_T01_PACKET,
-    t03_packet_path: Path = DEFAULT_T03_PACKET,
-    t04_packet_path: Path = DEFAULT_T04_PACKET,
-    t10_packet_path: Path = DEFAULT_T10_PACKET,
-    t11_packet_path: Path = DEFAULT_T11_PACKET,
-    t12_packet_path: Path = DEFAULT_T12_PACKET,
+    packet_paths: Mapping[str, Path] | None = None,
 ) -> dict[str, Any]:
     """Load source packets used by the relation-skeleton catalog."""
 
+    paths = dict(DEFAULT_FOCUSED_PACKET_PATHS)
+    if packet_paths is not None:
+        paths.update(packet_paths)
     return {
-        "t01_packet": load_artifact(_resolve(t01_packet_path)),
-        "t03_packet": load_artifact(_resolve(t03_packet_path)),
-        "t04_packet": load_artifact(_resolve(t04_packet_path)),
-        "t10_packet": load_artifact(_resolve(t10_packet_path)),
-        "t11_packet": load_artifact(_resolve(t11_packet_path)),
-        "t12_packet": load_artifact(_resolve(t12_packet_path)),
+        f"{template_id.lower()}_packet": load_artifact(_resolve(paths[template_id]))
+        for template_id in FOCUSED_TEMPLATE_IDS
     }
 
 
 def _validate_sources(source_payloads: dict[str, Any], errors: list[str]) -> None:
-    validators = (
-        ("T01", "t01_packet", load_t01_sources, validate_t01_packet),
-        ("T03", "t03_packet", load_t03_sources, validate_t03_packet),
-        ("T04", "t04_packet", load_t04_sources, validate_t04_packet),
-        ("T10", "t10_packet", load_t10_sources, validate_t10_packet),
-        ("T11", "t11_packet", load_t11_sources, validate_t11_packet),
-        ("T12", "t12_packet", load_t12_sources, validate_t12_packet),
-    )
-    for label, key, load_sources, validate in validators:
+    for label in FOCUSED_TEMPLATE_IDS:
+        key = f"{label.lower()}_packet"
+        checker = FOCUSED_CHECKERS[label]
+        load_sources = checker.load_source_payloads
+        validate = checker.validate_payload
         packet = source_payloads.get(key)
         if not isinstance(packet, dict):
             errors.append(f"source {label} packet must be an object")
@@ -177,12 +154,10 @@ def _expected_payload(
 ) -> dict[str, Any] | None:
     try:
         return relation_skeleton_catalog_payload(
-            source_payloads["t01_packet"],
-            source_payloads["t03_packet"],
-            source_payloads["t04_packet"],
-            source_payloads["t10_packet"],
-            source_payloads["t11_packet"],
-            source_payloads["t12_packet"],
+            {
+                template_id: source_payloads[f"{template_id.lower()}_packet"]
+                for template_id in FOCUSED_TEMPLATE_IDS
+            }
         )
     except (AssertionError, KeyError, TypeError, ValueError) as exc:
         errors.append(f"source-bound relation skeleton catalog failed: {exc}")
@@ -275,7 +250,7 @@ def _validate_t10_skeleton(skeleton: dict[str, Any], errors: list[str]) -> None:
         skeleton.get("contradiction_type"),
         "strict_directed_cycle",
     )
-    expect_equal(errors, "T10 source_packet", skeleton.get("source_packet"), EXPECTED_SOURCE_ARTIFACTS[3])
+    expect_equal(errors, "T10 source_packet", skeleton.get("source_packet"), EXPECTED_SOURCE_ARTIFACTS[9])
     expect_equal(errors, "T10 source_template_id", skeleton.get("source_template_id"), "T10")
     expect_equal(errors, "T10 source_family_id", skeleton.get("source_family_id"), "F12")
     coverage = skeleton.get("coverage")
@@ -312,40 +287,20 @@ def _validate_skeletons(payload: dict[str, Any], errors: list[str]) -> None:
     skeletons = _skeletons_by_id(payload, errors)
     if EXPECTED_SKELETON_IDS[0] in skeletons:
         _validate_t01_skeleton(skeletons[EXPECTED_SKELETON_IDS[0]], errors)
-    if EXPECTED_SKELETON_IDS[4] in skeletons:
-        _validate_t10_skeleton(skeletons[EXPECTED_SKELETON_IDS[4]], errors)
-    expected_family_counts = {
-        "VC-T03-F05-strict-self-edge": (EXPECTED_SOURCE_ARTIFACTS[1], "T03", "F05", "strict_self_edge", 18, 1),
-        "VC-T03-F15-strict-self-edge": (EXPECTED_SOURCE_ARTIFACTS[1], "T03", "F15", "strict_self_edge", 2, 1),
-        "VC-T04-F13-strict-self-edge": (EXPECTED_SOURCE_ARTIFACTS[2], "T04", "F13", "strict_self_edge", 2, 1),
-        "VC-T11-F07-strict-directed-cycle": (
-            EXPECTED_SOURCE_ARTIFACTS[4],
-            "T11",
-            "F07",
-            "strict_directed_cycle",
-            6,
-            3,
-        ),
-        "VC-T12-F16-strict-directed-cycle": (
-            EXPECTED_SOURCE_ARTIFACTS[5],
-            "T12",
-            "F16",
-            "strict_directed_cycle",
-            2,
-            3,
-        ),
-    }
+    if "VC-T10-F12-strict-directed-cycle" in skeletons:
+        _validate_t10_skeleton(skeletons["VC-T10-F12-strict-directed-cycle"], errors)
+    source_by_template = dict(zip(FOCUSED_TEMPLATE_IDS, EXPECTED_SOURCE_ARTIFACTS, strict=True))
     for skeleton_id, (
-        source_packet,
         template_id,
         family_id,
         contradiction_type,
         assignment_count,
         strict_edge_count,
-    ) in expected_family_counts.items():
+    ) in EXPECTED_FAMILY_DETAILS.items():
         skeleton = skeletons.get(skeleton_id)
         if skeleton is None:
             continue
+        source_packet = source_by_template[template_id]
         expect_equal(errors, f"{skeleton_id} source_packet", skeleton.get("source_packet"), source_packet)
         expect_equal(errors, f"{skeleton_id} source_template_id", skeleton.get("source_template_id"), template_id)
         expect_equal(errors, f"{skeleton_id} source_family_id", skeleton.get("source_family_id"), family_id)
@@ -408,7 +363,7 @@ def validate_payload(
         "n": 9,
         "row_size": 4,
         "cyclic_order": list(range(9)),
-        "skeleton_count": 7,
+        "skeleton_count": len(EXPECTED_SKELETON_IDS),
         "skeleton_ids": list(EXPECTED_SKELETON_IDS),
         "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
         "provenance": PROVENANCE,
@@ -474,12 +429,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--check", action="store_true", help="validate an existing artifact")
     parser.add_argument("--json", action="store_true", help="print stable JSON summary")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--t01-packet", type=Path, default=DEFAULT_T01_PACKET)
-    parser.add_argument("--t03-packet", type=Path, default=DEFAULT_T03_PACKET)
-    parser.add_argument("--t04-packet", type=Path, default=DEFAULT_T04_PACKET)
-    parser.add_argument("--t10-packet", type=Path, default=DEFAULT_T10_PACKET)
-    parser.add_argument("--t11-packet", type=Path, default=DEFAULT_T11_PACKET)
-    parser.add_argument("--t12-packet", type=Path, default=DEFAULT_T12_PACKET)
+    for template_id in FOCUSED_TEMPLATE_IDS:
+        parser.add_argument(
+            f"--{template_id.lower()}-packet",
+            type=Path,
+            default=DEFAULT_FOCUSED_PACKET_PATHS[template_id],
+            help=f"Path to focused {template_id} local lemma packet JSON.",
+        )
     return parser.parse_args(argv)
 
 
@@ -498,12 +454,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         sources = load_source_payloads(
-            t01_packet_path=args.t01_packet,
-            t03_packet_path=args.t03_packet,
-            t04_packet_path=args.t04_packet,
-            t10_packet_path=args.t10_packet,
-            t11_packet_path=args.t11_packet,
-            t12_packet_path=args.t12_packet,
+            packet_paths={
+                template_id: getattr(args, f"{template_id.lower()}_packet")
+                for template_id in FOCUSED_TEMPLATE_IDS
+            }
         )
     except (OSError, json.JSONDecodeError) as exc:
         print(f"FAILED: could not load source artifacts: {exc}", file=sys.stderr)
@@ -511,12 +465,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.write:
         payload = relation_skeleton_catalog_payload(
-            sources["t01_packet"],
-            sources["t03_packet"],
-            sources["t04_packet"],
-            sources["t10_packet"],
-            sources["t11_packet"],
-            sources["t12_packet"],
+            {
+                template_id: sources[f"{template_id.lower()}_packet"]
+                for template_id in FOCUSED_TEMPLATE_IDS
+            }
         )
         if args.assert_expected:
             assert_expected_relation_skeleton_catalog(payload)

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -479,7 +479,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--json",
         ),
         claim_scope=(
-            "Seven-entry relation-skeleton catalog for focused n=9 "
+            "Sixteen-entry relation-skeleton catalog for focused n=9 "
             "vertex-circle quotient motifs; proof-mining scaffolding only, "
             "not a proof of n=9, counterexample, or independent review "
             "completion."

--- a/src/erdos97/relation_skeleton_catalog.py
+++ b/src/erdos97/relation_skeleton_catalog.py
@@ -15,7 +15,7 @@ SCHEMA = "erdos97.relation_skeleton_catalog.v1"
 STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 CLAIM_SCOPE = (
-    "Seven-entry relation-skeleton catalog for focused n=9 vertex-circle "
+    "Sixteen-entry relation-skeleton catalog for focused n=9 vertex-circle "
     "selected-distance quotient obstructions; proof-mining scaffolding only, "
     "not a proof of n=9, not a counterexample, not an independent review of "
     "the exhaustive checker, and not a global status update."
@@ -25,27 +25,64 @@ PROVENANCE = {
     "command": "python scripts/check_relation_skeleton_catalog.py --assert-expected --write",
 }
 
+SELF_EDGE_TEMPLATE_IDS = ("T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09")
+STRICT_CYCLE_TEMPLATE_IDS = ("T10", "T11", "T12")
+FOCUSED_TEMPLATE_IDS = (*SELF_EDGE_TEMPLATE_IDS, *STRICT_CYCLE_TEMPLATE_IDS)
+
 EXPECTED_SKELETON_IDS = (
     "VC-T01-F09-strict-self-edge",
+    "VC-T02-F01-strict-self-edge",
+    "VC-T02-F04-strict-self-edge",
+    "VC-T02-F08-strict-self-edge",
+    "VC-T02-F14-strict-self-edge",
     "VC-T03-F05-strict-self-edge",
     "VC-T03-F15-strict-self-edge",
     "VC-T04-F13-strict-self-edge",
+    "VC-T05-F10-strict-self-edge",
+    "VC-T06-F11-strict-self-edge",
+    "VC-T07-F06-strict-self-edge",
+    "VC-T08-F02-strict-self-edge",
+    "VC-T09-F03-strict-self-edge",
     "VC-T10-F12-strict-directed-cycle",
     "VC-T11-F07-strict-directed-cycle",
     "VC-T12-F16-strict-directed-cycle",
 )
 EXPECTED_CONTRADICTION_TYPE_COUNTS = {
     "strict_directed_cycle": 3,
-    "strict_self_edge": 4,
+    "strict_self_edge": 13,
 }
 EXPECTED_SOURCE_ARTIFACTS = (
     "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
     "data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json",
     "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t06_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t07_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json",
+    "data/certificates/n9_vertex_circle_t09_self_edge_lemma_packet.json",
     "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json",
     "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json",
     "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json",
 )
+EXPECTED_FAMILY_DETAILS = {
+    "VC-T01-F09-strict-self-edge": ("T01", "F09", "strict_self_edge", 6, 1),
+    "VC-T02-F01-strict-self-edge": ("T02", "F01", "strict_self_edge", 18, 1),
+    "VC-T02-F04-strict-self-edge": ("T02", "F04", "strict_self_edge", 18, 1),
+    "VC-T02-F08-strict-self-edge": ("T02", "F08", "strict_self_edge", 2, 1),
+    "VC-T02-F14-strict-self-edge": ("T02", "F14", "strict_self_edge", 2, 1),
+    "VC-T03-F05-strict-self-edge": ("T03", "F05", "strict_self_edge", 18, 1),
+    "VC-T03-F15-strict-self-edge": ("T03", "F15", "strict_self_edge", 2, 1),
+    "VC-T04-F13-strict-self-edge": ("T04", "F13", "strict_self_edge", 2, 1),
+    "VC-T05-F10-strict-self-edge": ("T05", "F10", "strict_self_edge", 18, 1),
+    "VC-T06-F11-strict-self-edge": ("T06", "F11", "strict_self_edge", 18, 1),
+    "VC-T07-F06-strict-self-edge": ("T07", "F06", "strict_self_edge", 18, 1),
+    "VC-T08-F02-strict-self-edge": ("T08", "F02", "strict_self_edge", 18, 1),
+    "VC-T09-F03-strict-self-edge": ("T09", "F03", "strict_self_edge", 18, 1),
+    "VC-T10-F12-strict-directed-cycle": ("T10", "F12", "strict_directed_cycle", 18, 2),
+    "VC-T11-F07-strict-directed-cycle": ("T11", "F07", "strict_directed_cycle", 6, 3),
+    "VC-T12-F16-strict-directed-cycle": ("T12", "F16", "strict_directed_cycle", 2, 3),
+}
 DOES_NOT_PROVE = (
     "n=9",
     "Erdos Problem #97",
@@ -64,21 +101,10 @@ def _source_artifact(path: str, role: str, packet: Mapping[str, Any]) -> dict[st
     }
 
 
-def _source_artifacts(
-    t01_packet: Mapping[str, Any],
-    t03_packet: Mapping[str, Any],
-    t04_packet: Mapping[str, Any],
-    t10_packet: Mapping[str, Any],
-    t11_packet: Mapping[str, Any],
-    t12_packet: Mapping[str, Any],
-) -> list[dict[str, Any]]:
+def _source_artifacts(focused_packets: Mapping[str, Mapping[str, Any]]) -> list[dict[str, Any]]:
     return [
-        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[0], "focused T01/F09 self-edge local lemma packet", t01_packet),
-        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[1], "focused T03 self-edge local lemma packet", t03_packet),
-        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[2], "focused T04/F13 self-edge local lemma packet", t04_packet),
-        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[3], "focused T10/F12 strict-cycle local lemma packet", t10_packet),
-        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[4], "focused T11/F07 strict-cycle local lemma packet", t11_packet),
-        _source_artifact(EXPECTED_SOURCE_ARTIFACTS[5], "focused T12/F16 strict-cycle local lemma packet", t12_packet),
+        _source_artifact(path, f"focused {template_id} local lemma packet", focused_packets[template_id])
+        for template_id, path in zip(FOCUSED_TEMPLATE_IDS, EXPECTED_SOURCE_ARTIFACTS, strict=True)
     ]
 
 
@@ -297,8 +323,8 @@ def _t10_skeleton(packet: Mapping[str, Any]) -> dict[str, Any]:
     steps = _cycle_steps(family_packet)
     strict_edges = [_strict_edge_from_cycle_step(step) for step in steps]
     return {
-        "skeleton_id": EXPECTED_SKELETON_IDS[4],
-        "source_packet": EXPECTED_SOURCE_ARTIFACTS[3],
+        "skeleton_id": "VC-T10-F12-strict-directed-cycle",
+        "source_packet": EXPECTED_SOURCE_ARTIFACTS[9],
         "source_template_id": str(packet["template_id"]),
         "source_family_id": str(family_packet["family_id"]),
         "obstruction_system": "vertex_circle_selected_distance_quotient",
@@ -375,49 +401,34 @@ def _strict_cycle_family_skeleton(
 
 
 def relation_skeleton_catalog_payload(
-    t01_packet: Mapping[str, Any],
-    t03_packet: Mapping[str, Any],
-    t04_packet: Mapping[str, Any],
-    t10_packet: Mapping[str, Any],
-    t11_packet: Mapping[str, Any],
-    t12_packet: Mapping[str, Any],
+    focused_packets: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, Any]:
-    """Return the expanded relation-skeleton catalog."""
+    """Return the focused-packet relation-skeleton catalog."""
 
+    for template_id in FOCUSED_TEMPLATE_IDS:
+        packet = focused_packets[template_id]
+        if str(packet.get("template_id")) != template_id:
+            raise ValueError(f"expected {template_id} packet, got {packet.get('template_id')!r}")
     skeletons = [
-        _t01_skeleton(t01_packet),
+        _t01_skeleton(focused_packets["T01"]),
         *(
             _self_edge_family_skeleton(
-                packet=t03_packet,
+                packet=focused_packets[template_id],
                 family_packet=family_packet,
-                source_packet=EXPECTED_SOURCE_ARTIFACTS[1],
+                source_packet=EXPECTED_SOURCE_ARTIFACTS[FOCUSED_TEMPLATE_IDS.index(template_id)],
             )
-            for family_packet in _family_packets(t03_packet, expected_template="T03")
+            for template_id in SELF_EDGE_TEMPLATE_IDS[1:]
+            for family_packet in _family_packets(focused_packets[template_id], expected_template=template_id)
         ),
-        *(
-            _self_edge_family_skeleton(
-                packet=t04_packet,
-                family_packet=family_packet,
-                source_packet=EXPECTED_SOURCE_ARTIFACTS[2],
-            )
-            for family_packet in _family_packets(t04_packet, expected_template="T04")
-        ),
-        _t10_skeleton(t10_packet),
+        _t10_skeleton(focused_packets["T10"]),
         *(
             _strict_cycle_family_skeleton(
-                packet=t11_packet,
+                packet=focused_packets[template_id],
                 family_packet=family_packet,
-                source_packet=EXPECTED_SOURCE_ARTIFACTS[4],
+                source_packet=EXPECTED_SOURCE_ARTIFACTS[FOCUSED_TEMPLATE_IDS.index(template_id)],
             )
-            for family_packet in _family_packets(t11_packet, expected_template="T11")
-        ),
-        *(
-            _strict_cycle_family_skeleton(
-                packet=t12_packet,
-                family_packet=family_packet,
-                source_packet=EXPECTED_SOURCE_ARTIFACTS[5],
-            )
-            for family_packet in _family_packets(t12_packet, expected_template="T12")
+            for template_id in STRICT_CYCLE_TEMPLATE_IDS[1:]
+            for family_packet in _family_packets(focused_packets[template_id], expected_template=template_id)
         ),
     ]
     payload = {
@@ -440,14 +451,7 @@ def relation_skeleton_catalog_payload(
             "No proof of the n=9 case is claimed.",
             "No proof of Erdos Problem #97 and no counterexample are claimed.",
         ],
-        "source_artifacts": _source_artifacts(
-            t01_packet,
-            t03_packet,
-            t04_packet,
-            t10_packet,
-            t11_packet,
-            t12_packet,
-        ),
+        "source_artifacts": _source_artifacts(focused_packets),
         "provenance": PROVENANCE,
     }
     assert_expected_relation_skeleton_catalog(payload)
@@ -480,7 +484,7 @@ def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> Non
         "n": 9,
         "row_size": 4,
         "cyclic_order": list(range(9)),
-        "skeleton_count": 7,
+        "skeleton_count": len(EXPECTED_SKELETON_IDS),
         "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
         "skeleton_ids": list(EXPECTED_SKELETON_IDS),
         "provenance": PROVENANCE,
@@ -491,7 +495,7 @@ def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> Non
 
     skeletons = _skeletons_by_id(payload)
     t01 = skeletons[EXPECTED_SKELETON_IDS[0]]
-    t10 = skeletons[EXPECTED_SKELETON_IDS[4]]
+    t10 = skeletons["VC-T10-F12-strict-directed-cycle"]
 
     if t01["contradiction_type"] != "strict_self_edge":
         raise AssertionError("T01 skeleton must be a strict self-edge")
@@ -519,33 +523,19 @@ def assert_expected_relation_skeleton_catalog(payload: Mapping[str, Any]) -> Non
     if len(t10["relation_quotient"]["strict_edges"]) != 2:
         raise AssertionError("T10 skeleton must have two displayed strict edges")
 
-    expected_source_packets = {
-        "VC-T01-F09-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[0],
-        "VC-T03-F05-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[1],
-        "VC-T03-F15-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[1],
-        "VC-T04-F13-strict-self-edge": EXPECTED_SOURCE_ARTIFACTS[2],
-        "VC-T10-F12-strict-directed-cycle": EXPECTED_SOURCE_ARTIFACTS[3],
-        "VC-T11-F07-strict-directed-cycle": EXPECTED_SOURCE_ARTIFACTS[4],
-        "VC-T12-F16-strict-directed-cycle": EXPECTED_SOURCE_ARTIFACTS[5],
-    }
-    for skeleton_id, source_packet in expected_source_packets.items():
+    source_by_template = dict(zip(FOCUSED_TEMPLATE_IDS, EXPECTED_SOURCE_ARTIFACTS, strict=True))
+    for skeleton_id, (template_id, *_rest) in EXPECTED_FAMILY_DETAILS.items():
+        source_packet = source_by_template[template_id]
         if skeletons[skeleton_id]["source_packet"] != source_packet:
             raise AssertionError(f"{skeleton_id} source packet changed")
 
-    expected_family_counts = {
-        "VC-T03-F05-strict-self-edge": ("T03", "F05", "strict_self_edge", 18, 1),
-        "VC-T03-F15-strict-self-edge": ("T03", "F15", "strict_self_edge", 2, 1),
-        "VC-T04-F13-strict-self-edge": ("T04", "F13", "strict_self_edge", 2, 1),
-        "VC-T11-F07-strict-directed-cycle": ("T11", "F07", "strict_directed_cycle", 6, 3),
-        "VC-T12-F16-strict-directed-cycle": ("T12", "F16", "strict_directed_cycle", 2, 3),
-    }
     for skeleton_id, (
         template_id,
         family_id,
         contradiction_type,
         assignment_count,
         strict_edge_count,
-    ) in expected_family_counts.items():
+    ) in EXPECTED_FAMILY_DETAILS.items():
         skeleton = skeletons[skeleton_id]
         if skeleton["source_template_id"] != template_id or skeleton["source_family_id"] != family_id:
             raise AssertionError(f"{skeleton_id} source ids changed")

--- a/tests/test_relation_skeleton_catalog.py
+++ b/tests/test_relation_skeleton_catalog.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 
 from erdos97.relation_skeleton_catalog import (
+    EXPECTED_FAMILY_DETAILS,
     EXPECTED_SKELETON_IDS,
     EXPECTED_SOURCE_ARTIFACTS,
+    FOCUSED_TEMPLATE_IDS,
     assert_expected_relation_skeleton_catalog,
     relation_skeleton_catalog_payload,
 )
@@ -40,11 +42,11 @@ def test_relation_skeleton_catalog_counts_and_scope() -> None:
     assert "not a proof of n=9" in payload["claim_scope"]
     assert "not a counterexample" in payload["claim_scope"]
     assert "not an independent review" in payload["claim_scope"]
-    assert payload["skeleton_count"] == 7
+    assert payload["skeleton_count"] == 16
     assert payload["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
     assert payload["contradiction_type_counts"] == {
         "strict_directed_cycle": 3,
-        "strict_self_edge": 4,
+        "strict_self_edge": 13,
     }
 
 
@@ -86,7 +88,7 @@ def test_relation_skeleton_catalog_records_t10_strict_cycle() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     skeleton = _skeletons_by_id(payload)["VC-T10-F12-strict-directed-cycle"]
 
-    assert skeleton["source_packet"] == EXPECTED_SOURCE_ARTIFACTS[3]
+    assert skeleton["source_packet"] == EXPECTED_SOURCE_ARTIFACTS[9]
     assert skeleton["source_template_id"] == "T10"
     assert skeleton["source_family_id"] == "F12"
     assert skeleton["contradiction_type"] == "strict_directed_cycle"
@@ -121,43 +123,33 @@ def test_relation_skeleton_catalog_records_t10_strict_cycle() -> None:
     ]
 
 
-def test_relation_skeleton_catalog_records_new_self_edge_families() -> None:
+def test_relation_skeleton_catalog_records_family_level_skeletons() -> None:
     payload = load_artifact(DEFAULT_ARTIFACT)
     skeletons = _skeletons_by_id(payload)
+    source_by_template = dict(zip(FOCUSED_TEMPLATE_IDS, EXPECTED_SOURCE_ARTIFACTS, strict=True))
 
-    expected = {
-        "VC-T03-F05-strict-self-edge": (
-            EXPECTED_SOURCE_ARTIFACTS[1],
-            "T03",
-            "F05",
-            18,
-            [[3, 7], [2, 3], [1, 2], [1, 7]],
-        ),
-        "VC-T03-F15-strict-self-edge": (
-            EXPECTED_SOURCE_ARTIFACTS[1],
-            "T03",
-            "F15",
-            2,
-            [[1, 4], [1, 2], [2, 3], [3, 4]],
-        ),
-        "VC-T04-F13-strict-self-edge": (
-            EXPECTED_SOURCE_ARTIFACTS[2],
-            "T04",
-            "F13",
-            2,
-            [[1, 5], [3, 5], [1, 3], [1, 2]],
-        ),
-    }
-    for skeleton_id, (source_packet, template_id, family_id, assignment_count, equality_chain) in expected.items():
+    for skeleton_id, (
+        template_id,
+        family_id,
+        contradiction_type,
+        assignment_count,
+        strict_edge_count,
+    ) in EXPECTED_FAMILY_DETAILS.items():
         skeleton = skeletons[skeleton_id]
-        assert skeleton["source_packet"] == source_packet
+        assert skeleton["source_packet"] == source_by_template[template_id]
         assert skeleton["source_template_id"] == template_id
         assert skeleton["source_family_id"] == family_id
-        assert skeleton["contradiction_type"] == "strict_self_edge"
+        assert skeleton["contradiction_type"] == contradiction_type
         assert skeleton["coverage"]["assignment_count"] == assignment_count  # type: ignore[index]
-        assert skeleton["relation_quotient"]["equality_chains"] == [equality_chain]  # type: ignore[index]
-        assert len(skeleton["relation_quotient"]["strict_edges"]) == 1  # type: ignore[index]
-        assert skeleton["conclusion"]["kind"] == "strict_self_edge"  # type: ignore[index]
+        assert len(skeleton["relation_quotient"]["strict_edges"]) == strict_edge_count  # type: ignore[index]
+        if contradiction_type == "strict_self_edge":
+            assert skeleton["conclusion"]["kind"] == "strict_self_edge"  # type: ignore[index]
+            assert skeleton["relation_quotient"]["equality_chains"][0][0] == (  # type: ignore[index]
+                skeleton["conclusion"]["strict_from_pair"]  # type: ignore[index]
+            )
+        else:
+            assert skeleton["conclusion"]["kind"] == "strict_directed_cycle"  # type: ignore[index]
+            assert skeleton["conclusion"]["cycle_length"] == strict_edge_count  # type: ignore[index]
 
 
 def test_relation_skeleton_catalog_records_new_strict_cycle_families() -> None:
@@ -165,8 +157,8 @@ def test_relation_skeleton_catalog_records_new_strict_cycle_families() -> None:
     skeletons = _skeletons_by_id(payload)
 
     expected = {
-        "VC-T11-F07-strict-directed-cycle": (EXPECTED_SOURCE_ARTIFACTS[4], "T11", "F07", 6, 3),
-        "VC-T12-F16-strict-directed-cycle": (EXPECTED_SOURCE_ARTIFACTS[5], "T12", "F16", 2, 3),
+        "VC-T11-F07-strict-directed-cycle": (EXPECTED_SOURCE_ARTIFACTS[10], "T11", "F07", 6, 3),
+        "VC-T12-F16-strict-directed-cycle": (EXPECTED_SOURCE_ARTIFACTS[11], "T12", "F16", 2, 3),
     }
     for skeleton_id, (source_packet, template_id, family_id, assignment_count, cycle_length) in expected.items():
         skeleton = skeletons[skeleton_id]
@@ -187,7 +179,7 @@ def test_relation_skeleton_catalog_checker_passes_lightweight() -> None:
 
     assert errors == []
     assert summary["ok"] is True
-    assert summary["skeleton_count"] == 7
+    assert summary["skeleton_count"] == 16
     assert summary["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
 
 
@@ -240,12 +232,10 @@ def test_relation_skeleton_catalog_artifact_matches_generator() -> None:
     checked_in = load_artifact(DEFAULT_ARTIFACT)
 
     assert checked_in == relation_skeleton_catalog_payload(
-        sources["t01_packet"],
-        sources["t03_packet"],
-        sources["t04_packet"],
-        sources["t10_packet"],
-        sources["t11_packet"],
-        sources["t12_packet"],
+        {
+            template_id: sources[f"{template_id.lower()}_packet"]
+            for template_id in FOCUSED_TEMPLATE_IDS
+        }
     )
 
 
@@ -269,7 +259,7 @@ def test_relation_skeleton_catalog_checker_cli_json() -> None:
     assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
-    assert payload["skeleton_count"] == 7
+    assert payload["skeleton_count"] == 16
     assert payload["skeleton_ids"] == list(EXPECTED_SKELETON_IDS)
 
 


### PR DESCRIPTION
## Summary
- expand `relation_skeleton_catalog.json` from 7 to 16 family-level skeletons
- add T02 and T05-T09 self-edge packet skeletons so the catalog mirrors the stored local-lemma packet coverage
- refactor the relation-skeleton checker to load/validate all focused T01-T12 packets
- update provenance metadata, audit claim scope, docs, and tests

## Scope / non-claim
- review-pending proof-mining scaffold only
- not a proof of n=9
- not a counterexample
- not an independent review of the exhaustive checker
- no global status update

## Validation
- `python scripts/check_relation_skeleton_catalog.py --assert-expected --write`
- `python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json`
- `python -m ruff check src\erdos97\relation_skeleton_catalog.py scripts\check_relation_skeleton_catalog.py tests\test_relation_skeleton_catalog.py`
- `python -m pytest tests\test_relation_skeleton_catalog.py -q`
- `python -m pytest tests\test_relation_skeleton_catalog.py -q -m "artifact"`
- `python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`948 passed, 285 deselected`)