### PR TITLE
[codex] Expose block6 sixth-row survivor audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).
+- For the block-6 fifth/sixth-row survivor diagnostics, which explain why
+  very local closure subclaims fail before the stronger full-extension gates
+  take over, read
+  [`docs/block6-fragile-fifth-row-obstruction-catalog.md`](docs/block6-fragile-fifth-row-obstruction-catalog.md)
+  and
+  [`docs/block6-fragile-sixth-row-survivor-catalog.md`](docs/block6-fragile-sixth-row-survivor-catalog.md).
 - For the rich-triple closure / bootstrap-core bridge fork, read
   [`docs/bootstrap-core-bridge.md`](docs/bootstrap-core-bridge.md).
 - For the bootstrap-core rank/capacity crosswalk on current fixed-row

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -208,6 +208,16 @@ The scope remains bounded to block-preserving oriented shuffles; it is not
 arbitrary cyclic-order closure, all selected-row closure, the fragile bridge,
 or Erdos Problem #97.
 
+The block-6 fifth/sixth-row survivor diagnostics are exact bounded negative
+controls for overly local bridge claims. They show that all `166` clean
+fifth-row states have a clean legal sixth-row continuation, every unordered
+added-center pair supports clean six-row states, and the low-support branch
+continues through many clean seventh and eighth rows before only `12` clean
+seven-row states become terminal at the eighth-row test. This is natural-order
+proof-mining bookkeeping only, not a fragile-bridge proof or realizability
+claim; see `docs/block6-fragile-sixth-row-survivor-catalog.md` and
+`scripts/check_block6_fragile_sixth_row_survivors.py`.
+
 ### Bootstrap-core bridge
 
 Status: `LEMMA` / bridge fork.

--- a/STATE.md
+++ b/STATE.md
@@ -118,6 +118,15 @@ bookkeeping, not arbitrary cyclic-order closure, all selected-row closure, the
 fragile bridge, or Erdos #97. See
 `data/certificates/block6_oriented_block_reversal_closure.json`.
 
+The block-6 row-depth survivor diagnostics record why still more local bridge
+subclaims fail inside the same negative-control family: all `166` clean
+fifth-row states admit a clean sixth row, every unordered added-center pair
+has clean six-row support, and the low-support branch has many clean seventh
+and eighth-row continuations before only `12` clean seven-row states become
+eighth-row terminal. This is bounded natural-order proof-mining information,
+not a fragile-bridge proof or Euclidean realization claim. See
+`docs/block6-fragile-sixth-row-survivor-catalog.md`.
+
 A separate rich-triple closure bridge records that ear-orderability is
 equivalent to bootstrap rank at most 3. Failure of that rank condition yields
 inclusion-minimal generating cores with deletion closures, private halos, and a

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -77,7 +77,11 @@ Use this queue when no more specific issue is selected.
    explicit cyclic reversal to cover the two first-block-reversed orientation
    families as well, for `1848` oriented-block shuffle orders. The next useful
    PR should widen beyond block-preserving shuffles, or explain which richer
-   bridge hypothesis would rule out the remaining arbitrary-order gap.
+   bridge hypothesis would rule out the remaining arbitrary-order gap. The
+   row-depth scout
+   `python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
+   records a bounded negative control against fifth-row-only and
+   sixth-row-only closure claims before attempting such a bridge.
 4. Use the bootstrap-core crosswalk and the bootstrap / vertex-circle overlay
    in `docs/bootstrap-core-crosswalk.md` and
    `docs/bootstrap-vertex-circle-overlay.md` to design a sharper condition.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -514,6 +514,14 @@ condition that the surviving multi-block family does not automatically satisfy:
   outside the packet, so the next useful widening should leave the
   block-preserving orientation family or state a genuine minimal/rich-class
   bridge hypothesis.
+- block-6 row-depth survivor evidence, as recorded in
+  `docs/block6-fragile-sixth-row-survivor-catalog.md` and checked by
+  `scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`.
+  It shows that fifth-row-only and sixth-row-only closure subclaims fail:
+  all `166` clean fifth-row states admit a clean sixth row, and the
+  low-support branch still has many clean seventh/eighth continuations. This
+  is useful mainly as a negative control for bridge hypotheses that are too
+  local.
 
 Acceptance standard: a strengthened bridge should be stated as a necessary
 condition for minimal counterexamples and should reject at least one abstract

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -781,6 +781,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="block6_fragile_sixth_row_survivors",
+        command=(
+            "python",
+            "scripts/check_block6_fragile_sixth_row_survivors.py",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Block-6 row-depth survivor catalog for legal sixth rows after "
+            "clean fifth-row states and low-support seventh/eighth-row "
+            "continuations; bounded natural-order negative control only, not "
+            "a fragile-bridge proof, not a proof of Erdos Problem #97, and "
+            "not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="block6_terminal_crossing_vertex_circle_sample",
         command=(
             "python",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -259,3 +259,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_block6_fragile_sixth_row_survivors.py "
+        "--assert-expected --json"
+        in command_texts
+    )


### PR DESCRIPTION
## Summary
- register the existing block-6 sixth-row survivor checker in the artifact audit command list
- surface the bounded fifth/sixth-row negative-control diagnostic in README, STATE, RESULTS, backlog, and review priorities
- keep the scope explicitly natural-order / proof-mining only

## Scope / non-claim
- bounded block-6 negative-control bookkeeping only
- not a fragile-bridge proof
- not a proof of Erdos Problem #97
- not a counterexample
- no global status update

## Validation
- `python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --json`
- `python -m pytest tests\test_block6_fragile_sixth_row_survivors.py -q`
- `python -m pytest tests\test_run_artifact_audit.py -q`
- `python -m ruff check scripts\run_artifact_audit.py tests\test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`953 passed, 285 deselected`)