### PR TITLE
[codex] Register n8 independent obstruction recheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/n8-incidence-enumeration.md`](docs/n8-incidence-enumeration.md).
 - For the `n=8` exact survivor obstruction artifact, read
   [`docs/n8-exact-survivors.md`](docs/n8-exact-survivors.md).
+- For the SymPy-free independent recheck of the `n=8` cyclic-order counts and
+  11 survivor-class obstructions, read
+  [`docs/n8-independent-obstruction.md`](docs/n8-independent-obstruction.md).
 - For the review-pending exhaustive `n=9` vertex-circle finite-case checker,
   read [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 - For the derived `n=9` vertex-circle template lemma-candidate catalog, read

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -92,6 +92,13 @@ used. See `docs/n8-incidence-enumeration.md`,
 `docs/n8-exact-survivors.md`, `data/incidence/n8_incidence_completeness.json`,
 and `certificates/n8_exact_analysis.json`.
 
+The independent SymPy-free recheck in `docs/n8-independent-obstruction.md`
+uses separate rational-arithmetic code to reproduce the cyclic-order counts
+for all 15 classes and independently kill 11 classes. It intentionally leaves
+the Groebner-dependent classes `3`, `4`, `5`, and `14` to the original exact
+survivor checker, so it is an audit-strengthening cross-check rather than an
+independent public proof.
+
 ### Proof-note draft: geometric exclusion of n <= 8
 
 Status: proof-note draft; independent review requested.

--- a/STATE.md
+++ b/STATE.md
@@ -38,6 +38,13 @@ equal-distance algebra kills the other 14. See
 External independent review remains recommended before public theorem-style
 claims.
 
+A separate SymPy-free independent recheck covers the cyclic-order counts for
+all 15 `n=8` survivor classes and independently kills 11 of them by
+cyclic-order or rational linear-span arguments. It deliberately does not cover
+the Groebner-based classes `3`, `4`, `5`, and `14`, so it is a defensive
+cross-check rather than an independent replacement for the full exact
+survivor artifact. See `docs/n8-independent-obstruction.md`.
+
 For the general bridge problem, minimality now gives a small proved foothold:
 every minimal counterexample admits a partial fragile-cover witness system made
 from exact critical 4-ties. This is necessary structure only; the block-6

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -196,7 +196,12 @@ Use this queue when no more specific issue is selected.
    C13/C19 template records and C25/C29 availability records now exist, but
    they are not cyclic-order coverage or obstructions for the larger frontier.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
-   with an independent input-data replay.
+   with an independent input-data replay. The current SymPy-free
+   `n=8` replay command,
+   `python scripts/independent_n8_obstruction_recheck.py --check --json`,
+   covers the cyclic-order counts and 11 non-Groebner survivor-class kills;
+   the remaining `n=8` audit gap is still the Groebner-based classes `3`,
+   `4`, `5`, and especially `14`.
 
 ## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,6 +227,9 @@ put detailed reconciliation in the canonical synthesis.
   `n=8` incidence-completeness enumeration.
 - [`n8-exact-survivors.md`](n8-exact-survivors.md): exact obstruction pass for
   the 15 `n=8` incidence survivor classes.
+- [`n8-independent-obstruction.md`](n8-independent-obstruction.md): SymPy-free
+  cross-check of the `n=8` cyclic-order counts and 11 survivor-class
+  obstructions.
 - [`n8-geometric-proof.md`](n8-geometric-proof.md): proof-note draft giving a
   compact geometric obstruction for bad convex octagons via isosceles-triangle
   counting and exterior-turn angles.

--- a/docs/n8-exact-survivors.md
+++ b/docs/n8-exact-survivors.md
@@ -196,6 +196,7 @@ Run from the repository root after installing the development dependencies:
 ```bash
 pip install -e .[dev]
 python scripts/independent_check_n8_artifacts.py --check --json
+python scripts/independent_n8_obstruction_recheck.py --check --json
 python scripts/analyze_n8_exact_survivors.py --check --json
 python scripts/analyze_n8_exact_survivors.py --check --json --check-compatible-orders-data data/incidence/n8_compatible_orders.json --check-exact-analysis-data certificates/n8_exact_analysis.json
 pytest -q
@@ -218,6 +219,12 @@ survivor JSON, incidence-completeness artifact, compatible-order artifact, and
 exact-analysis artifact agree with each other. It reports this as a repo-local
 artifact audit pending external review, not as a standalone public theorem
 claim.
+
+The `independent_n8_obstruction_recheck.py` entrypoint is a SymPy-free
+second-source replay for the parts that do not require Groebner machinery: it
+recomputes the compatible cyclic-order counts for all 15 classes and
+independently kills 11 classes. It does not cover the Groebner-based classes
+`3`, `4`, `5`, and `14`.
 
 The expanded polynomial systems and full compatible cyclic-order lists are stored
 as reproducibility artifacts:

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -44,6 +44,20 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope="Repo-local n=8 exact survivor obstruction audit pending external review.",
     ),
     AuditCommand(
+        ident="n8_independent_obstruction_recheck",
+        command=(
+            "python",
+            "scripts/independent_n8_obstruction_recheck.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "SymPy-free independent cross-check for n=8 cyclic-order counts "
+            "and 11 of 15 survivor-class obstructions; repo-local audit "
+            "pending external review, not a public theorem claim."
+        ),
+    ),
+    AuditCommand(
         ident="round2_certificates",
         command=("python", "scripts/check_round2_certificates.py"),
         claim_scope="Fixed-pattern and fixed-order round-two certificate regression checks only.",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -38,6 +38,10 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/independent_n8_obstruction_recheck.py --check --json"
+        in command_texts
+    )
+    assert (
         "python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json"
         in command_texts
     )


### PR DESCRIPTION
## Summary

- Register the existing SymPy-free `n=8` independent obstruction recheck in the artifact audit command list.
- Surface the recheck in the README, docs index, `STATE.md`, `RESULTS.md`, and the n=8 survivor docs.
- Keep the claim boundary explicit: the recheck covers cyclic-order counts plus 11 of 15 survivor-class obstructions, while Groebner-dependent classes `3`, `4`, `5`, and `14` remain delegated to the original exact survivor artifact.

## Scope

This is an audit-strengthening repo-local cross-check only. It is not a general proof, not a counterexample, and not an independent public theorem claim.

## Validation

- `python scripts/independent_n8_obstruction_recheck.py --check --json`
- `python -m pytest tests\test_n8_independent_obstruction.py -q`
- `python -m pytest tests\test_run_artifact_audit.py -q`
- `python -m ruff check scripts\run_artifact_audit.py tests\test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`953 passed, 285 deselected`)